### PR TITLE
Improve installations status check

### DIFF
--- a/.changeset/petite-geese-start.md
+++ b/.changeset/petite-geese-start.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Improved installations status check.


### PR DESCRIPTION
In this PR, the installation status check logic has been improved. The updated logic now considers loading states only when selected installations might be disabled. If the selected installations are always enabled, the data is displayed even before the status check is complete.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
