### PR TITLE
Hide provider filter when there is only one provider available

### DIFF
--- a/.changeset/grumpy-seas-sin.md
+++ b/.changeset/grumpy-seas-sin.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Hide provider filter when there is only one provider available.

--- a/plugins/gs/src/components/clusters/ClustersPage/filters/ProviderPicker/ProviderPicker.tsx
+++ b/plugins/gs/src/components/clusters/ClustersPage/filters/ProviderPicker/ProviderPicker.tsx
@@ -4,6 +4,7 @@ import { ClusterData, useClustersData } from '../../../ClustersDataProvider';
 import { ProviderFilter } from '../filters';
 import { MultiplePicker, MultiplePickerOption } from '../../../../UI';
 import { formatClusterProvider } from '../../../utils';
+import { useInstallations } from '../../../../hooks';
 
 const TITLE = 'Provider';
 
@@ -19,6 +20,7 @@ function formatOption(item: ClusterData): MultiplePickerOption | undefined {
 }
 
 export const ProviderPicker = () => {
+  const { installationsInfo } = useInstallations();
   const {
     data,
     filters,
@@ -41,6 +43,13 @@ export const ProviderPicker = () => {
       provider: new ProviderFilter(selectedValues),
     });
   };
+
+  const availableProviders = new Set(
+    installationsInfo.flatMap(installation => installation.providers),
+  );
+  if (availableProviders.size <= 1) {
+    return null;
+  }
 
   return (
     <MultiplePicker


### PR DESCRIPTION
### What does this PR do?

When there is only one provider available, there is no need to display the Provider filter. In this PR, the use case where only one provider is available is being handled.

The list of available providers is determined using the `gs.installations.[INSTALLATION].providers` configuration. An alternative approach would be to calculate the list based on the fetched resources. However, this would require handling the state when the resource fetching is still in progress—either by initially hiding the filter and then showing it, or vice versa. in both cases there would be additional flickering in the UI.

### How does it look like?

Only one provider available:
<img width="1433" alt="Screenshot 2025-06-02 at 10 53 38" src="https://github.com/user-attachments/assets/9f9573a9-ca00-41d7-8fcd-ba3266811691" />

Several providers available:
<img width="1433" alt="Screenshot 2025-06-02 at 10 53 15" src="https://github.com/user-attachments/assets/5e12e7f3-7e97-4ebb-ab02-648bbff673ed" />

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/33537.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
