### PR TITLE
Fix helm chart to allow for branding configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix helm chart to allow for branding configmap.
+
 ## [0.124.0] - 2026-04-23
 
 ### Added

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -90,27 +90,7 @@ branding:
 
 > **Note:** ConfigMaps are limited to 1 MB total. For binary images (PNG, ICO) this can be tight because they must be base64-encoded under `binaryData`, which adds ~33% overhead.
 
-### Option B: Init container with OCI image (for larger or binary assets)
-
-Build a small container image containing your assets and use an init container to copy them into a shared volume:
-
-```yaml
-branding:
-  enabled: true
-  volume:
-    emptyDir: {}
-  initContainers:
-    - name: fetch-branding
-      image: gsoci.azurecr.io/giantswarm/my-branding-assets:latest
-      command: ['cp', '-r', '/assets/.', '/branding/']
-      volumeMounts:
-        - name: branding-assets
-          mountPath: /branding
-```
-
-This approach has no size limits and stores binary files natively.
-
-### Option C: ConfigMap with binary data
+### Option B: ConfigMap with binary data
 
 For a small number of PNGs alongside SVGs, you can mix `data` and `binaryData` in a single ConfigMap:
 
@@ -140,12 +120,11 @@ base64 -w0 favicon-32x32.png
 
 ### Helm values
 
-| Key                       | Default                | Description                                                                              |
-| ------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
-| `branding.enabled`        | `false`                | Enable the branding volume mount and config                                              |
-| `branding.assetsPath`     | `/app/branding-assets` | Path inside the container where assets are mounted                                       |
-| `branding.volume`         | `{}`                   | Kubernetes volume source (e.g. `configMap`, `emptyDir`, `persistentVolumeClaim`)         |
-| `branding.initContainers` | `[]`                   | Init containers to run before the main container (e.g. to copy assets from an OCI image) |
+| Key                         | Default                | Description                                                                                                          |
+| --------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `branding.enabled`          | `false`                | Enable the branding volume mount and config                                                                          |
+| `branding.assetsPath`       | `/app/branding-assets` | Path inside the container where assets are mounted                                                                   |
+| `branding.volume.configMap` | `{}`                   | ConfigMap volume source (see `io.k8s.api.core.v1.ConfigMapVolumeSource`); currently the only supported volume source |
 
 ## How it works
 

