### PR TITLE
feat(ai-chat): stream reasoning tokens from vLLM-style models

### DIFF
--- a/.changeset/ai-chat-stream-reasoning-from-vllm.md
+++ b/.changeset/ai-chat-stream-reasoning-from-vllm.md
@@ -1,0 +1,28 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+Stream reasoning tokens from OpenAI-compatible models (vLLM) to the chat UI.
+
+When `aiChat.openai.api: chat` is configured (the vLLM/llama.cpp/SGLang
+path), the backend now talks to the model via `@ai-sdk/openai-compatible`
+instead of `@ai-sdk/openai`'s chat-completions client. The
+openai-compatible provider understands the `delta.reasoning` and
+`delta.reasoning_content` SSE fields that these servers emit when a
+reasoning parser is enabled (e.g. vLLM's
+`--reasoning-parser nemotron_v3` for Nemotron-Super), and forwards them
+as proper LanguageModelV3 reasoning stream parts. The OpenAI Responses
+path (`aiChat.openai.api: responses`, the default for real OpenAI),
+Azure, and Anthropic flows are unchanged.
+
+Also unconditionally renders the `Reasoning` and `ReasoningGroup`
+assistant-ui slots in `Thread.tsx` (previously gated behind the
+`ai-chat-verbose-debugging` feature flag). Without the slots, the
+streamed reasoning was silently dropped on the frontend even when the
+backend emitted it -- the chat just showed the "Thinking..." spinner
+for the full reasoning phase and then a sudden burst of answer text.
+
+Visible effect: with a reasoning-capable model the user now sees a
+collapsible "Reasoning" block that streams in token-by-token starting
+within ~500ms of pressing send, followed by the final answer.

--- a/plugins/ai-chat-backend/package.json
+++ b/plugins/ai-chat-backend/package.json
@@ -29,6 +29,7 @@
     "@ai-sdk/azure": "^3.0.34",
     "@ai-sdk/mcp": "^1.0.13",
     "@ai-sdk/openai": "^3.0.19",
+    "@ai-sdk/openai-compatible": "^2.0.41",
     "@backstage/backend-defaults": "backstage:^",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/config": "backstage:^",

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -7,6 +7,7 @@ import {
 import { Config } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createAzure } from '@ai-sdk/azure';
 import {
@@ -146,6 +147,20 @@ export async function createRouter(
     baseURL: openaiBaseUrl,
   });
 
