### PR TITLE
Add guest auth provider for local development

### DIFF
--- a/.changeset/clean-castle-emerge.md
+++ b/.changeset/clean-castle-emerge.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Allow hiding the Backstage Identity card on the settings general page via extension config.

--- a/.changeset/plain-falcon-thrive.md
+++ b/.changeset/plain-falcon-thrive.md
@@ -1,0 +1,5 @@
+---
+'backend': minor
+---
+
+Add optional guest auth provider, enabled via `ENABLE_GUEST_AUTH` environment variable.

--- a/.changeset/rare-lantern-melt.md
+++ b/.changeset/rare-lantern-melt.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Use `ProxiedSignInPage` with guest provider as fallback when Dex auth is not configured.

--- a/.changeset/unique-forest-hover.md
+++ b/.changeset/unique-forest-hover.md
@@ -1,0 +1,8 @@
+---
+'app': minor
+'backend': minor
+'backend-headless-service': minor
+'@internal/backend-common': minor
+---
+
+Use custom X-Backstage-Token header for Backstage identity tokens to avoid conflicts with ingress-level Basic auth on the Authorization header.

--- a/.changeset/wise-lagoon-venture.md
+++ b/.changeset/wise-lagoon-venture.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Make sidebar nav items configurable via NFS extensions. Search, catalog, AI chat, and scaffolder sidebar items now respect their extension enabled state. Dividers between groups are only rendered when the group has visible items.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -139,12 +139,13 @@ kubernetes:
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   environment: development
-  providers:
-    # GitHub OAuth example
-    # github:
-    #   development:
-    #     clientId: ${GITHUB_OAUTH_CLIENT_ID}
-    #     clientSecret: ${GITHUB_OAUTH_CLIENT_SECRET}
+  # GitHub OAuth example
+  # providers:
+  #   github:
+  #     development:
+  #       clientId: ${GITHUB_OAUTH_CLIENT_ID}
+  #       clientSecret: ${GITHUB_OAUTH_CLIENT_SECRET}
+  providers: {}
 
 scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -172,23 +172,31 @@ export const appOverrides = createFrontendModule({
     SignInPageBlueprint.make({
       params: {
         loader: async () => {
-          const { SignInPage } = await import('@backstage/core-components');
-          const DexSignInPage = (props: {
+          const { SignInPage, ProxiedSignInPage } =
+            await import('@backstage/core-components');
+          const CustomSignInPage = (props: {
             onSignInSuccess: (identityApi: any) => void;
           }) => {
             const configApi = useApi(configApiRef);
-            const providers = [];
             if (configApi.has('gs.authProvider')) {
-              providers.push({
-                id: 'dex-auth-provider',
-                title: 'Dex',
-                message: 'Sign in using Dex',
-                apiRef: gsAuthApiRef,
-              });
+              return (
+                <SignInPage
+                  {...props}
+                  auto
+                  providers={[
+                    {
+                      id: 'dex-auth-provider',
+                      title: 'Dex',
+                      message: 'Sign in using Dex',
+                      apiRef: gsAuthApiRef,
+                    },
+                  ]}
+                />
+              );
             }
-            return <SignInPage {...props} auto providers={providers} />;
+            return <ProxiedSignInPage {...props} provider="guest" />;
           };
-          return DexSignInPage;
+          return CustomSignInPage;
         },
       },
     }),

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -111,6 +111,10 @@ export const appOverrides = createFrontendModule({
                   config: configApi,
                   urlPrefixAllowlist:
                     GSDiscoveryApiClient.getUrlPrefixAllowlist(configApi),
+                  header: {
+                    name: 'X-Backstage-Token',
+                    value: (token: string) => `Bearer ${token}`,
+                  },
                 }),
               ],
             }),

--- a/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/app/src/modules/nav/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
 } from '@backstage/core-components';
 import { compatWrapper } from '@backstage/core-compat-api';
 import { useApiHolder } from '@backstage/core-plugin-api';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { NavContentBlueprint } from '@backstage/plugin-app-react';
 import { SidebarLogo } from './SidebarLogo';
 import { NavItemIcon } from './NavItemIcon';
