### PR TITLE
fix(app): add key to scaffolder sidebar item

### DIFF
--- a/.changeset/fix-sidebar-missing-key-warning.md
+++ b/.changeset/fix-sidebar-missing-key-warning.md
@@ -1,0 +1,7 @@
+---
+'app': patch
+---
+
+Fix React "Each child in a list should have a unique key prop" warning
+emitted on the root page by adding a `key` to the scaffolder "Create..."
+`SidebarItem` in the main sidebar.

--- a/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/app/src/modules/nav/Sidebar.tsx
@@ -92,6 +92,7 @@ export const SidebarContent = NavContentBlueprint.make({
         <AiChatSidebarItem key="ai-chat" />,
         scaffolderItem && (
           <SidebarItem
+            key="create"
             icon={CreateComponentIcon}
             to="create"
             text="Create..."


### PR DESCRIPTION
## Summary
- Add an explicit `key` to the scaffolder "Create..." `SidebarItem` in `packages/app/src/modules/nav/Sidebar.tsx` so it matches the other children of the "Menu" `SidebarGroup`, silencing React's "Each child in a list should have a unique key prop" warning emitted on the root page.

## Test plan
- [ ] `yarn start` and load the root page — no "unique key prop" warning in the console.
- [ ] Sidebar renders the Create... item as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)