+  // OpenAI-compatible provider for `aiChat.openai.api: chat` (vLLM and similar
+  // OpenAI-compatible servers). Unlike `@ai-sdk/openai`'s chat path, this
+  // provider handles the `delta.reasoning` / `delta.reasoning_content` SSE
+  // fields that vLLM emits when `--reasoning-parser` is configured (e.g.
+  // `nemotron_v3` for Nemotron-Super), and forwards them as proper
+  // `reasoning-start` / `reasoning-delta` / `reasoning-end` LanguageModelV3
+  // stream parts. Without this, the reasoning phase appears as silence to
+  // the chat UI and only the post-think answer text streams through.
+  const openaiCompatible = createOpenAICompatible({
+    name: 'openai-compatible',
+    baseURL: openaiBaseUrl ?? '',
+    apiKey: openaiApiKey,
+  });
+
   const anthropic = createAnthropic({
     apiKey: anthropicApiKey,
     baseURL: anthropicBaseUrl,
@@ -239,7 +254,9 @@ export async function createRouter(
       if (isAzureConfigured) {
         openaiCompatibleModel = azure.chat(modelName);
       } else if (openaiApi === 'chat') {
-        openaiCompatibleModel = openai.chat(modelName);
+        // Use @ai-sdk/openai-compatible for vLLM-style chat-completions servers
+        // so reasoning chunks are surfaced (see provider construction above).
+        openaiCompatibleModel = openaiCompatible.chatModel(modelName);
       } else {
         openaiCompatibleModel = openai(modelName);
       }
@@ -357,6 +374,7 @@ export async function createRouter(
         let providerName = 'openai';
         if (isAnthropicModel) providerName = 'anthropic';
         else if (isAzureConfigured) providerName = 'azure';
+        else if (openaiApi === 'chat') providerName = 'openai-compatible';
 
         const toolEntries = Object.entries(allTools).map(([name, t]) => ({
           name,

--- a/plugins/ai-chat/src/components/AiChat/Thread.tsx
+++ b/plugins/ai-chat/src/components/AiChat/Thread.tsx
@@ -182,10 +182,14 @@ const AssistantMessage = () => {
         <MessagePrimitive.Parts
           components={{
             Text: StreamingMarkdownText,
+            // Reasoning is always rendered when the model emits it (e.g.
+            // Anthropic extended thinking, vLLM `--reasoning-parser`).
+            // Without this slot the reasoning phase appears as silence to
+            // the user even when the SDK is streaming reasoning chunks.
+            Reasoning: Reasoning,
+            ReasoningGroup: ReasoningGroup,
             ...(verboseDebugging
               ? {
-                  Reasoning: Reasoning,
-                  ReasoningGroup: ReasoningGroup,
                   ToolGroup: ToolGroup,
                   tools: {
                     by_name: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ai-sdk/openai-compatible@npm:^2.0.41":
+  version: 2.0.41
+  resolution: "@ai-sdk/openai-compatible@npm:2.0.41"
+  dependencies:
+    "@ai-sdk/provider": "npm:3.0.8"
+    "@ai-sdk/provider-utils": "npm:4.0.23"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/3f91ad098edfedff46d9fa14b015fa46e235cc460cfdf45f1fb3f5114baa625684436770993aa7b969dbbf5f835a640e062c75cbf3ae72bd746ce6a37f2636f2
+  languageName: node
+  linkType: hard
+
 "@ai-sdk/openai@npm:3.0.53, @ai-sdk/openai@npm:^3.0.19":
   version: 3.0.53
   resolution: "@ai-sdk/openai@npm:3.0.53"
@@ -10420,6 +10432,7 @@ __metadata:
     "@ai-sdk/azure": "npm:^3.0.34"
     "@ai-sdk/mcp": "npm:^1.0.13"
     "@ai-sdk/openai": "npm:^3.0.19"
+    "@ai-sdk/openai-compatible": "npm:^2.0.41"
     "@backstage/backend-defaults": "backstage:^"
     "@backstage/backend-plugin-api": "backstage:^"
     "@backstage/backend-test-utils": "backstage:^"


### PR DESCRIPTION
## Summary

When `aiChat.openai.api: chat` is configured (the vLLM/llama.cpp/SGLang path), swap the backend's model client from `@ai-sdk/openai` (chat-completions) to `@ai-sdk/openai-compatible`, and surface the streamed reasoning in the chat UI.

## Why

`@ai-sdk/openai@3.0.x`'s chat-completions chunk schema (`openaiChatChunkSchema`) only declares `delta.content` and `delta.tool_calls`. Zod silently drops the `delta.reasoning` / `delta.reasoning_content` SSE fields that vLLM emits when a reasoning parser is configured (e.g. `--reasoning-parser nemotron_v3` for Nemotron-Super, `deepseek_r1` for DeepSeek, etc.). Result for the BWI Backstage demo on `nemotron-nvfp4`:

- vLLM IS reasoning -- verified at the wire level, `delta.reasoning` chunks stream from `/v1/chat/completions` immediately
- the AI SDK never emits a single `reasoning-delta` UI part, so the chat UI just shows the "Thinking..." spinner for the whole reasoning phase (often >10 s)
- when vLLM finally crosses the `</think>` boundary and starts emitting `delta.content`, the answer text streams normally -- but it looks like "all output at once" because the reasoning was invisible

`@ai-sdk/openai-compatible@2.x` is the upstream-blessed provider for OpenAI-compatible servers. Its chunk schema declares both `reasoning_content` and `reasoning`, and its stream loop emits proper `reasoning-start` / `reasoning-delta` / `reasoning-end` LanguageModelV3 parts, which the AI SDK UI message stream and `@assistant-ui/react`'s `MessagePrimitive.Parts` already know how to render via the existing `Reasoning` / `ReasoningGroup` components.

## Verified

End-to-end against the live BWI `nemotron-nvfp4` ISVC (vLLM eugr-2026041801 nightly, `--reasoning-parser nemotron_v3`), via a small standalone script using exactly the same SDK combo this PR ships:

| event | wall time |
|---|---|
| request sent | 0 ms |
| first `reasoning-delta` | 446 ms |
| reasoning streams token-by-token | through 11.3 s (436 chars) |
| first `text-delta` | 11,775 ms |
| `finish` (reason=stop) | 21,878 ms |

Without this PR those 11 s between request and first `text-delta` are total silence on the SSE going to the browser.

## Changes

- **`plugins/ai-chat-backend`**
  - Add dependency on `@ai-sdk/openai-compatible@^2.0.41` (clean version match -- both packages already pin `@ai-sdk/provider@3.0.8` and `@ai-sdk/provider-utils@4.0.23`).
  - In `router.ts`, construct an `openaiCompatible` provider alongside the existing `openai` / `anthropic` / `azure` providers, and route the `aiChat.openai.api === 'chat'` branch through it. The Responses API path (default for real OpenAI), Azure, and Anthropic flows are untouched.
  - Add `'openai-compatible'` to the debug header `provider` field for the same branch so the in-browser debug panel reports the correct provider.

- **`plugins/ai-chat`**
  - In `Thread.tsx`, register the `Reasoning` and `ReasoningGroup` assistant-ui slots unconditionally instead of only when the `ai-chat-verbose-debugging` feature flag is on. Without these slots, the streamed reasoning would still be silently dropped at the UI level even after the backend fix.

## Provider routing matrix after this PR

| `aiChat.openai.api` | provider | reasoning streamed? |
|---|---|---|
| `chat` (vLLM, llama.cpp, SGLang) | `@ai-sdk/openai-compatible` | yes (this PR) |
| `responses` (default, real OpenAI) | `@ai-sdk/openai` Responses API | yes (already supported) |
| Azure (when `aiChat.azure.*` configured) | `@ai-sdk/azure` | unchanged |
| Anthropic (`claude-*` model) | `@ai-sdk/anthropic` | unchanged (already wired with `providerOptions.anthropic.thinking`) |

## Test plan

- [x] `yarn install` -- single new dep resolves cleanly, no provider/provider-utils version conflict
- [x] `yarn workspace @giantswarm/backstage-plugin-ai-chat-backend lint` -- clean
- [x] `yarn workspace @giantswarm/backstage-plugin-ai-chat lint` -- clean
- [x] `yarn tsc` -- clean across the whole workspace
- [x] Standalone end-to-end check against live BWI `nemotron-nvfp4` (numbers above)
- [ ] CI green (will verify on this PR)
- [ ] Roll the new `backstage` chart version into the BWI GitOps repo's `backstage/release.yaml` once the auto-release tag fires, then visually confirm reasoning streams in the BWI Backstage demo

Made-with: Cursor

Made with [Cursor](https://cursor.com)