### PR TITLE
Modify GitHub auth provider defaultScopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Modify GitHub auth provider default scopes to prevent multiple sign in popups.
+
 ## [0.1.9] - 2023-07-28
 
 ### Changed


### PR DESCRIPTION
### What does this PR do?

With current GitHub integration when some plugin requests access token with greater scope, login popup is shown with a request for additional permissions - [docs](https://github.com/backstage/backstage/blob/master/docs/auth/oauth.md#sequence-diagram). To prevent this behaviour, `defaultScopes` for the GitHub authentication API was changed to include all the scopes needed by different plugins. 

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/27008.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
