### PR TITLE
Add guest auth, custom identity header, and portal customizations

### DIFF
--- a/.changeset/clean-castle-emerge.md
+++ b/.changeset/clean-castle-emerge.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Allow hiding the Backstage Identity card on the settings general page via extension config.

--- a/.changeset/plain-falcon-thrive.md
+++ b/.changeset/plain-falcon-thrive.md
@@ -1,0 +1,5 @@
+---
+'backend': minor
+---
+
+Add optional guest auth provider, enabled via `ENABLE_GUEST_AUTH` environment variable.

--- a/.changeset/rare-lantern-melt.md
+++ b/.changeset/rare-lantern-melt.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Use `ProxiedSignInPage` with guest provider as fallback when Dex auth is not configured.

--- a/.changeset/unique-forest-hover.md
+++ b/.changeset/unique-forest-hover.md
@@ -1,0 +1,8 @@
+---
+'app': minor
+'backend': minor
+'backend-headless-service': minor
+'@internal/backend-common': minor
+---
+
+Use custom X-Backstage-Token header for Backstage identity tokens to avoid conflicts with ingress-level Basic auth on the Authorization header.

--- a/.changeset/wise-lagoon-venture.md
+++ b/.changeset/wise-lagoon-venture.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Make sidebar nav items configurable via NFS extensions. Search, catalog, AI chat, and scaffolder sidebar items now respect their extension enabled state. Dividers between groups are only rendered when the group has visible items.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -158,12 +158,13 @@ kubernetes:
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   environment: development
-  providers:
-    # GitHub OAuth example
-    # github:
-    #   development:
-    #     clientId: ${GITHUB_OAUTH_CLIENT_ID}
-    #     clientSecret: ${GITHUB_OAUTH_CLIENT_SECRET}
+  # GitHub OAuth example
+  # providers:
+  #   github:
+  #     development:
+  #       clientId: ${GITHUB_OAUTH_CLIENT_ID}
+  #       clientSecret: ${GITHUB_OAUTH_CLIENT_SECRET}
+  providers: {}
 
   # see https://backstage.io/docs/ai/mcp-actions#client-id-metadata-documents
   # to learn more about client id metadata documents

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -172,23 +172,31 @@ export const appOverrides = createFrontendModule({
     SignInPageBlueprint.make({
       params: {
         loader: async () => {
-          const { SignInPage } = await import('@backstage/core-components');
-          const DexSignInPage = (props: {
+          const { SignInPage, ProxiedSignInPage } =
+            await import('@backstage/core-components');
+          const CustomSignInPage = (props: {
             onSignInSuccess: (identityApi: any) => void;
           }) => {
             const configApi = useApi(configApiRef);
-            const providers = [];
             if (configApi.has('gs.authProvider')) {
-              providers.push({
-                id: 'dex-auth-provider',
-                title: 'Dex',
-                message: 'Sign in using Dex',
-                apiRef: gsAuthApiRef,
-              });
+              return (
+                <SignInPage
+                  {...props}
+                  auto
+                  providers={[
+                    {
+                      id: 'dex-auth-provider',
+                      title: 'Dex',
+                      message: 'Sign in using Dex',
+                      apiRef: gsAuthApiRef,
+                    },
+                  ]}
+                />
+              );
             }
-            return <SignInPage {...props} auto providers={providers} />;
+            return <ProxiedSignInPage {...props} provider="guest" />;
           };
-          return DexSignInPage;
+          return CustomSignInPage;
         },
       },
     }),

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -111,6 +111,10 @@ export const appOverrides = createFrontendModule({
                   config: configApi,
                   urlPrefixAllowlist:
                     GSDiscoveryApiClient.getUrlPrefixAllowlist(configApi),
+                  header: {
+                    name: 'X-Backstage-Token',
+                    value: (token: string) => `Bearer ${token}`,
+                  },
                 }),
               ],
             }),

--- a/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/app/src/modules/nav/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
 } from '@backstage/core-components';
 import { compatWrapper } from '@backstage/core-compat-api';
 import { useApiHolder } from '@backstage/core-plugin-api';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { NavContentBlueprint } from '@backstage/plugin-app-react';
 import { SidebarLogo } from './SidebarLogo';
 import { NavItemIcon } from './NavItemIcon';
