### PR TITLE
Use username from email in Dex sign-in resolver

### DIFF
--- a/.changeset/new-rivers-tap.md
+++ b/.changeset/new-rivers-tap.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-auth-backend-module-gs': minor
+---
+
+Changed Dex sign-in resolver to use username from email as user reference when it's available.

--- a/plugins/auth-backend-module-gs/src/module.ts
+++ b/plugins/auth-backend-module-gs/src/module.ts
@@ -58,6 +58,18 @@ const customSignInResolver: SignInResolver<OidcAuthResult> = async (
     return signInWithGuestUser(ctx);
   }
 
+  if (userInfo.email) {
+    const username = userInfo.email.split('@')[0];
+    const userRef = `user:default/${username}`;
+
+    return ctx.issueToken({
+      claims: {
+        sub: userRef,
+        ent: [userRef],
+      },
+    });
+  }
+
   return signInWithGuestUser(ctx);
 };
 


### PR DESCRIPTION
### What does this PR do?

In this PR, the Dex sign-in resolver was updated. Previously, all customer users were signed in with a guest identity. Now, if an `email` is available in the user info received from Dex, it is used to form a unique user reference.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3963.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
