### PR TITLE
Show resource name as title of the deployment details pane

### DIFF
--- a/.changeset/tidy-animals-rescue.md
+++ b/.changeset/tidy-animals-rescue.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Show resource name as title of the deployment details pane

--- a/plugins/gs/src/components/UI/DetailsPane/DetailsPane.tsx
+++ b/plugins/gs/src/components/UI/DetailsPane/DetailsPane.tsx
@@ -66,7 +66,7 @@ const DrawerContent = ({
 
 type DetailsPaneProps = {
   paneId: string;
-  title: string;
+  title?: string;
   render: (props: {
     kind: string;
     installationName: string;
@@ -98,7 +98,7 @@ export const DetailsPane = ({ paneId, title, render }: DetailsPaneProps) => {
       open={isOpen}
       onClose={handleClose}
     >
-      <DrawerContent title={title} onClose={handleClose}>
+      <DrawerContent title={title ?? name} onClose={handleClose}>
         {render({ kind, installationName, name, namespace })}
       </DrawerContent>
     </Drawer>

--- a/plugins/gs/src/components/deployments/DeploymentsPage/DefaultDeploymentsPage.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentsPage/DefaultDeploymentsPage.tsx
@@ -58,7 +58,6 @@ export function DefaultDeploymentsPage(props: DefaultDeploymentsPageProps) {
           <DeploymentsTable baseRouteRef={deploymentsRouteRef} />
           <DetailsPane
             paneId={DEPLOYMENT_DETAILS_PANE_ID}
-            title="Deployment details"
             render={({ kind, installationName, name, namespace }) => (
               <>
                 {kind === 'app' && (

--- a/plugins/gs/src/components/deployments/EntityDeploymentsContent/EntityDeploymentsContent.tsx
+++ b/plugins/gs/src/components/deployments/EntityDeploymentsContent/EntityDeploymentsContent.tsx
@@ -48,7 +48,6 @@ export const EntityDeploymentsContent = () => {
         </InstallationsWrapper>
         <DetailsPane
           paneId={DEPLOYMENT_DETAILS_PANE_ID}
-          title="Deployment details"
           render={({ kind, installationName, name, namespace }) => (
             <>
               {kind === 'app' && (


### PR DESCRIPTION
### What does this PR do?

Shows the resource (HelmRelease or App) name as the title of the deployment details pane.

### How does it look like?

Before

![image](https://github.com/user-attachments/assets/37dcfd2d-8d79-47ce-944d-cb8e4af9b955)

After

![image](https://github.com/user-attachments/assets/6c6e995f-45a7-4855-a6f2-cc6dbd3e66e6)

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
