### PR TITLE
Remove default filter "owned" in the catalog list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The catalog now shows all components by default, instead of only the owned ones. To only see you team's components, click the *Owned*  filter.
+
 ## [0.1.16] - 2023-08-10
 
 ### Fixed

--- a/packages/app/src/components/catalog/CustomCatalogPage.tsx
+++ b/packages/app/src/components/catalog/CustomCatalogPage.tsx
@@ -47,7 +47,6 @@ export function CustomCatalogPage(props: CustomCatalogPageProps) {
   const {
     columns,
     actions,
-    initiallySelectedFilter = 'owned',
     initialKind = 'component',
     tableOptions = {},
     emptyContent,
@@ -67,7 +66,7 @@ export function CustomCatalogPage(props: CustomCatalogPageProps) {
             <CatalogFilterLayout.Filters>
               <EntityKindPicker initialFilter={initialKind} />
               <EntityTypePicker />
-              <UserListPicker initialFilter={initiallySelectedFilter} />
+              <UserListPicker />
               <EntityOwnerPicker mode={ownerPickerMode} />
               <EntityLifecyclePicker />
               <EntityTagPicker />


### PR DESCRIPTION
### What does this PR do?

The catalog now shows all components by default, instead of only the owned ones.

### What is the effect of this change to users?

See above. To only see the own team's components, users must click the *Owned*  filter.

### How does it look like?

skip

### Any background context you can provide?

The fact that the catalog overview is filtered by default confused me many times. In order to find a certain component, I stumbled into an empty search result and then had to realize the filter state and click on "All" to remove the "Owned" filter.

I'm thinking that an unfiltered initial state is more easy to work with in most cases, and should meet more users' expectations.

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated