### PR TITLE
Fix DeploymentDetailsPicker scaffolder field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- GS plugin: Fix the error in the DeploymentDetailsPicker scaffolder field when pre-selected installation was missing in the form data.
+
 ## [0.37.0] - 2024-09-24
 
 ### Added

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { GSContext } from '../../GSContext';
 import {
@@ -56,11 +56,15 @@ const DeploymentDetailsPickerField = ({
   const initiallySelectedInstallations =
     installations.length === 1 ? [installations[0]] : [];
 
-  const [selectedInstallations, setSelectedInstallations] = useState<string[]>(
-    installationNameValue
-      ? [installationNameValue]
-      : initiallySelectedInstallations,
-  );
+  const selectedInstallations = installationNameValue
+    ? [installationNameValue]
+    : initiallySelectedInstallations;
+
+  useEffect(() => {
+    if (!installationNameValue && installations.length === 1) {
+      onInstallationSelect(installations[0]);
+    }
+  });
 
   const installationsErrors = installationsStatuses.some(
     installationStatus => installationStatus.isError,
@@ -68,7 +72,6 @@ const DeploymentDetailsPickerField = ({
 
   const handleInstallationSelect = (selectedItems: string[]) => {
     if (selectedItems.length === 1) {
-      setSelectedInstallations(selectedItems);
       onInstallationSelect(selectedItems[0]);
     }
   };


### PR DESCRIPTION
### What does this PR do?

There is an error in the DeploymentDetailsPicker scaffolder field - when there is only one installation available it's being automatically selected. The problem is that the form selector widget is being pre-selected but the form data is not being updated. As a result pre-selected installation is missing in the final form data state. In this PR this issue was fixed.

- [x] CHANGELOG.md has been updated
