### PR TITLE
Some CircleCI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,6 @@ jobs:
     steps:
       - checkout
       
-      # - restore_cache:
-      #     keys:
-      #       - v3-npm-deps-{{ checksum "yarn.lock" }}
-      
       - run:
           name: Print node and yarn version info
           command: |
@@ -76,11 +72,6 @@ jobs:
       - run:
           name: Install dependencies
           command: yarn install --frozen-lockfile
-      
-      # - save_cache:
-      #     paths:
-      #       - node_modules
-      #     key: v3-npm-deps-{{ checksum "yarn.lock" }}
 
       - run:
           name: Typecheck code using the TypeScript compiler


### PR DESCRIPTION
### What does this PR do?

- Turn off dependency caching in CircleCI, for faster and cheaper CI runs
- Use latest architect-orb
- Use NodeJS v20 base image in CircleCI
- Rename workflow and job that were both named `build` to reduce ambiguity

This started as an attempt to understand dependency caching in CircleCI and make it fast.

- [The CI run for the first commit](https://app.circleci.com/pipelines/github/giantswarm/backstage/987/workflows/bdf0559b-f3d5-4050-8e5a-ca3623220328/jobs/3459) started with a fresh cache key, so there was no cache to restore. Installing dependencies took 1m 29s, saving the cache took 1m 11s. Total duration 3m 45s.
- [The CI run for the second commit](https://app.circleci.com/pipelines/github/giantswarm/backstage/988/workflows/ea91434c-02cf-4d3d-999d-d99e49095cb2/jobs/3461) hit a cache. Restoring the cache took 30 seconds. Installing dependencies took 1m 39 seconds (longer than without cache!). Total 3m 22s.
- [Third run without cache](https://app.circleci.com/pipelines/github/giantswarm/backstage/989/workflows/8b27559e-3855-4e5e-bcb5-6710715633f8/jobs/3467). Total 2m 37s.

### What is the effect of this change to users?

None, pure dev change.
