### PR TITLE
Change InstallationsPicker to use Autocomplete component

### DIFF
--- a/.changeset/olive-humans-type.md
+++ b/.changeset/olive-humans-type.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Changed InstallationsPicker to use Autocomplete component.

--- a/plugins/gs/src/components/InstallationsPicker/InstallationsPicker.tsx
+++ b/plugins/gs/src/components/InstallationsPicker/InstallationsPicker.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Box } from '@material-ui/core';
-import { MultipleSelect } from '../UI/MultipleSelect';
 import useDebounce from 'react-use/esm/useDebounce';
 import { useLocation } from 'react-router-dom';
 import qs from 'qs';
 import isEqual from 'lodash/isEqual';
+import { Autocomplete } from '../UI';
 
 type InstallationsPickerProps = {
   installations: string[];
@@ -56,14 +55,12 @@ export const InstallationsPicker = ({
   }));
 
   return (
-    <Box pb={1} pt={1}>
-      <MultipleSelect
-        label="Installations"
-        items={items}
-        selected={selectedInstallations}
-        disabledItems={disabledInstallations}
-        onChange={handleChange}
-      />
-    </Box>
+    <Autocomplete
+      label="Installations"
+      items={items}
+      selectedValues={selectedInstallations}
+      disabledItems={disabledInstallations}
+      onChange={handleChange}
+    />
   );
 };

--- a/plugins/gs/src/components/InstallationsWrapper/InstallationsWrapper.tsx
+++ b/plugins/gs/src/components/InstallationsWrapper/InstallationsWrapper.tsx
@@ -1,13 +1,10 @@
 import { Grid, makeStyles } from '@material-ui/core';
-import { useInstallations, useInstallationsStatuses } from '../hooks';
-import { InstallationsSelector } from '../InstallationsSelector';
+import { useInstallations } from '../hooks';
+import { InstallationsPicker } from '../InstallationsPicker';
 
 export const useStyles = makeStyles({
   fullWidth: {
     maxWidth: '100%',
-  },
-  installationsSelectorContainer: {
-    maxWidth: 350,
   },
 });
 
@@ -21,12 +18,9 @@ export const InstallationsWrapper = ({
   const {
     installations,
     selectedInstallations,
-    activeInstallations,
     disabledInstallations,
     setSelectedInstallations,
   } = useInstallations();
-
-  const { installationsStatuses } = useInstallationsStatuses();
 
   const classes = useStyles();
 
@@ -36,14 +30,11 @@ export const InstallationsWrapper = ({
 
   return (
     <Grid container spacing={3} direction="column">
-      <Grid item className={classes.installationsSelectorContainer}>
-        <InstallationsSelector
+      <Grid item>
+        <InstallationsPicker
           installations={installations}
           selectedInstallations={selectedInstallations}
-          activeInstallations={activeInstallations}
           disabledInstallations={disabledInstallations}
-          installationsStatuses={installationsStatuses}
-          multiple
           onChange={handleSelectedInstallationsChange}
         />
       </Grid>

--- a/plugins/gs/src/components/UI/Autocomplete/Autocomplete.tsx
+++ b/plugins/gs/src/components/UI/Autocomplete/Autocomplete.tsx
@@ -20,6 +20,7 @@ import AutocompleteComponent, {
 } from '@material-ui/lab/Autocomplete';
 import { merge } from 'lodash';
 import classNames from 'classnames';
+import { Chip } from '@material-ui/core';
 
 const useStyles = makeStyles(
   theme => ({
@@ -186,6 +187,7 @@ type AutocompleteProps = {
   }[];
   label: string;
   selectedValues?: string[];
+  disabledItems?: string[];
   onChange?: (selected: string[]) => void;
   renderLabel?: (label: string) => ReactNode;
   disabled?: boolean;
@@ -195,6 +197,7 @@ export const Autocomplete = ({
   items,
   label,
   selectedValues,
+  disabledItems,
   onChange,
   renderLabel,
   disabled = false,
@@ -226,6 +229,9 @@ export const Autocomplete = ({
       name={`${label.toLowerCase().replace(/\s/g, '-')}-autocomplete`}
       options={items}
       getOptionLabel={option => option.label}
+      getOptionDisabled={option =>
+        disabledItems?.includes(option.value) ?? false
+      }
       value={value}
       disabled={disabled}
       onChange={(_event, selectedItems) => {
@@ -241,6 +247,16 @@ export const Autocomplete = ({
           value={option.value}
         />
       )}
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
+          <Chip
+            label={option.label}
+            size="small"
+            {...getTagProps({ index })}
+            disabled={disabledItems?.includes(option.value) ?? false}
+          />
+        ))
+      }
     />
   );
 };

--- a/plugins/gs/src/components/clusters/ClustersPage/DefaultFilters.tsx
+++ b/plugins/gs/src/components/clusters/ClustersPage/DefaultFilters.tsx
@@ -9,6 +9,7 @@ import { AppVersionPicker } from './filters/AppVersionPicker';
 import { LocationPicker } from './filters/LocationPicker';
 import { ProviderPicker } from './filters/ProviderPicker';
 import { LabelPicker } from './filters/LabelPicker';
+import { Box } from '@material-ui/core';
 
 export const DefaultFilters = () => {
   const {
@@ -24,12 +25,14 @@ export const DefaultFilters = () => {
 
   return (
     <>
-      <InstallationsPicker
-        installations={installations}
-        selectedInstallations={selectedInstallations}
-        disabledInstallations={disabledInstallations}
-        onChange={handleSelectedInstallationsChange}
-      />
+      <Box pb={1} pt={1}>
+        <InstallationsPicker
+          installations={installations}
+          selectedInstallations={selectedInstallations}
+          disabledInstallations={disabledInstallations}
+          onChange={handleSelectedInstallationsChange}
+        />
+      </Box>
       <ProviderPicker />
       <LocationPicker />
       <KindPicker />

--- a/plugins/gs/src/components/deployments/DeploymentsPage/DefaultFilters.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentsPage/DefaultFilters.tsx
@@ -8,6 +8,7 @@ import { NamespacePicker } from './filters/NamespacePicker';
 import { StatusPicker } from './filters/StatusPicker';
 import { LabelPicker } from './filters/LabelPicker';
 import { AppPicker } from './filters/AppPicker';
+import { Box } from '@material-ui/core';
 
 export const DefaultFilters = () => {
   const {
@@ -23,12 +24,14 @@ export const DefaultFilters = () => {
 
   return (
     <>
-      <InstallationsPicker
-        installations={installations}
-        selectedInstallations={selectedInstallations}
-        disabledInstallations={disabledInstallations}
-        onChange={handleSelectedInstallationsChange}
-      />
+      <Box pb={1} pt={1}>
+        <InstallationsPicker
+          installations={installations}
+          selectedInstallations={selectedInstallations}
+          disabledInstallations={disabledInstallations}
+          onChange={handleSelectedInstallationsChange}
+        />
+      </Box>
       <AppPicker />
       <VersionPicker />
       <TargetClusterPicker />


### PR DESCRIPTION
### What does this PR do?

In this PR, `InstallationsPicker` was changed to use `Autocomplete` component instead of `MultipleSelect`.

### How does it look like?
Deployments table view:
<img width="1433" alt="Screenshot 2025-05-22 at 17 28 28" src="https://github.com/user-attachments/assets/1803b2e7-090c-47f0-8a9e-18b97654ba8d" />

Catalog item deployments view:
<img width="1421" alt="Screenshot 2025-05-22 at 17 27 54" src="https://github.com/user-attachments/assets/4fde0812-68e4-48f2-97e7-424f3fcd1952" />


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
