### PR TITLE
Ignore techdocs warning

### DIFF
--- a/.changeset/happy-poets-spend.md
+++ b/.changeset/happy-poets-spend.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Added a rule to Sentry configuration to ignore TechDocs warnings.

--- a/packages/backend/src/rootLogger.ts
+++ b/packages/backend/src/rootLogger.ts
@@ -25,6 +25,9 @@ export const rootLogger = createServiceFactory({
             tracesSampleRate: logConfig.getNumber('tracesSampleRate'),
           },
           level: 'warn',
+          ignoreErrors: [
+            /^Index for techdocs was not created: indexer received 0 documents$/,
+          ],
         }),
       );
     }


### PR DESCRIPTION
### What does this PR do?

We do not generate tech docs in advance, and because of that we receive a lot of warning in Sentry like this:
```
Index for techdocs was not created: indexer received 0 documents
```
In this PR, I added a rule to ignore such warnings to decrease our errors budget usage in Sentry.

<img width="993" alt="Screenshot 2025-04-17 at 10 29 58" src="https://github.com/user-attachments/assets/b8619413-9b79-4477-91d1-cf21c208cd39" />

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
