### PR TITLE
Add Docs menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add Docs menu item.
+
 ## [0.4.0] - 2023-08-21
 
 - Change condition for when to show links. Now links can be shown for all entity kinds.

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
+import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import LogoFull from './LogoFull';
 import LogoIcon from './LogoIcon';
 import {
@@ -61,6 +62,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarGroup label="Menu" icon={<MenuIcon />}>
         {/* Global nav, not org-specific */}
         <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
+        <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
         {/* End global nav */}
       </SidebarGroup>
       <SidebarSpace />


### PR DESCRIPTION
### What does this PR do?

This PR adds back the Docs menu entry that we have hidden initially, when we didn't have techdocs.

### How does it look like?

![image](https://github.com/giantswarm/backstage/assets/273727/efba3d8d-dd0a-4ada-99f0-c54e09c96d7f)

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
