### PR TITLE
feat(ai-chat): make welcome screen configurable

### DIFF
--- a/.changeset/calm-rainbow-nestle.md
+++ b/.changeset/calm-rainbow-nestle.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+Add optional `aiChat.welcome.{title,subtitle,suggestions}` config to customize the AI chat welcome screen. Falls back to the built-in defaults when not set.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -232,6 +232,17 @@ aiChat:
   #   systemPrompt:
   #     $file: ./my-system-prompt.md
 
+  # Optional: customize the welcome screen shown before the first message.
+  # Any key omitted falls back to the built-in default. Up to 3 suggestions
+  # are picked at random per mount. An empty `suggestions` array hides the
+  # suggestion cards entirely.
+  # welcome:
+  #   title: 'How can I help you today?'
+  #   subtitle: 'Not sure what to do here? Try one of these questions.'
+  #   suggestions:
+  #     - 'What applications are available for deployment?'
+  #     - 'Who are my team mates?'
+
   # Optional: MCP servers configuration
   # mcp:
   #   - name: backstage-actions

--- a/plugins/ai-chat/config.d.ts
+++ b/plugins/ai-chat/config.d.ts
@@ -1,6 +1,27 @@
 export interface Config {
   /** Configuration for AI Chat plugin */
   aiChat?: {
+    /** Optional: customize the welcome screen shown before the first message */
+    welcome?: {
+      /**
+       * Optional: override the welcome screen title.
+       * @visibility frontend
+       */
+      title?: string;
+      /**
+       * Optional: override the welcome screen subtitle.
+       * @visibility frontend
+       */
+      subtitle?: string;
+      /**
+       * Optional: suggested questions shown as clickable cards.
+       * When set, replaces the built-in list. Up to 3 are picked at
+       * random per mount. An empty array hides the cards.
+       * @visibility frontend
+       */
+      suggestions?: string[];
+    };
+
     /** Optional: MCP servers configuration */
     mcp?: Array<{
       /**

--- a/plugins/ai-chat/src/components/AiChat/Thread.tsx
+++ b/plugins/ai-chat/src/components/AiChat/Thread.tsx
@@ -7,7 +7,11 @@ import {
   BranchPickerPrimitive,
   useAssistantApi,
 } from '@assistant-ui/react';
-import { useApi, featureFlagsApiRef } from '@backstage/core-plugin-api';
+import {
+  useApi,
+  configApiRef,
+  featureFlagsApiRef,
+} from '@backstage/core-plugin-api';
 import IconButton from '@material-ui/core/IconButton';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
@@ -33,7 +37,10 @@ import {
   ContextUsageDisplay,
 } from './assistant-ui-components';
 
-const EXAMPLE_QUESTIONS = [
+const DEFAULT_WELCOME_TITLE = 'How can I help you today?';
+const DEFAULT_WELCOME_SUBTITLE =
+  'Not sure what to do here? Try one of these questions.';
+const DEFAULT_WELCOME_SUGGESTIONS = [
   'What applications are available for deployment?',
   'Are there any clusters unhealthy right now?',
   'Who are my team mates?',
@@ -46,11 +53,23 @@ const EXAMPLE_QUESTIONS = [
 const ThreadWelcome = () => {
   const classes = useStyles();
   const api = useAssistantApi();
+  const configApi = useApi(configApiRef);
+
+  const title =
+    configApi.getOptionalString('aiChat.welcome.title') ??
+    DEFAULT_WELCOME_TITLE;
+  const subtitle =
+    configApi.getOptionalString('aiChat.welcome.subtitle') ??
+    DEFAULT_WELCOME_SUBTITLE;
 
   const selectedQuestions = useMemo(() => {
-    const shuffled = [...EXAMPLE_QUESTIONS].sort(() => Math.random() - 0.5);
+    const configured = configApi.getOptionalStringArray(
+      'aiChat.welcome.suggestions',
+    );
+    const pool = configured ?? DEFAULT_WELCOME_SUGGESTIONS;
+    const shuffled = [...pool].sort(() => Math.random() - 0.5);
     return shuffled.slice(0, 3);
-  }, []);
+  }, [configApi]);
 
   const handleSuggestionClick = (question: string) => {
     api
@@ -60,12 +79,8 @@ const ThreadWelcome = () => {
 
   return (
     <div className={classes.welcomeContainer}>
-      <Typography className={classes.welcomeTitle}>
-        How can I help you today?
-      </Typography>
-      <Typography className={classes.welcomeSubtitle}>
-        Not sure what to do here? Try one of these questions.
-      </Typography>
+      <Typography className={classes.welcomeTitle}>{title}</Typography>
+      <Typography className={classes.welcomeSubtitle}>{subtitle}</Typography>
       <div className={classes.suggestionsContainer}>
         {selectedQuestions.map(question => (
           <ButtonBase


### PR DESCRIPTION
### What does this PR do?

Adds three optional config keys — `aiChat.welcome.title`, `aiChat.welcome.subtitle`, and `aiChat.welcome.suggestions` — that let operators customize the welcome screen shown before the first message in the AI chat. Each key independently falls back to its built-in default, so there is no behavior change unless a key is explicitly set. Up to 3 suggestions are still picked at random per mount.

### What is the effect of this change to users?

Operators can tailor the greeting and suggested questions to their portal's audience (translated copy, domain-specific prompts, org-specific examples). End users see no change unless the operator overrides one or more keys.

### How does it look like?

No visual change by default.

Example config:

```yaml
aiChat:
  welcome:
    title: 'How can I help you today?'
    subtitle: 'Not sure what to try? Pick one of the suggestions below.'
    suggestions:
      - 'Which clusters exist in the platform?'
      - 'What can I do here?'
      - 'Which MCP tools are available?'
      - 'Tell me a joke about DevOps engineers'
```

With the above, title, subtitle, and cards reflect the configured values.

### Any background context you can provide?

Extends the pattern established by the recently-landed `aiChat.systemPrompt` override, continuing to move hardcoded AI-chat strings into app config.

### Do the docs need to be updated?

No — the commented block added to `app-config.yaml` documents the shape, and `plugins/ai-chat/config.d.ts` is the schema source of truth.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

🤖 Generated with [Claude Code](https://claude.com/claude-code)