### PR TITLE
Make it possible to hide Opsgenie page

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -146,7 +146,11 @@ const routes = (
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
     <Route
       path="/opsgenie"
-      element={<OpsgeniePage onCallListCardsCount={100} />}
+      element={
+        <GSFeatureEnabled feature="opsgenie">
+          <OpsgeniePage onCallListCardsCount={100} />
+        </GSFeatureEnabled>
+      }
     />
     <Route path="/clusters" element={<GSClustersPage />} />
     <FeatureFlagged with="show-flux-runtime">

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -70,9 +70,9 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         {/* Global nav, not org-specific */}
         <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
         <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
-        <ConfigurationAvailable configKey="opsgenie.domain">
+        <GSFeatureEnabled feature="opsgenie">
           <SidebarItem icon={ReportProblemIcon} to="opsgenie" text="OpsGenie" />
-        </ConfigurationAvailable>
+        </GSFeatureEnabled>
         <FeatureFlagged with="show-flux-runtime">
           <SidebarItem icon={FluxIcon} to="flux-runtime" text="Flux Runtime" />
         </FeatureFlagged>


### PR DESCRIPTION
### What does this PR do?

Opsgenie page and Opsgenie menu item are being displayed no matter if they configured properly or not. This PR makes it possible to configure if Opsgenie enabled or not.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/29552.
