### PR TITLE
Improve tool call rendering and chat UX

### DIFF
--- a/.changeset/deep-thunder-heal.md
+++ b/.changeset/deep-thunder-heal.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': minor
+---
+
+Redesign tool call and tool group UI with compact inline layout, argument summary previews, inline status icons, and tool name breakdown in grouped headers.

--- a/.changeset/sweet-nebula-unfold.md
+++ b/.changeset/sweet-nebula-unfold.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Flush SSE chunks through compression middleware so streamed AI responses
+reach the client in real time instead of arriving as a single batch.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -128,6 +128,7 @@ permission:
 mcpActions:
   name: 'My Company Backstage' # defaults to "backstage"
   description: 'Tools for managing your software catalog, creating new services from templates, and exploring your developer portal' # optional
+  namespacedToolNames: false
 
 proxy:
   ### Example for how to add a proxy endpoint for the frontend.

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -413,6 +413,22 @@ export async function createRouter(
         res.setHeader('Access-Control-Expose-Headers', 'X-AI-Chat-Debug-Meta');
       }
 
+      // Backstage's root HTTP router applies compression() middleware
+      // globally, which buffers res.write() calls. For SSE this means
+      // every event is held until res.end(), defeating real-time streaming.
+      // Wrap res.write to auto-flush after each write so chunks reach the
+      // client as the LLM produces them.
+      const originalWrite = res.write;
+      res.write = function flushingWrite(
+        ...args: Parameters<typeof originalWrite>
+      ) {
+        const ret = originalWrite.apply(res, args);
+        if (typeof (res as any).flush === 'function') {
+          (res as any).flush();
+        }
+        return ret;
+      } as typeof originalWrite;
+
       result.pipeUIMessageStreamToResponse(res);
     } catch (error) {
       chatLogger.error('Error in chat endpoint', error as Error);

--- a/plugins/ai-chat/src/components/AiChat/Thread.tsx
+++ b/plugins/ai-chat/src/components/AiChat/Thread.tsx
@@ -3,6 +3,7 @@ import {
   ThreadPrimitive,
   ComposerPrimitive,
   MessagePrimitive,
+  ErrorPrimitive,
   ActionBarPrimitive,
   BranchPickerPrimitive,
   useAssistantApi,
@@ -227,9 +228,9 @@ const AssistantMessage = () => {
           }}
         />
         <MessagePrimitive.Error>
-          <div className={classes.errorMessage}>
-            Error occurred. Please try again.
-          </div>
+          <ErrorPrimitive.Root className={classes.errorMessage}>
+            <ErrorPrimitive.Message />
+          </ErrorPrimitive.Root>
         </MessagePrimitive.Error>
       </div>
       <div className={classes.messageActionsContainer}>

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/Reasoning.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/Reasoning.tsx
@@ -338,6 +338,12 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
           .join(' ')}
         aria-expanded={isOpen}
       >
+        <ExpandMoreIcon
+          className={[
+            classes.triggerChevron,
+            isOpen ? classes.triggerChevronOpen : classes.triggerChevronClosed,
+          ].join(' ')}
+        />
         <span className={classes.triggerLabel}>
           <span>{triggerLabel}</span>
           {isReasoningStreaming ? (
@@ -346,12 +352,6 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
             </span>
           ) : null}
         </span>
-        <ExpandMoreIcon
-          className={[
-            classes.triggerChevron,
-            isOpen ? classes.triggerChevronOpen : classes.triggerChevronClosed,
-          ].join(' ')}
-        />
       </button>
 
       <Collapse in={isOpen} timeout={ANIMATION_DURATION}>

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/StreamingMarkdownText.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/StreamingMarkdownText.tsx
@@ -5,7 +5,7 @@ import remarkGfm from 'remark-gfm';
 import { createMarkdownComponents, useMarkdownStyles } from './MarkdownText';
 
 // Characters revealed per animation frame (~300 chars/sec at 60fps).
