### PR TITLE
Remove check for policy/v1/PodDisruptionBudget

### DIFF
--- a/helm/backstage/templates/pdb.yaml
+++ b/helm/backstage/templates/pdb.yaml
@@ -1,5 +1,3 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
----
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -12,4 +10,3 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.name }}
-{{- end }}

--- a/helm/backstage/templates/pdb.yaml
+++ b/helm/backstage/templates/pdb.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "labels.backstage" $ | nindent 4 }}
 spec:
   maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: {{ .Values.name }}


### PR DESCRIPTION
This PR simplifies the helm chart by removing a check that is no longer relevant. It was relevant when we had clusters with Kubernetes versions < 1.21