### PR TITLE
Configure backend secret for production environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Configure backend secret for production environments.
+
 ## [0.18.0] - 2024-03-26
 
 ### Changed

--- a/app-config.devportal.production.yaml
+++ b/app-config.devportal.production.yaml
@@ -9,6 +9,9 @@ app:
       tracesSampleRate: 0.5
 
 backend:
+  auth:
+    keys:
+      - secret: ${BACKEND_SECRET}
   baseUrl: https://devportal.giantswarm.io
   listen:
     port: 7007

--- a/app-config.snail.production.yaml
+++ b/app-config.snail.production.yaml
@@ -3,6 +3,9 @@ app:
   baseUrl: https://portal.snail.gaws.gigantic.io
 
 backend:
+  auth:
+    keys:
+      - secret: ${BACKEND_SECRET}
   baseUrl: https://portal.snail.gaws.gigantic.io
   listen:
     port: 7007

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -5,13 +5,6 @@ organization:
   name: My Company
 
 backend:
-  # Used for enabling authentication, secret is shared by all backend plugins
-  # See https://backstage.io/docs/auth/service-to-service-auth for
-  # information on the format
-  # auth:
-  #   keys:
-  #     - secret: ${BACKEND_SECRET}
-
   auth:
     # TODO: once plugins have been migrated we can remove this, but right now it
     # is require for the backend to work

--- a/helm/backstage/ci/ci-values-case1.yaml
+++ b/helm/backstage/ci/ci-values-case1.yaml
@@ -12,6 +12,7 @@ hostnames: ["test"]
 registry:
   domain: gsoci.azurecr.io
 authSessionSecret: fooBar
+backendSecret: testBackendSecret
 catalogLocationUrl: "https://example.com/catalog-info.yaml"
 circleci:
   apiToken: dummyToken

--- a/helm/backstage/templates/secrets.yaml
+++ b/helm/backstage/templates/secrets.yaml
@@ -65,6 +65,9 @@ data:
   {{- if .Values.dexAuthCredentials.snail.clientSecret }}
   AUTH_DEX_SNAIL_CLIENT_SECRET: {{ .Values.dexAuthCredentials.snail.clientSecret }}
   {{- end }}
+  {{- if .Values.backendSecret }}
+  BACKEND_SECRET: {{ .Values.backendSecret }}
+  {{- end }}
   {{- if .Values.catalogLocationUrl }}
   CATALOG_LOCATION_URL: {{ .Values.catalogLocationUrl }}
   {{- end }}

--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -5,6 +5,9 @@
         "authSessionSecret": {
             "type": "string"
         },
+        "backendSecret": {
+            "type": "string"
+        },
         "backstageDiscovery": {
             "type": "object",
             "properties": {

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -28,6 +28,8 @@ resources:
 
 authSessionSecret: ""
 
+backendSecret: ""
+
 catalogLocationUrl: ""
 
 circleci:


### PR DESCRIPTION
### What does this PR do?

In this PR `backendSecret` was configured for the production environments. It's needed to make service-to-service auth work after upgrade to Backstage 1.24. The local development setup is not impacted by this, as temporary keys are generated under the hood. But for the production setup, we need to provide a secret that enables backend plugins to communicate with each other.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/30319.

- [x] CHANGELOG.md has been updated
