### PR TITLE
Expose organization in the DeploymentDetailsPicker scaffolder field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- GS plugin: Expose organization of the selected cluster in the DeploymentDetailsPicker scaffolder field.
+
 ## [0.34.0] - 2024-08-30
 
 ### Changed

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
@@ -5,6 +5,7 @@ import {
   Cluster,
   getClusterName,
   getClusterNamespace,
+  getClusterOrganization,
   getProviderConfigName,
   ProviderConfig,
 } from '@internal/plugin-gs-common';
@@ -149,6 +150,7 @@ export const DeploymentDetailsPicker = ({
     installationName,
     clusterName,
     clusterNamespace,
+    clusterOrganization,
     wcProviderConfig,
     mcProviderConfig,
   } = formData ?? {};
@@ -158,6 +160,7 @@ export const DeploymentDetailsPicker = ({
       installationName: selectedInstallation,
       clusterName: '',
       clusterNamespace: '',
+      clusterOrganization: '',
       wcProviderConfig: '',
       mcProviderConfig: '',
     });
@@ -171,6 +174,7 @@ export const DeploymentDetailsPicker = ({
       installationName: selectedInstallation,
       clusterName: getClusterName(selectedCluster),
       clusterNamespace: getClusterNamespace(selectedCluster) ?? '',
+      clusterOrganization: getClusterOrganization(selectedCluster) ?? '',
       wcProviderConfig: wcProviderConfig ?? '',
       mcProviderConfig: mcProviderConfig ?? '',
     });
@@ -184,6 +188,7 @@ export const DeploymentDetailsPicker = ({
       installationName: selectedInstallation,
       clusterName: clusterName ?? '',
       clusterNamespace: clusterNamespace ?? '',
+      clusterOrganization: clusterOrganization ?? '',
       wcProviderConfig: getProviderConfigName(selectedProviderConfig),
       mcProviderConfig: mcProviderConfig ?? '',
     });
@@ -197,6 +202,7 @@ export const DeploymentDetailsPicker = ({
       installationName: selectedInstallation,
       clusterName: clusterName ?? '',
       clusterNamespace: clusterNamespace ?? '',
+      clusterOrganization: clusterOrganization ?? '',
       wcProviderConfig: wcProviderConfig ?? '',
       mcProviderConfig: getProviderConfigName(selectedProviderConfig),
     });

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/schema.ts
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/schema.ts
@@ -6,6 +6,7 @@ export const DeploymentDetailsPickerFieldSchema = makeFieldSchemaFromZod(
     installationName: z.string(),
     clusterName: z.string(),
     clusterNamespace: z.string(),
+    clusterOrganization: z.string(),
     wcProviderConfig: z.string(),
     mcProviderConfig: z.string(),
   }),


### PR DESCRIPTION
### What does this PR do?

DeploymentDetailsPicker scaffolder field now exposes an organization of a selected cluster. It can be used in a template like this:
```
targetPath: management-clusters/gazelle/organizations/${{ parameters.deployment.clusterOrganization }}
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3470.

- [x] CHANGELOG.md has been updated
