### PR TITLE
Fix cluster selectors

### DIFF
--- a/.changeset/clean-hotels-spend.md
+++ b/.changeset/clean-hotels-spend.md
@@ -1,0 +1,7 @@
+---
+'@giantswarm/backstage-plugin-kubernetes-react': patch
+'@giantswarm/backstage-plugin-flux': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fixed Cluster selectors when only one cluster is configured.

--- a/plugins/flux/src/components/FluxPage/filters/ClusterPicker/ClusterPicker.tsx
+++ b/plugins/flux/src/components/FluxPage/filters/ClusterPicker/ClusterPicker.tsx
@@ -17,12 +17,8 @@ export const ClusterPicker = () => {
     [setActiveCluster],
   );
 
-  if (clusters.length <= 1) {
-    return null;
-  }
-
   return (
-    <Box pb={1} pt={1}>
+    <Box py={clusters.length > 1 ? 1 : undefined}>
       <SingleClusterSelector
         onActiveClusterChange={handleActiveClusterChange}
       />

--- a/plugins/gs/src/components/flux/CustomFluxPage/filters/ClusterPicker/ClusterPicker.tsx
+++ b/plugins/gs/src/components/flux/CustomFluxPage/filters/ClusterPicker/ClusterPicker.tsx
@@ -20,12 +20,8 @@ export const ClusterPicker = () => {
     [setActiveCluster],
   );
 
-  if (clusters.length <= 1) {
-    return null;
-  }
-
   return (
-    <Box pb={1} pt={1}>
+    <Box py={clusters.length > 1 ? 1 : undefined}>
       <SingleClusterSelector
         clusters={clusters}
         disabledClusters={disabledInstallations}

--- a/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.tsx
+++ b/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.tsx
@@ -18,12 +18,8 @@ export const InstallationPicker = ({
   const { disabledInstallations, isLoading: isLoadingDisabledInstallations } =
     useDisabledInstallations();
 
-  if (clusters.length <= 1) {
-    return null;
-  }
-
   return (
-    <Box pb={1} pt={1}>
+    <Box py={clusters.length > 1 ? 1 : undefined}>
       <MultipleClustersSelector
         label="Installations"
         persistToURL={persistToURL}

--- a/plugins/kubernetes-react/src/components/MultipleClustersSelector/MultipleClustersSelector.tsx
+++ b/plugins/kubernetes-react/src/components/MultipleClustersSelector/MultipleClustersSelector.tsx
@@ -109,21 +109,19 @@ export const MultipleClustersSelector = ({
   };
 
   const activeClusters = useMemo(() => {
-    const allSelectedClusters =
+    const selected =
       clusters.length === 1 || selectedClusters.length === 0
         ? clusters
         : selectedClusters;
 
     if (
-      allSelectedClusters.some(cluster => disabledClusters.includes(cluster)) &&
+      selected.some(cluster => disabledClusters.includes(cluster)) &&
       isLoadingDisabledClusters
     ) {
       return []; // Some selected clusters are potentially disabled, waiting for status check to complete
     }
 
-    return allSelectedClusters.filter(
-      cluster => !disabledClusters.includes(cluster),
-    );
+    return selected.filter(cluster => !disabledClusters.includes(cluster));
   }, [clusters, disabledClusters, isLoadingDisabledClusters, selectedClusters]);
 
   useEffect(() => {
@@ -136,6 +134,10 @@ export const MultipleClustersSelector = ({
     label: cluster,
     value: cluster,
   }));
+
+  if (clusters.length <= 1) {
+    return null;
+  }
 
   return (
     <Autocomplete


### PR DESCRIPTION
### What does this PR do?

Cluster selectors have been incorrectly handling the situation when only one cluster is configured. This PR fixes the issue.


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
