### PR TITLE
Delete openid-client dependency

### DIFF
--- a/plugins/gs/package.json
+++ b/plugins/gs/package.json
@@ -58,7 +58,6 @@
     "date-fns-tz": "^3.0.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
-    "openid-client": "^6.1.3",
     "qs": "^6.14.0",
     "react-use": "^17.2.4",
     "semver": "^7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9310,7 +9310,6 @@ __metadata:
     jwt-decode: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
     msw: "npm:^2.0.0"
-    openid-client: "npm:^6.1.3"
     qs: "npm:^6.14.0"
     react-use: "npm:^17.2.4"
     semver: "npm:^7.6.0"


### PR DESCRIPTION
### What does this PR do?

`openid-client` dependency has been deleted as not being used.

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
