### PR TITLE
Fix entity deployments cluster selector

### DIFF
--- a/.changeset/bright-symbols-live.md
+++ b/.changeset/bright-symbols-live.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fixed catalog entity deployments cluster selector.

--- a/plugins/gs/src/components/deployments/EntityDeploymentsContent/EntityDeploymentsContent.tsx
+++ b/plugins/gs/src/components/deployments/EntityDeploymentsContent/EntityDeploymentsContent.tsx
@@ -4,7 +4,7 @@ import {
   SupportButton,
 } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { Grid } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import {
   getDeploymentNamesFromEntity,
   getIngressHostFromEntity,
@@ -30,22 +30,18 @@ const DeploymentsContent = () => {
   const { clusters } = useClustersInfo();
 
   return (
-    <Grid container spacing={3}>
-      {clusters.length > 1 ? (
-        <Grid item xs={12}>
-          <InstallationPicker />
-        </Grid>
-      ) : null}
-      <Grid item xs={12}>
-        <DeploymentsTable
-          baseRouteRef={entityDeploymentsRouteRef}
-          sourceLocation={sourceLocation}
-          grafanaDashboard={grafanaDashboard}
-          ingressHost={ingressHost}
-          context="catalog-entity"
-        />
-      </Grid>
-    </Grid>
+    <>
+      <Box mb={clusters.length > 1 ? 2 : undefined}>
+        <InstallationPicker />
+      </Box>
+      <DeploymentsTable
+        baseRouteRef={entityDeploymentsRouteRef}
+        sourceLocation={sourceLocation}
+        grafanaDashboard={grafanaDashboard}
+        ingressHost={ingressHost}
+        context="catalog-entity"
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
### What does this PR do?

Cluster selector on the entity deployments page has been working incorrectly when only one cluster is configured. This PR fixes the issue.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
