### PR TITLE
Enable codecov badge in techdocs

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -37,6 +37,7 @@ backend:
       - 'data:'
       - 'https://avatars.githubusercontent.com'
       - 'https://circleci.com'
+      - 'https://codecov.io'
       - 'https://dl.circleci.com'
       - 'https://godoc.org'
       - 'https://goreportcard.com'


### PR DESCRIPTION
### What does this PR do?

Adds the `codecov.io` domain for cross domain access, to enable another badge type.

### What is the effect of this change to users?

The coedcov badge will display correctly.

Before:

<img width="523" alt="image" src="https://github.com/giantswarm/backstage/assets/273727/e4ecb809-3063-4816-8e53-719ff7c38b11">
