### PR TITLE
Speed up Circle CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,6 @@ workflows:
       - build-container:
           context: architect
           requires:
-            - test
-            - lint
             - build
           <<: *job_filters
       - architect/push-to-app-catalog:


### PR DESCRIPTION
This PR merges several CI steps into the `build` one.

The individual steps in CircleCI used restoring a peristed workspace, which took as long as the function we execute. Chaining all steps in a linear war reduces the overhead of persisting the workspace. This way the entire workflow takes roughly 6 minuts instead of 8 to 9.