### PR TITLE
Improve resource page layout

### DIFF
--- a/.changeset/sweet-meals-add.md
+++ b/.changeset/sweet-meals-add.md
@@ -1,0 +1,5 @@
+---
+'app': minor
+---
+
+Improved resource entity page layout

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -433,20 +433,20 @@ const resourcePage = (
       <Grid container spacing={2} alignItems="flex-start">
         {entityWarningContent}
 
-        <Grid item md={8}>
+        <Grid item xs={12} md={8}>
           <EntityAboutCard variant="gridItem" />
         </Grid>
 
         <EntitySwitch>
           <EntitySwitch.Case if={isEntityGSKratixResource}>
-            <Grid item md={8}>
+            <Grid item xs={12} md={4}>
               <EntityGSKratixStatusCard />
             </Grid>
           </EntitySwitch.Case>
         </EntitySwitch>
         <EntitySwitch>
           <EntitySwitch.Case if={isLinksAvailable}>
-            <Grid item md={4}>
+            <Grid item xs={12} md={4}>
               <EntityLinksCard cols={1} />
             </Grid>
           </EntitySwitch.Case>
@@ -454,7 +454,7 @@ const resourcePage = (
 
         <EntitySwitch>
           <EntitySwitch.Case if={isEntityGSInstallationResource}>
-            <Grid item md={8}>
+            <Grid item xs={12} md={8}>
               <EntityGSInstallationDetailsCard />
             </Grid>
           </EntitySwitch.Case>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -430,30 +430,33 @@ const domainPage = (
 const resourcePage = (
   <EntityLayout>
     <EntityLayout.Route path="/" title="Overview">
-      <Grid container spacing={3} alignItems="flex-start">
+      <Grid container spacing={2} alignItems="flex-start">
         {entityWarningContent}
-        <Grid item md={6}>
+
+        <Grid item md={8}>
           <EntityAboutCard variant="gridItem" />
         </Grid>
-        <Grid item container spacing={3} md={6}>
-          <EntitySwitch>
-            <EntitySwitch.Case if={isEntityGSKratixResource}>
-              <Grid item xs={12}>
-                <EntityGSKratixStatusCard />
-              </Grid>
-            </EntitySwitch.Case>
-          </EntitySwitch>
-          <EntitySwitch>
-            <EntitySwitch.Case if={isLinksAvailable}>
-              <Grid item xs={12}>
-                <EntityLinksCard />
-              </Grid>
-            </EntitySwitch.Case>
-          </EntitySwitch>
-        </Grid>
+
+        <EntitySwitch>
+          <EntitySwitch.Case if={isEntityGSKratixResource}>
+            <Grid item md={8}>
+              <EntityGSKratixStatusCard />
+            </Grid>
+          </EntitySwitch.Case>
+        </EntitySwitch>
+        <EntitySwitch>
+          <EntitySwitch.Case if={isLinksAvailable}>
+            <Grid item md={4}>
+              <EntityLinksCard cols={1} />
+            </Grid>
+          </EntitySwitch.Case>
+        </EntitySwitch>
+
         <EntitySwitch>
           <EntitySwitch.Case if={isEntityGSInstallationResource}>
-            <EntityGSInstallationDetailsCard />
+            <Grid item md={8}>
+              <EntityGSInstallationDetailsCard />
+            </Grid>
           </EntitySwitch.Case>
         </EntitySwitch>
       </Grid>

--- a/plugins/gs/src/components/catalog/EntityInstallationDetailsCard/EntityInstallationDetailsCard.tsx
+++ b/plugins/gs/src/components/catalog/EntityInstallationDetailsCard/EntityInstallationDetailsCard.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { InfoCard, Link, MarkdownContent } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { AboutField } from '@backstage/plugin-catalog';
+import { ScrollContainer } from '../../UI';
 
 const useStyles = makeStyles({
   notSpecified: {
@@ -63,8 +64,8 @@ export function EntityInstallationDetailsCard() {
             )}
           </Grid>
           <Grid container spacing={5}>
-            <AboutField label="Escalation matrix">
-              <>
+            <AboutField label="Escalation matrix" gridSizes={{ xs: 12 }}>
+              <ScrollContainer>
                 {(entity.metadata.annotations?.[
                   'giantswarm.io/escalation-matrix'
                 ] && (
@@ -77,7 +78,7 @@ export function EntityInstallationDetailsCard() {
                   </pre>
                 )) ||
                   notSpecified}
-              </>
+              </ScrollContainer>
             </AboutField>
           </Grid>
         </InfoCard>


### PR DESCRIPTION
### What does this PR do?

- Improves the rendering of the Link panel by using one column only internally, also setting a lower width
- Increase the width of the About panel
- Limits the width of the installation details panel

An `EntityGSKratixStatusCard` component will be rendered with the same width as the About panel, and as a consequence will be shown underneath the About panel, not next to it.

### How does it look like?

Before

![image](https://github.com/user-attachments/assets/d9e82e0b-73ce-4a26-88ef-3d9209b0eda2)

After

![image](https://github.com/user-attachments/assets/ae4d2ef4-3719-4b9d-909f-6cef536f8bfd)


### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
