### PR TITLE
Add roadmap link, rename release notes link

### DIFF
--- a/.changeset/bitter-bees-occur.md
+++ b/.changeset/bitter-bees-occur.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Added developer portal roadmap link to homepage

--- a/plugins/gs/src/components/home/ResourcesCard/ResourcesCard.tsx
+++ b/plugins/gs/src/components/home/ResourcesCard/ResourcesCard.tsx
@@ -32,9 +32,20 @@ const resources = [
     url: 'https://github.com/giantswarm/backstage/releases',
     label: (
       <>
-        <Typography variant="inherit">Backstage</Typography>
+        <Typography variant="inherit">Portal</Typography>
         <br />
         <Typography variant="inherit">changelog</Typography>
+      </>
+    ),
+    icon: <BackstageIcon />,
+  },
+  {
+    url: 'https://github.com/orgs/giantswarm/projects/273/views/28?filterQuery=-status%3A%22Done+%E2%9C%85%22+kind%3A%22Epic+%F0%9F%8E%AF%22%2C%22Rock+%F0%9F%AA%A8%22%2C%22Feature+%F0%9F%92%AB%22+label%3Aui%2Fbackstage',
+    label: (
+      <>
+        <Typography variant="inherit">Portal</Typography>
+        <br />
+        <Typography variant="inherit">roadmap</Typography>
       </>
     ),
     icon: <BackstageIcon />,


### PR DESCRIPTION
THis PR changes the label of the relewase notes link on the home page and adds a roadmap link