### PR TITLE
Fix source reference namespace for Kustomizations

### DIFF
--- a/.changeset/slimy-chairs-grin.md
+++ b/.changeset/slimy-chairs-grin.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs-common': patch
+---
+
+Fixed source reference namespace for Kustomization objects.

--- a/plugins/gs-common/src/api/utils/kustomizations.ts
+++ b/plugins/gs-common/src/api/utils/kustomizations.ts
@@ -44,6 +44,6 @@ export function getKustomizationSourceRef(kustomization: Kustomization) {
     apiVersion,
     kind,
     name,
-    namespace: namespace ?? 'default',
+    namespace: namespace ?? kustomization.metadata.namespace,
   };
 }


### PR DESCRIPTION
### What does this PR do?

Fallback to Kustomization's namespace when it's missing in the source reference.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
