### PR TITLE
Change cluster app column to display provider specific cluster app version

### DIFF
--- a/.changeset/wild-peaches-juggle.md
+++ b/.changeset/wild-peaches-juggle.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs-common': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Changed CLUSTER APP column in clusters list to display provider specific cluster app version.

--- a/plugins/gs-common/src/api/utils/providerClusters.ts
+++ b/plugins/gs-common/src/api/utils/providerClusters.ts
@@ -1,6 +1,7 @@
 import * as capa from '../../model/capa';
 import * as capv from '../../model/capv';
 import * as capz from '../../model/capz';
+import { Labels } from '../constants';
 import { ProviderCluster, ProviderClusterIdentity } from '../types';
 import { extractIDFromARN, getApiGroupFromApiVersion } from './helpers';
 
@@ -98,6 +99,27 @@ export function isVSphereCluster(kind: string, apiVersion: string) {
   return (
     kind === capv.VSphereClusterKind && apiGroup === capv.VSphereClusterApiGroup
   );
+}
+
+export function getProviderClusterAppVersion(providerCluster: ProviderCluster) {
+  return providerCluster.metadata.labels?.[Labels.labelAppVersion];
+}
+
+export function getProviderClusterAppSourceLocation(
+  providerCluster: ProviderCluster,
+) {
+  const { kind, apiVersion } = providerCluster;
+
+  switch (true) {
+    case isAWSCluster(kind, apiVersion):
+      return 'https://github.com/giantswarm/cluster-aws';
+    case isAzureCluster(kind, apiVersion):
+      return 'https://github.com/giantswarm/cluster-azure';
+    case isVSphereCluster(kind, apiVersion):
+      return 'https://github.com/giantswarm/cluster-vsphere';
+    default:
+      return undefined;
+  }
 }
 
 export function getProviderClusterLocation(providerCluster: ProviderCluster) {

--- a/plugins/gs/src/components/clusters/ClustersTable/ClustersTable.tsx
+++ b/plugins/gs/src/components/clusters/ClustersTable/ClustersTable.tsx
@@ -10,7 +10,6 @@ import type {
 } from '@giantswarm/backstage-plugin-gs-common';
 import {
   findResourceByRef,
-  getClusterAppVersion,
   getClusterControlPlaneRef,
   getClusterCreationTimestamp,
   getClusterDescription,
@@ -21,6 +20,8 @@ import {
   getClusterReleaseVersion,
   getClusterServicePriority,
   getControlPlaneK8sVersion,
+  getProviderClusterAppSourceLocation,
+  getProviderClusterAppVersion,
   getProviderClusterIdentityAWSAccountId,
   getProviderClusterIdentityRef,
   getProviderClusterLocation,
@@ -79,6 +80,14 @@ const ClustersTableView = ({
       providerCluster,
       providerClusterIdentity,
     }) => {
+      const appVersion = providerCluster
+        ? getProviderClusterAppVersion(providerCluster)
+        : undefined;
+
+      const appSourceLocation = providerCluster
+        ? getProviderClusterAppSourceLocation(providerCluster)
+        : undefined;
+
       const kubernetesVersion = controlPlane
         ? getControlPlaneK8sVersion(controlPlane)
         : undefined;
@@ -102,7 +111,8 @@ const ClustersTableView = ({
         priority: getClusterServicePriority(cluster),
         status: calculateClusterStatus(cluster),
         apiVersion: cluster.apiVersion,
-        appVersion: getClusterAppVersion(cluster),
+        appVersion,
+        appSourceLocation,
         kubernetesVersion,
         releaseVersion: getClusterReleaseVersion(cluster),
         location,
@@ -164,6 +174,7 @@ export const ClustersTable = () => {
   });
 
   const providerClustersRequired =
+    visibleColumns.includes('appVersion') ||
     visibleColumns.includes('location') ||
     visibleColumns.includes('awsAccountId');
 

--- a/plugins/gs/src/components/clusters/ClustersTable/columns.tsx
+++ b/plugins/gs/src/components/clusters/ClustersTable/columns.tsx
@@ -26,6 +26,7 @@ export type Row = {
   status: string;
   apiVersion: string;
   appVersion?: string;
+  appSourceLocation?: string;
   releaseVersion?: string;
   kubernetesVersion?: string;
   location?: string;
@@ -118,7 +119,7 @@ export const getInitialColumns = (): TableColumn<Row>[] => [
         <Version
           version={row.appVersion || ''}
           highlight
-          sourceLocation="https://github.com/giantswarm/cluster"
+          sourceLocation={row.appSourceLocation}
           displayWarning={false}
         />
       );


### PR DESCRIPTION
### What does this PR do?

In this PR, `CLUSTER APP` column in clusters list was changed to display information about `cluster-PROVIDER` app version instead of `cluster` app version. It's taken from the `app.kubernetes.io/version` label of the infrastructure cluster resource.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3216.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
