### PR TITLE
Show deployments entity content for all components with corresponding annotation

### DIFF
--- a/.changeset/lemon-loops-greet.md
+++ b/.changeset/lemon-loops-greet.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Fixed how deployments entity content is displayed.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -62,6 +62,7 @@ import {
   EntityGSKratixStatusCard,
   isEntityGSInstallationResource,
   isEntityGSKratixResource,
+  isEntityGSDeploymentsAvailable,
 } from '@giantswarm/backstage-plugin-gs';
 
 function isLinksAvailable(entity: Entity) {
@@ -177,13 +178,17 @@ const appcatalogEntityPage = (
   </EntityLayout>
 );
 
-const serviceEntityPage = (
+const componentEntityPage = (
   <EntityLayout>
     <EntityLayout.Route path="/" title="Overview">
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/deployments" title="Deployments">
+    <EntityLayout.Route
+      if={isEntityGSDeploymentsAvailable}
+      path="/deployments"
+      title="Deployments"
+    >
       <EntityGSDeploymentsContent />
     </EntityLayout.Route>
 
@@ -294,9 +299,6 @@ const defaultEntityPage = (
 
 const componentPage = (
   <EntitySwitch>
-    <EntitySwitch.Case if={isComponentType('service')}>
-      {serviceEntityPage}
-    </EntitySwitch.Case>
     <EntitySwitch.Case if={isComponentType('customer')}>
       {baseEntityPage}
     </EntitySwitch.Case>
@@ -307,7 +309,7 @@ const componentPage = (
       {appcatalogEntityPage}
     </EntitySwitch.Case>
 
-    <EntitySwitch.Case>{defaultEntityPage}</EntitySwitch.Case>
+    <EntitySwitch.Case>{componentEntityPage}</EntitySwitch.Case>
   </EntitySwitch>
 );
 


### PR DESCRIPTION
### What does this PR do?

This PR changes for what catalog entities we display "Deployments" content. Previously it was displayed for all entities of kind "Component" and type "service". Now it's being displayed for all entities of kind "Component" that have `giantswarm.io/deployment-names` annotation set.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3941.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
