### PR TITLE
Change installation provider label for vsphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change installation provider label "VSphere vintage" to "VSphere".
+
 ## [0.39.0] - 2024-10-01
 
 ### Added

--- a/plugins/gs/src/components/catalog/EntityProviderPicker/EntityProviderPicker.tsx
+++ b/plugins/gs/src/components/catalog/EntityProviderPicker/EntityProviderPicker.tsx
@@ -8,7 +8,7 @@ const providerLabels: Record<string, string> = {
   capz: 'CAPZ',
   aws: 'AWS vintage',
   'cloud-director': 'Cloud Director vintage',
-  vsphere: 'VSphere vintage',
+  vsphere: 'VSphere',
   kvm: 'KVM',
 };
 


### PR DESCRIPTION
### What does this PR do?

This fixes the vsphere label from "VSphere vintage" to "VSphere", as all VSphere installation are CAPI, not vintage.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
