### PR TITLE
Delete container after the session ends

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,9 @@
   },
 
   "runArgs": [
+    // Delete the container after the session ends.
+    "--rm",
+
     // Read environment variables from .env file
     "--env-file",
     ".env",


### PR DESCRIPTION
Changes the devcontainer config so that the container gets deleted after the session ends.

This reduces disk uses and ensures a fresh start for every session.