### PR TITLE
Set default registry domain to gsoci

### DIFF
--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -12,7 +12,7 @@ port: 7007
 hostnames: []
 
 registry:
-  domain: quay.io
+  domain: gsoci.azurecr.io
 
 authSessionSecret: ""
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3017

### What does this PR do?

Modifies default registry domain in app config to `gsoci.azurecr.io` instead of `quay.io`.

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated
