### PR TITLE
Limit renovate to 1 concurrent PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Limit renovate to 1 concurrent PR.
+
 ## [0.14.0] - 2024-01-16
 
 ### Changed

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,5 +13,11 @@
       "matchPackagePrefixes": ["@testing-library"],
       "groupName": "testing-library packages"
     }
+  ],
+  "prConcurrentLimit": 1,
+  "schedule": [
+    "every weekend",
+    "every weekday after 6pm",
+    "every weekday before 6am"
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Renovate configuration was changed. By creating only 1 concurrent PR at a time we can decrease the amount of CI runs for this repo.

- [x] CHANGELOG.md has been updated
