### PR TITLE
Fix catalog routing issue

### DIFF
--- a/.changeset/mean-impalas-yell.md
+++ b/.changeset/mean-impalas-yell.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Fixed catalog routing issue.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -111,16 +111,6 @@ const routes = (
     <Route path="/" element={<HomepageCompositionRoot />}>
       <HomePage />
     </Route>
-    <Route
-      path="/installations"
-      element={
-        <GSFeatureEnabled feature="installationsPage">
-          <CatalogIndexPage />
-        </GSFeatureEnabled>
-      }
-    >
-      <GSInstallationsPage />
-    </Route>
     <Route path="/catalog" element={<CatalogIndexPage />}>
       <GSCustomCatalogPage />
     </Route>
@@ -135,7 +125,6 @@ const routes = (
       path="/docs/:namespace/:kind/:name/*"
       element={<TechDocsReaderPage />}
     />
-
     <Route
       path="/create"
       element={
@@ -188,6 +177,14 @@ const routes = (
       element={
         <GSFeatureEnabled feature="deploymentsPage">
           <GSDeploymentsPage />
+        </GSFeatureEnabled>
+      }
+    />
+    <Route
+      path="/installations"
+      element={
+        <GSFeatureEnabled feature="installationsPage">
+          <GSInstallationsPage />
         </GSFeatureEnabled>
       }
     />


### PR DESCRIPTION
### What does this PR do?

Fix for routing issue in catalog. `<CatalogIndexPage />` wrapper around installations page component was not needed and caused the catalog route reference to be overriden.

<img width="1524" alt="Screenshot 2025-06-26 at 17 08 13" src="https://github.com/user-attachments/assets/686ee701-8b9b-4bbf-bc7c-be7e034f6ffa" />

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/32821.

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
