### PR TITLE
Fix catalog routing issue

### DIFF
--- a/.changeset/giant-signs-smile.md
+++ b/.changeset/giant-signs-smile.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Fixed catalog routing.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -111,9 +111,6 @@ const routes = (
     <Route path="/" element={<HomepageCompositionRoot />}>
       <HomePage />
     </Route>
-    <Route path="/catalog" element={<CatalogIndexPage />}>
-      <GSCustomCatalogPage />
-    </Route>
     <Route
       path="/installations"
       element={
@@ -123,6 +120,9 @@ const routes = (
       }
     >
       <GSInstallationsPage />
+    </Route>
+    <Route path="/catalog" element={<CatalogIndexPage />}>
+      <GSCustomCatalogPage />
     </Route>
     <Route
       path="/catalog/:namespace/:kind/:name"


### PR DESCRIPTION
### What does this PR do?

Quick fix for routing issue in catalog:

<img width="1524" alt="Screenshot 2025-06-26 at 17 08 13" src="https://github.com/user-attachments/assets/6e7253cd-424c-4cf8-a0d7-a272edf49980" />

Needs further investigation why catalog link URLs depend on the order of `<Route />` components.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/32821.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
