### PR TITLE
Fix how cluster type is determined for deployments

### DIFF
--- a/.changeset/thin-gifts-rush.md
+++ b/.changeset/thin-gifts-rush.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs-common': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fixed how cluster type is determined for deployments.

--- a/plugins/gs-common/src/api/utils/apps.ts
+++ b/plugins/gs-common/src/api/utils/apps.ts
@@ -76,20 +76,29 @@ export function getAppStatus(app: App) {
   return app.status?.release.status;
 }
 
-export function isAppTargetClusterManagementCluster(app: App) {
-  return app.spec?.kubeConfig.inCluster === true;
+export function isAppTargetClusterManagementCluster(
+  app: App,
+  installationName: string,
+) {
+  return (
+    app.spec?.kubeConfig.inCluster === true ||
+    app.spec?.kubeConfig.secret?.name === `${installationName}-kubeconfig`
+  );
 }
 
 export function getAppTargetClusterName(app: App, installationName: string) {
-  if (isAppTargetClusterManagementCluster(app)) {
+  if (isAppTargetClusterManagementCluster(app, installationName)) {
     return installationName;
   }
 
   return app.metadata.labels?.[Labels.labelCluster];
 }
 
-export function getAppTargetClusterNamespace(app: App) {
-  if (isAppTargetClusterManagementCluster(app)) {
+export function getAppTargetClusterNamespace(
+  app: App,
+  installationName: string,
+) {
+  if (isAppTargetClusterManagementCluster(app, installationName)) {
     return Constants.MANAGEMENT_CLUSTER_NAMESPACE;
   }
 

--- a/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
+++ b/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
@@ -88,7 +88,7 @@ export const AppDetails = ({
   }
 
   const clusterName = getAppTargetClusterName(app, installationName);
-  const clusterNamespace = getAppTargetClusterNamespace(app);
+  const clusterNamespace = getAppTargetClusterNamespace(app, installationName);
   const lastAppliedRevision = formatVersion(getAppCurrentVersion(app) ?? '');
   const lastAttemptedRevision = formatVersion(getAppVersion(app) ?? '');
   const sourceName = formatAppCatalogName(getAppCatalogName(app) ?? '');

--- a/plugins/gs/src/components/deployments/DeploymentsTable/DeploymentsTable.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentsTable/DeploymentsTable.tsx
@@ -51,8 +51,11 @@ const DeploymentsTableView = ({
           installationName,
           kind: 'app',
           clusterName: getAppTargetClusterName(deployment, installationName),
-          clusterNamespace: getAppTargetClusterNamespace(deployment),
-          clusterType: calculateClusterType(deployment),
+          clusterNamespace: getAppTargetClusterNamespace(
+            deployment,
+            installationName,
+          ),
+          clusterType: calculateClusterType(deployment, installationName),
           name: deployment.metadata.name,
           namespace: deployment.metadata.namespace,
           version: formatVersion(getAppCurrentVersion(deployment) ?? ''),
@@ -73,7 +76,7 @@ const DeploymentsTableView = ({
             installationName,
           ),
           clusterNamespace: getHelmReleaseTargetClusterNamespace(deployment),
-          clusterType: calculateClusterType(deployment),
+          clusterType: calculateClusterType(deployment, installationName),
           name: deployment.metadata.name,
           namespace: deployment.metadata.namespace,
           version: formatVersion(

--- a/plugins/gs/src/components/deployments/utils.ts
+++ b/plugins/gs/src/components/deployments/utils.ts
@@ -5,9 +5,12 @@ import {
 } from '@giantswarm/backstage-plugin-gs-common';
 import { ClusterTypes } from '../clusters/utils';
 
-export function calculateClusterType(deployment: Deployment) {
+export function calculateClusterType(
+  deployment: Deployment,
+  installationName: string,
+) {
   if (deployment.kind === 'App') {
-    return isAppTargetClusterManagementCluster(deployment)
+    return isAppTargetClusterManagementCluster(deployment, installationName)
       ? ClusterTypes.Management
       : ClusterTypes.Workload;
   }


### PR DESCRIPTION
### What does this PR do?

In this PR, the logic for determining if an App CR targets a management cluster was fixed to correctly handle App CRs deployed by a bundle.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3847.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
