### PR TITLE
Fix how error messages are displayed for deployments

### DIFF
--- a/.changeset/mighty-queens-cross.md
+++ b/.changeset/mighty-queens-cross.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fixed how error messages are displayed for deployments.

--- a/plugins/gs/src/components/UI/StatusMessage/StatusMessage.tsx
+++ b/plugins/gs/src/components/UI/StatusMessage/StatusMessage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { makeStyles, Typography } from '@material-ui/core';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    whiteSpace: 'pre-line',
+  },
+}));
+
+export const StatusMessage = ({ children }: { children: React.ReactNode }) => {
+  const classes = useStyles();
+
+  return (
+    <Typography variant="inherit" className={classes.root}>
+      {children}
+    </Typography>
+  );
+};

--- a/plugins/gs/src/components/UI/StatusMessage/index.ts
+++ b/plugins/gs/src/components/UI/StatusMessage/index.ts
@@ -1,0 +1,1 @@
+export { StatusMessage } from './StatusMessage';

--- a/plugins/gs/src/components/UI/index.ts
+++ b/plugins/gs/src/components/UI/index.ts
@@ -18,6 +18,7 @@ export { MultipleSelect } from './MultipleSelect';
 export { NotAvailable } from './NotAvailable';
 export { ScrollContainer } from './ScrollContainer';
 export { SimpleAccordion } from './SimpleAccordion';
+export { StatusMessage } from './StatusMessage';
 export { StructuredMetadataList } from './StructuredMetadataList';
 export { Toolkit } from './Toolkit';
 export { Version } from './Version';

--- a/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
+++ b/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
@@ -170,7 +170,7 @@ export const AppDetails = ({
           sourceLocation={sourceLocation}
         />
 
-        <Grid item>
+        <Grid item xs={12}>
           <AppDetailsStatus app={app} />
         </Grid>
 

--- a/plugins/gs/src/components/deployments/AppDetailsStatus/AppDetailsStatus.tsx
+++ b/plugins/gs/src/components/deployments/AppDetailsStatus/AppDetailsStatus.tsx
@@ -3,7 +3,13 @@ import { Box, Paper } from '@material-ui/core';
 import type { App } from '@giantswarm/backstage-plugin-gs-common';
 import { getAppStatus } from '@giantswarm/backstage-plugin-gs-common';
 import { useAppStatusDetails } from '../../hooks';
-import { ContentRow, DeploymentStatusCard, Heading } from '../../UI';
+import {
+  ContentRow,
+  DeploymentStatusCard,
+  Heading,
+  ScrollContainer,
+  StatusMessage,
+} from '../../UI';
 
 const StatusCard = ({
   status,
@@ -49,7 +55,15 @@ export const AppDetailsStatus = ({ app }: AppDetailsStatusProps) => {
 
   return (
     <StatusCard status={status} lastTransitionTime={lastTransitionTime}>
-      {reason && <ContentRow title="Reason">{reason}</ContentRow>}
+      {reason && (
+        <ContentRow title="Reason">
+          <ScrollContainer>
+            <StatusMessage>
+              <code>{reason}</code>
+            </StatusMessage>
+          </ScrollContainer>
+        </ContentRow>
+      )}
     </StatusCard>
   );
 };

--- a/plugins/gs/src/components/deployments/HelmReleaseDetailsStatusConditions/HelmReleaseDetailsStatusConditions.tsx
+++ b/plugins/gs/src/components/deployments/HelmReleaseDetailsStatusConditions/HelmReleaseDetailsStatusConditions.tsx
@@ -18,7 +18,12 @@ import CheckCircleOutlinedIcon from '@material-ui/icons/CheckCircleOutlined';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import type { HelmRelease } from '@giantswarm/backstage-plugin-gs-common';
 import { compareDates } from '../../utils/helpers';
-import { DateComponent, Heading, ScrollContainer } from '../../UI';
+import {
+  DateComponent,
+  Heading,
+  ScrollContainer,
+  StatusMessage,
+} from '../../UI';
 
 const StyledCancelOutlinedIcon = styled(CancelOutlinedIcon)(({ theme }) => ({
   marginRight: 10,
@@ -130,18 +135,16 @@ const ConditionCard = ({
             <Grid item xs={12}>
               <Box>
                 <Typography variant="subtitle2">Reason:</Typography>
-                <Typography variant="body2" component="pre">
-                  {condition.reason}
-                </Typography>
+                <StatusMessage>{condition.reason}</StatusMessage>
               </Box>
             </Grid>
             <Grid item xs={12}>
               <Box>
                 <Typography variant="subtitle2">Message:</Typography>
                 <ScrollContainer>
-                  <Typography variant="body2" component="pre">
+                  <StatusMessage>
                     <code>{condition.message}</code>
-                  </Typography>
+                  </StatusMessage>
                 </ScrollContainer>
               </Box>
             </Grid>


### PR DESCRIPTION
### What does this PR do?

In this PR, styles of error messages for deployments were fixed.

### How does it look like?
HelmRelease:
<img width="448" alt="Screenshot 2025-04-09 at 17 16 33" src="https://github.com/user-attachments/assets/1000ac80-4211-4edc-9e2f-b91eeca81a2b" />

App CR:
<img width="448" alt="Screenshot 2025-04-09 at 17 17 32" src="https://github.com/user-attachments/assets/b30e8616-868b-4111-83bd-e7cb9b71f97d" />

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3971.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
