### PR TITLE
Fetch only supported infrastructure cluster identity resources

### DIFF
--- a/.changeset/dry-queens-guess.md
+++ b/.changeset/dry-queens-guess.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs-common': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fetch only supported infrastructure cluster identity resources.

--- a/plugins/gs-common/src/api/utils/providerClusters.ts
+++ b/plugins/gs-common/src/api/utils/providerClusters.ts
@@ -160,10 +160,34 @@ export function getProviderClusterIdentityAWSAccountId(
   return roleARN ? extractIDFromARN(roleARN) : undefined;
 }
 
+/**
+ * Checks if the given provider cluster kind is supported by the plugin.
+ *
+ * @param kind - The provider cluster kind to check.
+ * @returns `true` if the `kind` is a supported provider cluster kind, otherwise `false`.
+ */
 export function isSupportedProviderCluster(kind: string) {
   return [
     capa.AWSClusterKind,
     capv.VSphereClusterKind,
     capz.AzureClusterKind,
+  ].includes(kind);
+}
+
+/**
+ * Checks if the given provider cluster identity kind is supported by the plugin.
+ *
+ * For AWS clusters only the `AWSClusterRoleIdentity` kind is supported.
+ * For Azure clusters only the `AzureClusterIdentity` kind is supported.
+ * For vSphere clusters only the `VSphereClusterIdentity` kind is supported.
+ *
+ * @param kind - The cluster identity kind to check.
+ * @returns `true` if the `kind` is a supported provider cluster identity kind, otherwise `false`.
+ */
+export function isSupportedProviderClusterIdentity(kind: string) {
+  return [
+    capa.AWSClusterRoleIdentityKind,
+    capv.VSphereClusterIdentityKind,
+    capz.AzureClusterIdentityKind,
   ].includes(kind);
 }

--- a/plugins/gs/src/components/hooks/useProviderClustersIdentities.ts
+++ b/plugins/gs/src/components/hooks/useProviderClustersIdentities.ts
@@ -8,6 +8,7 @@ import {
   type ProviderClusterIdentity,
   type List,
   type InstallationObjectRef,
+  isSupportedProviderClusterIdentity,
 } from '@giantswarm/backstage-plugin-gs-common';
 import { gsKubernetesApiRef, KubernetesApi } from '../../apis/kubernetes';
 import { getK8sGetPath, getK8sListPath } from './utils/k8sPath';
@@ -104,7 +105,9 @@ export function useProviderClustersIdentities(
   const identityRefs = providerClusterResources
     .map(({ installationName, ...providerCluster }) => {
       const identityRef = getProviderClusterIdentityRef(providerCluster);
-      return identityRef ? { installationName, ...identityRef } : undefined;
+      return identityRef && isSupportedProviderClusterIdentity(identityRef.kind)
+        ? { installationName, ...identityRef }
+        : undefined;
     })
     .filter(Boolean) as InstallationObjectRef[];
   const refs = isExperimentalDataFetchingEnabled


### PR DESCRIPTION
### What does this PR do?

This change should fix an error during clusters fetching for unsupported provider cluster identities.

![image (5)](https://github.com/user-attachments/assets/4712bcab-42a4-43cb-bf52-983593b609bf)

### Any background context you can provide?

[(Please link issues or summarize.)](https://gigantic.slack.com/archives/C02GDJJ68Q1/p1738060015759449)

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
