### PR TITLE
Add telemetry pageview events

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import HomeIcon from '@material-ui/icons/Home';
@@ -24,6 +24,9 @@ import {
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import { GSFeatureEnabled, GSMainMenu } from '@giantswarm/backstage-plugin-gs';
+import { useTelemetryDeck } from '@typedigital/telemetrydeck-react';
+import { useLocation } from 'react-router-dom';
+import { getTelemetryPageViewPayload } from '../../utils/telemetry';
 
 const useSidebarLogoStyles = makeStyles({
   root: {
@@ -53,39 +56,50 @@ const SidebarLogo = () => {
   );
 };
 
-export const Root = ({ children }: PropsWithChildren<{}>) => (
-  <SidebarPage>
-    <Sidebar>
-      <SidebarLogo />
-      <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
-        <SidebarSearchModal />
-      </SidebarGroup>
-      <SidebarDivider />
-      <SidebarGroup label="Menu" icon={<MenuIcon />}>
-        {/* Global nav, not org-specific */}
-        <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
-        <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
-        <GSFeatureEnabled feature="scaffolder">
-          <SidebarItem
-            icon={CreateComponentIcon}
-            to="create"
-            text="Create..."
-          />
-        </GSFeatureEnabled>
+export const Root = ({ children }: PropsWithChildren<{}>) => {
+  const { signal } = useTelemetryDeck();
+  const location = useLocation();
 
-        {/* End global nav */}
-      </SidebarGroup>
-      <GSMainMenu />
-      <SidebarSpace />
-      <SidebarDivider />
-      <SidebarGroup
-        label="Settings"
-        icon={<UserSettingsSignInAvatar />}
-        to="/settings"
-      >
-        <SidebarSettings />
-      </SidebarGroup>
-    </Sidebar>
-    {children}
-  </SidebarPage>
-);
+  useEffect(() => {
+    (async () => {
+      await signal('pageview', getTelemetryPageViewPayload(location));
+    })();
+  }, [location, signal]);
+
+  return (
+    <SidebarPage>
+      <Sidebar>
+        <SidebarLogo />
+        <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
+          <SidebarSearchModal />
+        </SidebarGroup>
+        <SidebarDivider />
+        <SidebarGroup label="Menu" icon={<MenuIcon />}>
+          {/* Global nav, not org-specific */}
+          <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
+          <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
+          <GSFeatureEnabled feature="scaffolder">
+            <SidebarItem
+              icon={CreateComponentIcon}
+              to="create"
+              text="Create..."
+            />
+          </GSFeatureEnabled>
+
+          {/* End global nav */}
+        </SidebarGroup>
+        <GSMainMenu />
+        <SidebarSpace />
+        <SidebarDivider />
+        <SidebarGroup
+          label="Settings"
+          icon={<UserSettingsSignInAvatar />}
+          to="/settings"
+        >
+          <SidebarSettings />
+        </SidebarGroup>
+      </Sidebar>
+      {children}
+    </SidebarPage>
+  );
+};

--- a/packages/app/src/components/TelemetryProvider/TelemetryProvider.tsx
+++ b/packages/app/src/components/TelemetryProvider/TelemetryProvider.tsx
@@ -15,14 +15,15 @@ export const TelemetryProvider = ({
   const configApi = useApi(configApiRef);
   const telemetryConfig = configApi.getOptionalConfig('app.telemetrydeck');
 
-  if (!telemetryConfig || !backstageIdentity) {
-    return children;
-  }
+  const testMode = window.location.hostname === 'localhost' || !telemetryConfig;
 
   const td = createTelemetryDeck({
-    appID: telemetryConfig.getString('appID'),
-    salt: telemetryConfig.getString('salt'),
-    clientUser: backstageIdentity.userEntityRef,
+    appID: telemetryConfig ? telemetryConfig.getString('appID') : 'test',
+    salt: telemetryConfig ? telemetryConfig.getString('salt') : 'test',
+    clientUser: backstageIdentity
+      ? backstageIdentity.userEntityRef
+      : 'anonymous',
+    testMode,
   });
 
   return (

--- a/packages/app/src/utils/telemetry.test.ts
+++ b/packages/app/src/utils/telemetry.test.ts
@@ -1,0 +1,144 @@
+import { getTelemetryPageViewPayload } from './telemetry';
+import { Location } from 'react-router';
+
+describe('getTelemetryPageViewPayload', () => {
+  const createLocation = (pathname: string): Location => ({
+    pathname,
+    search: '',
+    hash: '',
+    state: null,
+    key: '',
+  });
+
+  it('should return correct payload for catalog index page', () => {
+    const location = createLocation('/catalog');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Catalog index',
+      path: '/catalog',
+    });
+  });
+
+  it('should return correct payload for catalog entity page', () => {
+    const location = createLocation('/catalog/default/component/my-component');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Catalog entity',
+      entityNamespace: 'default',
+      entityKind: 'component',
+      entityName: 'my-component',
+      tab: 'overview',
+      path: '/catalog/default/component/my-component',
+    });
+  });
+
+  it('should return correct payload for catalog entity page with tab', () => {
+    const location = createLocation(
+      '/catalog/default/component/my-component/pull-requests',
+    );
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Catalog entity',
+      entityNamespace: 'default',
+      entityKind: 'component',
+      entityName: 'my-component',
+      tab: 'pull-requests',
+      path: '/catalog/default/component/my-component/pull-requests',
+    });
+  });
+
+  it('should return correct payload for docs index page', () => {
+    const location = createLocation('/docs');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Docs index',
+      path: '/docs',
+    });
+  });
+
+  it('should return correct payload for docs entity page', () => {
+    const location = createLocation('/docs/default/component/my-component');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Docs entity',
+      entityNamespace: 'default',
+      entityKind: 'component',
+      entityName: 'my-component',
+      path: '/docs/default/component/my-component',
+    });
+  });
+
+  it('should return correct payload for software templates index page', () => {
+    const location = createLocation('/create');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Software Templates index',
+      path: '/create',
+    });
+  });
+
+  it('should return correct payload for software template page', () => {
+    const location = createLocation('/create/default/template/my-template');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Software Template',
+      templateNamespace: 'default',
+      templateName: 'my-template',
+      path: '/create/default/template/my-template',
+    });
+  });
+
+  it('should return correct payload for settings page', () => {
+    const location = createLocation('/settings');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Settings',
+      path: '/settings',
+    });
+  });
+
+  it('should return correct payload for settings page with tab', () => {
+    const location = createLocation('/settings/feature-flags');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Settings',
+      path: '/settings/feature-flags',
+    });
+  });
+
+  it('should return correct payload for installations index page', () => {
+    const location = createLocation('/installations');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Installations index',
+      path: '/installations',
+    });
+  });
+
+  it('should return correct payload for clusters index page', () => {
+    const location = createLocation('/clusters');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Clusters index',
+      path: '/clusters',
+    });
+  });
+
+  it('should return correct payload for search page', () => {
+    const location = createLocation('/search');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Search',
+      path: '/search',
+    });
+  });
+
+  it('should return Unknown page payload for unknown paths', () => {
+    const location = createLocation('/unknown');
+    const result = getTelemetryPageViewPayload(location);
+    expect(result).toEqual({
+      page: 'Unknown page',
+      path: '/unknown',
+    });
+  });
+});

