### PR TITLE
Push chart archive to control-plane app catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,19 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - architect/push-to-app-catalog:
+          executor: app-build-suite
+          name: push-to-control-plane-app-catalog
+          context: architect
+          app_catalog: "control-plane-catalog"
+          app_catalog_test: "control-plane-test-catalog"
+          chart: "backstage"
+          persist_chart_archive: true
+          requires:
+            - build-container
+          filters:
+            tags:
+              only: /^v.*/
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Push chart archive to control-plane app catalog.
+
 ## [0.8.0] - 2023-09-19
 
 ### Added


### PR DESCRIPTION
### What does this PR do?

Push chart archive to `control-plane` app catalog to be able to deploy to `snail`.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/28217.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
