### PR TITLE
Fix version in the Flux status widget

### DIFF
--- a/.changeset/spotty-windows-glow.md
+++ b/.changeset/spotty-windows-glow.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-flux-react': patch
+---
+
+Fixed version in the Flux status widget.


### PR DESCRIPTION
### What does this PR do?

The Flux status widget has been fixed to display the Flux version. The version is retrieved from the `app.kubernetes.io/version` label of a Flux controller Deployment resource, first from `metadata.labels`, and if missing, then from `spec.template.metadata.labels`.

### How does it look like?

<img width="721" height="377" alt="Screenshot 2025-09-04 at 10 15 45" src="https://github.com/user-attachments/assets/3f6194b2-42f1-4678-921a-1c6cbb2694a6" />

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/4051

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
