### PR TITLE
Remove badges from chart docs template

### DIFF
--- a/helm/backstage/README.md.gotmpl
+++ b/helm/backstage/README.md.gotmpl
@@ -1,8 +1,6 @@
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.badgesSection" . }}
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}


### PR DESCRIPTION
Removes the badges section from the chart docs template, to avoid false positives in the precommit workflow.