### PR TITLE
Fix cluster details page

### DIFF
--- a/.changeset/clever-nails-hear.md
+++ b/.changeset/clever-nails-hear.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fixed a bug where the cluster details page may be displayed as blank.

--- a/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
+++ b/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
@@ -94,7 +94,7 @@ export const ClusterLayout = ({ children }: ClusterLayoutProps) => {
             },
           ];
         }),
-    [cluster],
+    [cluster, isLoading, isGSUser],
   );
 
   return (
@@ -104,7 +104,11 @@ export const ClusterLayout = ({ children }: ClusterLayoutProps) => {
         subtitle={cluster ? getClusterDescription(cluster) : undefined}
         type="resource - kubernetes cluster"
       />
-      {isLoading && <Progress />}
+      {isLoading && (
+        <Content>
+          <Progress />
+        </Content>
+      )}
       {cluster && <RoutedTabs routes={routes} />}
       {error && !cluster && clusterApp ? (
         <Content>


### PR DESCRIPTION
### What does this PR do?

Currently, there is a bug where the cluster details page may be displayed as blank. This PR fixes the issue.

<img width="1535" alt="Screenshot 2025-04-16 at 10 25 19" src="https://github.com/user-attachments/assets/f343f6be-096f-473a-b1e2-b3267f87613b" />

### Any background context you can provide?

Closes https://github.com/giantswarm/giantswarm/issues/33283.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
