### PR TITLE
Fix Grafana alerts link

### DIFF
--- a/.changeset/vast-bats-kiss.md
+++ b/.changeset/vast-bats-kiss.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fixed alerts dashboard link.

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/ClusterToolsCard.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterToolsCard/ClusterToolsCard.tsx
@@ -15,7 +15,7 @@ const defaultLinks = [
   {
     label: 'Alerts',
     icon: 'NotificationsNone',
-    url: 'https://grafana.${{BASE_DOMAIN}}/alerting',
+    url: 'https://grafana.${{BASE_DOMAIN}}/alerting?orgId=2',
   },
   {
     label: 'Web UI',


### PR DESCRIPTION
### What does this PR do?

Grafana alerts link was fixed with the correct `orgId` parameter.

### Any background context you can provide?

Towards https://gigantic.slack.com/archives/C02GDJJ68Q1/p1750921951444199

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
