### PR TITLE
Remove `BACKEND_SECRET` environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@
 
 AUTH_SESSION_SECRET=randomsecretstring
 BACKSTAGE_ENVIRONMENT=development
-BACKEND_SECRET=secret
 VERSION=development
 NODE_OPTIONS=--no-node-snapshot
 NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/helm/backstage/ci/ci-values-case1.yaml
+++ b/helm/backstage/ci/ci-values-case1.yaml
@@ -12,7 +12,6 @@ hostnames: ['test']
 registry:
   domain: gsoci.azurecr.io
 authSessionSecret: fooBar
-backendSecret: testBackendSecret
 circleci:
   apiToken: dummyToken
 dexAuthCredentials:

--- a/helm/backstage/templates/secrets.yaml
+++ b/helm/backstage/templates/secrets.yaml
@@ -17,9 +17,6 @@ data:
   {{- if .Values.authSessionSecret }}
   AUTH_SESSION_SECRET: {{ .Values.authSessionSecret }}
   {{- end }}
-  {{- if .Values.backendSecret }}
-  BACKEND_SECRET: {{ .Values.backendSecret }}
-  {{- end }}
   {{- if .Values.circleci.apiToken }}
   CIRCLECI_API_TOKEN: {{ .Values.circleci.apiToken }}
   {{- end }}

--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -16,9 +16,6 @@
         }
       }
     },
-    "backendSecret": {
-      "type": "string"
-    },
     "backstageDiscovery": {
       "type": "object",
       "properties": {

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -30,8 +30,6 @@ resources:
 
 authSessionSecret: ''
 
-backendSecret: ''
-
 circleci:
   apiToken: ''
 


### PR DESCRIPTION
### What does this PR do?

`BACKEND_SECRET` env variable is being used in a `backend.auth.keys` config that is used in production and has been deprecated. Configuration will be deleted so we don't need this env variable anymore.

### Any background context you can provide?

Should fix [this issue](https://giantswarm.sentry.io/issues/6130257547/?project=4505675382587392&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=2).

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
