### PR TITLE
Add GitOps indicator to the Deployment details pane

### DIFF
--- a/.changeset/ripe-bugs-cough.md
+++ b/.changeset/ripe-bugs-cough.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs-common': minor
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Added GitOps indicator to the Deployment details pane.

--- a/plugins/gs-common/src/api/utils/helmreleases.ts
+++ b/plugins/gs-common/src/api/utils/helmreleases.ts
@@ -128,3 +128,18 @@ export function getHelmReleaseSourceName(
 ): string | undefined {
   return helmRelease.spec?.chart.spec.sourceRef?.name;
 }
+
+export function getHelmReleaseKustomizationName(helmrelease: HelmRelease) {
+  return helmrelease.metadata.labels?.[Labels.labelKustomizationName];
+}
+
+export function getHelmReleaseKustomizationNamespace(helmrelease: HelmRelease) {
+  return helmrelease.metadata.labels?.[Labels.labelKustomizationNamespace];
+}
+
+export function isHelmReleaseManagedByFlux(helmrelease: HelmRelease) {
+  return (
+    Boolean(getHelmReleaseKustomizationName(helmrelease)) &&
+    Boolean(getHelmReleaseKustomizationNamespace(helmrelease))
+  );
+}

--- a/plugins/gs/src/components/GitOpsCard/GitOpsCard.tsx
+++ b/plugins/gs/src/components/GitOpsCard/GitOpsCard.tsx
@@ -8,16 +8,16 @@ import {
   Typography,
 } from '@material-ui/core';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
-import { useCurrentCluster } from '../../../ClusterDetailsPage/useCurrentCluster';
-import { GitOpsIcon } from '../../../../../assets/icons/CustomIcons';
-import { AsyncValue, ExternalLink } from '../../../../UI';
+
 import {
-  App,
+  Deployment,
   getAppKustomizationName,
   getAppKustomizationNamespace,
   getGitRepositoryKind,
   getGitRepositoryRevision,
   getGitRepositoryUrl,
+  getHelmReleaseKustomizationName,
+  getHelmReleaseKustomizationNamespace,
   getKustomizationPath,
   getKustomizationSourceRef,
   GitRepository,
@@ -25,22 +25,28 @@ import {
   Kustomization,
   KustomizationKind,
 } from '@giantswarm/backstage-plugin-gs-common';
-import { useResource } from '../../../../hooks';
-import { useGitOpsSourceLink } from '../../../../hooks/useClusterLinks';
+import { useGitOpsSourceLink, useResource } from '../hooks';
+import { GitOpsIcon } from '../../assets/icons/CustomIcons';
+import { AsyncValue, ExternalLink } from '../UI';
 
 const InfoIcon = styled(InfoOutlinedIcon)(({ theme }) => ({
   color: theme.palette.text.secondary,
 }));
 
-type ClusterGitOpsCardProps = {
-  clusterApp: App;
+type GitOpsCardProps = {
+  deployment: Deployment;
+  installationName: string;
 };
 
-export function ClusterGitOpsCard({ clusterApp }: ClusterGitOpsCardProps) {
-  const { installationName } = useCurrentCluster();
-
-  const kustomizationName = getAppKustomizationName(clusterApp);
-  const kustomizationNamespace = getAppKustomizationNamespace(clusterApp);
+export function GitOpsCard({ deployment, installationName }: GitOpsCardProps) {
+  const kustomizationName =
+    deployment.kind === 'App'
+      ? getAppKustomizationName(deployment)
+      : getHelmReleaseKustomizationName(deployment);
+  const kustomizationNamespace =
+    deployment.kind === 'App'
+      ? getAppKustomizationNamespace(deployment)
+      : getHelmReleaseKustomizationNamespace(deployment);
   const {
     data: kustomization,
     isLoading: kustomizationIsLoading,

--- a/plugins/gs/src/components/GitOpsCard/index.ts
+++ b/plugins/gs/src/components/GitOpsCard/index.ts
@@ -1,0 +1,1 @@
+export { GitOpsCard } from './GitOpsCard';

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterGitOpsCard/index.ts
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterGitOpsCard/index.ts
@@ -1,1 +1,0 @@
-export { ClusterGitOpsCard } from './ClusterGitOpsCard';

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterOverview.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterOverview.tsx
@@ -6,7 +6,6 @@ import { ClusterAccessCard } from './ClusterAccessCard';
 import { ClusterPolicyComplianceCard } from './ClusterPolicyComplianceCard';
 import { ClusterLabelsCard } from './ClusterLabelsCard';
 import { ClusterToolsCard } from './ClusterToolsCard';
-import { ClusterGitOpsCard } from './ClusterGitOpsCard';
 import { useResource } from '../../../hooks';
 import { useCurrentCluster } from '../../ClusterDetailsPage/useCurrentCluster';
 import {
@@ -17,6 +16,7 @@ import {
   hasClusterAppLabel,
   isAppManagedByFlux,
 } from '@giantswarm/backstage-plugin-gs-common';
+import { GitOpsCard } from '../../../GitOpsCard';
 
 export const ClusterOverview = () => {
   const { cluster, installationName } = useCurrentCluster();
@@ -77,7 +77,10 @@ export const ClusterOverview = () => {
           </Grid>
           {isGitOpsManaged && (
             <Grid item xs={12}>
-              <ClusterGitOpsCard clusterApp={clusterApp} />
+              <GitOpsCard
+                deployment={clusterApp}
+                installationName={installationName}
+              />
             </Grid>
           )}
           <Grid item xs={12}>

--- a/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
+++ b/plugins/gs/src/components/deployments/AppDetails/AppDetails.tsx
@@ -22,6 +22,7 @@ import {
   getAppTargetClusterNamespace,
   App,
   AppKind,
+  isAppManagedByFlux,
 } from '@giantswarm/backstage-plugin-gs-common';
 import { useCatalogEntitiesForDeployments, useResource } from '../../hooks';
 import {
@@ -40,6 +41,7 @@ import {
 import { AppDetailsStatus } from '../AppDetailsStatus';
 import { RevisionDetails } from '../RevisionDetails';
 import { clusterDetailsRouteRef } from '../../../routes';
+import { GitOpsCard } from '../../GitOpsCard';
 
 type AppDetailsProps = {
   installationName: string;
@@ -128,6 +130,8 @@ export const AppDetails = ({
     <NotAvailable />
   );
 
+  const isGitOpsManaged = isAppManagedByFlux(app);
+
   return (
     <div>
       {ingressHost || grafanaDashboard ? (
@@ -163,6 +167,12 @@ export const AppDetails = ({
             </CardContent>
           </Card>
         </Grid>
+
+        {isGitOpsManaged && (
+          <Grid item xs={12}>
+            <GitOpsCard deployment={app} installationName={installationName} />
+          </Grid>
+        )}
 
         <RevisionDetails
           lastAppliedRevision={lastAppliedRevision}

--- a/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
+++ b/plugins/gs/src/components/deployments/HelmReleaseDetails/HelmReleaseDetails.tsx
@@ -23,6 +23,7 @@ import {
   getHelmReleaseSourceKind,
   HelmRelease,
   HelmReleaseKind,
+  isHelmReleaseManagedByFlux,
 } from '@giantswarm/backstage-plugin-gs-common';
 import { useCatalogEntitiesForDeployments, useResource } from '../../hooks';
 import { formatSource, formatVersion } from '../../utils/helpers';
@@ -37,6 +38,7 @@ import {
 import { RevisionDetails } from '../RevisionDetails/RevisionDetails';
 import { HelmReleaseDetailsStatusConditions } from '../HelmReleaseDetailsStatusConditions';
 import { clusterDetailsRouteRef } from '../../../routes';
+import { GitOpsCard } from '../../GitOpsCard';
 
 type HelmReleaseDetailsProps = {
   installationName: string;
@@ -133,6 +135,8 @@ export const HelmReleaseDetails = ({
     <NotAvailable />
   );
 
+  const isGitOpsManaged = isHelmReleaseManagedByFlux(helmrelease);
+
   return (
     <div>
       {ingressHost || grafanaDashboard ? (
@@ -168,6 +172,15 @@ export const HelmReleaseDetails = ({
             </CardContent>
           </Card>
         </Grid>
+
+        {isGitOpsManaged && (
+          <Grid item xs={12}>
+            <GitOpsCard
+              deployment={helmrelease}
+              installationName={installationName}
+            />
+          </Grid>
+        )}
 
         <RevisionDetails
           lastAppliedRevision={lastAppliedRevision}

--- a/plugins/gs/src/components/hooks/index.ts
+++ b/plugins/gs/src/components/hooks/index.ts
@@ -6,6 +6,7 @@ export * from './useCurrentUser';
 export * from './useDeploymentStatusDetails';
 export * from './useDetailsPane';
 export * from './useFilters';
+export * from './useGitOpsSourceLink';
 export * from './useGrafanaDashboardLink';
 export * from './useHelmReleases';
 export * from './useInstallations';

--- a/plugins/gs/src/components/hooks/useClusterLinks.ts
+++ b/plugins/gs/src/components/hooks/useClusterLinks.ts
@@ -1,5 +1,4 @@
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { formatTemplateString } from '../utils/formatTemplateString';
 
 export const useGrafanaDashboardLink = (
   installationName: string,
@@ -63,55 +62,4 @@ export const useWebUILink = (
   }
 
   return `https://happa.${baseDomain}/organizations/${organizationName}/clusters/${clusterName}`;
-};
-
-export const useGitOpsSourceLink = ({
-  url,
-  revision,
-  path,
-}: {
-  url?: string;
-  revision?: string;
-  path?: string;
-}) => {
-  const config = useApi(configApiRef);
-  const gitopsRepositoriesConfig = config.getOptionalConfigArray(
-    `gs.gitopsRepositories`,
-  );
-
-  if (!url || !revision || !path || !gitopsRepositoriesConfig) {
-    return undefined;
-  }
-
-  const data = {
-    PATH: path,
-    REVISION: revision,
-  };
-
-  const gitopsRepositoryConfig = gitopsRepositoriesConfig.find(configItem => {
-    const pattern = configItem.getString('gitRepositoryUrlPattern');
-    const regexp = new RegExp(pattern);
-    return regexp.test(url);
-  });
-
-  if (gitopsRepositoryConfig) {
-    const pattern = gitopsRepositoryConfig.getString('gitRepositoryUrlPattern');
-    const targetUrl = gitopsRepositoryConfig.getString('targetUrl');
-
-    const regexp = new RegExp(pattern);
-    const matchResult = url.match(regexp);
-
-    if (matchResult && matchResult.groups) {
-      const formattedUrl = formatTemplateString(targetUrl, {
-        data: {
-          ...data,
-          ...matchResult.groups,
-        },
-      });
-
-      return new URL(formattedUrl).toString();
-    }
-  }
-
-  return undefined;
 };

--- a/plugins/gs/src/components/hooks/useGitOpsSourceLink.test.tsx
+++ b/plugins/gs/src/components/hooks/useGitOpsSourceLink.test.tsx
@@ -3,7 +3,7 @@ import { configApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider } from '@backstage/core-app-api';
 import { mockApis, TestApiRegistry } from '@backstage/test-utils';
 import { renderHook } from '@testing-library/react';
-import { useGitOpsSourceLink } from './useClusterLinks';
+import { useGitOpsSourceLink } from './useGitOpsSourceLink';
 
 describe('useGitOpsSourceLink', () => {
   describe('when configuration for Git repository URL patterns is not provided', () => {

--- a/plugins/gs/src/components/hooks/useGitOpsSourceLink.ts
+++ b/plugins/gs/src/components/hooks/useGitOpsSourceLink.ts
@@ -1,0 +1,53 @@
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { formatTemplateString } from '../utils/formatTemplateString';
+
+export const useGitOpsSourceLink = ({
+  url,
+  revision,
+  path,
+}: {
+  url?: string;
+  revision?: string;
+  path?: string;
+}) => {
+  const config = useApi(configApiRef);
+  const gitopsRepositoriesConfig = config.getOptionalConfigArray(
+    `gs.gitopsRepositories`,
+  );
+
+  if (!url || !revision || !path || !gitopsRepositoriesConfig) {
+    return undefined;
+  }
+
+  const data = {
+    PATH: path,
+    REVISION: revision,
+  };
+
+  const gitopsRepositoryConfig = gitopsRepositoriesConfig.find(configItem => {
+    const pattern = configItem.getString('gitRepositoryUrlPattern');
+    const regexp = new RegExp(pattern);
+    return regexp.test(url);
+  });
+
+  if (gitopsRepositoryConfig) {
+    const pattern = gitopsRepositoryConfig.getString('gitRepositoryUrlPattern');
+    const targetUrl = gitopsRepositoryConfig.getString('targetUrl');
+
+    const regexp = new RegExp(pattern);
+    const matchResult = url.match(regexp);
+
+    if (matchResult && matchResult.groups) {
+      const formattedUrl = formatTemplateString(targetUrl, {
+        data: {
+          ...data,
+          ...matchResult.groups,
+        },
+      });
+
+      return new URL(formattedUrl).toString();
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
### What does this PR do?

In this PR, GitOps indicator was added to the Deployment details pane. The same logic is used as on the Cluster details page.

### How does it look like?

<img width="552" alt="Screenshot 2025-04-10 at 10 29 05" src="https://github.com/user-attachments/assets/961ec1f4-7bd0-436c-924d-1723fa96fd6c" />

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/33231.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
