### PR TITLE
Handle resource status when dependency is not ready

### DIFF
--- a/.changeset/two-horses-win.md
+++ b/.changeset/two-horses-win.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-flux': patch
+---
+
+Handle Flux resource status when dependency is not ready.

--- a/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceCard.tsx
+++ b/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceCard.tsx
@@ -106,14 +106,16 @@ export const ResourceCard = ({
   highlighted,
   error,
 }: ResourceCardProps) => {
-  const { readyStatus, isReconciling, isSuspended } =
+  const { readyStatus, isDependencyNotReady, isReconciling, isSuspended } =
     useResourceStatus(resource);
+
+  const inactive = isSuspended || isDependencyNotReady;
 
   return (
     <ResourceWrapper
       highlighted={highlighted}
       error={readyStatus === 'False' || error}
-      inactive={isSuspended}
+      inactive={inactive}
     >
       <Box display="flex" flexDirection="column" flexGrow={1} p={2} pt={1}>
         <ResourceInfo
@@ -122,6 +124,7 @@ export const ResourceCard = ({
           namespace={namespace}
           targetCluster={targetCluster}
           readyStatus={readyStatus}
+          isDependencyNotReady={isDependencyNotReady}
           isReconciling={isReconciling}
           isSuspended={isSuspended}
           resource={resource}

--- a/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceInfo/ResourceInfo.tsx
+++ b/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceInfo/ResourceInfo.tsx
@@ -22,6 +22,7 @@ type ResourceInfoProps = {
     | OCIRepository
     | HelmRepository;
   readyStatus: 'True' | 'False' | 'Unknown';
+  isDependencyNotReady: boolean;
   isReconciling: boolean;
   isSuspended: boolean;
   nowrap?: boolean;
@@ -34,10 +35,13 @@ export const ResourceInfo = ({
   targetCluster,
   resource,
   readyStatus,
+  isDependencyNotReady,
   isReconciling,
   isSuspended,
   nowrap = false,
 }: ResourceInfoProps) => {
+  const inactive = isSuspended || isDependencyNotReady;
+
   return (
     <Box>
       <Box
@@ -46,11 +50,12 @@ export const ResourceInfo = ({
         justifyContent="space-between"
         mb={0.5}
       >
-        <ResourceHeading name={name} inactive={isSuspended} nowrap={nowrap} />
+        <ResourceHeading name={name} inactive={inactive} nowrap={nowrap} />
 
         {resource && (
           <ResourceStatus
             readyStatus={readyStatus}
+            isDependencyNotReady={isDependencyNotReady}
             isReconciling={isReconciling}
             isSuspended={isSuspended}
           />

--- a/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceStatus/ResourceStatus.tsx
+++ b/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceStatus/ResourceStatus.tsx
@@ -9,12 +9,14 @@ const useStyles = makeStyles(() => ({
 
 type ResourceStatusProps = {
   readyStatus: 'True' | 'False' | 'Unknown';
+  isDependencyNotReady: boolean;
   isReconciling: boolean;
   isSuspended: boolean;
 };
 
 export const ResourceStatus = ({
   readyStatus,
+  isDependencyNotReady,
   isReconciling,
   isSuspended,
 }: ResourceStatusProps) => {
@@ -25,8 +27,11 @@ export const ResourceStatus = ({
   if (readyStatus === 'True') {
     elText = 'Ready';
     elStatus = 'ok';
-  } else if (readyStatus === 'False') {
+  } else if (readyStatus === 'False' && !isDependencyNotReady) {
     elText = 'Not ready';
+    elStatus = 'error';
+  } else if (readyStatus === 'False' && isDependencyNotReady) {
+    elText = 'Not ready (dep)';
     elStatus = 'error';
   }
   if (isReconciling) {

--- a/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceStatus/useResourceStatus.ts
+++ b/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceStatus/useResourceStatus.ts
@@ -35,6 +35,7 @@ export function useResourceStatus(
 
   return {
     readyStatus,
+    isDependencyNotReady: readyCondition?.reason === 'DependencyNotReady',
     isReconciling: Boolean(resource?.isReconciling()),
     isSuspended: Boolean(resource?.isSuspended()),
   };

--- a/plugins/flux/src/components/FluxOverview/ResourceNode/ResourceNode.tsx
+++ b/plugins/flux/src/components/FluxOverview/ResourceNode/ResourceNode.tsx
@@ -68,15 +68,17 @@ export const ResourceNode = ({
   onExpand,
 }: ResourceNodeProps) => {
   const classes = useStyles();
-  const { readyStatus, isReconciling, isSuspended } =
+  const { readyStatus, isDependencyNotReady, isReconciling, isSuspended } =
     useResourceStatus(resource);
+
+  const inactive = isSuspended || isDependencyNotReady;
 
   return (
     <ResourceWrapper
       className={classes.node}
       highlighted={highlighted}
       error={readyStatus === 'False' || error}
-      inactive={isSuspended}
+      inactive={inactive}
     >
       <Box display="flex">
         {expandable ? (
@@ -108,6 +110,7 @@ export const ResourceNode = ({
             namespace={namespace}
             targetCluster={targetCluster}
             readyStatus={readyStatus}
+            isDependencyNotReady={isDependencyNotReady}
             isReconciling={isReconciling}
             isSuspended={isSuspended}
             resource={resource}


### PR DESCRIPTION
### What does this PR do?

Changes in this PR, visually differentiate resources in "Not ready" status and resources that are "Not ready" because their dependencies are not ready.

### How does it look like?

<img width="1458" height="831" alt="Screenshot 2025-08-12 at 12 18 34" src="https://github.com/user-attachments/assets/114379dc-8f10-41fb-83d4-207431747eff" />

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/4051.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
