### PR TITLE
Change Grafana link on cluster details page

### DIFF
--- a/.changeset/swift-lies-impress.md
+++ b/.changeset/swift-lies-impress.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Changed Grafana link on cluster details page.

--- a/plugins/gs/src/components/UI/Toolkit/Toolkit.tsx
+++ b/plugins/gs/src/components/UI/Toolkit/Toolkit.tsx
@@ -9,13 +9,13 @@ import classNames from 'classnames';
 
 type Tool =
   | {
-      label: string;
+      label: React.ReactNode;
       url: string;
       icon: React.ReactNode;
       disabled?: false;
     }
   | {
-      label: string;
+      label: React.ReactNode;
       url: string;
       icon: React.ReactNode;
       disabled: true;
@@ -39,7 +39,6 @@ const useStyles = makeStyles(theme => ({
   label: {
     marginTop: theme.spacing(1),
     minWidth: '72px',
-    maxWidth: '82px',
     fontSize: '0.9em',
     lineHeight: '1.25',
     overflowWrap: 'break-word',
@@ -68,7 +67,7 @@ export const Toolkit = ({ tools }: ToolkitProps) => {
 
   return (
     <List className={classes.toolkit}>
-      {tools.map((tool: Tool) => {
+      {tools.map((tool, idx) => {
         const el = (
           <>
             <ListItemIcon
@@ -91,7 +90,7 @@ export const Toolkit = ({ tools }: ToolkitProps) => {
 
         if (tool.disabled) {
           return (
-            <Tooltip title={tool.disabledNote} key={tool.label}>
+            <Tooltip title={tool.disabledNote} key={idx}>
               <Typography
                 variant="inherit"
                 color="textSecondary"
@@ -104,7 +103,7 @@ export const Toolkit = ({ tools }: ToolkitProps) => {
         }
 
         return (
-          <Link key={tool.label} to={tool.url} className={classes.tool}>
+          <Link key={idx} to={tool.url} className={classes.tool}>
             {el}
           </Link>
         );

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/ClusterToolsCard.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/ClusterToolsCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardContent } from '@material-ui/core';
+import { Card, CardContent, Typography } from '@material-ui/core';
 import PublicIcon from '@material-ui/icons/Public';
 import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import { useCurrentCluster } from '../../../ClusterDetailsPage/useCurrentCluster';
@@ -12,7 +12,7 @@ import {
 } from '@giantswarm/backstage-plugin-gs-common';
 import {
   useGrafanaAlertsLink,
-  useGrafanaDashboardsLink,
+  useGrafanaDashboardLink,
   useWebUILink,
 } from '../../../../hooks/useClusterLinks';
 
@@ -32,10 +32,10 @@ export function ClusterToolsCard() {
     ? ''
     : `Web UI link is not available. Base domain is not configured for '${installationName}' installation.`;
 
-  const dashboardsLink = useGrafanaDashboardsLink(installationName);
-  const dashboardsLinkDisabledNote = dashboardsLink
+  const dashboardLink = useGrafanaDashboardLink(installationName, clusterName);
+  const dashboardsLinkDisabledNote = dashboardLink
     ? ''
-    : `Grafana dashboards link is not available. Base domain is not configured for '${installationName}' installation.`;
+    : `Cluster overview dashboard link is not available. Base domain is not configured for '${installationName}' installation.`;
 
   const alertsLink = useGrafanaAlertsLink(installationName);
   const alertsLinkDisabledNote = alertsLink
@@ -44,8 +44,18 @@ export function ClusterToolsCard() {
 
   const tools = [
     {
-      url: dashboardsLink ?? '',
-      label: 'Dashboards',
+      url: dashboardLink ?? '',
+      label: (
+        <>
+          <Typography variant="inherit" noWrap>
+            Cluster overview
+          </Typography>
+          <br />
+          <Typography variant="inherit" noWrap>
+            dashboard
+          </Typography>
+        </>
+      ),
       icon: <GrafanaIcon />,
       disabled: Boolean(dashboardsLinkDisabledNote),
       disabledNote: dashboardsLinkDisabledNote,

--- a/plugins/gs/src/components/home/ResourcesCard/ResourcesCard.tsx
+++ b/plugins/gs/src/components/home/ResourcesCard/ResourcesCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardContent } from '@material-ui/core';
+import { Card, CardContent, Typography } from '@material-ui/core';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
 import { Toolkit } from '../../UI';
@@ -8,17 +8,35 @@ import { BackstageIcon } from '../../../assets/icons/CustomIcons';
 const resources = [
   {
     url: 'https://docs.giantswarm.io',
-    label: 'Giant Swarm Docs',
+    label: (
+      <>
+        <Typography variant="inherit">Giant Swarm</Typography>
+        <br />
+        <Typography variant="inherit">Docs</Typography>
+      </>
+    ),
     icon: <MenuBookIcon />,
   },
   {
     url: 'https://github.com/giantswarm',
-    label: 'Giant Swarm GitHub',
+    label: (
+      <>
+        <Typography variant="inherit">Giant Swarm</Typography>
+        <br />
+        <Typography variant="inherit">GitHub</Typography>
+      </>
+    ),
     icon: <GitHubIcon />,
   },
   {
     url: 'https://github.com/giantswarm/backstage/releases',
-    label: 'Backstage changelog',
+    label: (
+      <>
+        <Typography variant="inherit">Backstage</Typography>
+        <br />
+        <Typography variant="inherit">changelog</Typography>
+      </>
+    ),
     icon: <BackstageIcon />,
   },
 ];

--- a/plugins/gs/src/components/hooks/useClusterLinks.ts
+++ b/plugins/gs/src/components/hooks/useClusterLinks.ts
@@ -1,7 +1,8 @@
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
-export const useGrafanaDashboardsLink = (
+export const useGrafanaDashboardLink = (
   installationName: string,
+  clusterName: string,
 ): string | undefined => {
   const config = useApi(configApiRef);
   const baseDomain = config.getOptionalString(
@@ -12,7 +13,18 @@ export const useGrafanaDashboardsLink = (
     return undefined;
   }
 
-  return `https://grafana.${baseDomain}/dashboards`;
+  const queryStringData = {
+    orgId: '1',
+    from: 'now-6h',
+    to: 'now',
+    timezone: 'browser',
+    'var-datasource': 'default',
+    'var-cluster': clusterName,
+  };
+
+  const searchParams = new URLSearchParams(queryStringData);
+
+  return `https://grafana.${baseDomain}/d/gs_cluster-overview/cluster-overview?${searchParams.toString()}`;
 };
 
 export const useGrafanaAlertsLink = (


### PR DESCRIPTION
### What does this PR do?

In this PR, a link to Grafana dashboard on cluster details page was changed. Now it brings a user to the new "Cluster Overview Dashboard".

### How does it look like?

<img width="1293" alt="Screenshot 2025-02-05 at 13 55 30" src="https://github.com/user-attachments/assets/0b38432b-0027-47b5-b82e-84eaec6e8c6a" />

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/3852.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