--- a/helm/backstage/README.md
+++ b/helm/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.123.0](https://img.shields.io/badge/Version-0.123.0-informational?style=flat-square) ![AppVersion: 0.123.0](https://img.shields.io/badge/AppVersion-0.123.0-informational?style=flat-square)
+![Version: 0.124.0](https://img.shields.io/badge/Version-0.124.0-informational?style=flat-square) ![AppVersion: 0.124.0](https://img.shields.io/badge/AppVersion-0.124.0-informational?style=flat-square)
 
 Backstage app provided by Giant Swarm
 
@@ -78,11 +78,11 @@ Backstage app provided by Giant Swarm
 | database.postgresql.clusterNameSuffix | string | `"cnpg"` | Suffix appended to the chart name to form the CNPG cluster resource name |
 | database.postgresql.storageSize | string | `"5Gi"` | Persistent volume size for the PostgreSQL CNPG cluster |
 | database.postgresql.image | string | `"giantswarm/postgresql-cnpg:18.0@sha256:7c998e8352408ff5dbb74bcd945c3ef6578b7185c97aca9b89e4cc9fcbdf4716"` | PostgreSQL container image for the CNPG cluster (registry.domain is prepended) |
-| branding | object | `{"assetsPath":"/app/branding-assets","enabled":false,"initContainers":[],"volume":{}}` | Custom branding/UI asset settings (logos served by the gs-backend plugin) |
+| branding | object | `{"assetsPath":"/app/branding-assets","enabled":false,"volume":{"configMap":{}}}` | Custom branding/UI asset settings (logos served by the gs-backend plugin) |
 | branding.enabled | bool | `false` | Enable serving custom branding assets (logos) from a mounted volume |
 | branding.assetsPath | string | `"/app/branding-assets"` | Filesystem path inside the container where branding assets are mounted |
-| branding.volume | object | `{}` | Volume source for the branding assets (e.g. configMap, persistentVolumeClaim, emptyDir) |
-| branding.initContainers | list | `[]` | Init containers that populate the branding assets volume before the main container starts |
+| branding.volume | object | `{"configMap":{}}` | Volume source for the branding assets. Currently only the `configMap` source is supported; the volume `name` is supplied by the chart. |
+| branding.volume.configMap | object | `{}` | ConfigMap volume source. At minimum, set `.name` to the name of the ConfigMap holding the assets |
 | backstage | object | `{"appConfig":{},"args":[],"command":["node","packages/backend"],"extraAppConfig":[],"extraEnvVars":[],"extraEnvVarsCM":[],"extraEnvVarsSecrets":[],"extraVolumeMounts":[],"extraVolumes":[]}` | Backstage application parameters |
 | backstage.command | list | `["node","packages/backend"]` | Container command to start the Backstage backend |
 | backstage.args | list | `[]` | Additional command arguments passed to the Backstage container |

--- a/helm/backstage/templates/deployments.yaml
+++ b/helm/backstage/templates/deployments.yaml
@@ -40,10 +40,6 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      {{- if and .Values.branding.enabled .Values.branding.initContainers }}
-      initContainers:
-        {{- toYaml .Values.branding.initContainers | nindent 8 }}
-      {{- end }}
       containers:
         - name: {{ .Values.image.name }}
           image: "{{ .Values.registry.domain }}/{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"

--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -135,18 +135,16 @@
                     "description": "Enable serving custom branding assets (logos) from a mounted volume",
                     "type": "boolean"
                 },
-                "initContainers": {
-                    "description": "Init containers that populate the branding assets volume before the main container starts",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Container"
-                    }
-                },
                 "volume": {
-                    "description": "Volume source for the branding assets (e.g. configMap, persistentVolumeClaim, emptyDir)",
+                    "description": "Volume source for the branding assets. Currently only the `configMap` source is supported; the volume `name` is supplied by the chart.",
                     "type": "object",
-                    "items": {
-                        "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Volume"
+                    "properties": {
+                        "configMap": {
+                            "description": "ConfigMap volume source. At minimum, set `.name` to the name of the ConfigMap holding the assets",
+                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource",
+                            "type": "object",
+                            "additionalProperties": true
+                        }
                     },
                     "additionalProperties": false
                 }
@@ -759,24 +757,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.AppArmorProfile": {
-                    "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
-                    "type": "object",
-                    "required": [
-                        "type"
-                    ],
-                    "properties": {
-                        "localhostProfile": {
-                            "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
-                            "type": "string"
-                        },
-                        "type": {
-                            "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.AzureDiskVolumeSource": {
                     "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
                     "type": "object",
@@ -862,27 +842,6 @@
                             "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
                             "type": "object",
                             "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.Capabilities": {
-                    "description": "Adds and removes POSIX capabilities from running containers.",
-                    "type": "object",
-                    "properties": {
-                        "add": {
-                            "description": "Added capabilities",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "drop": {
-                            "description": "Removed capabilities",
-                            "type": "array",
-                            "items": {
                                 "type": "string"
                             }
                         }
@@ -982,21 +941,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.ConfigMapEnvSource": {
-                    "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                            "type": "string"
-                        },
-                        "optional": {
-                            "description": "Specify whether the ConfigMap must be defined",
-                            "type": "boolean"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.ConfigMapKeySelector": {
                     "description": "Selects a key from a ConfigMap.",
                     "type": "object",
@@ -1064,234 +1008,6 @@
                         "optional": {
                             "description": "optional specify whether the ConfigMap or its keys must be defined",
                             "type": "boolean"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.Container": {
-                    "description": "A single application container that you want to run within a pod.",
-                    "type": "object",
-                    "required": [
-                        "name"
-                    ],
-                    "properties": {
-                        "args": {
-                            "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "command": {
-                            "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "env": {
-                            "description": "List of environment variables to set in the container. Cannot be updated.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvVar"
-                            }
-                        },
-                        "envFrom": {
-                            "description": "List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.EnvFromSource"
-                            }
-                        },
-                        "image": {
-                            "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
-                            "type": "string"
-                        },
-                        "imagePullPolicy": {
-                            "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
-                            "type": "string"
-                        },
-                        "lifecycle": {
-                            "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Lifecycle"
-                        },
-                        "livenessProbe": {
-                            "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
-                        },
-                        "name": {
-                            "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
-                            "type": "string"
-                        },
-                        "ports": {
-                            "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerPort"
-                            }
-                        },
-                        "readinessProbe": {
-                            "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
-                        },
-                        "resizePolicy": {
-                            "description": "Resources resize policy for the container. This field cannot be set on ephemeral containers.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
-                            }
-                        },
-                        "resources": {
-                            "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceRequirements"
-                        },
-                        "restartPolicy": {
-                            "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Additionally, setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
-                            "type": "string"
-                        },
-                        "restartPolicyRules": {
-                            "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod's RestartPolicy.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerRestartRule"
-                            }
-                        },
-                        "securityContext": {
-                            "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecurityContext"
-                        },
-                        "startupProbe": {
-                            "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Probe"
-                        },
-                        "stdin": {
-                            "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
-                            "type": "boolean"
-                        },
-                        "stdinOnce": {
-                            "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
-                            "type": "boolean"
-                        },
-                        "terminationMessagePath": {
-                            "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
-                            "type": "string"
-                        },
-                        "terminationMessagePolicy": {
-                            "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
-                            "type": "string"
-                        },
-                        "tty": {
-                            "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
-                            "type": "boolean"
-                        },
-                        "volumeDevices": {
-                            "description": "volumeDevices is the list of block devices to be used by the container.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeDevice"
-                            }
-                        },
-                        "volumeMounts": {
-                            "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.VolumeMount"
-                            }
-                        },
-                        "workingDir": {
-                            "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.ContainerPort": {
-                    "description": "ContainerPort represents a network port in a single container.",
-                    "type": "object",
-                    "required": [
-                        "containerPort"
-                    ],
-                    "properties": {
-                        "containerPort": {
-                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 \u003c x \u003c 65536.",
-                            "type": "integer",
-                            "format": "int32"
-                        },
-                        "hostIP": {
-                            "description": "What host IP to bind the external port to.",
-                            "type": "string"
-                        },
-                        "hostPort": {
-                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 \u003c x \u003c 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
-                            "type": "integer",
-                            "format": "int32"
-                        },
-                        "name": {
-                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
-                            "type": "string"
-                        },
-                        "protocol": {
-                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.ContainerResizePolicy": {
-                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
-                    "type": "object",
-                    "required": [
-                        "resourceName",
-                        "restartPolicy"
-                    ],
-                    "properties": {
-                        "resourceName": {
-                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
-                            "type": "string"
-                        },
-                        "restartPolicy": {
-                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.ContainerRestartRule": {
-                    "description": "ContainerRestartRule describes how a container exit is handled.",
-                    "type": "object",
-                    "required": [
-                        "action"
-                    ],
-                    "properties": {
-                        "action": {
-                            "description": "Specifies the action taken on a container exit if the requirements are satisfied. The only possible value is \"Restart\" to restart the container.",
-                            "type": "string"
-                        },
-                        "exitCodes": {
-                            "description": "Represents the exit codes to check on container exits.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes": {
-                    "description": "ContainerRestartRuleOnExitCodes describes the condition for handling an exited container based on its exit codes.",
-                    "type": "object",
-                    "required": [
-                        "operator"
-                    ],
-                    "properties": {
-                        "operator": {
-                            "description": "Represents the relationship between the container exit code(s) and the specified values. Possible values are: - In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
-                            "type": "string"
-                        },
-                        "values": {
-                            "description": "Specifies the set of values to check for container exit codes. At most 255 elements are allowed.",
-                            "type": "array",
-                            "items": {
-                                "type": "integer",
-                                "format": "int32"
-                            }
                         }
                     },
                     "additionalProperties": false
@@ -1371,25 +1087,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.EnvFromSource": {
-                    "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
-                    "type": "object",
-                    "properties": {
-                        "configMapRef": {
-                            "description": "The ConfigMap to select from",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
-                        },
-                        "prefix": {
-                            "description": "Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.",
-                            "type": "string"
-                        },
-                        "secretRef": {
-                            "description": "The Secret to select from",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SecretEnvSource"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.EnvVar": {
                     "description": "EnvVar represents an environment variable present in a Container.",
                     "type": "object",
@@ -1446,20 +1143,6 @@
                         "volumeClaimTemplate": {
                             "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `\u003cpod name\u003e-\u003cvolume name\u003e` where `\u003cvolume name\u003e` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.\n\nRequired, must not be nil.",
                             "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.PersistentVolumeClaimTemplate"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.ExecAction": {
-                    "description": "ExecAction describes a \"run in container\" action.",
-                    "type": "object",
-                    "properties": {
-                        "command": {
-                            "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
                         }
                     },
                     "additionalProperties": false
@@ -1601,25 +1284,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.GRPCAction": {
-                    "description": "GRPCAction specifies an action involving a GRPC service.",
-                    "type": "object",
-                    "required": [
-                        "port"
-                    ],
-                    "properties": {
-                        "port": {
-                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
-                            "type": "integer",
-                            "format": "int32"
-                        },
-                        "service": {
-                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.GitRepoVolumeSource": {
                     "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
                     "type": "object",
@@ -1661,58 +1325,6 @@
                         "readOnly": {
                             "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                             "type": "boolean"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.HTTPGetAction": {
-                    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
-                    "type": "object",
-                    "required": [
-                        "port"
-                    ],
-                    "properties": {
-                        "host": {
-                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
-                            "type": "string"
-                        },
-                        "httpHeaders": {
-                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HTTPHeader"
-                            }
-                        },
-                        "path": {
-                            "description": "Path to access on the HTTP server.",
-                            "type": "string"
-                        },
-                        "port": {
-                            "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-                        },
-                        "scheme": {
-                            "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.HTTPHeader": {
-                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
-                    "type": "object",
-                    "required": [
-                        "name",
-                        "value"
-                    ],
-                    "properties": {
-                        "name": {
-                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
-                            "type": "string"
-                        },
-                        "value": {
-                            "description": "The header field value",
-                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -1830,48 +1442,6 @@
                         "path": {
                             "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
                             "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.Lifecycle": {
-                    "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
-                    "type": "object",
-                    "properties": {
-                        "postStart": {
-                            "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LifecycleHandler"
-                        },
-                        "preStop": {
-                            "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.LifecycleHandler"
-                        },
-                        "stopSignal": {
-                            "description": "StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.LifecycleHandler": {
-                    "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
-                    "type": "object",
-                    "properties": {
-                        "exec": {
-                            "description": "Exec specifies a command to execute in the container.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ExecAction"
-                        },
-                        "httpGet": {
-                            "description": "HTTPGet specifies an HTTP GET request to perform.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HTTPGetAction"
-                        },
-                        "sleep": {
-                            "description": "Sleep represents a duration that the container should sleep.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SleepAction"
-                        },
-                        "tcpSocket": {
-                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.TCPSocketAction"
                         }
                     },
                     "additionalProperties": false
@@ -2093,59 +1663,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.Probe": {
-                    "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
-                    "type": "object",
-                    "properties": {
-                        "exec": {
-                            "description": "Exec specifies a command to execute in the container.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ExecAction"
-                        },
-                        "failureThreshold": {
-                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
-                            "type": "integer",
-                            "format": "int32"
-                        },
-                        "grpc": {
-                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.GRPCAction"
-                        },
-                        "httpGet": {
-                            "description": "HTTPGet specifies an HTTP GET request to perform.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.HTTPGetAction"
-                        },
-                        "initialDelaySeconds": {
-                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-                            "type": "integer",
-                            "format": "int32"
-                        },
-                        "periodSeconds": {
-                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
-                            "type": "integer",
-                            "format": "int32"
-                        },
-                        "successThreshold": {
-                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
-                            "type": "integer",
-                            "format": "int32"
-                        },
-                        "tcpSocket": {
-                            "description": "TCPSocket specifies a connection to a TCP port.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.TCPSocketAction"
-                        },
-                        "terminationGracePeriodSeconds": {
-                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
-                            "type": "integer",
-                            "format": "int64"
-                        },
-                        "timeoutSeconds": {
-                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-                            "type": "integer",
-                            "format": "int32"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.ProjectedVolumeSource": {
                     "description": "Represents a projected volume source",
                     "type": "object",
@@ -2246,24 +1763,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.ResourceClaim": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
-                    "type": "object",
-                    "required": [
-                        "name"
-                    ],
-                    "properties": {
-                        "name": {
-                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
-                            "type": "string"
-                        },
-                        "request": {
-                            "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.ResourceFieldSelector": {
                     "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
                     "type": "object",
@@ -2281,57 +1780,6 @@
                         },
                         "resource": {
                             "description": "Required: resource to select",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.ResourceRequirements": {
-                    "description": "ResourceRequirements describes the compute resource requirements.",
-                    "type": "object",
-                    "properties": {
-                        "claims": {
-                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis field depends on the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.ResourceClaim"
-                            }
-                        },
-                        "limits": {
-                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                            "type": "object",
-                            "additionalProperties": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-                            }
-                        },
-                        "requests": {
-                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                            "type": "object",
-                            "additionalProperties": {
-                                "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-                            }
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.SELinuxOptions": {
-                    "description": "SELinuxOptions are the labels to be applied to the container",
-                    "type": "object",
-                    "properties": {
-                        "level": {
-                            "description": "Level is SELinux level label that applies to the container.",
-                            "type": "string"
-                        },
-                        "role": {
-                            "description": "Role is a SELinux role label that applies to the container.",
-                            "type": "string"
-                        },
-                        "type": {
-                            "description": "Type is a SELinux type label that applies to the container.",
-                            "type": "string"
-                        },
-                        "user": {
-                            "description": "User is a SELinux user label that applies to the container.",
                             "type": "string"
                         }
                     },
@@ -2385,39 +1833,6 @@
                         "volumeName": {
                             "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
                             "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.SeccompProfile": {
-                    "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
-                    "type": "object",
-                    "required": [
-                        "type"
-                    ],
-                    "properties": {
-                        "localhostProfile": {
-                            "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
-                            "type": "string"
-                        },
-                        "type": {
-                            "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.SecretEnvSource": {
-                    "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                            "type": "string"
-                        },
-                        "optional": {
-                            "description": "Specify whether the Secret must be defined",
-                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false
@@ -2493,63 +1908,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.SecurityContext": {
-                    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
-                    "type": "object",
-                    "properties": {
-                        "allowPrivilegeEscalation": {
-                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
-                            "type": "boolean"
-                        },
-                        "appArmorProfile": {
-                            "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.AppArmorProfile"
-                        },
-                        "capabilities": {
-                            "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.Capabilities"
-                        },
-                        "privileged": {
-                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
-                            "type": "boolean"
-                        },
-                        "procMount": {
-                            "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. Note that this field cannot be set when spec.os.name is windows.",
-                            "type": "string"
-                        },
-                        "readOnlyRootFilesystem": {
-                            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
-                            "type": "boolean"
-                        },
-                        "runAsGroup": {
-                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
-                            "type": "integer",
-                            "format": "int64"
-                        },
-                        "runAsNonRoot": {
-                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-                            "type": "boolean"
-                        },
-                        "runAsUser": {
-                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
-                            "type": "integer",
-                            "format": "int64"
-                        },
-                        "seLinuxOptions": {
-                            "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SELinuxOptions"
-                        },
-                        "seccompProfile": {
-                            "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod \u0026 container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.SeccompProfile"
-                        },
-                        "windowsOptions": {
-                            "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.ServiceAccountTokenProjection": {
                     "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
                     "type": "object",
@@ -2569,21 +1927,6 @@
                         "path": {
                             "description": "path is the path relative to the mount point of the file to project the token into.",
                             "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.SleepAction": {
-                    "description": "SleepAction describes a \"sleep\" action.",
-                    "type": "object",
-                    "required": [
-                        "seconds"
-                    ],
-                    "properties": {
-                        "seconds": {
-                            "description": "Seconds is the number of seconds to sleep.",
-                            "type": "integer",
-                            "format": "int64"
                         }
                     },
                     "additionalProperties": false
@@ -2611,24 +1954,6 @@
                         "volumeNamespace": {
                             "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
                             "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.TCPSocketAction": {
-                    "description": "TCPSocketAction describes an action based on opening a socket",
-                    "type": "object",
-                    "required": [
-                        "port"
-                    ],
-                    "properties": {
-                        "host": {
-                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
-                            "type": "string"
-                        },
-                        "port": {
-                            "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-                            "$ref": "#/$defs/_definitions.json/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
                         }
                     },
                     "additionalProperties": false
@@ -2817,25 +2142,6 @@
                     },
                     "additionalProperties": false
                 },
-                "io.k8s.api.core.v1.VolumeDevice": {
-                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
-                    "type": "object",
-                    "required": [
-                        "name",
-                        "devicePath"
-                    ],
-                    "properties": {
-                        "devicePath": {
-                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
-                            "type": "string"
-                        },
-                        "name": {
-                            "description": "name must match the name of a persistentVolumeClaim in the pod",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "io.k8s.api.core.v1.VolumeMount": {
                     "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "type": "object",
@@ -2948,29 +2254,6 @@
                         },
                         "volumePath": {
                             "description": "volumePath is the path that identifies vSphere volume vmdk",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "io.k8s.api.core.v1.WindowsSecurityContextOptions": {
-                    "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
-                    "type": "object",
-                    "properties": {
-                        "gmsaCredentialSpec": {
-                            "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
-                            "type": "string"
-                        },
-                        "gmsaCredentialSpecName": {
-                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
-                            "type": "string"
-                        },
-                        "hostProcess": {
-                            "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
-                            "type": "boolean"
-                        },
-                        "runAsUserName": {
-                            "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "string"
                         }
                     },
@@ -3198,16 +2481,6 @@
                     "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
                     "type": "string",
                     "format": "date-time"
-                },
-                "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "integer"
-                        }
-                    ]
                 }
             }
         }

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -204,13 +204,11 @@ branding:
   # -- Filesystem path inside the container where branding assets are mounted
   assetsPath: /app/branding-assets
 
-  # @schema itemRef:https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Volume
-  # -- Volume source for the branding assets (e.g. configMap, persistentVolumeClaim, emptyDir)
-  volume: {}
-
-  # @schema itemRef:https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Container
-  # -- Init containers that populate the branding assets volume before the main container starts
-  initContainers: []
+  # -- Volume source for the branding assets. Currently only the `configMap` source is supported; the volume `name` is supplied by the chart.
+  volume:
+    # @schema $ref:https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource;additionalProperties:true
+    # -- ConfigMap volume source. At minimum, set `.name` to the name of the ConfigMap holding the assets
+    configMap: {}
 
 # -- Backstage application parameters
 backstage:


### PR DESCRIPTION
### What does this PR do?

Fixes this problem with the values schema:

```
values don't meet the specifications of the schema(s):
backstage:
* at '/branding/volume': additional properties 'configMap' not allowed
```

Also removes the idea of using a PVC or initContainers to inject brand assets.

### Do the docs need to be updated?

Done

### Should this change be mentioned in the release notes?

Added changelog entry