### PR TITLE
Fix Grafana link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- GS plugin: Fix Grafana link application name.
+
 ## [0.37.1] - 2024-09-25
 
 ### Fixes

--- a/plugins/gs/src/components/hooks/useGrafanaDashboardLink.ts
+++ b/plugins/gs/src/components/hooks/useGrafanaDashboardLink.ts
@@ -8,7 +8,7 @@ const typedUrl = (
 ): string => {
   const queryStringData = {
     'var-cluster': clusterName,
-    'var-application': applicationName,
+    'var-application': `default-${applicationName}`,
   };
 
   const searchParams = new URLSearchParams(queryStringData);


### PR DESCRIPTION
### What does this PR do?

Grafana link was fixed - now application name parameter contains `default-` prefix.

- [x] CHANGELOG.md has been updated
