### PR TITLE
Add option to hide provider config selectors in the DeploymentDetailsPicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- GS plugin: Add option to hide provider config selectors in the DeploymentDetailsPicker scaffolder field.
+
 ## [0.35.3] - 2024-09-17
 
 ### Changed

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/ClusterSelector.tsx
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/ClusterSelector.tsx
@@ -17,7 +17,7 @@ type ClusterSelectorProps = {
   error?: boolean;
   installations: string[];
   selectedCluster?: string;
-  onChange: (installationName: string, cluster: Cluster) => void;
+  onChange: (cluster: Cluster) => void;
 };
 
 export const ClusterSelector = ({
@@ -54,7 +54,7 @@ export const ClusterSelector = ({
   const handleChange = (selectedItem: string) => {
     const { installationName, ...cluster } = clusterResourcesMap[selectedItem];
 
-    onChange(installationName, cluster);
+    onChange(cluster);
   };
 
   return (

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/ProviderConfigSelector.tsx
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/ProviderConfigSelector.tsx
@@ -17,7 +17,7 @@ type ProviderConfigSelectorProps = {
   error?: boolean;
   installations: string[];
   selectedProviderConfig?: string;
-  onChange: (installationName: string, providerConfig: ProviderConfig) => void;
+  onChange: (providerConfig: ProviderConfig) => void;
 };
 
 export const ProviderConfigSelector = ({
@@ -57,7 +57,7 @@ export const ProviderConfigSelector = ({
     const { installationName, ...providerConfig } =
       providerConfigResourcesMap[selectedItem];
 
-    onChange(installationName, providerConfig);
+    onChange(providerConfig);
   };
 
   return (

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/schema.ts
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/schema.ts
@@ -7,8 +7,15 @@ export const DeploymentDetailsPickerFieldSchema = makeFieldSchemaFromZod(
     clusterName: z.string(),
     clusterNamespace: z.string(),
     clusterOrganization: z.string(),
-    wcProviderConfig: z.string(),
-    mcProviderConfig: z.string(),
+    wcProviderConfig: z.string().optional(),
+    mcProviderConfig: z.string().optional(),
+  }),
+  z.object({
+    displayProviderConfigsSelectors: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Allow to select provider configs.'),
   }),
 );
 


### PR DESCRIPTION
### What does this PR do?

DeploymentDetailsPicker scaffolder field was changed to allow to hide provider config selector via configuration option. In a template it can be configured like this:
```
properties:
  deployment:
    type: object
    ui:field: GSDeploymentDetailsPicker
    ui:options:
      displayProviderConfigsSelectors: true
```

### How does it look like?

With selectors:
<img width="1235" alt="Screenshot 2024-09-20 at 13 36 21" src="https://github.com/user-attachments/assets/7fc9bbb5-9aee-46c0-a673-ccec01da8bbe">

Without selectors:
<img width="1235" alt="Screenshot 2024-09-20 at 13 37 26" src="https://github.com/user-attachments/assets/b61a4214-8f05-4adf-a33b-7500a395402d">

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3470.

- [x] CHANGELOG.md has been updated
