### PR TITLE
Filter catalog to owned components by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve entity dependencies page.
 - Update Backstage packages to v1.17.5.
+- The catalog now shows *owned* components by default again instead of *all*.
 
 ## [0.5.0] - 2023-08-22
 
 ### Changed
+
 - Add Docs menu item.
 - Read catalog data from URL location.
 

--- a/packages/app/src/components/catalog/CustomCatalogPage.tsx
+++ b/packages/app/src/components/catalog/CustomCatalogPage.tsx
@@ -47,6 +47,7 @@ export function CustomCatalogPage(props: CustomCatalogPageProps) {
   const {
     columns,
     actions,
+    initiallySelectedFilter = 'owned',
     initialKind = 'component',
     tableOptions = {},
     emptyContent,
@@ -66,7 +67,7 @@ export function CustomCatalogPage(props: CustomCatalogPageProps) {
             <CatalogFilterLayout.Filters>
               <EntityKindPicker initialFilter={initialKind} />
               <EntityTypePicker />
-              <UserListPicker />
+              <UserListPicker initialFilter={initiallySelectedFilter} />
               <EntityOwnerPicker mode={ownerPickerMode} />
               <EntityLifecyclePicker />
               <EntityTagPicker />


### PR DESCRIPTION
### What does this PR do?

This reverts https://github.com/giantswarm/backstage/pull/63 due to many people's request

### What is the effect of this change to users?

When opening the catalog, users will at first only see entitie sowned by their teams.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
