### PR TITLE
Add links to Grafana and Web UI to cluster details page

### DIFF
--- a/.changeset/fluffy-crews-notice.md
+++ b/.changeset/fluffy-crews-notice.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Add links to Grafana and Web UI to cluster details page.

--- a/plugins/gs/config.d.ts
+++ b/plugins/gs/config.d.ts
@@ -12,6 +12,7 @@ export interface Config {
         authProvider: string;
         oidcTokenProvider?: string;
         grafanaUrl?: string;
+        baseDomain?: string;
         apiVersionOverrides?: {
           [pluralKind: string]: string;
         };

--- a/plugins/gs/src/components/UI/Toolkit/Toolkit.tsx
+++ b/plugins/gs/src/components/UI/Toolkit/Toolkit.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { Link } from '@backstage/core-components';
+import List from '@material-ui/core/List';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import { makeStyles } from '@material-ui/core/styles';
+import { Tooltip, Typography } from '@material-ui/core';
+import classNames from 'classnames';
+
+type Tool =
+  | {
+      label: string;
+      url: string;
+      icon: React.ReactNode;
+      disabled?: false;
+    }
+  | {
+      label: string;
+      url: string;
+      icon: React.ReactNode;
+      disabled: true;
+      disabledNote: string;
+    };
+
+type ToolkitProps = {
+  tools: Tool[];
+};
+
+const useStyles = makeStyles(theme => ({
+  toolkit: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    textAlign: 'center',
+    padding: 0,
+  },
+  tool: {
+    margin: theme.spacing(0.5, 1),
+  },
+  label: {
+    marginTop: theme.spacing(1),
+    width: '72px',
+    fontSize: '0.9em',
+    lineHeight: '1.25',
+    overflowWrap: 'break-word',
+    color: theme.palette.text.primary,
+  },
+  labelDisabled: {
+    color: theme.palette.text.disabled,
+  },
+  icon: {
+    width: '64px',
+    height: '64px',
+    borderRadius: '50px',
+    justifyContent: 'center',
+    alignItems: 'center',
+    boxShadow: theme.shadows[1],
+    backgroundColor: theme.palette.background.default,
+    color: theme.palette.text.primary,
+  },
+  iconDisabled: {
+    color: theme.palette.text.disabled,
+  },
+}));
+
+export const Toolkit = ({ tools }: ToolkitProps) => {
+  const classes = useStyles();
+
+  return (
+    <List className={classes.toolkit}>
+      {tools.map((tool: Tool) => {
+        const el = (
+          <>
+            <ListItemIcon
+              className={classNames(classes.icon, {
+                [classes.iconDisabled]: tool.disabled,
+              })}
+            >
+              {tool.icon}
+            </ListItemIcon>
+            <ListItemText
+              secondaryTypographyProps={{
+                className: classNames(classes.label, {
+                  [classes.labelDisabled]: tool.disabled,
+                }),
+              }}
+              secondary={tool.label}
+            />
+          </>
+        );
+
+        if (tool.disabled) {
+          return (
+            <Tooltip title={tool.disabledNote} key={tool.label}>
+              <Typography
+                variant="inherit"
+                color="textSecondary"
+                className={classes.tool}
+              >
+                {el}
+              </Typography>
+            </Tooltip>
+          );
+        }
+
+        return (
+          <Link key={tool.label} to={tool.url} className={classes.tool}>
+            {el}
+          </Link>
+        );
+      })}
+    </List>
+  );
+};

--- a/plugins/gs/src/components/UI/Toolkit/index.ts
+++ b/plugins/gs/src/components/UI/Toolkit/index.ts
@@ -1,0 +1,1 @@
+export { Toolkit } from './Toolkit';

--- a/plugins/gs/src/components/UI/index.ts
+++ b/plugins/gs/src/components/UI/index.ts
@@ -12,4 +12,5 @@ export { KubernetesVersion } from './KubernetesVersion';
 export { NotAvailable } from './NotAvailable';
 export { SimpleAccordion } from './SimpleAccordion';
 export { StructuredMetadataList } from './StructuredMetadataList';
+export { Toolkit } from './Toolkit';
 export { Version } from './Version';

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterOverview.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterOverview.tsx
@@ -8,6 +8,7 @@ import { ClusterLabelsCard } from './ClusterLabelsCard';
 import { ClusterInstallationCard } from './ClusterInstallationCard';
 import { useCurrentCluster } from '../../ClusterDetailsPage/useCurrentCluster';
 import { isManagementCluster } from '@giantswarm/backstage-plugin-gs-common';
+import { ClusterToolsCard } from './ClusterToolsCard';
 
 export const ClusterOverview = () => {
   const { cluster, installationName } = useCurrentCluster();
@@ -35,6 +36,9 @@ export const ClusterOverview = () => {
                 <ClusterInstallationCard />
               </Grid>
             )}
