### PR TITLE
Fix GitHub Actions plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix GitHub Actions plugin.
+
 ## [0.16.0] - 2024-03-05
 
 ### Changed

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -1,4 +1,5 @@
 import {
+  ScmAuth,
   ScmIntegrationsApi,
   scmIntegrationsApiRef,
 } from '@backstage/integration-react';
@@ -25,6 +26,7 @@ export const apis: AnyApiFactory[] = [
     deps: { configApi: configApiRef },
     factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
   }),
+  ScmAuth.createDefaultApiFactory(),
   /**
    * Custom GitHub API configuration to modify defaultScopes to include all the scopes that different plugins need.
    * It's needed to prevent different plugins to request additional permissions over sign in popup.


### PR DESCRIPTION
### What does this PR do?

GitHub Actions plugin is currently broken. The reason is that `ScmAuth` API is not configured correctly - configuration code was deleted by mistake during [refactoring](https://github.com/giantswarm/backstage/pull/250).

In this PR I bring `ScmAuth` API configuration back.

### What is the effect of this change to users?

GitHub Actions plugin should work again.

### Any background context you can provide?

Closes https://github.com/giantswarm/giantswarm/issues/30119.

- [x] CHANGELOG.md has been updated