@@ -22,30 +23,44 @@ import {
 import {
   AIChatIcon,
   aiChatDrawerApiRef,
+  rootRouteRef as aiChatRouteRef,
 } from '@giantswarm/backstage-plugin-ai-chat-react';
 
 function AiChatSidebarItem() {
   const apiHolder = useApiHolder();
   const drawerApi = apiHolder.get(aiChatDrawerApiRef);
+  const aiChatLink = useRouteRef(aiChatRouteRef);
 
-  if (!drawerApi) return null;
-
-  return (
-    <SidebarItem
-      icon={() => (
-        <NavItemIcon>
-          <AIChatIcon />
-        </NavItemIcon>
-      )}
-      text="AI Assistant"
-      onClick={() => drawerApi.toggleDrawer()}
-    />
+  const icon = () => (
+    <NavItemIcon>
+      <AIChatIcon />
+    </NavItemIcon>
   );
+
+  if (drawerApi) {
+    return (
+      <SidebarItem
+        icon={icon}
+        text="AI Assistant"
+        onClick={() => drawerApi.toggleDrawer()}
+      />
+    );
+  }
+
+  if (aiChatLink) {
+    return <SidebarItem icon={icon} to={aiChatLink()} text="AI Assistant" />;
+  }
+
+  return null;
 }
 
 export const SidebarContent = NavContentBlueprint.make({
   params: {
     component: ({ navItems }) => {
+      const searchItem = navItems.take('page:search');
+      const catalogItem = navItems.take('page:catalog');
+      const scaffolderItem = navItems.take('page:scaffolder');
+      const aiChatItem = navItems.take('page:ai-chat');
       const nav = navItems.withComponent(item => (
         <SidebarItem
           icon={() => <NavItemIcon>{item.icon}</NavItemIcon>}
@@ -54,29 +69,53 @@ export const SidebarContent = NavContentBlueprint.make({
         />
       ));
 
+      const group1 = [
+        nav.take('page:home'),
+        catalogItem && (
+          <SidebarItem
+            key="catalog"
+            icon={FolderIcon}
+            to="catalog"
+            text="Catalog"
+          />
+        ),
+        nav.take('page:techdocs'),
+      ].filter(Boolean);
+
+      const group2 = [
+        nav.take('page:gs/deployments'),
+        nav.take('page:gs/clusters'),
+        nav.take('page:gs/installations'),
+        nav.take('page:flux'),
+      ].filter(Boolean);
+
+      const group3 = [
+        aiChatItem && <AiChatSidebarItem key="ai-chat" />,
+        scaffolderItem && (
+          <SidebarItem
+            icon={CreateComponentIcon}
+            to="create"
+            text="Create..."
+          />
+        ),
+      ].filter(Boolean);
+
+      const menuGroups = [group1, group2, group3].filter(g => g.length > 0);
+
       return compatWrapper(
         <Sidebar>
           <SidebarLogo />
-          <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
-            <SidebarSearchModal />
-          </SidebarGroup>
-          <SidebarDivider />
+
+          {searchItem && (
+            <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
+              <SidebarSearchModal />
+            </SidebarGroup>
+          )}
           <SidebarGroup label="Menu" icon={<MenuIcon />}>
-            {nav.take('page:home')}
-            <SidebarItem icon={FolderIcon} to="catalog" text="Catalog" />
-            {nav.take('page:techdocs')}
-            <SidebarDivider />
-            {nav.take('page:gs/deployments')}
-            {nav.take('page:gs/clusters')}
-            {nav.take('page:gs/installations')}
-            {nav.take('page:flux')}
-            <SidebarDivider />
-            <AiChatSidebarItem />
-            <SidebarItem
-              icon={CreateComponentIcon}
-              to="create"
-              text="Create..."
-            />
+            {menuGroups.flatMap((group, i) => [
+              <SidebarDivider key={`divider-${i}`} />,
+              ...group,
+            ])}
           </SidebarGroup>
           <SidebarSpace />
           <SidebarDivider />

--- a/packages/app/src/modules/userSettings/GeneralPage.tsx
+++ b/packages/app/src/modules/userSettings/GeneralPage.tsx
@@ -1,0 +1,57 @@
+import { lazy } from 'react';
+import { SubPageBlueprint } from '@backstage/frontend-plugin-api';
+
+const LazyGeneralSettings = lazy(async () => {
+  const [
+    {
+      UserSettingsProfileCard,
+      UserSettingsAppearanceCard,
+      UserSettingsIdentityCard,
+    },
+    { Content },
+    { default: Grid },
+  ] = await Promise.all([
+    import('@backstage/plugin-user-settings'),
+    import('@backstage/core-components'),
+    import('@material-ui/core/Grid'),
+  ]);
+
+  return {
+    default: ({ showIdentityCard }: { showIdentityCard: boolean }) => (
+      <Content>
+        <Grid container direction="row" spacing={3}>
+          <Grid item xs={12} md={6}>
+            <UserSettingsProfileCard />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <UserSettingsAppearanceCard />
+          </Grid>
+          {showIdentityCard && (
+            <Grid item xs={12} md={6}>
+              <UserSettingsIdentityCard />
+            </Grid>
+          )}
+        </Grid>
+      </Content>
+    ),
+  };
+});
+
+export const GeneralPage = SubPageBlueprint.makeWithOverrides({
+  name: 'general',
+  config: {
+    schema: {
+      showIdentityCard: z => z.boolean().default(true),
+    },
+  },
+  factory(originalFactory, { config }) {
+    const showIdentityCard = config.showIdentityCard;
+    return originalFactory({
+      path: 'general',
+      title: 'General',
+      loader: async () => (
+        <LazyGeneralSettings showIdentityCard={showIdentityCard} />
+      ),
+    });
+  },
+});

--- a/packages/app/src/modules/userSettings/index.ts
+++ b/packages/app/src/modules/userSettings/index.ts
@@ -1,7 +1,8 @@
 import { createFrontendModule } from '@backstage/frontend-plugin-api';
+import { GeneralPage } from './GeneralPage';
 import { ProviderSettings } from './ProviderSettings';
 
 export const userSettingsPluginOverrides = createFrontendModule({
   pluginId: 'user-settings',
-  extensions: [ProviderSettings],
+  extensions: [GeneralPage, ProviderSettings],
 });

--- a/packages/backend-common/src/httpAuth.ts
+++ b/packages/backend-common/src/httpAuth.ts
@@ -1,0 +1,50 @@
+import {
+  createServiceFactory,
+  coreServices,
+} from '@backstage/backend-plugin-api';
+import { DefaultHttpAuthService } from '@backstage/backend-defaults/httpAuth';
+
+/**
+ * Custom httpAuth service factory that reads the Backstage identity token
+ * from the `X-Backstage-Token` header, falling back to the standard
+ * `Authorization: Bearer` header.
+ *
+ * This avoids conflicts when an external proxy (e.g. nginx ingress) uses
+ * Basic auth on the `Authorization` header.
+ */
+export const customHttpAuthServiceFactory = createServiceFactory({
+  service: coreServices.httpAuth,
+  deps: {
+    auth: coreServices.auth,
+    discovery: coreServices.discovery,
+    plugin: coreServices.pluginMetadata,
+  },
+  factory({ auth, discovery, plugin }) {
+    return DefaultHttpAuthService.create({
+      auth,
+      discovery,
+      pluginId: plugin.getId(),
+      getTokenFromRequest(req) {
+        // Try custom header first (set by the frontend fetchApi middleware)
+        const customHeader = req.headers['x-backstage-token'];
+        if (typeof customHeader === 'string') {
+          const matches = customHeader.match(/^Bearer[ ]+(\S+)$/i);
+          if (matches?.[1]) {
+            return { token: matches[1] };
+          }
+        }
+
+        // Fall back to standard Authorization: Bearer header
+        const authHeader = req.headers.authorization;
+        if (typeof authHeader === 'string') {
+          const matches = authHeader.match(/^Bearer[ ]+(\S+)$/i);
+          if (matches?.[1]) {
+            return { token: matches[1] };
+          }
+        }
+
+        return { token: undefined };
+      },
+    });
+  },
+});

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -1,1 +1,2 @@
 export { rootLogger } from './rootLogger';
+export { customHttpAuthServiceFactory } from './httpAuth';

--- a/packages/backend-headless-service/src/index.ts
+++ b/packages/backend-headless-service/src/index.ts
@@ -1,8 +1,15 @@
 import 'global-agent/bootstrap';
 import { createBackend } from '@backstage/backend-defaults';
-import { rootLogger } from '@internal/backend-common';
+import {
+  customHttpAuthServiceFactory,
+  rootLogger,
+} from '@internal/backend-common';
 
 const backend = createBackend();
+
+// Override default httpAuth to read tokens from X-Backstage-Token header,
+// avoiding conflicts with ingress-level Basic auth on the Authorization header.
+backend.add(customHttpAuthServiceFactory);
 
 // auth plugin
 backend.add(import('@backstage/plugin-auth-backend'));

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,7 @@
     "@backstage/plugin-app-backend": "backstage:^",
     "@backstage/plugin-auth-backend": "backstage:^",
     "@backstage/plugin-auth-backend-module-github-provider": "backstage:^",
+    "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^",
     "@backstage/plugin-auth-node": "backstage:^",
     "@backstage/plugin-catalog-backend": "backstage:^",
     "@backstage/plugin-catalog-backend-module-aws": "backstage:^",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,8 +1,15 @@
 import 'global-agent/bootstrap';
 import { createBackend } from '@backstage/backend-defaults';
-import { rootLogger } from '@internal/backend-common';
+import {
+  customHttpAuthServiceFactory,
+  rootLogger,
+} from '@internal/backend-common';
 
 const backend = createBackend();
+
+// Override default httpAuth to read tokens from X-Backstage-Token header,
+// avoiding conflicts with ingress-level Basic auth on the Authorization header.
+backend.add(customHttpAuthServiceFactory);
 
 backend.add(import('@backstage/plugin-app-backend'));
 backend.add(import('@backstage/plugin-proxy-backend'));

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -26,6 +26,9 @@ backend.add(import('@giantswarm/backstage-plugin-techdocs-backend-module-gs'));
 
 // auth plugin
 backend.add(import('@backstage/plugin-auth-backend'));
+if (process.env.ENABLE_GUEST_AUTH) {
+  backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
+}
 backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 backend.add(import('@giantswarm/backstage-plugin-auth-backend-module-gs'));
 

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -18,7 +18,8 @@ export function createDebugFetch(): typeof globalThis.fetch {
         const safeHeaders = headers
           ? Object.fromEntries(
               Object.entries(headers).map(([k, v]) =>
-                k.toLowerCase() === 'authorization'
+                k.toLowerCase() === 'authorization' ||
+                k.toLowerCase() === 'x-backstage-token'
                   ? [k, '[REDACTED]']
                   : [k, v],
               ),

--- a/plugins/ai-chat/src/hooks/useChatSetup.ts
+++ b/plugins/ai-chat/src/hooks/useChatSetup.ts
@@ -140,7 +140,7 @@ export function useChatSetup() {
     const mcpHeaders = await getMCPAuthHeaders();
 
     return {
-      Authorization: `Bearer ${token}`,
+      'X-Backstage-Token': `Bearer ${token}`,
       'X-Conversation-Id': conversationIdRef.current,
       ...(verboseDebugging && { 'X-AI-Chat-Debug': 'true' }),
       ...mcpHeaders,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,6 +6412,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.50.2&npm=0.2.18, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.18":
+  version: 0.2.18
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.18"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.0"
+    "@backstage/catalog-model": "npm:^1.8.0"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/plugin-auth-node": "npm:^0.7.0"
+    passport-oauth2: "npm:^1.7.0"
+  checksum: 10c0/7440fa2e6d310b932e0f861506a7fd05fa8fb4d40cf5290f40a774b31ec6c8efe561735c18d06b08ebbd48fffde330e54445eca0b4e8b235e3a325dcc57dfaf4
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-oidc-provider@backstage:^::backstage=1.50.2&npm=0.4.15, @backstage/plugin-auth-backend-module-oidc-provider@npm:^0.4.15":
   version: 0.4.15
   resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.15"
@@ -24306,6 +24319,7 @@ __metadata:
     "@backstage/plugin-app-backend": "backstage:^"
     "@backstage/plugin-auth-backend": "backstage:^"
     "@backstage/plugin-auth-backend-module-github-provider": "backstage:^"
+    "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^"
     "@backstage/plugin-auth-node": "backstage:^"
     "@backstage/plugin-catalog-backend": "backstage:^"
     "@backstage/plugin-catalog-backend-module-aws": "backstage:^"
@@ -38340,7 +38354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"passport-oauth2@npm:1.x.x, passport-oauth2@npm:^1.8.0":
+"passport-oauth2@npm:1.x.x, passport-oauth2@npm:^1.7.0, passport-oauth2@npm:^1.8.0":
   version: 1.8.0
   resolution: "passport-oauth2@npm:1.8.0"
   dependencies:


### PR DESCRIPTION
### What does this PR do?

Adds several features to support running Backstage as a customer-facing portal alongside the existing internal deployment:

- **Guest auth provider** — optional backend guest auth via `ENABLE_GUEST_AUTH` env var, with `ProxiedSignInPage` fallback when Dex is not configured
- **Custom identity header** — sends Backstage identity tokens via `X-Backstage-Token` instead of `Authorization` to avoid conflicts with ingress-level Basic auth
- **Configurable sidebar** — nav items (search, catalog, AI chat, scaffolder) now respect NFS extension enabled state; dividers only render between non-empty groups
- **Settings page** — identity card visibility on the general settings page is configurable via extension config
- **Config fix** — `auth.providers` defaults to `{}` instead of `null` to prevent errors when no providers are configured

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/36072.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))