### PR TITLE
feat(ai-chat): verbose debug logging via feature flag

### DIFF
--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -333,7 +333,12 @@ export async function createRouter(
           messageCount: sanitizedMessages.length,
           hadUnsupportedContent,
         };
-        res.setHeader('X-AI-Chat-Debug-Meta', JSON.stringify(debugMeta));
+        // Base64-encode so non-ASCII characters in the system prompt or
+        // tool descriptions don't violate HTTP header byte restrictions.
+        res.setHeader(
+          'X-AI-Chat-Debug-Meta',
+          Buffer.from(JSON.stringify(debugMeta), 'utf-8').toString('base64'),
+        );
       }
 
       result.pipeUIMessageStreamToResponse(res);

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -196,7 +196,12 @@ export async function createRouter(
       effectiveSystemPrompt += failureNote;
     }
 
-    const isDebugRequest = req.headers['x-ai-chat-debug'] === 'true';
+    // Debug metadata is gated on non-production builds in addition to the
+    // request header, so toggling the feature flag in production can never
+    // leak backend internals (system prompt, tool schemas) to the browser.
+    const isDebugRequest =
+      process.env.NODE_ENV !== 'production' &&
+      req.headers['x-ai-chat-debug'] === 'true';
 
     try {
       // Select the appropriate provider based on model type
@@ -297,24 +302,25 @@ export async function createRouter(
 
       // When the frontend debug flag is active, attach metadata about what
       // the backend sends to the LLM so it can be logged in the browser console.
+      // Gated to non-production above, so header size is not a concern here.
       if (isDebugRequest) {
-        const toolNames = Object.keys(allTools);
         let providerName = 'openai';
         if (isAnthropicModel) providerName = 'anthropic';
         else if (isAzureConfigured) providerName = 'azure';
 
+        const toolEntries = Object.entries(allTools).map(([name, t]) => ({
+          name,
+          description: (t as { description?: string }).description,
+        }));
+
         const debugMeta = {
           model: modelName,
           provider: providerName,
-          systemPromptLength: effectiveSystemPrompt.length,
-          systemPromptPreview: effectiveSystemPrompt.substring(0, 500),
-          tools:
-            toolNames.length > 50
-              ? [
-                  ...toolNames.slice(0, 50),
-                  `...and ${toolNames.length - 50} more`,
-                ]
-              : toolNames,
+          // Full system prompt the backend prepends to the user messages.
+          systemPrompt: effectiveSystemPrompt,
+          // Tools with descriptions (input schemas omitted to keep the
+          // header under browser/Node limits for large tool catalogs).
+          tools: toolEntries,
           mcpServers: {
             connected: connectedServers,
             failed: failedServers.map(s => s.name),
@@ -322,6 +328,8 @@ export async function createRouter(
           providerOptions: isAnthropicModel
             ? { thinking: { type: 'enabled', budgetTokens: 10000 } }
             : undefined,
+          // Message transformations applied server-side (useful to spot
+          // when the frontend's messages differ from what the LLM sees).
           messageCount: sanitizedMessages.length,
           hadUnsupportedContent,
         };

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -196,6 +196,8 @@ export async function createRouter(
       effectiveSystemPrompt += failureNote;
     }
 
+    const isDebugRequest = req.headers['x-ai-chat-debug'] === 'true';
+
     try {
       // Select the appropriate provider based on model type
       // When Azure is configured, non-Anthropic models route through Azure
@@ -239,6 +241,17 @@ export async function createRouter(
         messageCount: deduplicatedMessages.length,
       });
 
+      // Build the combined tool set
+      const allTools = {
+        ...frontendTools(tools),
+        ...mcpTools,
+        ...mcpResourceTools,
+        listSkills,
+        getSkill,
+        ...userTools,
+        ...contextUsageTools,
+      };
+
       const result = streamText({
         model: selectedModel as any,
         messages: systemMessage
@@ -246,18 +259,7 @@ export async function createRouter(
           : sanitizedMessages,
         system: isAnthropicModel ? undefined : effectiveSystemPrompt,
         abortSignal: req.socket ? undefined : undefined,
-        tools: {
-          ...frontendTools(tools),
-          ...mcpTools,
-          ...mcpResourceTools,
-          // Skill tools
-          listSkills,
-          getSkill,
-          // User tools (request-scoped)
-          ...userTools,
-          // Context usage tool
-          ...contextUsageTools,
-        } as ToolSet,
+        tools: allTools as ToolSet,
         providerOptions: isAnthropicModel
           ? {
               anthropic: {
@@ -292,6 +294,39 @@ export async function createRouter(
       res.setHeader('Transfer-Encoding', 'chunked');
       res.setHeader('Cache-Control', 'no-cache');
       res.setHeader('Connection', 'keep-alive');
+
+      // When the frontend debug flag is active, attach metadata about what
+      // the backend sends to the LLM so it can be logged in the browser console.
+      if (isDebugRequest) {
+        const toolNames = Object.keys(allTools);
+        let providerName = 'openai';
+        if (isAnthropicModel) providerName = 'anthropic';
+        else if (isAzureConfigured) providerName = 'azure';
+
+        const debugMeta = {
+          model: modelName,
+          provider: providerName,
+          systemPromptLength: effectiveSystemPrompt.length,
+          systemPromptPreview: effectiveSystemPrompt.substring(0, 500),
+          tools:
+            toolNames.length > 50
+              ? [
+                  ...toolNames.slice(0, 50),
+                  `...and ${toolNames.length - 50} more`,
+                ]
+              : toolNames,
+          mcpServers: {
+            connected: connectedServers,
+            failed: failedServers.map(s => s.name),
+          },
+          providerOptions: isAnthropicModel
+            ? { thinking: { type: 'enabled', budgetTokens: 10000 } }
+            : undefined,
+          messageCount: sanitizedMessages.length,
+          hadUnsupportedContent,
+        };
+        res.setHeader('X-AI-Chat-Debug-Meta', JSON.stringify(debugMeta));
+      }
 
       result.pipeUIMessageStreamToResponse(res);
     } catch (error) {

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -339,6 +339,10 @@ export async function createRouter(
           'X-AI-Chat-Debug-Meta',
           Buffer.from(JSON.stringify(debugMeta), 'utf-8').toString('base64'),
         );
+        // Browsers hide non-standard response headers from JavaScript on
+        // cross-origin requests unless explicitly exposed. Frontend on
+        // :3000, backend on :7007 makes every request cross-origin.
+        res.setHeader('Access-Control-Expose-Headers', 'X-AI-Chat-Debug-Meta');
       }
 
       result.pipeUIMessageStreamToResponse(res);

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -62,12 +62,11 @@ export function createDebugFetch(): typeof globalThis.fetch {
         );
         console.log('Model:', meta.model);
         console.log('Provider:', meta.provider);
-        console.log(
-          `System prompt: ${meta.systemPromptLength} chars`,
-          meta.systemPromptPreview
-            ? `\n${meta.systemPromptPreview}${meta.systemPromptLength > 500 ? '...' : ''}`
-            : '',
-        );
+        if (typeof meta.systemPrompt === 'string') {
+          console.log(
+            `System prompt (${meta.systemPrompt.length} chars):\n${meta.systemPrompt}`,
+          );
+        }
         console.log(`Tools (${meta.tools?.length ?? 0}):`, meta.tools);
         console.log('MCP servers:', meta.mcpServers);
         if (meta.providerOptions) {

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -1,0 +1,315 @@
+/* eslint-disable no-console */
+
+/**
+ * Creates a fetch wrapper that logs outgoing requests and incoming SSE
+ * stream events to the browser console.  Designed to be passed as the
+ * `fetch` option of `AssistantChatTransport` when the
+ * `ai-chat-verbose-debugging` feature flag is active.
+ *
+ * All logging is wrapped in try/catch so it can never break the chat.
+ */
+export function createDebugFetch(): typeof globalThis.fetch {
+  return async (input, init) => {
+    // --- 1. Log the outgoing request ---
+    try {
+      if (init?.body) {
+        const body = JSON.parse(init.body as string);
+        const headers = init.headers as Record<string, string> | undefined;
+        const safeHeaders = headers
+          ? Object.fromEntries(
+              Object.entries(headers).map(([k, v]) =>
+                k.toLowerCase() === 'authorization'
+                  ? [k, '[REDACTED]']
+                  : [k, v],
+              ),
+            )
+          : undefined;
+
+        console.groupCollapsed(
+          '%c[AI Chat Debug]%c Outgoing request',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+        );
+        console.log('URL:', input);
+        if (safeHeaders) console.log('Headers:', safeHeaders);
+        console.log('Messages:', body.messages);
+        if (body.tools && Object.keys(body.tools).length > 0) {
+          console.log('Frontend tools:', body.tools);
+        }
+        // Log any extra body fields besides messages/tools
+        const { messages: _m, tools: _t, ...rest } = body;
+        if (Object.keys(rest).length > 0) {
+          console.log('Other body fields:', rest);
+        }
+        console.groupEnd();
+      }
+    } catch {
+      // Ignore logging errors
+    }
+
+    // --- 2. Execute the real fetch ---
+    const response = await globalThis.fetch(input, init);
+
+    // --- 3. Log backend debug metadata header ---
+    try {
+      const debugMeta = response.headers.get('X-AI-Chat-Debug-Meta');
+      if (debugMeta) {
+        const meta = JSON.parse(debugMeta);
+        console.groupCollapsed(
+          '%c[AI Chat Debug]%c Backend metadata',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+        );
+        console.log('Model:', meta.model);
+        console.log('Provider:', meta.provider);
+        console.log(
+          `System prompt: ${meta.systemPromptLength} chars`,
+          meta.systemPromptPreview
+            ? `\n${meta.systemPromptPreview}${meta.systemPromptLength > 500 ? '...' : ''}`
+            : '',
+        );
+        console.log(`Tools (${meta.tools?.length ?? 0}):`, meta.tools);
+        console.log('MCP servers:', meta.mcpServers);
+        if (meta.providerOptions) {
+          console.log('Provider options:', meta.providerOptions);
+        }
+        console.log('Messages after sanitization:', meta.messageCount);
+        if (meta.hadUnsupportedContent) {
+          console.warn('Unsupported content was stripped from messages');
+        }
+        console.groupEnd();
+      }
+    } catch {
+      // Ignore parse/logging errors
+    }
+
+    // --- 4. Clone response and consume the clone for SSE logging ---
+    try {
+      const cloned = response.clone();
+      consumeSSEStream(cloned).catch(() => {
+        // Ignore stream read errors
+      });
+    } catch {
+      // Ignore clone errors
+    }
+
+    return response;
+  };
+}
+
+/**
+ * Reads an SSE response body from a cloned Response and logs each event.
+ */
+interface StreamCounters {
+  totalEvents: number;
+  textDeltaChars: number;
+  toolCalls: string[];
+  reasoningDeltas: number;
+  steps: number;
+  lastFinishReason: string | undefined;
+}
+
+function handleEvent(parsed: any, counters: StreamCounters) {
+  counters.totalEvents++;
+  categorizeEvent(parsed, {
+    onTextDelta(chars) {
+      counters.textDeltaChars += chars;
+    },
+    onToolCall(name) {
+      if (!counters.toolCalls.includes(name)) counters.toolCalls.push(name);
+    },
+    onReasoningDelta() {
+      counters.reasoningDeltas++;
+    },
+    onStepStart() {
+      counters.steps++;
+    },
+    onFinish(reason) {
+      counters.lastFinishReason = reason;
+    },
+  });
+}
+
+async function consumeSSEStream(response: Response): Promise<void> {
+  const body = response.body;
+  if (!body) return;
+
+  const reader = body.pipeThrough(new TextDecoderStream()).getReader();
+  let buffer = '';
+  const startTime = performance.now();
+
+  const counters: StreamCounters = {
+    totalEvents: 0,
+    textDeltaChars: 0,
+    toolCalls: [],
+    reasoningDeltas: 0,
+    steps: 0,
+    lastFinishReason: undefined,
+  };
+
+  try {
+    let result = await reader.read();
+    while (!result.done) {
+      buffer += result.value;
+
+      // SSE events are separated by double newlines
+      let boundary = buffer.indexOf('\n\n');
+      while (boundary !== -1) {
+        const eventBlock = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+
+        processEventBlock(eventBlock, {
+          onEvent(parsed) {
+            handleEvent(parsed, counters);
+          },
+        });
+
+        boundary = buffer.indexOf('\n\n');
+      }
+
+      result = await reader.read();
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  // --- Summary ---
+  const duration = ((performance.now() - startTime) / 1000).toFixed(1);
+  console.groupCollapsed(
+    '%c[AI Chat Debug]%c Stream complete (%ss)',
+    'color:#7c3aed;font-weight:bold',
+    'color:inherit',
+    duration,
+  );
+  console.log(`Total events: ${counters.totalEvents}`);
+  console.log(`Text delta chars: ${counters.textDeltaChars}`);
+  if (counters.toolCalls.length > 0) {
+    console.log(`Tool calls: ${counters.toolCalls.join(', ')}`);
+  }
+  if (counters.reasoningDeltas > 0) {
+    console.log(`Reasoning deltas: ${counters.reasoningDeltas}`);
+  }
+  if (counters.steps > 0) {
+    console.log(`Steps: ${counters.steps}`);
+  }
+  if (counters.lastFinishReason) {
+    console.log(`Finish reason: ${counters.lastFinishReason}`);
+  }
+  console.groupEnd();
+}
+
+/**
+ * Parses a single SSE event block (lines between double-newline boundaries)
+ * and calls the callback with the parsed JSON data.
+ */
+function processEventBlock(
+  block: string,
+  { onEvent }: { onEvent: (data: any) => void },
+) {
+  try {
+    const lines = block.split('\n');
+    for (const line of lines) {
+      if (line.startsWith('data: ')) {
+        const jsonStr = line.slice(6);
+        if (jsonStr === '[DONE]') return;
+        const parsed = JSON.parse(jsonStr);
+        onEvent(parsed);
+      }
+    }
+  } catch {
+    // Ignore parse errors for individual events
+  }
+}
+
+interface EventCallbacks {
+  onTextDelta: (chars: number) => void;
+  onToolCall: (name: string) => void;
+  onReasoningDelta: () => void;
+  onStepStart: () => void;
+  onFinish: (reason: string) => void;
+}
+
+/**
+ * Categorizes a parsed SSE event and updates counters.
+ * Also logs the event to the console.
+ */
+function categorizeEvent(event: any, callbacks: EventCallbacks) {
+  try {
+    // The AI SDK UI message stream uses a type-based protocol.
+    // Common types: text-delta, tool-call, tool-result, step-start,
+    // step-finish, reasoning, finish, error
+    const type = event.type ?? event.event ?? 'unknown';
+
+    switch (type) {
+      case 'text-delta':
+        callbacks.onTextDelta(event.textDelta?.length ?? 0);
+        // Don't log every text delta to avoid flooding
+        break;
+      case 'tool-call':
+        callbacks.onToolCall(event.toolName ?? event.name ?? 'unknown');
+        console.log(
+          '%c[AI Chat Debug]%c Tool call: %s',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+          event.toolName ?? event.name,
+          event.args ?? event.arguments,
+        );
+        break;
+      case 'tool-result':
+        console.log(
+          '%c[AI Chat Debug]%c Tool result: %s',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+          event.toolName ?? event.toolCallId,
+          event.result,
+        );
+        break;
+      case 'step-start':
+        callbacks.onStepStart();
+        console.log(
+          '%c[AI Chat Debug]%c Step start',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+        );
+        break;
+      case 'step-finish':
+      case 'finish':
+        if (event.finishReason) {
+          callbacks.onFinish(event.finishReason);
+        }
+        console.log(
+          '%c[AI Chat Debug]%c %s (reason: %s)',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+          type,
+          event.finishReason ?? 'n/a',
+          event.usage ?? '',
+        );
+        break;
+      case 'reasoning':
+      case 'reasoning-delta':
+        callbacks.onReasoningDelta();
+        // Don't log every reasoning delta to avoid flooding
+        break;
+      case 'error':
+        console.error(
+          '%c[AI Chat Debug]%c Stream error:',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+          event,
+        );
+        break;
+      default:
+        console.log(
+          '%c[AI Chat Debug]%c SSE event [%s]:',
+          'color:#7c3aed;font-weight:bold',
+          'color:inherit',
+          type,
+          event,
+        );
+        break;
+    }
+  } catch {
+    // Ignore categorization errors
+  }
+}

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -54,7 +54,12 @@ export function createDebugFetch(): typeof globalThis.fetch {
     try {
       const debugMeta = response.headers.get('X-AI-Chat-Debug-Meta');
       if (debugMeta) {
-        const meta = JSON.parse(debugMeta);
+        // Decode base64 + utf-8 (needed for non-ASCII characters in the
+        // system prompt or tool descriptions).
+        const decoded = new TextDecoder('utf-8').decode(
+          Uint8Array.from(atob(debugMeta), c => c.charCodeAt(0)),
+        );
+        const meta = JSON.parse(decoded);
         console.groupCollapsed(
           '%c[AI Chat Debug]%c Backend metadata',
           'color:#7c3aed;font-weight:bold',

--- a/plugins/ai-chat/src/hooks/useChatSetup.ts
+++ b/plugins/ai-chat/src/hooks/useChatSetup.ts
@@ -66,9 +66,12 @@ export function useChatSetup() {
   const featureFlagsApi = useApi(featureFlagsApiRef);
   const conversationIdRef = useRef<string | null>(null);
 
-  const verboseDebugging = featureFlagsApi.isActive(
-    'ai-chat-verbose-debugging',
-  );
+  // Verbose debugging is only enabled in non-production builds to avoid
+  // leaking backend internals (system prompt, tool schemas) to end users
+  // who toggle the feature flag in production.
+  const verboseDebugging =
+    process.env.NODE_ENV !== 'production' &&
+    featureFlagsApi.isActive('ai-chat-verbose-debugging');
   const debugFetch = useMemo(
     () => (verboseDebugging ? createDebugFetch() : undefined),
     [verboseDebugging],

--- a/plugins/ai-chat/src/hooks/useChatSetup.ts
+++ b/plugins/ai-chat/src/hooks/useChatSetup.ts
@@ -18,6 +18,7 @@ import {
 } from 'ai';
 import useAsync from 'react-use/esm/useAsync';
 import { mcpAuthProvidersApiRef } from '../api';
+import { createDebugFetch } from './createDebugFetch';
 
 /**
  * Tools whose results are rendered as self-contained UI cards.
@@ -64,6 +65,14 @@ export function useChatSetup() {
   const mcpAuthProvidersApi = useApi(mcpAuthProvidersApiRef);
   const featureFlagsApi = useApi(featureFlagsApiRef);
   const conversationIdRef = useRef<string | null>(null);
+
+  const verboseDebugging = featureFlagsApi.isActive(
+    'ai-chat-verbose-debugging',
+  );
+  const debugFetch = useMemo(
+    () => (verboseDebugging ? createDebugFetch() : undefined),
+    [verboseDebugging],
+  );
 
   const { value: apiUrl } = useAsync(async () => {
     const baseUrl = await discoveryApi.getBaseUrl('ai-chat');
@@ -130,15 +139,17 @@ export function useChatSetup() {
     return {
       Authorization: `Bearer ${token}`,
       'X-Conversation-Id': conversationIdRef.current,
+      ...(verboseDebugging && { 'X-AI-Chat-Debug': 'true' }),
       ...mcpHeaders,
     };
-  }, [identityApi, getMCPAuthHeaders, featureFlagsApi]);
+  }, [identityApi, getMCPAuthHeaders, featureFlagsApi, verboseDebugging]);
 
   const runtime = useChatRuntime({
     sendAutomaticallyWhen: shouldSendAutomatically,
     transport: new AssistantChatTransport({
       api: apiUrl,
       headers: getHeaders,
+      fetch: debugFetch,
     }),
   });
 


### PR DESCRIPTION
This PR enables very verbose debug logging to the browser console in non-production environments, depending on the `ai-chat-verbose-debugging` feature flag.

## Summary
- When the `ai-chat-verbose-debugging` feature flag is active, the frontend now logs full request/response details to the browser console
- A custom `fetch` wrapper on `AssistantChatTransport` logs outgoing messages, incoming SSE stream events (tool calls, results, steps, errors), and a stream summary with duration and counts
- The backend attaches an `X-AI-Chat-Debug-Meta` response header containing model, provider, system prompt preview, full tool list, MCP server status, and provider options — giving full visibility into what is sent to the LLM

## Test plan
- [ ] Enable `ai-chat-verbose-debugging` in Settings > Feature Flags
- [ ] Open browser DevTools console and send a chat message
- [ ] Verify `[AI Chat Debug] Outgoing request` group appears with messages and headers (Authorization redacted)
- [ ] Verify `[AI Chat Debug] Backend metadata` group appears with model, tools, system prompt preview
- [ ] Verify tool calls and results are logged in real-time during streaming
- [ ] Verify `[AI Chat Debug] Stream complete` summary appears with event counts and duration
- [ ] Verify the chat still works normally with the flag enabled
- [ ] Disable the flag and verify no debug logging appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)