### PR TITLE
Add kubernetes plugin configuration to snail app-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GS plugin: Make HelmRelease conditions in the deployment details pane collapsed by default.
 - GS plugin: Display source and updated timestamp in the deployment details pane.
 
+### Fixed
+
+- Add kubernetes plugin configuration to snail app-config.
+
 ## [0.16.3] - 2024-03-13
 
 ### Changed

--- a/app-config.snail.yaml
+++ b/app-config.snail.yaml
@@ -3,6 +3,13 @@ backend:
     allow:
     - host: "*.gigantic.io"
 
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters: []
+
 auth:
   environment: development
   session:


### PR DESCRIPTION
### What does this PR do?

Backstage on snail fails to start because Kubernetes plugin configuration is missing:
```
Backend failed to start up Error: Kubernetes configuration is missing
    at KubernetesBuilder.build (/app/node_modules/@backstage/plugin-kubernetes-backend/dist/index.cjs.js:1610:15)
    at createPlugin$4 (/app/packages/backend/dist/index.cjs.js:140:6)
    at main (/app/packages/backend/dist/index.cjs.js:419:38)
```

In this PR I fixed `app-config` for snail.

- [x] CHANGELOG.md has been updated
