### PR TITLE
Rollback db roles and env variables

### DIFF
--- a/helm/backstage/templates/database.yaml
+++ b/helm/backstage/templates/database.yaml
@@ -51,21 +51,6 @@ spec:
       cnpg.io/cluster: {{ .Chart.Name }}-{{ .Values.database.clusterNameSuffix }}
   podMetricsEndpoints:
   - port: metrics
-{{- range .Values.database.roles }}
----
-# managed role secret
-apiVersion: v1
-data:
-  username: {{ .name }}
-  password: {{ .password }}
-kind: Secret
-metadata:
-  name: {{ $.Chart.Name }}-{{ $.Values.database.clusterNameSuffix }}-{{ .name | b64dec }}
-  namespace: {{ $.Release.Namespace }}
-  labels:
-    cnpg.io/reload: "true"
-type: kubernetes.io/basic-auth
-{{- end }}
 ---
 # Postgresql cluster
 apiVersion: postgresql.cnpg.io/v1
@@ -80,16 +65,4 @@ spec:
   instances: 2
   storage:
     size: {{ .Values.database.storageSize }}
-  {{- if .Values.database.roles }}
-  managed:
-    roles:
-    {{- range .Values.database.roles }}
-    - name: {{ .name | b64dec | quote }}
-      ensure: present
-      login: true
-      superuser: false
-      passwordSecret:
-        name: {{ $.Chart.Name }}-{{ $.Values.database.clusterNameSuffix }}-{{ .name | b64dec }}
-    {{- end }}
-  {{- end }}
 {{- end }}

--- a/helm/backstage/templates/secrets.yaml
+++ b/helm/backstage/templates/secrets.yaml
@@ -29,18 +29,6 @@ data:
   {{- if .Values.grafana.apiToken }}
   GRAFANA_TOKEN: {{ .Values.grafana.apiToken }}
   {{- end }}
-  {{- if .Values.postgresql.host }}
-  POSTGRES_HOST: {{ .Values.postgresql.host }}
-  {{- end }}
-  {{- if .Values.postgresql.port }}
-  POSTGRES_PORT: {{ .Values.postgresql.port }}
-  {{- end }}
-  {{- if .Values.postgresql.user }}
-  POSTGRES_USER: {{ .Values.postgresql.user }}
-  {{- end }}
-  {{- if .Values.postgresql.password }}
-  POSTGRES_PASSWORD: {{ .Values.postgresql.password }}
-  {{- end }}
   {{- if .Values.quay.apiToken }}
   QUAY_TOKEN  : {{ .Values.quay.apiToken }}
   {{- end }}

--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -156,21 +156,6 @@
           "title": "Image repository",
           "description": "PostgreSQL image to use, without registry. Assumes the registry configured in .image.registry.domain."
         },
-        "roles": {
-          "type": "array",
-          "title": "Managed roles",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "password": {
-                "type": "string"
-              }
-            }
-          }
-        },
         "storageSize": {
           "type": "string",
           "title": "Storage size",
@@ -271,23 +256,6 @@
     },
     "port": {
       "type": "integer"
-    },
-    "postgresql": {
-      "type": "object",
-      "properties": {
-        "host": {
-          "type": "string"
-        },
-        "port": {
-          "type": "string"
-        },
-        "user": {
-          "type": "string"
-        },
-        "password": {
-          "type": "string"
-        }
-      }
     },
     "quay": {
       "type": "object",

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -14,12 +14,6 @@ image:
 
 port: 7007
 
-postgresql:
-  host: ''
-  port: ''
-  user: ''
-  password: ''
-
 registry:
   domain: gsoci.azurecr.io
 
@@ -136,7 +130,6 @@ database:
   clusterNameSuffix: pgsql
   # -- Repostory and tag to use for the PostgreSQL cluster. Registry will be set to .Values.registry.domain.
   image: giantswarm/postgresql-cnpg:17.4@sha256:458058e3db40bb83898d096e6d78c07d28a084731dd9758937b42a3943ce26d0
-  roles: []
   storageSize: 1Gi
 
 ingress:


### PR DESCRIPTION
### What does this PR do?

Roll back https://github.com/giantswarm/backstage/pull/821, https://github.com/giantswarm/backstage/pull/822 and https://github.com/giantswarm/backstage/pull/824.

These changes were introduced to enable sharing the database between Backstage deployments, which is no longer planned.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3991.