### PR TITLE
Check status of connected installations

### DIFF
--- a/.changeset/afraid-ducks-shop.md
+++ b/.changeset/afraid-ducks-shop.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Added logic to check availability status of connected installations.

--- a/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
+++ b/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
@@ -66,9 +66,7 @@ export class DiscoveryApiClient implements DiscoveryApi {
     return DiscoveryApiClient.installationsWithBaseUrlOverrides;
   }
 
-  private static getBaseUrlOverrides(
-    configApi: ConfigApi,
-  ): Record<string, string> {
+  static getBaseUrlOverrides(configApi: ConfigApi): Record<string, string> {
     const baseUrlOverrides: Record<string, string> = {};
     const installationsConfig = configApi.getOptionalConfig('gs.installations');
     if (installationsConfig) {

--- a/plugins/gs/src/components/InstallationsPicker/InstallationsPicker.tsx
+++ b/plugins/gs/src/components/InstallationsPicker/InstallationsPicker.tsx
@@ -9,12 +9,14 @@ import isEqual from 'lodash/isEqual';
 type InstallationsPickerProps = {
   installations: string[];
   selectedInstallations: string[];
+  disabledInstallations: string[];
   onChange?: (selectedInstallations: string[]) => void;
 };
 
 export const InstallationsPicker = ({
   installations,
   selectedInstallations,
+  disabledInstallations,
   onChange,
 }: InstallationsPickerProps) => {
   const [value, setValue] = useState(selectedInstallations);
@@ -59,6 +61,7 @@ export const InstallationsPicker = ({
         label="Installations"
         items={items}
         selected={selectedInstallations}
+        disabledItems={disabledInstallations}
         onChange={handleChange}
       />
     </Box>

--- a/plugins/gs/src/components/InstallationsSelector/InstallationsSelector.tsx
+++ b/plugins/gs/src/components/InstallationsSelector/InstallationsSelector.tsx
@@ -53,6 +53,8 @@ const InstallationPreview = ({
 type InstallationsSelectorProps = {
   installations: string[];
   selectedInstallations: string[];
+  activeInstallations: string[];
+  disabledInstallations?: string[];
   installationsStatuses: InstallationStatus[];
   multiple?: boolean;
   onChange?: (selectedInstallations: string[]) => void;
@@ -61,6 +63,8 @@ type InstallationsSelectorProps = {
 export const InstallationsSelector = ({
   installations,
   selectedInstallations,
+  activeInstallations,
+  disabledInstallations,
   installationsStatuses,
   multiple,
   onChange,
@@ -79,15 +83,15 @@ export const InstallationsSelector = ({
 
   const renderValue = useCallback(
     () =>
-      selectedInstallations.map((item, idx) => (
+      activeInstallations.map((item, idx) => (
         <InstallationPreview
           key={item}
           installationName={item}
           installationsStatuses={installationsStatuses}
-          isLastItem={idx === selectedInstallations.length - 1}
+          isLastItem={idx === activeInstallations.length - 1}
         />
       )),
-    [installationsStatuses, selectedInstallations],
+    [installationsStatuses, activeInstallations],
   );
 
   return multiple ? (
@@ -95,6 +99,7 @@ export const InstallationsSelector = ({
       label="Installations"
       items={installations}
       selectedItems={selectedInstallations}
+      disabledItems={disabledInstallations}
       renderValue={renderValue}
       onChange={handleChange}
     />
@@ -103,6 +108,7 @@ export const InstallationsSelector = ({
       label="Installation"
       items={installations}
       selectedItem={selectedInstallations[0]}
+      disabledItems={disabledInstallations}
       renderValue={renderValue}
       onChange={handleChange}
     />

--- a/plugins/gs/src/components/InstallationsWrapper/InstallationsWrapper.tsx
+++ b/plugins/gs/src/components/InstallationsWrapper/InstallationsWrapper.tsx
@@ -18,8 +18,13 @@ type InstallationsWrapperProps = {
 export const InstallationsWrapper = ({
   children,
 }: InstallationsWrapperProps) => {
-  const { installations, selectedInstallations, setSelectedInstallations } =
-    useInstallations();
+  const {
+    installations,
+    selectedInstallations,
+    activeInstallations,
+    disabledInstallations,
+    setSelectedInstallations,
+  } = useInstallations();
 
   const { installationsStatuses } = useInstallationsStatuses();
 
@@ -35,6 +40,8 @@ export const InstallationsWrapper = ({
         <InstallationsSelector
           installations={installations}
           selectedInstallations={selectedInstallations}
+          activeInstallations={activeInstallations}
+          disabledInstallations={disabledInstallations}
           installationsStatuses={installationsStatuses}
           multiple
           onChange={handleSelectedInstallationsChange}

--- a/plugins/gs/src/components/UI/MultipleSelect/MultipleSelect.tsx
+++ b/plugins/gs/src/components/UI/MultipleSelect/MultipleSelect.tsx
@@ -89,6 +89,7 @@ export type MultipleSelectProps = {
   onChange?: (arg: SelectedItems) => void;
   triggerReset?: boolean;
   disabled?: boolean;
+  disabledItems?: string[];
 };
 
 export function MultipleSelect(props: MultipleSelectProps) {
@@ -99,6 +100,7 @@ export function MultipleSelect(props: MultipleSelectProps) {
     onChange,
     triggerReset,
     disabled = false,
+    disabledItems,
   } = props;
   const classes = useStyles();
   const formControlLabelClasses = useFormControlLabelStyles();
@@ -147,6 +149,7 @@ export function MultipleSelect(props: MultipleSelectProps) {
                 />
               }
               label={item.label}
+              disabled={disabledItems?.includes(item.value)}
             />
           ))}
         </FormGroup>

--- a/plugins/gs/src/components/UI/MultipleSelectFormField/MultipleSelectFormField.tsx
+++ b/plugins/gs/src/components/UI/MultipleSelectFormField/MultipleSelectFormField.tsx
@@ -30,6 +30,7 @@ type MultipleSelectFormFieldProps = {
   error?: boolean;
   items: string[];
   selectedItems: string[];
+  disabledItems?: string[];
   renderValue?: (value: string[]) => ReactNode;
   onChange: (selectedItems: string[]) => void;
 };
@@ -43,6 +44,7 @@ export const MultipleSelectFormField = ({
   items,
   helperText,
   selectedItems,
+  disabledItems,
   renderValue,
   onChange,
 }: MultipleSelectFormFieldProps) => {
@@ -87,7 +89,11 @@ export const MultipleSelectFormField = ({
         MenuProps={MenuProps}
       >
         {items.map(item => (
-          <MenuItem key={item} value={item}>
+          <MenuItem
+            key={item}
+            value={item}
+            disabled={disabledItems?.includes(item)}
+          >
             <Checkbox checked={localSelectedItems.indexOf(item) > -1} />
             <ListItemText primary={item} />
           </MenuItem>

--- a/plugins/gs/src/components/UI/RadioFormField/RadioFormField.tsx
+++ b/plugins/gs/src/components/UI/RadioFormField/RadioFormField.tsx
@@ -17,6 +17,7 @@ type RadioFormFieldProps = {
   error?: boolean;
   items: string[];
   itemLabels?: string[];
+  disabledItems?: string[];
   selectedItem: string;
   renderValue?: (value: string) => React.ReactNode;
   onChange?: (selectedItem: string) => void;
@@ -30,6 +31,7 @@ export const RadioFormField = ({
   error,
   items,
   itemLabels,
+  disabledItems,
   helperText,
   selectedItem,
   onChange,
@@ -65,6 +67,7 @@ export const RadioFormField = ({
             value={item}
             control={<Radio color="primary" />}
             label={itemLabels && itemLabels[index] ? itemLabels[index] : item}
+            disabled={disabledItems?.includes(item)}
           />
         ))}
       </RadioGroup>

--- a/plugins/gs/src/components/UI/SelectFormField/SelectFormField.tsx
+++ b/plugins/gs/src/components/UI/SelectFormField/SelectFormField.tsx
@@ -29,6 +29,7 @@ type SelectFormFieldProps = {
   error?: boolean;
   items: string[];
   selectedItem: string;
+  disabledItems?: string[];
   renderValue?: (value: string) => React.ReactNode;
   onChange?: (selectedItem: string) => void;
 };
@@ -42,6 +43,7 @@ export const SelectFormField = ({
   items,
   helperText,
   selectedItem,
+  disabledItems,
   renderValue,
   onChange,
 }: SelectFormFieldProps) => {
@@ -77,7 +79,11 @@ export const SelectFormField = ({
         MenuProps={MenuProps}
       >
         {items.map(item => (
-          <MenuItem key={item} value={item}>
+          <MenuItem
+            key={item}
+            value={item}
+            disabled={disabledItems?.includes(item)}
+          >
             <ListItemText primary={item} />
           </MenuItem>
         ))}

--- a/plugins/gs/src/components/clusters/ClustersPage/DefaultFilters.tsx
+++ b/plugins/gs/src/components/clusters/ClustersPage/DefaultFilters.tsx
@@ -11,8 +11,12 @@ import { ProviderPicker } from './filters/ProviderPicker';
 import { LabelPicker } from './filters/LabelPicker';
 
 export const DefaultFilters = () => {
-  const { installations, selectedInstallations, setSelectedInstallations } =
-    useInstallations();
+  const {
+    installations,
+    selectedInstallations,
+    disabledInstallations,
+    setSelectedInstallations,
+  } = useInstallations();
 
   const handleSelectedInstallationsChange = (selectedItems: string[]) => {
     setSelectedInstallations(selectedItems);
@@ -23,6 +27,7 @@ export const DefaultFilters = () => {
       <InstallationsPicker
         installations={installations}
         selectedInstallations={selectedInstallations}
+        disabledInstallations={disabledInstallations}
         onChange={handleSelectedInstallationsChange}
       />
       <ProviderPicker />

--- a/plugins/gs/src/components/deployments/DeploymentsPage/DefaultFilters.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentsPage/DefaultFilters.tsx
@@ -10,8 +10,12 @@ import { LabelPicker } from './filters/LabelPicker';
 import { AppPicker } from './filters/AppPicker';
 
 export const DefaultFilters = () => {
-  const { installations, selectedInstallations, setSelectedInstallations } =
-    useInstallations();
+  const {
+    installations,
+    selectedInstallations,
+    disabledInstallations,
+    setSelectedInstallations,
+  } = useInstallations();
 
   const handleSelectedInstallationsChange = (selectedItems: string[]) => {
     setSelectedInstallations(selectedItems);
@@ -22,6 +26,7 @@ export const DefaultFilters = () => {
       <InstallationsPicker
         installations={installations}
         selectedInstallations={selectedInstallations}
+        disabledInstallations={disabledInstallations}
         onChange={handleSelectedInstallationsChange}
       />
       <AppPicker />

--- a/plugins/gs/src/components/hooks/useInstallations.ts
+++ b/plugins/gs/src/components/hooks/useInstallations.ts
@@ -1,6 +1,9 @@
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { useEffect } from 'react';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { useQueries } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
 import useLocalStorageState from 'use-local-storage-state';
+import { DiscoveryApiClient } from '../../apis/discovery/DiscoveryApiClient';
+import { getInstallationsQueriesInfo } from './utils/queries';
 
 export type InstallationInfo = {
   name: string;
@@ -10,10 +13,53 @@ export type InstallationInfo = {
   region?: string;
 };
 
+const STATUS_CHECK_TIMEOUT = 3000;
+const STATUS_CHECK_INTERVAL = 10000;
+
+const useDisabledInstallations = (installations: string[]) => {
+  const fetchApi = useApi(fetchApiRef);
+  const configApi = useApi(configApiRef);
+  const baseUrlOverrides = DiscoveryApiClient.getBaseUrlOverrides(configApi);
+  const installationsWithBaseUrlOverrides = Object.keys(baseUrlOverrides);
+
+  const queries = useQueries({
+    queries: installationsWithBaseUrlOverrides.map(installationName => {
+      const baseUrlOverride = baseUrlOverrides[installationName];
+      return {
+        queryKey: [installationName, 'status'],
+        queryFn: async () => {
+          const statusEndpoint = `${baseUrlOverride}/.backstage/health/v1/readiness`;
+          return fetchApi.fetch(statusEndpoint, {
+            signal: AbortSignal.timeout(STATUS_CHECK_TIMEOUT),
+          });
+        },
+        retry: false,
+        refetchInterval: STATUS_CHECK_INTERVAL,
+      };
+    }),
+  });
+
+  const { queries: installationsQueries } = getInstallationsQueriesInfo(
+    installationsWithBaseUrlOverrides,
+    queries,
+  );
+
+  return useMemo(() => {
+    return installations.filter(installation => {
+      const installationQuery = installationsQueries.find(
+        ({ installationName }) => installationName === installation,
+      );
+
+      return installationQuery && !installationQuery.query.isSuccess;
+    });
+  }, [installations, installationsQueries]);
+};
+
 export const useInstallations = (): {
   installations: string[];
   installationsInfo: InstallationInfo[];
   activeInstallations: string[];
+  disabledInstallations: string[];
   selectedInstallations: string[];
   setSelectedInstallations: (items: string[]) => void;
 } => {
@@ -58,13 +104,18 @@ export const useInstallations = (): {
     }
   }, [selectedInstallations, savedInstallations, setSavedInstallations]);
 
-  const activeInstallations =
-    selectedInstallations.length > 0 ? selectedInstallations : installations;
+  const disabledInstallations = useDisabledInstallations(installations);
+  const activeInstallations = (
+    selectedInstallations.length > 0 ? selectedInstallations : installations
+  ).filter(
+    installationName => !disabledInstallations.includes(installationName),
+  );
 
   return {
     installations,
     installationsInfo,
     activeInstallations,
+    disabledInstallations,
     selectedInstallations,
     setSelectedInstallations,
   };

--- a/plugins/gs/src/components/hooks/utils/queries.ts
+++ b/plugins/gs/src/components/hooks/utils/queries.ts
@@ -42,7 +42,10 @@ export const getInstallationsQueriesInfo = <T>(
 };
 
 export function getInstallationsStatuses(queryCache: QueryCache) {
-  const queries = queryCache.findAll({ type: 'active' });
+  const queries = queryCache.findAll({
+    type: 'active',
+    predicate: query => !query.queryKey.includes('status'),
+  });
   const queriesByInstallationName = new Map<string, Query[]>();
   queries.forEach(item => {
     const key = item.queryKey[0] ? (item.queryKey[0] as string) : null;

--- a/plugins/gs/src/components/scaffolder/ClusterPicker/ClusterPicker.tsx
+++ b/plugins/gs/src/components/scaffolder/ClusterPicker/ClusterPicker.tsx
@@ -111,11 +111,15 @@ const ClusterPickerField = ({
   onInstallationSelect,
   onClusterSelect,
 }: ClusterPickerFieldProps) => {
-  const { installations } = useInstallations();
+  const { installations, disabledInstallations } = useInstallations();
   const { installationsStatuses } = useInstallationsStatuses();
 
   const [selectedInstallations, setSelectedInstallations] = useState<string[]>(
     installationNameValue ? [installationNameValue] : [],
+  );
+
+  const activeInstallations = selectedInstallations.filter(
+    installationName => !disabledInstallations.includes(installationName),
   );
 
   const installationsErrors = installationsStatuses.some(
@@ -135,6 +139,8 @@ const ClusterPickerField = ({
         <InstallationsSelector
           installations={installations}
           selectedInstallations={selectedInstallations}
+          activeInstallations={activeInstallations}
+          disabledInstallations={disabledInstallations}
           installationsStatuses={installationsStatuses}
           multiple={false}
           onChange={handleInstallationSelect}

--- a/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
+++ b/plugins/gs/src/components/scaffolder/DeploymentDetailsPicker/DeploymentDetailsPicker.tsx
@@ -50,7 +50,7 @@ const DeploymentDetailsPickerField = ({
   onWCProviderConfigSelect,
   onMCProviderConfigSelect,
 }: DeploymentDetailsPickerFieldProps) => {
-  const { installations } = useInstallations();
+  const { installations, disabledInstallations } = useInstallations();
   const { installationsStatuses } = useInstallationsStatuses();
 
   const initiallySelectedInstallations =
@@ -59,6 +59,10 @@ const DeploymentDetailsPickerField = ({
   const selectedInstallations = installationNameValue
     ? [installationNameValue]
     : initiallySelectedInstallations;
+
+  const activeInstallations = selectedInstallations.filter(
+    installationName => !disabledInstallations.includes(installationName),
+  );
 
   useEffect(() => {
     if (!installationNameValue && installations.length === 1) {
@@ -82,6 +86,8 @@ const DeploymentDetailsPickerField = ({
         <InstallationsSelector
           installations={installations}
           selectedInstallations={selectedInstallations}
+          activeInstallations={activeInstallations}
+          disabledInstallations={disabledInstallations}
           installationsStatuses={installationsStatuses}
           onChange={handleInstallationSelect}
         />

--- a/plugins/gs/src/components/scaffolder/InstallationPicker/InstallationPicker.tsx
+++ b/plugins/gs/src/components/scaffolder/InstallationPicker/InstallationPicker.tsx
@@ -3,6 +3,8 @@ import { useInstallations, InstallationInfo } from '../../hooks';
 import { Grid } from '@material-ui/core';
 import { InstallationPickerProps } from './schema';
 import { RadioFormField } from '../../UI/RadioFormField';
+import { GSContext } from '../../GSContext';
+import { ErrorsProvider } from '../../Errors';
 
 type InstallationFieldProps = {
   id?: string;
@@ -31,7 +33,7 @@ const InstallationPickerField = ({
   installationNameValue,
   onInstallationSelect,
 }: InstallationFieldProps) => {
-  const { installationsInfo } = useInstallations();
+  const { disabledInstallations, installationsInfo } = useInstallations();
   const { installations, installationLabels } = useMemo(() => {
     let filteredInstallations = installationsInfo;
     const labels: string[] = [];
@@ -74,9 +76,12 @@ const InstallationPickerField = ({
     };
   }, [allowedProviders, allowedPipelines, installationsInfo]);
 
+  const activeInstallations = installations.filter(
+    installation => !disabledInstallations.includes(installation),
+  );
   const [selectedInstallation, setSelectedInstallation] = useState<
     string | undefined
-  >(installationNameValue ?? installations[0]);
+  >(installationNameValue ?? activeInstallations[0]);
 
   useEffect(() => {
     if (selectedInstallation && !installations.includes(selectedInstallation)) {
@@ -109,6 +114,7 @@ const InstallationPickerField = ({
           error={error}
           items={installations}
           itemLabels={installationLabels}
+          disabledItems={disabledInstallations}
           selectedItem={selectedInstallation ?? ''}
           onChange={handleChange}
         />
@@ -174,18 +180,22 @@ export const InstallationPicker = ({
   );
 
   return (
-    <InstallationPickerField
-      id={idSchema?.$id}
-      label={title}
-      helperText={description}
-      required={required}
-      error={rawErrors?.length > 0 && !formData}
-      installationNameValue={installationName}
-      onInstallationSelect={handleInstallationSelect}
-      requestUserCredentials={Boolean(requestUserCredentials)}
-      secretsKey={requestUserCredentials?.secretsKey}
-      allowedProviders={allowedProviders}
-      allowedPipelines={allowedPipelines}
-    />
+    <GSContext>
+      <ErrorsProvider>
+        <InstallationPickerField
+          id={idSchema?.$id}
+          label={title}
+          helperText={description}
+          required={required}
+          error={rawErrors?.length > 0 && !formData}
+          installationNameValue={installationName}
+          onInstallationSelect={handleInstallationSelect}
+          requestUserCredentials={Boolean(requestUserCredentials)}
+          secretsKey={requestUserCredentials?.secretsKey}
+          allowedProviders={allowedProviders}
+          allowedPipelines={allowedPipelines}
+        />
+      </ErrorsProvider>
+    </GSContext>
   );
 };


### PR DESCRIPTION
### What does this PR do?

This PR introduces a mechanism to periodically check the health of installations that rely on separate Backstage backend instances. If an installation's backend is unreachable (e.g., due to VPN or proxy requirements), the installation will be temporarily disabled in the UI. This prevents users from attempting to interact with unavailable installations. Status is being checked in the background every 10 seconds.

### How does it look like?

<img width="1296" alt="Screenshot 2025-05-22 at 11 30 51" src="https://github.com/user-attachments/assets/1ea839e5-660f-4820-a628-fc18a32e1794" />



- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
