### PR TITLE
Fix Flux resource status update

### DIFF
--- a/.changeset/free-books-trade.md
+++ b/.changeset/free-books-trade.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-flux': patch
+---
+
+Fixed Flux resource status transition.

--- a/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceStatus/useResourceStatus.ts
+++ b/plugins/flux/src/components/FluxOverview/ResourceCard/ResourceStatus/useResourceStatus.ts
@@ -20,22 +20,42 @@ export function useResourceStatus(
   const [readyStatus, setReadyStatus] = useState(
     readyCondition?.status || 'Unknown',
   );
+  const [isDependencyNotReady, setIsDependencyNotReady] = useState(
+    readyCondition?.reason === 'DependencyNotReady',
+  );
 
   useEffect(() => {
+    // Skip state update if no status or reconciliation is in progress
     if (
       !readyCondition?.status ||
-      readyCondition.status === readyStatus ||
-      readyCondition.status === 'Unknown'
+      (readyCondition.status === 'Unknown' &&
+        readyCondition.reason === 'Progressing')
+    ) {
+      return;
+    }
+
+    const newReadyStatus = readyCondition.status;
+    const newIsDependencyNotReady =
+      readyCondition.reason === 'DependencyNotReady';
+    if (
+      newReadyStatus === readyStatus &&
+      newIsDependencyNotReady === isDependencyNotReady
     ) {
       return;
     }
 
     setReadyStatus(readyCondition.status);
-  }, [readyCondition?.status, readyStatus]);
+    setIsDependencyNotReady(readyCondition.reason === 'DependencyNotReady');
+  }, [
+    isDependencyNotReady,
+    readyCondition?.reason,
+    readyCondition?.status,
+    readyStatus,
+  ]);
 
   return {
     readyStatus,
-    isDependencyNotReady: readyCondition?.reason === 'DependencyNotReady',
+    isDependencyNotReady,
     isReconciling: Boolean(resource?.isReconciling()),
     isSuspended: Boolean(resource?.isSuspended()),
   };


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in Flux resource status display when reconciliation is in progress. Currently, transition from "Not Ready (dep)", to "Ready" goes this way:

`Not Ready (dep)` -> `Not Ready, reconciling` -> `Ready`

This PR changes the display flow to:
`Not Ready (dep)` -> `Not Ready (dep), reconciling` -> `Ready`

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/4051.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
