### PR TITLE
Fix chart rendering with extraEnvVars set

### DIFF
--- a/.changeset/new-doors-build.md
+++ b/.changeset/new-doors-build.md
@@ -1,0 +1,6 @@
+---
+'backend': patch
+'backend-headless-service': patch
+---
+
+Fixed helm chart for extraEnvVars

--- a/helm/backstage/ci/ci-values-case1.yaml
+++ b/helm/backstage/ci/ci-values-case1.yaml
@@ -47,6 +47,9 @@ backstage:
   command: ['node', 'packages/backend']
   args: []
   extraAppConfig: []
+  extraEnvVars:
+    - name: VAR_NAME
+      value: value of the variable
 resources:
   verticalPodAutoscaler:
     enabled: true

--- a/helm/backstage/ci/ci-values-case1.yaml
+++ b/helm/backstage/ci/ci-values-case1.yaml
@@ -48,8 +48,10 @@ backstage:
   args: []
   extraAppConfig: []
   extraEnvVars:
-    - name: VAR_NAME
-      value: value of the variable
+    - name: GLOBAL_AGENT_HTTP_PROXY
+      value: http://12.34.56.78:3128
+    - name: GLOBAL_AGENT_NO_PROXY
+      value: 127.0.0.1,*.example.com
 resources:
   verticalPodAutoscaler:
     enabled: true

--- a/helm/backstage/templates/deployments.yaml
+++ b/helm/backstage/templates/deployments.yaml
@@ -108,9 +108,9 @@ spec:
                   name: {{ .Chart.Name }}-{{ .Values.database.postgresql.clusterNameSuffix }}-app
                   key: password
             {{- end }}
-          {{- if .Values.backstage.extraEnvVars }}
-          {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraEnvVars "context" $) | nindent 10 }}
-          {{- end }}
+            {{- if .Values.backstage.extraEnvVars }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.backstage.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- if .Values.githubAppCredentials }}
             - name: github-app-credentials


### PR DESCRIPTION
Fixes a problem where with `.backstage.extraEnvVars` the chart would not render