### PR TITLE
Allow to configure HTTP proxy for backend

### DIFF
--- a/.changeset/fresh-bulldogs-allow.md
+++ b/.changeset/fresh-bulldogs-allow.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Allow to configure HTTP proxy for backend.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -53,8 +53,10 @@
     "better-sqlite3": "^11.0.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
+    "global-agent": "^3.0.0",
     "node-gyp": "^11.0.0",
     "pg": "^8.10.0",
+    "undici": "^7.1.1",
     "winston": "^3.17.0",
     "winston-sentry-log": "^1.0.26"
   },

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,7 +1,27 @@
+import 'global-agent/bootstrap';
+import { setGlobalDispatcher, ProxyAgent } from 'undici';
 import { createBackend } from '@backstage/backend-defaults';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { githubAuthProvider } from './githubAuthProvider';
 import { rootLogger } from './rootLogger';
+
+const proxyEnv =
+  process.env.GLOBAL_AGENT_HTTP_PROXY || process.env.GLOBAL_AGENT_HTTPS_PROXY;
+
+if (proxyEnv) {
+  const proxyUrl = new URL(proxyEnv);
+  setGlobalDispatcher(
+    new ProxyAgent({
+      uri: proxyUrl.protocol + proxyUrl.host,
+      token:
+        proxyUrl.username && proxyUrl.password
+          ? `Basic ${Buffer.from(
+              `${proxyUrl.username}:${proxyUrl.password}`,
+            ).toString('base64')}`
+          : undefined,
+    }),
+  );
+}
 
 const backend = createBackend();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14743,8 +14743,10 @@
         better-sqlite3: "npm:^11.0.0"
         express: "npm:^4.17.1"
         express-promise-router: "npm:^4.1.0"
+        global-agent: "npm:^3.0.0"
         node-gyp: "npm:^11.0.0"
         pg: "npm:^8.10.0"
+        undici: "npm:^7.1.1"
         winston: "npm:^3.17.0"
         winston-sentry-log: "npm:^1.0.26"
       languageName: unknown
@@ -31112,6 +31114,13 @@
       dependencies:
         "@fastify/busboy": "npm:^2.0.0"
       checksum: 10c0/08d0f2596553aa0a54ca6e8e9c7f45aef7d042c60918564e3a142d449eda165a80196f6ef19ea2ef2e6446959e293095d8e40af1236f0d67223b06afac5ecad7
+      languageName: node
+      linkType: hard
+    
+    "undici@npm:^7.1.1":
+      version: 7.1.1
+      resolution: "undici@npm:7.1.1"
+      checksum: 10c0/0bffa25170e863714dee6bf973fc1cec29480d55bb29d3652470d2de78f7b03c18f3155347ec939df493135df7faccfb753e9a5795fe975923994c07faba0014
       languageName: node
       linkType: hard
     


### PR DESCRIPTION
### What does this PR do?

This PR allows to run backend behind a proxy. Proxy can be configured with environment variables:
```
GLOBAL_AGENT_HTTP_PROXY
GLOBAL_AGENT_HTTPS_PROXY
```

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