--- a/packages/app/src/utils/telemetry.ts
+++ b/packages/app/src/utils/telemetry.ts
@@ -1,0 +1,79 @@
+import { Location } from 'react-router';
+
+export function getTelemetryPageViewPayload(location: Location): {
+  [key: string]: string;
+} {
+  const pathname = location.pathname;
+  let payload = {};
+
+  switch (true) {
+    case pathname === '/catalog':
+      payload = { page: 'Catalog index' };
+      break;
+
+    case pathname.startsWith('/catalog'): {
+      const parts = pathname.split('/');
+      payload = {
+        page: 'Catalog entity',
+        entityNamespace: parts[2],
+        entityKind: parts[3],
+        entityName: parts[4],
+        tab: parts[5] ?? 'overview',
+      };
+      break;
+    }
+
+    case pathname === '/docs':
+      payload = { page: 'Docs index' };
+      break;
+
+    case pathname.startsWith('/docs'): {
+      const parts = pathname.split('/');
+      payload = {
+        page: 'Docs entity',
+        entityNamespace: parts[2],
+        entityKind: parts[3],
+        entityName: parts[4],
+      };
+      break;
+    }
+
+    case pathname === '/create':
+      payload = { page: 'Software Templates index' };
+      break;
+
+    case pathname.startsWith('/create'): {
+      const parts = pathname.split('/');
+      payload = {
+        page: 'Software Template',
+        templateNamespace: parts[2],
+        templateName: parts[4],
+      };
+      break;
+    }
+
+    case pathname.startsWith('/settings'):
+      payload = { page: 'Settings' };
+      break;
+
+    case pathname === '/installations':
+      payload = { page: 'Installations index' };
+      break;
+
+    case pathname === '/clusters':
+      payload = { page: 'Clusters index' };
+      break;
+
+    case pathname === '/search':
+      payload = { page: 'Search' };
+      break;
+
+    default:
+      payload = { page: 'Unknown page' };
+  }
+
+  return {
+    ...payload,
+    path: location.pathname,
+  };
+}


### PR DESCRIPTION
### What does this PR do?

With the changes from this PR we now send `pageview` events to `telemetrydeck`. Pages from the list below are being tracked (with the "page" parameter of the event payload):
```
/catalog => Catalog index
/catalog/default/component/my-component/TAB => Catalog entity
/docs => Docs index
/docs/default/component/my-component => Docs entity
/create => Software Templates index
/create/default/template/my-template => Software Template
/settings => Settings
/settings/TAB => Settings
/installations => Installations index
/clusters => Clusters index
/search => Search
```

If the visited page is not from the list, the `Unknown` page view event is send.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/31025#issuecomment-2390896840

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
