### PR TITLE
Remove deprecated @backstage/backend-common package

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@aws/aws-core-plugin-for-backstage-scaffolder-actions": "^0.2.6",
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-defaults": "backstage:^",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/backend-tasks": "^0.6.1",

--- a/plugins/auth-backend-module-gs/package.json
+++ b/plugins/auth-backend-module-gs/package.json
@@ -24,7 +24,6 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/config": "backstage:^",
     "@backstage/errors": "backstage:^",

--- a/plugins/scaffolder-backend-module-gs/package.json
+++ b/plugins/scaffolder-backend-module-gs/package.json
@@ -24,7 +24,6 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-scaffolder-node": "backstage:^"

--- a/plugins/techdocs-backend-module-gs/package.json
+++ b/plugins/techdocs-backend-module-gs/package.json
@@ -24,7 +24,6 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/catalog-model": "backstage:^",
     "@backstage/plugin-techdocs-node": "backstage:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7942,7 +7942,6 @@
       version: 0.0.0-use.local
       resolution: "@giantswarm/backstage-plugin-auth-backend-module-gs@workspace:plugins/auth-backend-module-gs"
       dependencies:
-        "@backstage/backend-common": "npm:^0.25.0"
         "@backstage/backend-plugin-api": "backstage:^"
         "@backstage/backend-test-utils": "backstage:^"
         "@backstage/cli": "backstage:^"
@@ -8028,7 +8027,6 @@
       version: 0.0.0-use.local
       resolution: "@giantswarm/backstage-plugin-scaffolder-backend-module-gs@workspace:plugins/scaffolder-backend-module-gs"
       dependencies:
-        "@backstage/backend-common": "npm:^0.25.0"
         "@backstage/backend-plugin-api": "backstage:^"
         "@backstage/backend-test-utils": "backstage:^"
         "@backstage/cli": "backstage:^"
@@ -8041,7 +8039,6 @@
       version: 0.0.0-use.local
       resolution: "@giantswarm/backstage-plugin-techdocs-backend-module-gs@workspace:plugins/techdocs-backend-module-gs"
       dependencies:
-        "@backstage/backend-common": "npm:^0.25.0"
         "@backstage/backend-plugin-api": "backstage:^"
         "@backstage/backend-test-utils": "backstage:^"
         "@backstage/catalog-model": "backstage:^"
@@ -15408,7 +15405,6 @@
       resolution: "backend@workspace:packages/backend"
       dependencies:
         "@aws/aws-core-plugin-for-backstage-scaffolder-actions": "npm:^0.2.6"
-        "@backstage/backend-common": "npm:^0.25.0"
         "@backstage/backend-defaults": "backstage:^"
         "@backstage/backend-plugin-api": "backstage:^"
         "@backstage/backend-tasks": "npm:^0.6.1"


### PR DESCRIPTION
### What does this PR do?

Remove unused `@backstage/backend-common` package.

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