-const CHARS_PER_FRAME = 5;
+const CHARS_PER_FRAME = 10;
 
 // How recently a message must have been created (ms) to receive animation.
 // Handles the case where all SSE chunks arrive in one TCP read and are batched

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolFallback.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolFallback.tsx
@@ -13,14 +13,43 @@ import { JsonHighlight } from '@giantswarm/backstage-plugin-ui-react';
 
 const ANIMATION_DURATION = 200;
 
+const SUMMARY_KEYS = [
+  'path',
+  'file_path',
+  'file',
+  'command',
+  'query',
+  'pattern',
+  'glob_pattern',
+  'search_term',
+  'url',
+  'description',
+  'prompt',
+  'name',
+  'skill',
+  'topic',
+  'kind',
+];
+
+function toolCallSummary(argsText: string): string | null {
+  try {
+    const args = JSON.parse(argsText);
+    for (const key of SUMMARY_KEYS) {
+      const val = args[key];
+      if (typeof val === 'string' && val.trim()) {
+        const text = val.trim();
+        return text.length > 80 ? `${text.slice(0, 77)}...` : text;
+      }
+    }
+  } catch {
+    /* ignore parse errors */
+  }
+  return null;
+}
+
 const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
-    borderRadius: 'var(--bui-radius-3)',
-    border: `1px solid ${theme.palette.divider}`,
-    paddingTop: theme.spacing(1.5),
-    paddingBottom: theme.spacing(1.5),
-    backgroundColor: 'var(--bui-bg-neutral-2)',
   },
   rootCancelled: {
     borderColor: theme.palette.action.disabled,
@@ -28,46 +57,53 @@ const useStyles = makeStyles(theme => ({
   },
   trigger: {
     display: 'flex',
-    width: '100%',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    fontSize: theme.typography.body2.fontSize,
+    gap: theme.spacing(0.75),
+    alignItems: 'flex-start',
+    fontSize: '0.8125rem',
+    lineHeight: 1.4,
     cursor: 'pointer',
     transition: theme.transitions.create('color'),
     color: theme.palette.text.primary,
     border: 'none',
     background: 'none',
+    padding: 0,
     textAlign: 'left',
     '&:hover': {
       color: theme.palette.text.secondary,
     },
   },
-  icon: {
-    fontSize: 16,
-    flexShrink: 0,
+  statusBadge: {
+    width: '14px',
+    height: '14px',
+    marginRight: '4px',
+    display: 'inline-block',
+    verticalAlign: 'text-bottom',
+    transform: 'scaleX(-1)',
   },
-  iconCancelled: {
-    color: theme.palette.text.disabled,
-  },
-  iconRunning: {
+  statusBadgeRunning: {
     animation: '$spin 1s linear infinite',
   },
   '@keyframes spin': {
-    from: { transform: 'rotate(0deg)' },
-    to: { transform: 'rotate(360deg)' },
+    from: { transform: 'scaleX(-1) rotate(0deg)' },
+    to: { transform: 'scaleX(-1) rotate(-360deg)' },
   },
-  labelWrapper: {
+  triggerLabel: {
     position: 'relative',
     display: 'inline-block',
     flexGrow: 1,
     textAlign: 'left',
-    lineHeight: 1,
+    fontWeight: 500,
+    lineHeight: 1.4,
+    minWidth: 0,
   },
   labelCancelled: {
     color: theme.palette.text.disabled,
     textDecoration: 'line-through',
+  },
+  summary: {
+    color: theme.palette.text.secondary,
+    fontWeight: 400,
+    marginLeft: theme.spacing(1),
   },
   shimmer: {
     pointerEvents: 'none',
@@ -78,12 +114,14 @@ const useStyles = makeStyles(theme => ({
     },
   },
   chevron: {
-    fontSize: 16,
+    width: 14,
+    height: 14,
     flexShrink: 0,
     transition: theme.transitions.create('transform', {
       duration: ANIMATION_DURATION,
       easing: theme.transitions.easing.easeOut,
     }),
+    marginTop: '2.5px',
   },
   chevronOpen: {
     transform: 'rotate(0deg)',
@@ -94,21 +132,23 @@ const useStyles = makeStyles(theme => ({
   content: {
     position: 'relative',
     overflow: 'hidden',
-    fontSize: theme.typography.body2.fontSize,
+    fontSize: '0.8125rem',
+    borderRadius: 'var(--bui-radius-2)',
+    border: `1px solid ${theme.palette.divider}`,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    backgroundColor: 'var(--bui-bg-neutral-2)',
+    marginTop: theme.spacing(1),
   },
   contentInner: {
-    marginTop: theme.spacing(1.5),
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),
-    borderTop: `1px solid ${theme.palette.divider}`,
-    paddingTop: theme.spacing(1),
   },
   args: {
     paddingTop: 0,
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(1.5),
+    paddingRight: theme.spacing(1.5),
   },
   codeBlock: {
     margin: 0,
@@ -119,27 +159,35 @@ const useStyles = makeStyles(theme => ({
   result: {
     borderTop: `1px dashed ${theme.palette.divider}`,
     paddingTop: theme.spacing(1),
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(3),
-    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(1.5),
+    paddingRight: theme.spacing(1.5),
     '&:first-child': {
       borderTop: 'none',
+      paddingTop: 0,
     },
   },
   resultHeader: {
-    fontWeight: 600,
-    marginTop: theme.spacing(1),
+    marginTop: 0,
+    marginBottom: theme.spacing(1),
   },
   error: {
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
+    borderTop: `1px dashed ${theme.palette.divider}`,
+    paddingTop: theme.spacing(1),
+    paddingLeft: theme.spacing(1.5),
+    paddingRight: theme.spacing(1.5),
+    color: theme.palette.error.main,
+    '&:first-child': {
+      borderTop: 'none',
+      paddingTop: 0,
+    },
   },
   errorHeader: {
     fontWeight: 600,
-    color: theme.palette.text.disabled,
+    marginTop: 0,
+    marginBottom: theme.spacing(1),
   },
   errorReason: {
-    color: theme.palette.text.disabled,
+    margin: 0,
   },
   argsCancelled: {
     opacity: 0.6,
@@ -177,12 +225,14 @@ const statusIconMap: Record<ToolStatus, React.ElementType> = {
 
 function ToolFallbackTrigger({
   toolName,
+  argsText,
   status,
   className,
   isOpen,
   onClick,
 }: {
   toolName: string;
+  argsText?: string;
   status?: ToolCallMessagePartStatus;
   className?: string;
   isOpen: boolean;
@@ -193,9 +243,10 @@ function ToolFallbackTrigger({
   const isRunning = statusType === 'running';
   const isCancelled =
     status?.type === 'incomplete' && status.reason === 'cancelled';
+  const showStatusBadge = statusType !== 'complete';
 
-  const Icon = statusIconMap[statusType];
-  const label = isCancelled ? 'Cancelled tool' : 'Used tool';
+  const StatusIcon = statusIconMap[statusType];
+  const summary = argsText && !isOpen ? toolCallSummary(argsText) : null;
 
   return (
     <button
@@ -204,37 +255,27 @@ function ToolFallbackTrigger({
       onClick={onClick}
       type="button"
     >
-      <Icon
-        data-slot="tool-fallback-trigger-icon"
-        className={`${classes.icon} ${isCancelled ? classes.iconCancelled : ''} ${
-          isRunning ? classes.iconRunning : ''
-        }`}
-      />
-      <span
-        data-slot="tool-fallback-trigger-label"
-        className={`${classes.labelWrapper} ${
-          isCancelled ? classes.labelCancelled : ''
-        }`}
-      >
-        <span>
-          {label}: <b>{toolName}</b>
-        </span>
-        {isRunning && (
-          <span
-            aria-hidden
-            data-slot="tool-fallback-trigger-shimmer"
-            className={classes.shimmer}
-          >
-            {label}: <b>{toolName}</b>
-          </span>
-        )}
-      </span>
       <ExpandMoreIcon
         data-slot="tool-fallback-trigger-chevron"
         className={`${classes.chevron} ${
           isOpen ? classes.chevronOpen : classes.chevronClosed
         }`}
       />
+
+      <span
+        data-slot="tool-fallback-trigger-label"
+        className={`${classes.triggerLabel} ${
+          isCancelled ? classes.labelCancelled : ''
+        }`}
+      >
+        {showStatusBadge && (
+          <StatusIcon
+            className={`${classes.statusBadge} ${isRunning ? classes.statusBadgeRunning : ''}`}
+          />
+        )}
+        <span>{toolName}</span>
+        {summary && <span className={classes.summary}>{summary}</span>}
+      </span>
     </button>
   );
 }
@@ -254,9 +295,11 @@ function ToolFallbackContent({
       in={isOpen}
       timeout={ANIMATION_DURATION}
       data-slot="tool-fallback-content"
-      className={`${classes.content} ${className || ''}`}
+      className={className}
     >
-      <div className={classes.contentInner}>{children}</div>
+      <div className={classes.content}>
+        <div className={classes.contentInner}>{children}</div>
+      </div>
     </Collapse>
   );
 }
@@ -367,16 +410,17 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
     <ToolFallbackRoot className={isCancelled ? classes.rootCancelled : ''}>
       <ToolFallbackTrigger
         toolName={toolName}
+        argsText={argsText}
         status={status}
         isOpen={isOpen}
         onClick={handleToggle}
       />
       <ToolFallbackContent isOpen={isOpen}>
-        <ToolFallbackError status={status} />
         <ToolFallbackArgs
           argsText={argsText}
           className={isCancelled ? classes.argsCancelled : ''}
         />
+        <ToolFallbackError status={status} />
         {!isCancelled && <ToolFallbackResult result={result} />}
       </ToolFallbackContent>
     </ToolFallbackRoot>

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolFallback.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolFallback.tsx
@@ -330,6 +330,44 @@ function ToolFallbackArgs({
   );
 }
 
+/**
+ * Recursively walk a value and inline any string that is itself valid JSON
+ * (or JSON wrapped in a markdown code fence). This keeps the wrapper structure
+ * (e.g. `content`, `isError`) visible while expanding inner text payloads
+ * into formatted objects instead of escaped strings.
+ */
+function inlineJsonStrings(value: unknown): unknown {
+  if (typeof value === 'string') {
+    let text = value;
+    // Strip markdown code fence wrapper if present
+    const fenceMatch = text.match(/^```\w*\n([\s\S]*?)\n```$/);
+    if (fenceMatch) {
+      text = fenceMatch[1];
+    }
+    try {
+      const parsed = JSON.parse(text);
+      // Only inline objects/arrays — primitive JSON values are fine as strings
+      if (parsed && typeof parsed === 'object') {
+        return parsed;
+      }
+    } catch {
+      /* not JSON, keep as string */
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(inlineJsonStrings);
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = inlineJsonStrings(v);
+    }
+    return out;
+  }
+  return value;
+}
+
 function ToolFallbackResult({
   result,
   className,
@@ -340,8 +378,9 @@ function ToolFallbackResult({
   const classes = useStyles();
   if (result === undefined) return null;
 
+  const expanded = inlineJsonStrings(result);
   const text =
-    typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+    typeof expanded === 'string' ? expanded : JSON.stringify(expanded, null, 2);
 
   return (
     <div

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolGroup.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolGroup.tsx
@@ -8,17 +8,21 @@ import {
   type FC,
   type PropsWithChildren,
 } from 'react';
-import {
-  Collapse,
-  makeStyles,
-  createStyles,
-  CircularProgress,
-} from '@material-ui/core';
+import { Collapse, makeStyles, createStyles } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { useScrollLock } from '@assistant-ui/react';
+import LoopIcon from '@material-ui/icons/Loop';
+import { useScrollLock, useAuiState } from '@assistant-ui/react';
 import classNames from 'classnames';
 
 const ANIMATION_DURATION = 200;
+
+function formatToolSummary(names: string[]): string {
+  const counts = new Map<string, number>();
+  for (const t of names) counts.set(t, (counts.get(t) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([name, n]) => (n > 1 ? `${name} x${n}` : name))
+    .join(', ');
+}
 
 const useStyles = makeStyles(theme =>
   createStyles({
@@ -40,8 +44,10 @@ const useStyles = makeStyles(theme =>
     },
     trigger: {
       display: 'flex',
-      alignItems: 'center',
-      fontSize: theme.typography.body2.fontSize,
+      gap: theme.spacing(0.75),
+      alignItems: 'flex-start',
+      fontSize: '0.8125rem',
+      lineHeight: 1.4,
       color: theme.palette.text.primary,
       cursor: 'pointer',
       border: 'none',
@@ -50,9 +56,6 @@ const useStyles = makeStyles(theme =>
       transition: theme.transitions.create('color'),
       '&:hover': {
         color: theme.palette.text.secondary,
-      },
-      '& > *:not(:last-child)': {
-        marginRight: theme.spacing(1),
       },
     },
     triggerOutline: {
@@ -68,14 +71,14 @@ const useStyles = makeStyles(theme =>
     loader: {
       flexShrink: 0,
     },
-    labelWrapper: {
+    triggerLabel: {
       position: 'relative',
       display: 'inline-block',
       textAlign: 'left',
-      fontWeight: theme.typography.fontWeightMedium as number,
-      lineHeight: 1,
+      fontWeight: 500,
+      lineHeight: 1.4,
     },
-    labelWrapperGrow: {
+    triggerLabelGrow: {
       flexGrow: 1,
     },
     shimmer: {
@@ -90,10 +93,12 @@ const useStyles = makeStyles(theme =>
       },
     },
     chevron: {
-      fontSize: 16,
+      width: 14,
+      height: 14,
       flexShrink: 0,
       transition: `transform ${ANIMATION_DURATION}ms ease-out`,
       transform: 'rotate(0deg)',
+      marginTop: '2.5px',
     },
     chevronClosed: {
       transform: 'rotate(-90deg)',
@@ -105,11 +110,12 @@ const useStyles = makeStyles(theme =>
       outline: 'none',
     },
     contentInner: {
-      marginTop: theme.spacing(2),
+      marginTop: theme.spacing(1),
+      paddingLeft: theme.spacing(2),
       display: 'flex',
       flexDirection: 'column',
       '& > *:not(:last-child)': {
-        marginBottom: theme.spacing(2),
+        marginBottom: theme.spacing(1),
       },
     },
     contentInnerOutline: {
@@ -125,6 +131,21 @@ const useStyles = makeStyles(theme =>
       paddingLeft: theme.spacing(4),
       paddingRight: theme.spacing(4),
       paddingTop: theme.spacing(3),
+    },
+    statusBadge: {
+      width: '14px',
+      height: '14px',
+      marginRight: '4px',
+      display: 'inline-block',
+      verticalAlign: 'text-bottom',
+      transform: 'scaleX(-1)',
+    },
+    statusBadgeRunning: {
+      animation: '$spin 1s linear infinite',
+    },
+    '@keyframes spin': {
+      from: { transform: 'scaleX(-1) rotate(0deg)' },
+      to: { transform: 'scaleX(-1) rotate(-360deg)' },
     },
   }),
 );
@@ -197,6 +218,7 @@ function ToolGroupRoot({
 type ToolGroupTriggerProps = {
   count: number;
   active?: boolean;
+  breakdown?: string;
   className?: string;
   onClick?: () => void;
 };
@@ -204,6 +226,7 @@ type ToolGroupTriggerProps = {
 function ToolGroupTrigger({
   count,
   active = false,
+  breakdown,
   className,
   onClick,
 }: ToolGroupTriggerProps) {
@@ -214,7 +237,9 @@ function ToolGroupTrigger({
   const { isOpen, handleOpenChange, variant } = context;
   const classes = useStyles();
 
-  const label = `${count} tool ${count === 1 ? 'call' : 'calls'}`;
+  const label = breakdown
+    ? `${count} tool ${count === 1 ? 'call' : 'calls'} (${breakdown})`
+    : `${count} tool ${count === 1 ? 'call' : 'calls'}`;
 
   const handleClick = () => {
     handleOpenChange(!isOpen);
@@ -235,37 +260,29 @@ function ToolGroupTrigger({
         className,
       )}
     >
-      {active && (
-        <CircularProgress
-          data-slot="tool-group-trigger-loader"
-          size={16}
-          className={classes.loader}
-        />
-      )}
-      <span
-        data-slot="tool-group-trigger-label"
-        className={classNames(classes.labelWrapper, {
-          [classes.labelWrapperGrow]:
-            variant === 'outline' || variant === 'muted',
-        })}
-      >
-        <span>{label}</span>
-        {active && (
-          <span
-            aria-hidden
-            data-slot="tool-group-trigger-shimmer"
-            className={classes.shimmer}
-          >
-            {label}
-          </span>
-        )}
-      </span>
       <ExpandMoreIcon
         data-slot="tool-group-trigger-chevron"
         className={classNames(classes.chevron, {
           [classes.chevronClosed]: !isOpen,
         })}
       />
+      <span
+        data-slot="tool-group-trigger-label"
+        className={classNames(classes.triggerLabel, {
+          [classes.triggerLabelGrow]:
+            variant === 'outline' || variant === 'muted',
+        })}
+      >
+        {active && (
+          <LoopIcon
+            className={classNames(
+              classes.statusBadge,
+              classes.statusBadgeRunning,
+            )}
+          />
+        )}
+        <span>{label}</span>
+      </span>
     </button>
   );
 }
@@ -315,9 +332,30 @@ const ToolGroupImpl: FC<
 > = ({ children, startIndex, endIndex }) => {
   const toolCount = endIndex - startIndex + 1;
 
+  const breakdown = useAuiState(s => {
+    const names = s.message.parts
+      .slice(startIndex, endIndex + 1)
+      .filter(
+        (p): p is typeof p & { type: 'tool-call'; toolName: string } =>
+          p.type === 'tool-call',
+      )
+      .map(p => p.toolName);
+    return names.length > 0 ? formatToolSummary(names) : undefined;
+  });
+
+  const isActive = useAuiState(s =>
+    s.message.parts
+      .slice(startIndex, endIndex + 1)
+      .some(p => p.status?.type === 'running'),
+  );
+
   return (
     <ToolGroupRoot>
-      <ToolGroupTrigger count={toolCount} />
+      <ToolGroupTrigger
+        count={toolCount}
+        active={isActive}
+        breakdown={breakdown}
+      />
       <ToolGroupContent>{children}</ToolGroupContent>
     </ToolGroupRoot>
   );

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolGroup.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ToolGroup.tsx
@@ -112,11 +112,6 @@ const useStyles = makeStyles(theme =>
     contentInner: {
       marginTop: theme.spacing(1),
       paddingLeft: theme.spacing(2),
-      display: 'flex',
-      flexDirection: 'column',
-      '& > *:not(:last-child)': {
-        marginBottom: theme.spacing(1),
-      },
     },
     contentInnerOutline: {
       marginTop: theme.spacing(3),
@@ -146,6 +141,11 @@ const useStyles = makeStyles(theme =>
     '@keyframes spin': {
       from: { transform: 'scaleX(-1) rotate(0deg)' },
       to: { transform: 'scaleX(-1) rotate(-360deg)' },
+    },
+    tools: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
     },
   }),
 );
@@ -312,7 +312,7 @@ function ToolGroupContent({ className, children }: ToolGroupContentProps) {
             [classes.contentInnerMuted]: variant === 'muted',
           })}
         >
-          {children}
+          <div className={classes.tools}>{children}</div>
         </div>
       </div>
     </Collapse>
@@ -327,12 +327,16 @@ type ToolGroupComponent = FC<
   Content: typeof ToolGroupContent;
 };
 
+const MIN_GROUP_SIZE = 3;
+
 const ToolGroupImpl: FC<
   PropsWithChildren<{ startIndex: number; endIndex: number }>
 > = ({ children, startIndex, endIndex }) => {
+  const classes = useStyles();
   const toolCount = endIndex - startIndex + 1;
 
   const breakdown = useAuiState(s => {
+    if (toolCount < MIN_GROUP_SIZE) return undefined;
     const names = s.message.parts
       .slice(startIndex, endIndex + 1)
       .filter(
@@ -343,11 +347,16 @@ const ToolGroupImpl: FC<
     return names.length > 0 ? formatToolSummary(names) : undefined;
   });
 
-  const isActive = useAuiState(s =>
-    s.message.parts
+  const isActive = useAuiState(s => {
+    if (toolCount < MIN_GROUP_SIZE) return false;
+    return s.message.parts
       .slice(startIndex, endIndex + 1)
-      .some(p => p.status?.type === 'running'),
-  );
+      .some(p => p.status?.type === 'running');
+  });
+
+  if (toolCount < MIN_GROUP_SIZE) {
+    return <div className={classes.tools}>{children}</div>;
+  }
 
   return (
     <ToolGroupRoot>

--- a/plugins/ai-chat/src/components/AiChat/styles.ts
+++ b/plugins/ai-chat/src/components/AiChat/styles.ts
@@ -152,7 +152,8 @@ export const useStyles = makeStyles((theme: Theme) =>
     messageActionsContainer: {
       display: 'flex',
       gap: theme.spacing(1),
-      paddingTop: theme.spacing(0.5),
+      paddingTop: theme.spacing(1.5),
+      minHeight: '32px',
     },
     branchPicker: {
       display: 'inline-flex',
@@ -201,7 +202,7 @@ export const useStyles = makeStyles((theme: Theme) =>
       color: theme.palette.error.contrastText,
       padding: theme.spacing(1.5, 2),
       borderRadius: 'var(--bui-radius-3)',
-      marginTop: theme.spacing(1),
+      marginTop: theme.spacing(2),
     },
   }),
 );


### PR DESCRIPTION
### What does this PR do?

Improves the AI chat plugin with several UX enhancements to tool call rendering, streaming behavior, and error handling.

### What is the effect of this change to users?

- Tool calls display with a compact inline layout showing argument summaries (file path, command, query, etc.) directly in the trigger
- Grouped tool calls show a breakdown of tool names in the header
- Status indicators use inline icons (spinning loop icon) instead of shimmer effects
- Chevrons moved before labels for consistency with reasoning groups
- Error messages use `ErrorPrimitive` to show actual error text instead of generic "Error occurred"
- Tool call errors display below arguments with improved styling
- Text reveal animation is faster (10 chars per frame)
- Nested JSON strings in tool call results are inlined for readability
- Small tool call groups (fewer than 3) render directly without a collapsible wrapper
- SSE streaming works correctly through compression middleware

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/36072.

### How does it look like?

1-2 tool calls render without grouping. Well known parameters preview in the tool call header:
<img width="819" height="260" alt="Screenshot 2026-04-23 at 10 22 31" src="https://github.com/user-attachments/assets/6f9ed8fe-9446-4d27-b097-ddb1298ce07d" />

Tool call details:
<img width="819" height="387" alt="Screenshot 2026-04-23 at 10 22 54" src="https://github.com/user-attachments/assets/5e762562-0d89-4100-973c-c73a04f6025d" />

Reasoning:
<img width="819" height="495" alt="Screenshot 2026-04-23 at 10 23 06" src="https://github.com/user-attachments/assets/09b30202-adbd-4125-9831-7131df94db56" />

Grouped tool calls:
<img width="819" height="606" alt="Screenshot 2026-04-23 at 10 25 53" src="https://github.com/user-attachments/assets/ff3e42e1-8b94-4ed9-9479-bfdcb49f72fc" />


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))