### PR TITLE
Prefix condition with Not in case status is False

### DIFF
--- a/.changeset/chilly-books-think.md
+++ b/.changeset/chilly-books-think.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Display HelmRelease deployment conditions with keyword "Not" if status is "False"

--- a/plugins/gs/src/components/deployments/HelmReleaseDetailsStatusConditions/HelmReleaseDetailsStatusConditions.tsx
+++ b/plugins/gs/src/components/deployments/HelmReleaseDetailsStatusConditions/HelmReleaseDetailsStatusConditions.tsx
@@ -76,6 +76,11 @@ const ConditionCard = ({
     setExpanded(!expanded);
   };
 
+  let conditionHeadline = condition.type;
+  if (condition.status === 'False') {
+    conditionHeadline = `Not ${condition.type.toLowerCase()}`;
+  }
+
   return (
     <Card>
       <CardHeader
@@ -91,7 +96,7 @@ const ConditionCard = ({
               ) : (
                 <StyledCancelOutlinedIcon />
               ))}
-            <Heading level="h3">{condition.type}</Heading>
+            <Heading level="h3">{conditionHeadline}</Heading>
           </Box>
         }
         titleTypographyProps={{ variant: undefined }}


### PR DESCRIPTION
### What does this PR do?

When displaying a HelmRelease's deployment details, if status is `False`, the according condition will be prefixed with "Not".

### How does it look like?

Before

![image](https://github.com/user-attachments/assets/5ae74af6-369c-4eee-96b8-58c311a66b39)

After

![image](https://github.com/user-attachments/assets/00b0ee23-64f5-4772-99e0-54e6bd63b9f7)


### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/3969

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
