### PR TITLE
Upgrade node base image to 20-bookworm-slim

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 
-FROM node:18-bookworm-slim
+FROM node:20-bookworm-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.


### PR DESCRIPTION
My goal was to check whether the different image results in fewer security vulnerabilities (https://github.com/giantswarm/giantswarm/issues/27746) but it doesn't.

Anyway, the image seems to work.