@@ -21,30 +22,43 @@ import {
 import {
   AIChatIcon,
   aiChatDrawerApiRef,
+  rootRouteRef as aiChatRouteRef,
 } from '@giantswarm/backstage-plugin-ai-chat-react';
 
 function AiChatSidebarItem() {
   const apiHolder = useApiHolder();
   const drawerApi = apiHolder.get(aiChatDrawerApiRef);
+  const aiChatLink = useRouteRef(aiChatRouteRef);
 
-  if (!drawerApi) return null;
-
-  return (
-    <SidebarItem
-      icon={() => (
-        <NavItemIcon>
-          <AIChatIcon />
-        </NavItemIcon>
-      )}
-      text="AI Assistant"
-      onClick={() => drawerApi.toggleDrawer()}
-    />
+  const icon = () => (
+    <NavItemIcon>
+      <AIChatIcon />
+    </NavItemIcon>
   );
+
+  if (drawerApi) {
+    return (
+      <SidebarItem
+        icon={icon}
+        text="AI Assistant"
+        onClick={() => drawerApi.toggleDrawer()}
+      />
+    );
+  }
+
+  if (aiChatLink) {
+    return <SidebarItem icon={icon} to={aiChatLink()} text="AI Assistant" />;
+  }
+
+  return null;
 }
 
 export const SidebarContent = NavContentBlueprint.make({
   params: {
     component: ({ navItems }) => {
+      const searchItem = navItems.take('page:search');
+      const catalogItem = navItems.take('page:catalog');
+      const aiChatItem = navItems.take('page:ai-chat');
       const nav = navItems.withComponent(item => (
         <SidebarItem
           icon={() => <NavItemIcon>{item.icon}</NavItemIcon>}
@@ -53,25 +67,47 @@ export const SidebarContent = NavContentBlueprint.make({
         />
       ));
 
+      const group1 = [
+        nav.take('page:home'),
+        catalogItem && (
+          <SidebarItem
+            key="catalog"
+            icon={FolderIcon}
+            to="catalog"
+            text="Catalog"
+          />
+        ),
+        nav.take('page:techdocs'),
+      ].filter(Boolean);
+
+      const group2 = [
+        nav.take('page:gs/deployments'),
+        nav.take('page:gs/clusters'),
+        nav.take('page:gs/installations'),
+        nav.take('page:flux'),
+      ].filter(Boolean);
+
+      const group3 = [
+        aiChatItem && <AiChatSidebarItem key="ai-chat" />,
+        nav.take('page:scaffolder'),
+      ].filter(Boolean);
+
+      const menuGroups = [group1, group2, group3].filter(g => g.length > 0);
+
       return compatWrapper(
         <Sidebar>
           <SidebarLogo />
-          <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
-            <SidebarSearchModal />
-          </SidebarGroup>
-          <SidebarDivider />
+
+          {searchItem && (
+            <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
+              <SidebarSearchModal />
+            </SidebarGroup>
+          )}
           <SidebarGroup label="Menu" icon={<MenuIcon />}>
-            {nav.take('page:home')}
-            <SidebarItem icon={FolderIcon} to="catalog" text="Catalog" />
-            {nav.take('page:techdocs')}
-            <SidebarDivider />
-            {nav.take('page:gs/deployments')}
-            {nav.take('page:gs/clusters')}
-            {nav.take('page:gs/installations')}
-            {nav.take('page:flux')}
-            <SidebarDivider />
-            <AiChatSidebarItem />
-            {nav.take('page:scaffolder')}
+            {menuGroups.flatMap((group, i) => [
+              <SidebarDivider key={`divider-${i}`} />,
+              ...group,
+            ])}
           </SidebarGroup>
           <SidebarSpace />
           <SidebarDivider />

--- a/packages/app/src/modules/userSettings/GeneralPage.tsx
+++ b/packages/app/src/modules/userSettings/GeneralPage.tsx
@@ -1,0 +1,57 @@
+import { lazy } from 'react';
+import { SubPageBlueprint } from '@backstage/frontend-plugin-api';
+
+const LazyGeneralSettings = lazy(async () => {
+  const [
+    {
+      UserSettingsProfileCard,
+      UserSettingsAppearanceCard,
+      UserSettingsIdentityCard,
+    },
+    { Content },
+    { default: Grid },
+  ] = await Promise.all([
+    import('@backstage/plugin-user-settings'),
+    import('@backstage/core-components'),
+    import('@material-ui/core/Grid'),
+  ]);
+
+  return {
+    default: ({ showIdentityCard }: { showIdentityCard: boolean }) => (
+      <Content>
+        <Grid container direction="row" spacing={3}>
+          <Grid item xs={12} md={6}>
+            <UserSettingsProfileCard />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <UserSettingsAppearanceCard />
+          </Grid>
+          {showIdentityCard && (
+            <Grid item xs={12} md={6}>
+              <UserSettingsIdentityCard />
+            </Grid>
+          )}
+        </Grid>
+      </Content>
+    ),
+  };
+});
+
+export const GeneralPage = SubPageBlueprint.makeWithOverrides({
+  name: 'general',
+  config: {
+    schema: {
+      showIdentityCard: z => z.boolean().default(true),
+    },
+  },
+  factory(originalFactory, { config }) {
+    const showIdentityCard = config.showIdentityCard;
+    return originalFactory({
+      path: 'general',
+      title: 'General',
+      loader: async () => (
+        <LazyGeneralSettings showIdentityCard={showIdentityCard} />
+      ),
+    });
+  },
+});

--- a/packages/app/src/modules/userSettings/index.ts
+++ b/packages/app/src/modules/userSettings/index.ts
@@ -1,7 +1,8 @@
 import { createFrontendModule } from '@backstage/frontend-plugin-api';
+import { GeneralPage } from './GeneralPage';
 import { ProviderSettings } from './ProviderSettings';
 
 export const userSettingsPluginOverrides = createFrontendModule({
   pluginId: 'user-settings',
-  extensions: [ProviderSettings],
+  extensions: [GeneralPage, ProviderSettings],
 });

--- a/packages/backend-common/src/httpAuth.ts
+++ b/packages/backend-common/src/httpAuth.ts
@@ -1,0 +1,50 @@
+import {
+  createServiceFactory,
+  coreServices,
+} from '@backstage/backend-plugin-api';
+import { DefaultHttpAuthService } from '@backstage/backend-defaults/httpAuth';
+
+/**
+ * Custom httpAuth service factory that reads the Backstage identity token
+ * from the `X-Backstage-Token` header, falling back to the standard
+ * `Authorization: Bearer` header.
+ *
+ * This avoids conflicts when an external proxy (e.g. nginx ingress) uses
+ * Basic auth on the `Authorization` header.
+ */
+export const customHttpAuthServiceFactory = createServiceFactory({
+  service: coreServices.httpAuth,
+  deps: {
+    auth: coreServices.auth,
+    discovery: coreServices.discovery,
+    plugin: coreServices.pluginMetadata,
+  },
+  factory({ auth, discovery, plugin }) {
+    return DefaultHttpAuthService.create({
+      auth,
+      discovery,
+      pluginId: plugin.getId(),
+      getTokenFromRequest(req) {
+        // Try custom header first (set by the frontend fetchApi middleware)
+        const customHeader = req.headers['x-backstage-token'];
+        if (typeof customHeader === 'string') {
+          const matches = customHeader.match(/^Bearer[ ]+(\S+)$/i);
+          if (matches?.[1]) {
+            return { token: matches[1] };
+          }
+        }
+
+        // Fall back to standard Authorization: Bearer header
+        const authHeader = req.headers.authorization;
+        if (typeof authHeader === 'string') {
+          const matches = authHeader.match(/^Bearer[ ]+(\S+)$/i);
+          if (matches?.[1]) {
+            return { token: matches[1] };
+          }
+        }
+
+        return { token: undefined };
+      },
+    });
+  },
+});

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -1,1 +1,2 @@
 export { rootLogger } from './rootLogger';
+export { customHttpAuthServiceFactory } from './httpAuth';

--- a/packages/backend-headless-service/src/index.ts
+++ b/packages/backend-headless-service/src/index.ts
@@ -1,8 +1,15 @@
 import 'global-agent/bootstrap';
 import { createBackend } from '@backstage/backend-defaults';
-import { rootLogger } from '@internal/backend-common';
+import {
+  customHttpAuthServiceFactory,
+  rootLogger,
+} from '@internal/backend-common';
 
 const backend = createBackend();
+
+// Override default httpAuth to read tokens from X-Backstage-Token header,
+// avoiding conflicts with ingress-level Basic auth on the Authorization header.
+backend.add(customHttpAuthServiceFactory);
 
 // auth plugin
 backend.add(import('@backstage/plugin-auth-backend'));

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,7 @@
     "@backstage/plugin-app-backend": "backstage:^",
     "@backstage/plugin-auth-backend": "backstage:^",
     "@backstage/plugin-auth-backend-module-github-provider": "backstage:^",
+    "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^",
     "@backstage/plugin-auth-node": "backstage:^",
     "@backstage/plugin-catalog-backend": "backstage:^",
     "@backstage/plugin-catalog-backend-module-aws": "backstage:^",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,8 +1,15 @@
 import 'global-agent/bootstrap';
 import { createBackend } from '@backstage/backend-defaults';
-import { rootLogger } from '@internal/backend-common';
+import {
+  customHttpAuthServiceFactory,
+  rootLogger,
+} from '@internal/backend-common';
 
 const backend = createBackend();
+
+// Override default httpAuth to read tokens from X-Backstage-Token header,
+// avoiding conflicts with ingress-level Basic auth on the Authorization header.
+backend.add(customHttpAuthServiceFactory);
 
 backend.add(import('@backstage/plugin-app-backend'));
 backend.add(import('@backstage/plugin-proxy-backend'));

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -26,6 +26,9 @@ backend.add(import('@giantswarm/backstage-plugin-techdocs-backend-module-gs'));
 
 // auth plugin
 backend.add(import('@backstage/plugin-auth-backend'));
+if (process.env.ENABLE_GUEST_AUTH) {
+  backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
+}
 backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 backend.add(import('@giantswarm/backstage-plugin-auth-backend-module-gs'));
 

--- a/plugins/ai-chat/src/hooks/useChatSetup.ts
+++ b/plugins/ai-chat/src/hooks/useChatSetup.ts
@@ -128,7 +128,7 @@ export function useChatSetup() {
     const mcpHeaders = await getMCPAuthHeaders();
 
     return {
-      Authorization: `Bearer ${token}`,
+      'X-Backstage-Token': `Bearer ${token}`,
       'X-Conversation-Id': conversationIdRef.current,
       ...mcpHeaders,
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3575,6 +3575,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-plugin-api@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@backstage/backend-plugin-api@npm:1.9.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.1"
+    "@backstage/config": "npm:^1.3.7"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/plugin-auth-node": "npm:^0.7.0"
+    "@backstage/plugin-permission-common": "npm:^0.9.8"
+    "@backstage/plugin-permission-node": "npm:^0.10.12"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    json-schema: "npm:^0.4.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10c0/caba6aca151b62be01eebeeb138f671f3b14ccceeaabde57a87e165f0f9d6ecfb9b0ac01c9c1ca3cef0fab86683c9dd725262be87cc55c26da83def788c5ed1e
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-test-utils@backstage:^::backstage=1.49.3&npm=1.11.1, @backstage/backend-test-utils@npm:^1.11.1":
   version: 1.11.1
   resolution: "@backstage/backend-test-utils@npm:1.11.1"
@@ -3660,6 +3682,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-client@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "@backstage/catalog-client@npm:1.15.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.8.0"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/filter-predicates": "npm:^0.1.2"
+    cross-fetch: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
+    uri-template: "npm:^2.0.0"
+  checksum: 10c0/c8880830ed1efb5ae7fa24ca4210da5d8cd72b436ba7f1fd22713724220f799bd8e9ac0162fcec45ac3540cfadc01fcdfcf0f99ea102c2e1261c6e3a4b41f9b4
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-client@npm:^1.7.0":
   version: 1.7.0
   resolution: "@backstage/catalog-client@npm:1.7.0"
@@ -3732,6 +3768,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-model@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@backstage/catalog-model@npm:1.8.0"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/types": "npm:^1.2.2"
+    ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.25.76"
+  checksum: 10c0/ba31bdca43051e82773cd6f99cbbc3787b939d5c5eb7127b127b4301d327c6a85d1b20e97a4387049a9626e0a1f10ecea7c7652e2af4f3c0fee140d63fef4089
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-common@npm:^0.1.14, @backstage/cli-common@npm:^0.1.17":
   version: 0.1.17
   resolution: "@backstage/cli-common@npm:0.1.17"
@@ -3784,6 +3834,18 @@ __metadata:
     global-agent: "npm:^3.0.0"
     undici: "npm:^7.2.3"
   checksum: 10c0/99bd1cca5db1bb97b400b10486933717b539ca03d4885f5db08ae0c52879c55f04e79e64af0b23f700cf3e1a913c946f6b3b29f6295304914838b0a5046d3823
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-common@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@backstage/cli-common@npm:0.2.1"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.0"
+    cross-spawn: "npm:^7.0.3"
+    global-agent: "npm:^3.0.0"
+    undici: "npm:^7.24.5"
+  checksum: 10c0/7eb3736d74f057c22c7d1a6f67a030e01422e123ba772710b461e9c937e33200332c6aca606c6ae1077e3e3384e22a1f0819212af536e7cd9efde731eea811b9
   languageName: node
   linkType: hard
 
@@ -4355,6 +4417,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "@backstage/config@npm:1.3.7"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/types": "npm:^1.2.2"
+    ms: "npm:^2.1.3"
+  checksum: 10c0/de4f88e0df17140dfe9d5041936a7dcb7c24aa5413af7b6cecb04b417d6370e43bee25d2deb91e07e4cf1442a9e7ef151f57c2bd60d8ec4f7f199e6bcfd9dedc
+  languageName: node
+  linkType: hard
+
 "@backstage/core-app-api@backstage:^::backstage=1.49.3&npm=1.19.6, @backstage/core-app-api@npm:^1.19.4, @backstage/core-app-api@npm:^1.19.6":
   version: 1.19.6
   resolution: "@backstage/core-app-api@npm:1.19.6"
@@ -4848,6 +4921,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@backstage/errors@npm:1.3.0"
+  dependencies:
+    "@backstage/types": "npm:^1.2.2"
+    serialize-error: "npm:^8.0.1"
+  checksum: 10c0/e47f4a42d989858ab148359a410a82e295b5090c3da8d3a761997fd95d41786183c4113d8db13525964d497c2963e2d532c32f93548bb35bd30c1b514c34af19
+  languageName: node
+  linkType: hard
+
 "@backstage/eslint-plugin@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/eslint-plugin@npm:0.2.2"
@@ -4881,6 +4964,19 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^4.0.2"
   checksum: 10c0/f4bce2259af0e953ef30d292394aeea614ae42fbd825678a3abc36a97a6020a9964f40046aa3dc189f040ecf9674fb30dbcbbfd2ff3f807a513ad0353094bea5
+  languageName: node
+  linkType: hard
+
+"@backstage/filter-predicates@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@backstage/filter-predicates@npm:0.1.2"
+  dependencies:
+    "@backstage/config": "npm:^1.3.7"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/types": "npm:^1.2.2"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10c0/41f02423a09f59beed97f27c9bf12f1845d236674859d0a5cf30bc85eceaf76dc42763e8d522ef0d69e85d5a3f79425cc42d0f6b82d8abe3b03d346cebe4b56d
   languageName: node
   linkType: hard
 
@@ -5648,6 +5744,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.49.3&npm=0.2.17, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.17":
+  version: 0.2.18
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.18"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.0"
+    "@backstage/catalog-model": "npm:^1.8.0"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/plugin-auth-node": "npm:^0.7.0"
+    passport-oauth2: "npm:^1.7.0"
+  checksum: 10c0/7440fa2e6d310b932e0f861506a7fd05fa8fb4d40cf5290f40a774b31ec6c8efe561735c18d06b08ebbd48fffde330e54445eca0b4e8b235e3a325dcc57dfaf4
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-oidc-provider@backstage:^::backstage=1.49.3&npm=0.4.14, @backstage/plugin-auth-backend-module-oidc-provider@npm:^0.4.14":
   version: 0.4.14
   resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.14"
@@ -5880,6 +5989,29 @@ __metadata:
     zod-to-json-schema: "npm:^3.21.4"
     zod-validation-error: "npm:^3.4.0"
   checksum: 10c0/eb7a8fdee8ab4d8656bdf0b75347136cbacd10d5232a0f435766f607334dc85ead9d18cfa382016adca9af51bc572a5cd3700d778f261eb18c14c7aef621436d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-node@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@backstage/plugin-auth-node@npm:0.7.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.0"
+    "@backstage/catalog-client": "npm:^1.15.0"
+    "@backstage/catalog-model": "npm:^1.8.0"
+    "@backstage/config": "npm:^1.3.7"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10c0/10bd84aeb55cd420109a8b972953a4fafd91a927a93e2bee14c82bc818954787d9c67bc4afdcbf18ea90ca34b170aa36ead0345881f27643d7d7e1c96a27c6a9
   languageName: node
   linkType: hard
 
@@ -6938,6 +7070,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.9.8":
+  version: 0.9.8
+  resolution: "@backstage/plugin-permission-common@npm:0.9.8"
+  dependencies:
+    "@backstage/config": "npm:^1.3.7"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/types": "npm:^1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    uuid: "npm:^11.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/21e0f3cfdeb175b1d65e0dda8aeaabeae620baa7974a4b21873ce9aebf4ead687a996b6903bebc9f99cbc97528d956944f6e06f7cf7160431cc3236dd1251b90
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@backstage:^::backstage=1.49.3&npm=0.10.11, @backstage/plugin-permission-node@npm:^0.10.11":
   version: 0.10.11
   resolution: "@backstage/plugin-permission-node@npm:0.10.11"
@@ -6971,6 +7118,24 @@ __metadata:
     zod: "npm:^3.25.76"
     zod-to-json-schema: "npm:^3.25.1"
   checksum: 10c0/132ba02e69621fc6e162fd3acd8f320bc67f2d6c0958af4f5386195aed822ea7bba2342ff7fc47df834d8a6aa8bcacee89cfb54bd8b9a0cb8029aba1a4d468da
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:^0.10.12":
+  version: 0.10.12
+  resolution: "@backstage/plugin-permission-node@npm:0.10.12"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.7"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/plugin-auth-node": "npm:^0.7.0"
+    "@backstage/plugin-permission-common": "npm:^0.9.8"
+    "@types/express": "npm:^4.17.6"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/5ce96d2c168586b5c9ae70e1df120d8829315d07e978029dc3ba8f5aff3548702abf5e7cb75504747ce2bcf63405dd764a69cc81dad065cad5a74985ad3df139
   languageName: node
   linkType: hard
 
@@ -22930,6 +23095,7 @@ __metadata:
     "@backstage/plugin-app-backend": "backstage:^"
     "@backstage/plugin-auth-backend": "backstage:^"
     "@backstage/plugin-auth-backend-module-github-provider": "backstage:^"
+    "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^"
     "@backstage/plugin-auth-node": "backstage:^"
     "@backstage/plugin-catalog-backend": "backstage:^"
     "@backstage/plugin-catalog-backend-module-aws": "backstage:^"
@@ -36856,7 +37022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"passport-oauth2@npm:1.x.x, passport-oauth2@npm:^1.8.0":
+"passport-oauth2@npm:1.x.x, passport-oauth2@npm:^1.7.0, passport-oauth2@npm:^1.8.0":
   version: 1.8.0
   resolution: "passport-oauth2@npm:1.8.0"
   dependencies:
@@ -43372,6 +43538,13 @@ __metadata:
   version: 7.3.0
   resolution: "undici@npm:7.3.0"
   checksum: 10c0/62c5e335725cadb02e19950932c7823fc330cbfd80106e6836daa6db1379aa727510b77de0a4e6f912087b288ded93f7daf4b8c154ad36fd5c9c4b96b26888b8
+  languageName: node
+  linkType: hard
+
+"undici@npm:^7.24.5":
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Adds support for guest authentication to simplify local development and testing:

- Registers the `@backstage/plugin-auth-backend-module-guest-provider` in the backend, gated behind the `ENABLE_GUEST_AUTH` environment variable
- Refactors the sign-in page to use `ProxiedSignInPage` with guest provider as fallback when Dex auth (`gs.authProvider`) is not configured

### What is the effect of this change to users?

No effect in production — guest auth is only enabled when `ENABLE_GUEST_AUTH` is explicitly set. For local development without Dex, the sign-in page now works instead of showing an empty provider list.

### Any background context you can provide?

Previously, when `gs.authProvider` was not configured, the sign-in page rendered with an empty providers array, making it impossible to sign in locally without Dex. Now it falls back to guest auth.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))