### PR TITLE
Remove @kubernetes/client-node package

### DIFF
--- a/.changeset/four-olives-crash.md
+++ b/.changeset/four-olives-crash.md
@@ -1,0 +1,11 @@
+---
+'@giantswarm/backstage-plugin-scaffolder-backend-module-gs': minor
+'app': minor
+'backend': minor
+'@giantswarm/backstage-plugin-auth-backend-module-gs': minor
+'@giantswarm/backstage-plugin-gs': minor
+'@giantswarm/backstage-plugin-gs-common': minor
+'@giantswarm/backstage-plugin-techdocs-backend-module-gs': minor
+---
+
+Updated dependencies.

--- a/plugins/scaffolder-backend-module-gs/package.json
+++ b/plugins/scaffolder-backend-module-gs/package.json
@@ -28,7 +28,6 @@
     "@backstage/config": "backstage:^",
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-scaffolder-node": "backstage:^",
-    "@kubernetes/client-node": "^0.22.3",
     "js-yaml": "^4.1.0",
     "zod": "^3.24.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9373,7 +9373,6 @@ __metadata:
     "@backstage/config": "backstage:^"
     "@backstage/errors": "backstage:^"
     "@backstage/plugin-scaffolder-node": "backstage:^"
-    "@kubernetes/client-node": "npm:^0.22.3"
     "@types/js-yaml": "npm:^4"
     js-yaml: "npm:^4.1.0"
     zod: "npm:^3.24.2"


### PR DESCRIPTION
### What does this PR do?

`@kubernetes/client-node` package was removed in this PR as it's not being used anymore.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
