### PR TITLE
fix(app): migrate user settings General page to configSchema

### DIFF
--- a/.changeset/fix-general-settings-deprecated-config-schema.md
+++ b/.changeset/fix-general-settings-deprecated-config-schema.md
@@ -1,0 +1,10 @@
+---
+'app': patch
+---
+
+Fix deprecation warning for the user settings General sub-page by migrating
+from the deprecated `config.schema` option to the new top-level `configSchema`
+option using a Standard Schema value from `zod` v4. Adds `zod@^4.3.6` as a
+direct dependency of `packages/app` so the schema resolves against a Zod
+build that includes JSON Schema conversion (the `zod/v4` subpath of Zod v3
+does not).

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -69,7 +69,8 @@
     "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "^6.3.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.32.3",

--- a/packages/app/src/modules/userSettings/GeneralPage.tsx
+++ b/packages/app/src/modules/userSettings/GeneralPage.tsx
@@ -1,5 +1,6 @@
 import { lazy } from 'react';
 import { SubPageBlueprint } from '@backstage/frontend-plugin-api';
+import { z } from 'zod';
 
 const LazyGeneralSettings = lazy(async () => {
   const [
@@ -39,10 +40,8 @@ const LazyGeneralSettings = lazy(async () => {
 
 export const GeneralPage = SubPageBlueprint.makeWithOverrides({
   name: 'general',
-  config: {
-    schema: {
-      showIdentityCard: z => z.boolean().default(true),
-    },
+  configSchema: {
+    showIdentityCard: z.boolean().default(true),
   },
   factory(originalFactory, { config }) {
     const showIdentityCard = config.showIdentityCard;

--- a/yarn.lock
+++ b/yarn.lock
@@ -23667,6 +23667,7 @@ __metadata:
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.3.0"
+    zod: "npm:^4.3.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Removes a deprecation warning logged on app load: `The config.schema option for extension config is deprecated. Use the configSchema option instead with Standard Schema values.`
- Migrates `packages/app/src/modules/userSettings/GeneralPage.tsx` from the deprecated `config.schema` (factory form: `z => z.boolean()…`) to the new top-level `configSchema` option with a Standard Schema value from `zod` v4.
- Adds `zod@^4.3.6` as a direct dependency of `packages/app`. The `zod/v4` subpath export from Zod v3 does not include JSON Schema conversion, so the extension throws `Config schema for field 'showIdentityCard' does not support JSON Schema conversion`. A real `zod@^4` install resolves that converter (matches the version bundled by `@backstage/frontend-plugin-api`).

## Test plan

- [ ] `yarn start` and load the app — no deprecation warning in the browser console for `showIdentityCard`
- [ ] Settings → General page loads; the Identity card respects the default (`showIdentityCard: true`) and can be toggled off via app config
- [ ] `yarn tsc` passes
- [ ] `yarn test --coverage packages/app --forceExit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)