### PR TITLE
Fix Grafana dashboard link for deployment

### DIFF
--- a/.changeset/cold-hotels-relate.md
+++ b/.changeset/cold-hotels-relate.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fix Grafana dashboard link for deployment by using "default" for namespace variable.

--- a/plugins/gs/src/components/UI/GrafanaDashboardLink/GrafanaDashboardLink.tsx
+++ b/plugins/gs/src/components/UI/GrafanaDashboardLink/GrafanaDashboardLink.tsx
@@ -37,7 +37,7 @@ export const GrafanaDashboardLink = ({
     dashboard,
     installationName,
     clusterName ?? '',
-    namespace ?? '',
+    namespace ?? 'default',
     applicationName,
   );
   if (!linkUrl) {

--- a/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
+++ b/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
@@ -98,7 +98,6 @@ export const AppDetails = ({
               dashboard={grafanaDashboard}
               installationName={installationName}
               clusterName={clusterName}
-              namespace={namespace}
               applicationName={name}
               text="Open Grafana dashboard for this application"
             />

--- a/plugins/gs/src/components/deployments/DeploymentActions/DeploymentActions.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentActions/DeploymentActions.tsx
@@ -16,7 +16,6 @@ export const DeploymentActions = ({
   installationName,
   clusterName,
   name,
-  namespace,
   grafanaDashboard,
   ingressHost,
 }: DeploymentActionsProps) => {
@@ -30,7 +29,6 @@ export const DeploymentActions = ({
           dashboard={grafanaDashboard}
           installationName={installationName}
           clusterName={clusterName}
-          namespace={namespace}
           applicationName={name}
           tooltip="Open Grafana dashboard for this application"
         />

--- a/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
+++ b/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
@@ -102,7 +102,6 @@ export const HelmReleaseDetails = ({
               dashboard={grafanaDashboard}
               installationName={installationName}
               clusterName={clusterName}
-              namespace={namespace}
               applicationName={name}
               text="Open Grafana dashboard for this application"
             />


### PR DESCRIPTION
### What does this PR do?

Fix Grafana dashboard link for deployment by using "default" for namespace variable.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
