### PR TITLE
Update CSP to include github.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update CSP (content security policy) for images.
+
 ## [0.35.2] - 2024-09-05
 
 ### Changed

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -24,6 +24,7 @@ backend:
       - 'https://circleci.com'
       - 'https://codecov.io'
       - 'https://dl.circleci.com'
+      - 'https://github.com'
       - 'https://godoc.org'
       - 'https://goreportcard.com'
       - 'https://img.shields.io'


### PR DESCRIPTION
### What does this PR do?

CSP configuration was updated to include github.com source for images.

This should fix broken images in documentation:

<img width="1298" alt="Screenshot 2024-09-17 at 12 34 31" src="https://github.com/user-attachments/assets/42a1b252-4172-4923-95d0-e01dfc3510fb">

- [x] CHANGELOG.md has been updated
