### PR TITLE
Update catalog url in app-config.local.yaml.example

### DIFF
--- a/app-config.local.yaml.example
+++ b/app-config.local.yaml.example
@@ -12,6 +12,6 @@
 catalog:
   locations:
     - type: url
-      target: https://github.com/giantswarm/github/blob/main/catalog/generated.yaml
+      target: https://github.com/giantswarm/github/blob/main/catalog/*.yaml
     # - type: file
     #   target: ../../catalog/catalog.yaml


### PR DESCRIPTION
This catalog makes the example for `app-config.local.yaml` work better for Giant Swarm developers. The old URL will no longer work soon.