+            <Grid item xs={12}>
+              <ClusterToolsCard />
+            </Grid>
             <Grid item xs={12}>
               <ClusterAccessCard />
             </Grid>

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/ClusterToolsCard.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/ClusterToolsCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Card, CardContent } from '@material-ui/core';
+import PublicIcon from '@material-ui/icons/Public';
+import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
+import { useCurrentCluster } from '../../../ClusterDetailsPage/useCurrentCluster';
+import { GrafanaIcon } from '../../../../../assets/icons/CustomIcons';
+import { Toolkit } from '../../../../UI';
+import {
+  getClusterName,
+  getClusterOrganization,
+  isManagementCluster,
+} from '@giantswarm/backstage-plugin-gs-common';
+import {
+  useGrafanaAlertsLink,
+  useGrafanaDashboardsLink,
+  useWebUILink,
+} from '../../../../hooks/useClusterLinks';
+
+export function ClusterToolsCard() {
+  const { cluster, installationName } = useCurrentCluster();
+
+  const clusterName = getClusterName(cluster);
+  const organizationName = getClusterOrganization(cluster);
+
+  const webUILink = useWebUILink(
+    installationName,
+    clusterName,
+    organizationName ?? '',
+    isManagementCluster(cluster, installationName),
+  );
+  const webUILinkDisabledNote = webUILink
+    ? ''
+    : `Web UI link is not available. Base domain is not configured for '${installationName}' installation.`;
+
+  const dashboardsLink = useGrafanaDashboardsLink(installationName);
+  const dashboardsLinkDisabledNote = dashboardsLink
+    ? ''
+    : `Grafana dashboards link is not available. Base domain is not configured for '${installationName}' installation.`;
+
+  const alertsLink = useGrafanaAlertsLink(installationName);
+  const alertsLinkDisabledNote = alertsLink
+    ? ''
+    : `Grafana alerts link is not available. Base domain is not configured for '${installationName}' installation.`;
+
+  const tools = [
+    {
+      url: dashboardsLink ?? '',
+      label: 'Dashboards',
+      icon: <GrafanaIcon />,
+      disabled: Boolean(dashboardsLinkDisabledNote),
+      disabledNote: dashboardsLinkDisabledNote,
+    },
+    {
+      url: alertsLink ?? '',
+      label: 'Alerts',
+      icon: <NotificationsNoneIcon />,
+      disabled: Boolean(alertsLinkDisabledNote),
+      disabledNote: alertsLinkDisabledNote,
+    },
+    {
+      url: webUILink ?? '',
+      label: 'Web UI',
+      icon: <PublicIcon />,
+      disabled: Boolean(webUILinkDisabledNote),
+      disabledNote: webUILinkDisabledNote,
+    },
+  ];
+
+  return (
+    <Card>
+      <CardContent>
+        <Toolkit tools={tools} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/index.ts
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/index.ts
@@ -1,0 +1,1 @@
+export { ClusterToolsCard } from './ClusterToolsCard';

--- a/plugins/gs/src/components/hooks/useClusterLinks.ts
+++ b/plugins/gs/src/components/hooks/useClusterLinks.ts
@@ -1,0 +1,53 @@
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+
+export const useGrafanaDashboardsLink = (
+  installationName: string,
+): string | undefined => {
+  const config = useApi(configApiRef);
+  const baseDomain = config.getOptionalString(
+    `gs.installations.${installationName}.baseDomain`,
+  );
+
+  if (!baseDomain) {
+    return undefined;
+  }
+
+  return `https://grafana.${baseDomain}/dashboards`;
+};
+
+export const useGrafanaAlertsLink = (
+  installationName: string,
+): string | undefined => {
+  const config = useApi(configApiRef);
+  const baseDomain = config.getOptionalString(
+    `gs.installations.${installationName}.baseDomain`,
+  );
+
+  if (!baseDomain) {
+    return undefined;
+  }
+
+  return `https://grafana.${baseDomain}/alerting`;
+};
+
+export const useWebUILink = (
+  installationName: string,
+  clusterName: string,
+  organizationName: string,
+  isManagementCluster: boolean = false,
+): string | undefined => {
+  const config = useApi(configApiRef);
+  const baseDomain = config.getOptionalString(
+    `gs.installations.${installationName}.baseDomain`,
+  );
+
+  if (!baseDomain) {
+    return undefined;
+  }
+
+  if (isManagementCluster) {
+    return `https://happa.${baseDomain}`;
+  }
+
+  return `https://happa.${baseDomain}/organizations/${organizationName}/clusters/${clusterName}`;
+};


### PR DESCRIPTION
### What does this PR do?

In this PR, links to external services were added to cluster details page:

1) Link to Grafana dashboards - brings a user to the list of dashboards for the MC that manages the current cluster.
2) Link to Grafana alerts - brings a user to the Grafana alerts for the MC that manages the current cluster.
3) Link to Web UI (Happa) - for a workload cluster brings a user to cluster details page in Web UI, for a management cluster brings a user to the home page in Web UI.

To enable links, additional configuration is needed with the base domain specified for each installation:
```
gs:
  installations:
    gazelle:
      baseDomain: gazelle.awsprod.gigantic.io
```

### How does it look like?

<img width="1296" alt="Screenshot 2025-01-14 at 10 42 39" src="https://github.com/user-attachments/assets/adff8973-8760-4121-bc8d-9c4181668e57" />

Disabled state when `baseUrl` is not configured for installation:
<img width="1296" alt="Screenshot 2025-01-14 at 10 43 06" src="https://github.com/user-attachments/assets/5a9f3f39-2e00-4b22-a7ff-f0a0702d1985" />

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/3812.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
