### PR TITLE
Fix backend startup when some OIDC issuers are not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- GS Auth: Fix backend startup when some OIDC issuers are not available.
+
 ## [0.22.0] - 2024-04-25
 
 ### Changed

--- a/plugins/auth-backend-module-gs-provider/src/module.ts
+++ b/plugins/auth-backend-module-gs-provider/src/module.ts
@@ -14,18 +14,36 @@ export const authModuleGsProviders = createBackendModule({
       deps: {
         providersExtensionPoint: authProvidersExtensionPoint,
         config: coreServices.rootConfig,
+        logger: coreServices.rootLogger,
       },
-      async init({ providersExtensionPoint, config }) {
+      async init({ providersExtensionPoint, config, logger }) {
         const providersConfig = config.getConfig('auth.providers');
         const configuredProviders: string[] = providersConfig?.keys() || [];
         const gsProviders = configuredProviders.filter(provider =>
           provider.startsWith('gs-'),
         );
+
         for (const providerName of gsProviders) {
-          providersExtensionPoint.registerProvider({
-            providerId: providerName,
-            factory: providers.oidc.create(),
-          });
+          try {
+            logger.info(`Configuring auth provider: ${providerName}`);
+            const providerConfig = providersConfig
+              .getConfig(providerName)
+              .getConfig(config.getString('auth.environment'));
+            const metadataUrl = providerConfig.getString('metadataUrl');
+            const response = await fetch(new URL(metadataUrl));
+            if (!response.ok) {
+              throw new Error(response.statusText);
+            }
+            providersExtensionPoint.registerProvider({
+              providerId: providerName,
+              factory: providers.oidc.create(),
+            });
+          } catch (err) {
+            logger.error(
+              `Failed to fetch issuer metadata for ${providerName} auth provider`,
+            );
+            logger.error((err as Error).toString());
+          }
         }
       },
     });


### PR DESCRIPTION
### What does this PR do?

When some GS OIDC issuers are not available `gs-providers` backend module blocks application backend from being able to start up. In this PR this case is being handled in a temporal way, we should find a better solution in future. 

### Any background context you can provide?

[(Slack issue)](https://gigantic.slack.com/archives/C02GDJJ68Q1/p1714050508811229)


- [x] CHANGELOG.md has been updated
