### PR TITLE
Fix version truncation on deployment details page

### DIFF
--- a/.changeset/noble-nebula-shine.md
+++ b/.changeset/noble-nebula-shine.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+'@giantswarm/backstage-plugin-ui-react': patch
+---
+
+Fix version truncation not working on deployment details page.

--- a/plugins/gs/src/components/UI/AboutField/AboutField.tsx
+++ b/plugins/gs/src/components/UI/AboutField/AboutField.tsx
@@ -1,9 +1,13 @@
 import { useElementFilter } from '@backstage/core-plugin-api';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
 import { ReactNode } from 'react';
 
 const useStyles = makeStyles(theme => ({
+  root: {
+    minWidth: 0,
+  },
   value: {
     fontWeight: 'bold',
     overflow: 'hidden',
@@ -45,7 +49,7 @@ export function AboutField(props: AboutFieldProps) {
     );
 
   return (
-    <div className={className}>
+    <div className={classNames(classes.root, className)}>
       <Typography variant="h2" className={classes.label}>
         {label}
       </Typography>

--- a/plugins/gs/src/components/UI/Version/Version.tsx
+++ b/plugins/gs/src/components/UI/Version/Version.tsx
@@ -208,6 +208,7 @@ export const Version = ({
                 ? getCommitURL(sourceLocation, commitHash)
                 : getReleaseNotesURL(sourceLocation, versionLabel)
             }
+            display={truncate ? 'flex' : 'inline-flex'}
           >
             {versionComponent}
           </ExternalLink>

--- a/plugins/ui-react/src/components/ExternalLink/ExternalLink.tsx
+++ b/plugins/ui-react/src/components/ExternalLink/ExternalLink.tsx
@@ -9,12 +9,23 @@ const StyledLaunchOutlinedIcon = styled(LaunchOutlinedIcon)(({ theme }) => ({
 type ExternalLinkProps = {
   href: string;
   children: React.ReactNode;
+  /**
+   * CSS display value for the inner flex container.
+   * Use 'flex' (block-level) when the link needs to participate in a width
+   * constraint chain (e.g. inside a flex/grid item for text truncation).
+   * @default 'inline-flex'
+   */
+  display?: 'flex' | 'inline-flex';
 };
 
-export const ExternalLink = ({ href, children }: ExternalLinkProps) => {
+export const ExternalLink = ({
+  href,
+  children,
+  display = 'inline-flex',
+}: ExternalLinkProps) => {
   return (
     <Link href={href} target="_blank" rel="noopener noreferrer">
-      <Box display="inline-flex" alignItems="center">
+      <Box display={display} alignItems="center">
         {children}
         <StyledLaunchOutlinedIcon />
       </Box>


### PR DESCRIPTION
### What does this PR do?

Fixes version string truncation (middle ellipsis) not working on the deployment details page Revision card, while it worked correctly in the deployments table.

### How does it look like?

Before:
<img width="710" height="133" alt="Screenshot 2026-04-10 at 12 56 43" src="https://github.com/user-attachments/assets/1fb4d07d-dbd8-4a36-9934-4f26f928a1ce" />

After:
<img width="710" height="133" alt="Screenshot 2026-04-10 at 12 40 12" src="https://github.com/user-attachments/assets/f4d9fb24-8a59-450e-b451-d0010e5b1335" />


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))