### PR TITLE
Fix Flux resources refetching

### DIFF
--- a/.changeset/stale-signs-jog.md
+++ b/.changeset/stale-signs-jog.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-flux-react': patch
+---
+
+Fixed Flux resources refetching when some clusters authentication is canceled by a user.

--- a/plugins/flux-react/src/hooks/useFluxResources/useFluxResources.ts
+++ b/plugins/flux-react/src/hooks/useFluxResources/useFluxResources.ts
@@ -156,14 +156,33 @@ export function useFluxResources(clusters: string | string[] | null) {
   useEffect(() => {
     const reconciling = kustomizations.some(k => k.isReconciling());
 
-    const newInterval = reconciling
+    let newInterval = reconciling
       ? RECONCILING_INTERVAL
       : NON_RECONCILING_INTERVAL;
+
+    const rejectedErrors = [
+      ...kustomizationsErrors,
+      ...helmReleasesErrors,
+      ...gitRepositoriesErrors,
+      ...helmRepositoriesErrors,
+      ...ociRepositoriesErrors,
+    ].some(({ error }) => error.name === 'RejectedError');
+    if (rejectedErrors) {
+      newInterval = 0;
+    }
 
     if (newInterval !== refetchInterval) {
       setRefetchInterval(newInterval);
     }
-  }, [kustomizations, refetchInterval]);
+  }, [
+    kustomizations,
+    refetchInterval,
+    kustomizationsErrors,
+    helmReleasesErrors,
+    gitRepositoriesErrors,
+    helmRepositoriesErrors,
+    ociRepositoriesErrors,
+  ]);
 
   return useMemo(() => {
     return {


### PR DESCRIPTION
### What does this PR do?

In the Flux overview UI, we constantly refetch resources to display the actual status. If a selected cluster requires authentication, a popup appears where a user can either sign in or reject authentication. In case the user rejects authentication, we display an error and data from other clusters. But when the next refetch happens, the auth popup appears again. This problem requires a thoughtful solution; in this PR, I simply stop refetching resources when there is a rejected authentication attempt.

### How does it look like?
<img width="1451" height="624" alt="Screenshot 2025-10-07 at 14 43 00" src="https://github.com/user-attachments/assets/3ea9f518-4e34-442c-8fee-adc64cccf31a" />


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
