### PR TITLE
Disable Report Issue addon for TechDocs plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Disable Report Issue addon for TechDocs plugin.
+
 ## [0.23.1] - 2024-06-06
 
 ### Fixes

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -17,8 +17,6 @@ import {
   techdocsPlugin,
   TechDocsReaderPage,
 } from '@backstage/plugin-techdocs';
-import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
-import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 import {
   DefaultProviderSettings,
   UserSettingsPage,
@@ -118,11 +116,7 @@ const routes = (
     <Route
       path="/docs/:namespace/:kind/:name/*"
       element={<TechDocsReaderPage />}
-    >
-      <TechDocsAddons>
-        <ReportIssue />
-      </TechDocsAddons>
-    </Route>
+    />
     <Route path="/create" element={<ScaffolderPage />} />
     <Route
       path="/catalog-import"


### PR DESCRIPTION
### What does this PR do?

Report Issue addon was disabled in this PR. By default the addon opens issues in a component's repository that doesn't match with how we do it at GS. So for now we've decided to disable the addon completely.

### How does it look like?

Before being disabled:
![](https://user-images.githubusercontent.com/273727/266607981-fb535fd0-4ede-4fd4-a788-1075085545e9.png)

### Any background context you can provide?

Closes https://github.com/giantswarm/giantswarm/issues/28099.

- [x] CHANGELOG.md has been updated
