### PR TITLE
Set PDB maxUnavailable=1

### DIFF
--- a/helm/backstage/templates/pdb.yaml
+++ b/helm/backstage/templates/pdb.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ .Values.name }}
     {{- include "labels.backstage" $ | nindent 4 }}
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: {{ .Values.name }}


### PR DESCRIPTION
### What does this PR do?

Previously, the PDB spec `minAvailable: 1` prevented the pod from being rescheduled by the autoscaler, resulting in keeping nodes up even with only the Backstage pod running. This results in low utilization of the node and us paying extra for an almost unused node.

### What is the effect of this change to users?

End users may notice a short unavailability more often of the pod gets moved to a different node, until we eventually mitigate this by other means.

### Any background context you can provide?

- https://github.com/giantswarm/giantswarm/issues/30255

The cluster-autoscaler logs messages like

    node ip-10-0-74-113.eu-central-1.compute.internal cannot be removed: not enough pod disruption budget to move devportal/backstage-566bdd7565-cjqqj

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated
