### PR TITLE
Fix mapping between deployments and catalog entities

### DIFF
--- a/.changeset/fifty-feet-remain.md
+++ b/.changeset/fifty-feet-remain.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Changed mapping between deployments and catalog entities to use all entities of kind "Component".

--- a/plugins/gs/src/components/hooks/useCatalogEntitiesForDeployments.ts
+++ b/plugins/gs/src/components/hooks/useCatalogEntitiesForDeployments.ts
@@ -9,7 +9,7 @@ export function useCatalogEntitiesForDeployments() {
   const catalogApi = useApi(catalogApiRef);
   const { value: catalogEntities } = useAsync(async () => {
     const entities = await catalogApi.getEntities({
-      filter: { kind: 'component', 'spec.type': 'service' },
+      filter: { kind: 'component' },
     });
 
     return entities.items;


### PR DESCRIPTION
### What does this PR do?

This PR fixes how deployments are being mapped to catalog entities. Previously we mapped only to entities of kind "Component" and type "service", now we use all entities of kind "Component".

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3941.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
