### PR TITLE
Reorder sections in the Flux resource details panel

### DIFF
--- a/.changeset/tricky-lamps-relate.md
+++ b/.changeset/tricky-lamps-relate.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-flux-react': patch
+---
+
+Reordered sections in the Flux resource details panel.

--- a/plugins/flux-react/src/components/FluxOverview/HelmReleaseDetails/HelmReleaseDetails.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/HelmReleaseDetails/HelmReleaseDetails.tsx
@@ -88,17 +88,17 @@ export const HelmReleaseDetails = ({
 
   return (
     <Box>
-      {source ? (
-        <Section heading="Source">
-          <ResourceCard
-            cluster={source.cluster}
-            kind={source.getKind()}
-            name={source.getName()}
-            namespace={source.getNamespace()}
-            resource={source}
-          />
-        </Section>
-      ) : null}
+      <Section heading="This HelmRelease">
+        <ResourceCard
+          cluster={helmRelease.cluster}
+          kind={helmRelease.getKind()}
+          name={helmRelease.getName()}
+          namespace={helmRelease.getNamespace()}
+          targetCluster={findTargetClusterName(helmRelease)}
+          resource={helmRelease}
+          highlighted
+        />
+      </Section>
 
       {parentKustomization ? (
         <Section heading="Kustomization">
@@ -113,17 +113,17 @@ export const HelmReleaseDetails = ({
         </Section>
       ) : null}
 
-      <Section heading="This HelmRelease">
-        <ResourceCard
-          cluster={helmRelease.cluster}
-          kind={helmRelease.getKind()}
-          name={helmRelease.getName()}
-          namespace={helmRelease.getNamespace()}
-          targetCluster={findTargetClusterName(helmRelease)}
-          resource={helmRelease}
-          highlighted
-        />
-      </Section>
+      {source ? (
+        <Section heading="Source">
+          <ResourceCard
+            cluster={source.cluster}
+            kind={source.getKind()}
+            name={source.getName()}
+            namespace={source.getNamespace()}
+            resource={source}
+          />
+        </Section>
+      ) : null}
 
       {dependencies ? (
         <Section heading="Dependencies">

--- a/plugins/flux-react/src/components/FluxOverview/KustomizationDetails/KustomizationDetails.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/KustomizationDetails/KustomizationDetails.tsx
@@ -77,17 +77,17 @@ export const KustomizationDetails = ({
 
   return (
     <Box>
-      {source ? (
-        <Section heading="Source">
-          <ResourceCard
-            cluster={source.cluster}
-            kind={source.getKind()}
-            name={source.getName()}
-            namespace={source.getNamespace()}
-            resource={source}
-          />
-        </Section>
-      ) : null}
+      <Section heading="This Kustomization">
+        <ResourceCard
+          cluster={kustomization.cluster}
+          kind={kustomization.getKind()}
+          name={kustomization.getName()}
+          namespace={kustomization.getNamespace()}
+          targetCluster={findTargetClusterName(kustomization)}
+          resource={kustomization}
+          highlighted
+        />
+      </Section>
 
       {parentKustomization ? (
         <Section heading="Parent Kustomization">
@@ -102,17 +102,18 @@ export const KustomizationDetails = ({
         </Section>
       ) : null}
 
-      <Section heading="This Kustomization">
-        <ResourceCard
-          cluster={kustomization.cluster}
-          kind={kustomization.getKind()}
-          name={kustomization.getName()}
-          namespace={kustomization.getNamespace()}
-          targetCluster={findTargetClusterName(kustomization)}
-          resource={kustomization}
-          highlighted
-        />
-      </Section>
+      {source ? (
+        <Section heading="Source">
+          <ResourceCard
+            cluster={source.cluster}
+            kind={source.getKind()}
+            name={source.getName()}
+            namespace={source.getNamespace()}
+            resource={source}
+          />
+        </Section>
+      ) : null}
+
       {dependencies ? (
         <Section heading="Dependencies">
           <Grid container spacing={3}>


### PR DESCRIPTION
### What does this PR do?

In this PR, the order of sections in the Flux UI details panel has been changed:

For HelmRelease:
- This HelmRelease
- Kustomization
- Source
- Dependencies

For Kustomization:
- This Kustomization
- Parent Kustomization
- Source
- Dependencies

### How does it look like?

<img width="1052" height="853" alt="Screenshot 2025-08-19 at 16 45 36" src="https://github.com/user-attachments/assets/17bf9071-bc76-4be3-8138-5dfdda9f3de1" />

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/4051.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
