### PR TITLE
Preselect installation if only one is available in DeploymentDetailsPicker scaffolder field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Preselect installation if only one is available in the DeploymentDetailsPicker scaffolder field.
+
 ## [0.32.1] - 2024-08-09
 
 ### Changed

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
@@ -65,8 +65,13 @@ const DeploymentDetailsPickerField = ({
   const { installations } = useInstallations();
   const { installationsStatuses } = useInstallationsStatuses();
 
+  const initiallySelectedInstallations =
+    installations.length === 1 ? [installations[0]] : [];
+
   const [selectedInstallations, setSelectedInstallations] = useState<string[]>(
-    installationNameValue ? [installationNameValue] : [],
+    installationNameValue
+      ? [installationNameValue]
+      : initiallySelectedInstallations,
   );
 
   const installationsErrors = installationsStatuses.some(
@@ -89,7 +94,6 @@ const DeploymentDetailsPickerField = ({
           installations={installations}
           selectedInstallations={selectedInstallations}
           installationsStatuses={installationsStatuses}
-          multiple={false}
           onChange={handleInstallationSelect}
         />
       </Grid>


### PR DESCRIPTION
### What does this PR do?

`DeploymentDetailsPicker` scaffolder field requires a user to select an installation before they can select a workload cluster and other details. When there is only one installation is configured the user has to do unnecessary step of selecting an installation from a list of one. 
In this PR Installation selector component was improved, so the installation is preselected in case there is only one in the list. 

### How does it look like?
`gazelle` installation is preselected since it's the only one available:
<img width="1447" alt="Screenshot 2024-08-21 at 09 25 44" src="https://github.com/user-attachments/assets/e7133718-d388-4008-ad31-f6ea85209255">

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3470.

- [x] CHANGELOG.md has been updated
