### PR TITLE
Fix ReleasePicker scaffolder field

### DIFF
--- a/.changeset/wise-adults-brake.md
+++ b/.changeset/wise-adults-brake.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fixed ReleasePicker scaffolder field to correctly format release version.

--- a/plugins/gs/src/components/scaffolder/ReleasePicker/ReleasePicker.tsx
+++ b/plugins/gs/src/components/scaffolder/ReleasePicker/ReleasePicker.tsx
@@ -119,7 +119,7 @@ export const ReleasePicker = ({
         return;
       }
 
-      onChange(getReleaseName(selectedRelease));
+      onChange(getReleaseVersion(selectedRelease));
     },
     [onChange],
   );


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in the "Test cluster" template. Release picker component uses release name that includes provider prefix instead of release version which causes cluster creation to fail.

### How does it look like?

Before:
<img width="1465" alt="Screenshot 2025-07-03 at 17 20 37" src="https://github.com/user-attachments/assets/d43e9437-8e35-4d41-a0b8-9f0d08a8096e" />

After:
<img width="1465" alt="Screenshot 2025-07-03 at 17 21 32" src="https://github.com/user-attachments/assets/afdb91cf-48b3-4562-982a-724b956bdb96" />


### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
