### PR TITLE
Improve ReleasePicker scaffolder component

### DIFF
--- a/.changeset/sweet-coats-own.md
+++ b/.changeset/sweet-coats-own.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs-common': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Improved ReleasePicker scaffolder field to allow to filter releases by provider.

--- a/plugins/gs-common/src/api/utils/releases.ts
+++ b/plugins/gs-common/src/api/utils/releases.ts
@@ -21,6 +21,10 @@ export function getReleaseGVK(apiVersion?: string) {
   return gvk;
 }
 
+export const getReleaseName = (release: Release) => {
+  return release.metadata.name;
+};
+
 export const getReleaseVersion = (release: Release) => {
   return normalizeReleaseVersion(release.metadata.name);
 };
@@ -67,8 +71,17 @@ export function isPreRelease(version: string): boolean {
   return preReleaseRegexp.test(version);
 }
 
+export const RELEASE_VERSION_PREFIXES: Record<string, string> = {
+  capa: 'aws-',
+  capz: 'azure-',
+  capv: 'vsphere-',
+};
+
 export function normalizeReleaseVersion(version: string): string {
-  const normalizedVersion = version.replace(/^(aws-|azure-|vsphere-)/, '');
+  const versionPrefixRegExp = new RegExp(
+    `^(${Object.values(RELEASE_VERSION_PREFIXES).join('|')})`,
+  );
+  const normalizedVersion = version.replace(versionPrefixRegExp, '');
   if (normalizedVersion.toLowerCase().startsWith('v')) {
     return normalizedVersion.substring(1);
   }

--- a/plugins/gs/src/components/scaffolder/ReleasePicker/schema.ts
+++ b/plugins/gs/src/components/scaffolder/ReleasePicker/schema.ts
@@ -4,6 +4,11 @@ import { makeFieldSchemaFromZod } from '@backstage/plugin-scaffolder';
 export const ReleasePickerFieldSchema = makeFieldSchemaFromZod(
   z.string(),
   z.object({
+    provider: z.string().optional().describe('The name of the provider to use'),
+    providerField: z
+      .string()
+      .optional()
+      .describe('The name of the field to use for the provider'),
     installationName: z
       .string()
       .optional()


### PR DESCRIPTION
### What does this PR do?

In this PR, `ReleasePicker` scaffolder component was improved to allow to filter releases by provider. It is possible that the list of releases fetched from a MC contains releases for different providers (e.g. `aws-30.0.0` and `vsphere-31.0.0` in one list). If no `provider` or `providerField` option is set for the picker, all the releases will be displayed to a user. If `provider` or `provider` field option is set, then the list will be filtered. For example:
```
    properties:
        releaseVersion:
          title: Release
          type: string
          description: The release version of the workload cluster.
          ui:field: GSReleasePicker
          ui:options:
            installationNameField: installation.installationName
            providerField: provider        # or provider: capz
```

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
