### PR TITLE
Fetch infrastructure cluster resources only for supported providers

### DIFF
--- a/.changeset/cool-ties-dance.md
+++ b/.changeset/cool-ties-dance.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs-common': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fetch infrastructure cluster resources only for supported providers.

--- a/plugins/gs-common/src/api/utils/providerClusters.ts
+++ b/plugins/gs-common/src/api/utils/providerClusters.ts
@@ -159,3 +159,11 @@ export function getProviderClusterIdentityAWSAccountId(
 
   return roleARN ? extractIDFromARN(roleARN) : undefined;
 }
+
+export function isSupportedProviderCluster(kind: string) {
+  return [
+    capa.AWSClusterKind,
+    capv.VSphereClusterKind,
+    capz.AzureClusterKind,
+  ].includes(kind);
+}

--- a/plugins/gs/src/components/hooks/useProviderClusters.ts
+++ b/plugins/gs/src/components/hooks/useProviderClusters.ts
@@ -8,6 +8,7 @@ import {
   type Cluster,
   type ProviderCluster,
   InstallationObjectRef,
+  isSupportedProviderCluster,
 } from '@giantswarm/backstage-plugin-gs-common';
 import { gsKubernetesApiRef, KubernetesApi } from '../../apis/kubernetes';
 import { getK8sGetPath, getK8sListPath } from './utils/k8sPath';
@@ -106,7 +107,9 @@ export function useProviderClusters(
   const infrastructureRefs = clusterResources
     .map(({ installationName, ...cluster }) => {
       const infrastructureRef = getClusterInfrastructureRef(cluster);
-      return infrastructureRef
+
+      return infrastructureRef &&
+        isSupportedProviderCluster(infrastructureRef.kind)
         ? { installationName, ...infrastructureRef }
         : undefined;
     })


### PR DESCRIPTION
### What does this PR do?

This change should fix an error during clusters fetching for unsupported provider.

![image (4)](https://github.com/user-attachments/assets/3bcdeccb-ae0e-4d60-a1ce-8a1bfd535d9b)

### Any background context you can provide?

https://gigantic.slack.com/archives/C02GDJJ68Q1/p1738060015759449

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
