### PR TITLE
Improve how errors are displayed in HelmRelease details

### DIFF
--- a/.changeset/three-pigs-roll.md
+++ b/.changeset/three-pigs-roll.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Improved how error messages are displayed in HelmRelease details panel.

--- a/plugins/gs/src/components/UI/ScrollContainer/ScrollContainer.tsx
+++ b/plugins/gs/src/components/UI/ScrollContainer/ScrollContainer.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    overflowX: 'auto',
+    width: '100%',
+  },
+}));
+
+export const ScrollContainer = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const classes = useStyles();
+
+  return <Box className={classes.root}>{children}</Box>;
+};

--- a/plugins/gs/src/components/UI/ScrollContainer/index.ts
+++ b/plugins/gs/src/components/UI/ScrollContainer/index.ts
@@ -1,0 +1,1 @@
+export { ScrollContainer } from './ScrollContainer';

--- a/plugins/gs/src/components/UI/index.ts
+++ b/plugins/gs/src/components/UI/index.ts
@@ -16,6 +16,7 @@ export { KubernetesVersion } from './KubernetesVersion';
 export * from './MultiplePicker';
 export { MultipleSelect } from './MultipleSelect';
 export { NotAvailable } from './NotAvailable';
+export { ScrollContainer } from './ScrollContainer';
 export { SimpleAccordion } from './SimpleAccordion';
 export { StructuredMetadataList } from './StructuredMetadataList';
 export { Toolkit } from './Toolkit';

--- a/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
+++ b/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
@@ -163,7 +163,7 @@ export const HelmReleaseDetails = ({
           sourceLocation={sourceLocation}
         />
 
-        <Grid item>
+        <Grid item xs={12}>
           <HelmReleaseDetailsStatusConditions helmrelease={helmrelease} />
         </Grid>
 

--- a/plugins/gs/src/components/deployments/HelmReleaseDetailsStatusConditions/HelmReleaseDetailsStatusConditions.tsx
+++ b/plugins/gs/src/components/deployments/HelmReleaseDetailsStatusConditions/HelmReleaseDetailsStatusConditions.tsx
@@ -9,6 +9,7 @@ import {
   Grid,
   IconButton,
   Paper,
+  Typography,
   makeStyles,
   styled,
 } from '@material-ui/core';
@@ -17,7 +18,7 @@ import CheckCircleOutlinedIcon from '@material-ui/icons/CheckCircleOutlined';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import type { HelmRelease } from '@giantswarm/backstage-plugin-gs-common';
 import { compareDates } from '../../utils/helpers';
-import { DateComponent, Heading, StructuredMetadataList } from '../../UI';
+import { DateComponent, Heading, ScrollContainer } from '../../UI';
 
 const StyledCancelOutlinedIcon = styled(CancelOutlinedIcon)(({ theme }) => ({
   marginRight: 10,
@@ -125,12 +126,26 @@ const ConditionCard = ({
       />
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         <CardContent className={classes.content}>
-          <StructuredMetadataList
-            metadata={{
-              Reason: condition.reason,
-              Message: condition.message,
-            }}
-          />
+          <Grid container>
+            <Grid item xs={12}>
+              <Box>
+                <Typography variant="subtitle2">Reason:</Typography>
+                <Typography variant="body2" component="pre">
+                  {condition.reason}
+                </Typography>
+              </Box>
+            </Grid>
+            <Grid item xs={12}>
+              <Box>
+                <Typography variant="subtitle2">Message:</Typography>
+                <ScrollContainer>
+                  <Typography variant="body2" component="pre">
+                    <code>{condition.message}</code>
+                  </Typography>
+                </ScrollContainer>
+              </Box>
+            </Grid>
+          </Grid>
         </CardContent>
       </Collapse>
     </Card>
@@ -161,7 +176,7 @@ export const HelmReleaseDetailsStatusConditions = ({
   return (
     <Grid container direction="column">
       {conditions.map((condition, idx) => (
-        <Grid item key={condition.type}>
+        <Grid item xs={12} key={condition.type}>
           <ConditionCard
             condition={condition}
             defaultState={


### PR DESCRIPTION
### What does this PR do?

In this PR, support for multi-line error messages was added to the HelmRelease details panel.

### How does it look like?
Before:
<img width="445" alt="Screenshot 2025-04-08 at 11 15 09" src="https://github.com/user-attachments/assets/fd91d37a-a8af-4a05-8a4f-cfa8943720d2" />

After:
<img width="445" alt="Screenshot 2025-04-08 at 18 07 52" src="https://github.com/user-attachments/assets/fb3305f2-8228-4c3f-bc7b-cd7bd7ba097a" />

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3971.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
