### PR TITLE
Remove 'default-' prefix in application name variable of dashboard link, add namespace variable

### DIFF
--- a/.changeset/two-queens-bathe.md
+++ b/.changeset/two-queens-bathe.md
@@ -2,4 +2,4 @@
 '@giantswarm/backstage-plugin-gs': patch
 ---
 
-Fix dashboard link for deployment
+Fix Grafana dashboard link for deployment by removing "default-" prefix from application name and adding a namespace variable.

--- a/plugins/gs/src/components/UI/GrafanaDashboardLink/GrafanaDashboardLink.tsx
+++ b/plugins/gs/src/components/UI/GrafanaDashboardLink/GrafanaDashboardLink.tsx
@@ -13,6 +13,7 @@ type GrafanaDashboardLinkProps = {
   dashboard: string;
   installationName: string;
   clusterName?: string;
+  namespace?: string;
   applicationName: string;
   text?: string;
   tooltip?: string;
@@ -22,6 +23,7 @@ export const GrafanaDashboardLink = ({
   dashboard,
   installationName,
   clusterName,
+  namespace,
   applicationName,
   text,
   tooltip,
@@ -35,6 +37,7 @@ export const GrafanaDashboardLink = ({
     dashboard,
     installationName,
     clusterName ?? '',
+    namespace ?? '',
     applicationName,
   );
   if (!linkUrl) {

--- a/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
+++ b/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
@@ -98,6 +98,7 @@ export const AppDetails = ({
               dashboard={grafanaDashboard}
               installationName={installationName}
               clusterName={clusterName}
+              namespace={namespace}
               applicationName={name}
               text="Open Grafana dashboard for this application"
             />

--- a/plugins/gs/src/components/deployments/DeploymentActions/DeploymentActions.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentActions/DeploymentActions.tsx
@@ -16,6 +16,7 @@ export const DeploymentActions = ({
   installationName,
   clusterName,
   name,
+  namespace,
   grafanaDashboard,
   ingressHost,
 }: DeploymentActionsProps) => {
@@ -29,6 +30,7 @@ export const DeploymentActions = ({
           dashboard={grafanaDashboard}
           installationName={installationName}
           clusterName={clusterName}
+          namespace={namespace}
           applicationName={name}
           tooltip="Open Grafana dashboard for this application"
         />

--- a/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
+++ b/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
@@ -102,6 +102,7 @@ export const HelmReleaseDetails = ({
               dashboard={grafanaDashboard}
               installationName={installationName}
               clusterName={clusterName}
+              namespace={namespace}
               applicationName={name}
               text="Open Grafana dashboard for this application"
             />

--- a/plugins/gs/src/components/hooks/useGrafanaDashboardLink.ts
+++ b/plugins/gs/src/components/hooks/useGrafanaDashboardLink.ts
@@ -4,10 +4,12 @@ const typedUrl = (
   baseUrl: string,
   dashboard: string,
   clusterName: string,
+  namespace: string,
   applicationName: string,
 ): string => {
   const queryStringData = {
     'var-cluster': clusterName,
+    'var-namespace': namespace,
     'var-application': applicationName,
   };
 
@@ -20,6 +22,7 @@ export const useGrafanaDashboardLink = (
   dashboard: string,
   installationName: string,
   clusterName: string,
+  namespace: string,
   applicationName: string,
 ): string | undefined => {
   const config = useApi(configApiRef);
@@ -31,5 +34,5 @@ export const useGrafanaDashboardLink = (
     return undefined;
   }
 
-  return typedUrl(baseUrl, dashboard, clusterName, applicationName);
+  return typedUrl(baseUrl, dashboard, clusterName, namespace, applicationName);
 };


### PR DESCRIPTION
### What does this PR do?

This adapts the dashboard link from the deployment item.

The static `default-` prefix on the application name is no longer wanted. In exchange, we have a namespace variable now which should be populated with the right value.

### What is the effect of this change to users?

The dashboard should show data immediately when navigating to it.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
