### PR TITLE
Run yarn install with --no-immutable in release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope internal",
     "postinstall": "yarn patch-package",
-    "release": "yarn changeset version && yarn install && ts-node scripts/prepare-release.ts && yarn prettier --write --log-level silent '{packages,plugins}/*/{package.json,CHANGELOG.md}' 'docs/releases/*.md' './{package.json,CHANGELOG.md}'"
+    "release": "yarn changeset version && yarn install --no-immutable && ts-node scripts/prepare-release.ts && yarn prettier --write --log-level silent '{packages,plugins}/*/{package.json,CHANGELOG.md}' 'docs/releases/*.md' './{package.json,CHANGELOG.md}'"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
### What does this PR do?

To fix release issue on CI, `yarn install` script has to be run with `--no-immutable` flag, because `yarn.lock` file is being modified in the process.

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
