### PR TITLE
Group backstage packages in renovate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Group backstage packages in renovate config.
+
 ## [0.8.1] - 2023-09-22
 
 ### Added

--- a/renovate.json
+++ b/renovate.json
@@ -22,5 +22,11 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["@backstage"],
+      "groupName": "backstage packages"
+    }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Backstage packages were grouped together in renovate config. I decided not to disable renovate for backstage packages completely so we have one PR as a reminder to update manually. I think in the future we can introduce some automation to run `yarn backstage-cli versions:bump`.

- [x] CHANGELOG.md has been updated
