### PR TITLE
Fetch from all installations when none is selected

### DIFF
--- a/.changeset/angry-cases-repeat.md
+++ b/.changeset/angry-cases-repeat.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Changed K8s API fetching to use all installations when none is selected.

--- a/plugins/gs/src/components/InstallationsPicker/InstallationsPicker.tsx
+++ b/plugins/gs/src/components/InstallationsPicker/InstallationsPicker.tsx
@@ -24,9 +24,7 @@ export const InstallationsPicker = ({
     const parsed = qs.parse(location.search, {
       ignoreQueryPrefix: true,
     });
-
-    const queryParameter = (parsed.installations ?? []) as string[];
-    const queryParameters = [queryParameter].flat().filter(Boolean) as string[];
+    const queryParameters = (parsed.installations ?? []) as string[];
     if (queryParameters.length) {
       setValue(queryParameters);
     }

--- a/plugins/gs/src/components/InstallationsWrapper/InstallationsWrapper.tsx
+++ b/plugins/gs/src/components/InstallationsWrapper/InstallationsWrapper.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 import { useInstallations, useInstallationsStatuses } from '../hooks';
 import { InstallationsSelector } from '../InstallationsSelector';
-import { EmptyState } from '@backstage/core-components';
 
 export const useStyles = makeStyles({
   fullWidth: {
@@ -43,15 +42,7 @@ export const InstallationsWrapper = ({
         />
       </Grid>
       <Grid item className={classes.fullWidth}>
-        {selectedInstallations.length === 0 ? (
-          <EmptyState
-            missing="data"
-            title="No Installations Selected"
-            description="Please select one or more installations."
-          />
-        ) : (
-          children
-        )}
+        {children}
       </Grid>
     </Grid>
   );

--- a/plugins/gs/src/components/hooks/useApps.ts
+++ b/plugins/gs/src/components/hooks/useApps.ts
@@ -5,8 +5,8 @@ import { useInstallations } from './useInstallations';
 import { useApiVersionOverrides } from './useApiVersionOverrides';
 
 export function useApps(installations?: string[]) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 

--- a/plugins/gs/src/components/hooks/useClusterSecretStores.ts
+++ b/plugins/gs/src/components/hooks/useClusterSecretStores.ts
@@ -8,8 +8,8 @@ import { useInstallations } from './useInstallations';
 import { useApiVersionOverrides } from './useApiVersionOverrides';
 
 export function useClusterSecretStores(installations?: string[]) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 

--- a/plugins/gs/src/components/hooks/useClusters.ts
+++ b/plugins/gs/src/components/hooks/useClusters.ts
@@ -29,8 +29,8 @@ function getInstallationOrganizationNamespaces(
 }
 
 export function useClusters(installations?: string[]) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 

--- a/plugins/gs/src/components/hooks/useFilters.ts
+++ b/plugins/gs/src/components/hooks/useFilters.ts
@@ -68,7 +68,13 @@ export function useFilters<Filters extends DefaultFilters = DefaultFilters>(
             | FacetFilter
             | undefined;
           if (filter?.toQueryValue) {
-            params[key] = filter.toQueryValue();
+            const queryValue = filter.toQueryValue();
+            if (
+              !Array.isArray(queryValue) ||
+              (Array.isArray(queryValue) && queryValue.length > 0)
+            ) {
+              params[key] = queryValue;
+            }
           }
           return params;
         },
@@ -83,9 +89,15 @@ export function useFilters<Filters extends DefaultFilters = DefaultFilters>(
           {
             ...oldParams,
             installations: installationsQueryParams,
-            filters: filtersQueryParams,
+            filters: Object.entries(filtersQueryParams).length
+              ? filtersQueryParams
+              : undefined,
           },
-          { addQueryPrefix: true, arrayFormat: 'repeat' },
+          {
+            addQueryPrefix: true,
+            arrayFormat: 'repeat',
+            allowEmptyArrays: true,
+          },
         );
         const newUrl = `${window.location.pathname}${newParams}`;
         window.history?.replaceState(null, document.title, newUrl);

--- a/plugins/gs/src/components/hooks/useHelmReleases.ts
+++ b/plugins/gs/src/components/hooks/useHelmReleases.ts
@@ -11,8 +11,8 @@ import { useInstallations } from './useInstallations';
 import { useApiVersionOverrides } from './useApiVersionOverrides';
 
 export function useHelmReleases(installations?: string[]) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 

--- a/plugins/gs/src/components/hooks/useInstallations.ts
+++ b/plugins/gs/src/components/hooks/useInstallations.ts
@@ -13,6 +13,7 @@ export type InstallationInfo = {
 export const useInstallations = (): {
   installations: string[];
   installationsInfo: InstallationInfo[];
+  activeInstallations: string[];
   selectedInstallations: string[];
   setSelectedInstallations: (items: string[]) => void;
 } => {
@@ -56,9 +57,13 @@ export const useInstallations = (): {
     }
   }, [selectedInstallations, savedInstallations, setSavedInstallations]);
 
+  const activeInstallations =
+    selectedInstallations.length > 0 ? selectedInstallations : installations;
+
   return {
     installations,
     installationsInfo,
+    activeInstallations,
     selectedInstallations,
     setSelectedInstallations,
   };

--- a/plugins/gs/src/components/hooks/useOrganizations.ts
+++ b/plugins/gs/src/components/hooks/useOrganizations.ts
@@ -147,8 +147,8 @@ async function checkListPermissions(
 }
 
 export function useOrganizations(installations?: string[]) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 

--- a/plugins/gs/src/components/hooks/useProviderConfigs.ts
+++ b/plugins/gs/src/components/hooks/useProviderConfigs.ts
@@ -7,8 +7,8 @@ import { useApiVersionOverrides } from './useApiVersionOverrides';
 const resourcePluralName = 'providerconfigs';
 
 export function useProviderConfigs(installations?: string[]) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 

--- a/plugins/gs/src/components/hooks/useReleases.ts
+++ b/plugins/gs/src/components/hooks/useReleases.ts
@@ -9,8 +9,8 @@ import { useInstallations } from './useInstallations';
 import { useApiVersionOverrides } from './useApiVersionOverrides';
 
 export function useReleases(installations?: string[]) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 

--- a/plugins/gs/src/components/hooks/useSecretStores.ts
+++ b/plugins/gs/src/components/hooks/useSecretStores.ts
@@ -7,8 +7,8 @@ import { useApiVersionOverrides } from './useApiVersionOverrides';
 const resourcePluralName = 'secretstores';
 
 export function useSecretStores(installations?: string[], namespace?: string) {
-  const { selectedInstallations: savedInstallations } = useInstallations();
-  const selectedInstallations = installations ?? savedInstallations;
+  const { activeInstallations } = useInstallations();
+  const selectedInstallations = installations ?? activeInstallations;
 
   const apiVersionOverrides = useApiVersionOverrides(selectedInstallations);
 


### PR DESCRIPTION
### What does this PR do?

In this PR, the behavior of the installation selectors was changed. Now, if no installations are selected, resources will be fetched from all installations.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3956.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
