### PR TITLE
Decouple branding from gs-backend plugin

### DIFF
--- a/.changeset/icy-lantern-observe.md
+++ b/.changeset/icy-lantern-observe.md
@@ -5,5 +5,3 @@
 ---
 
 Decouple custom branding from the gs-backend plugin. Branding asset serving moves to a dedicated `branding` backend plugin colocated in `packages/backend/src/branding/`, registered unconditionally so it works in deployments without a `gs:` config block. The frontend hook now resolves assets via the `branding` discovery prefix at `/api/branding/*`.
-
-**Breaking config change:** rename `gs.branding.assetsPath` to `app.branding.assetsPath` in `app-config.yaml`. The Helm chart's `branding.*` values are unchanged and emit the new key automatically.

--- a/.changeset/icy-lantern-observe.md
+++ b/.changeset/icy-lantern-observe.md
@@ -1,0 +1,9 @@
+---
+'app': patch
+'backend': patch
+'@giantswarm/backstage-plugin-gs-backend': patch
+---
+
+Decouple custom branding from the gs-backend plugin. Branding asset serving moves to a dedicated `branding` backend plugin colocated in `packages/backend/src/branding/`, registered unconditionally so it works in deployments without a `gs:` config block. The frontend hook now resolves assets via the `branding` discovery prefix at `/api/branding/*`.
+
+**Breaking config change:** rename `gs.branding.assetsPath` to `app.branding.assetsPath` in `app-config.yaml`. The Helm chart's `branding.*` values are unchanged and emit the new key automatically.

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -2,7 +2,7 @@
 
 The Dev Portal supports overriding the default sidebar logos, home page logo, and browser tab favicon with custom assets, without committing them to the source repository or loading them from external URLs.
 
-Assets are placed into a directory on the backend's filesystem and served by the `gs-backend` plugin. On the frontend, components check which assets are available and swap in the custom versions, falling back to the built-in defaults when none are provided.
+Assets are placed into a directory on the backend's filesystem and served by the built-in `branding` backend plugin (defined in `packages/backend/src/branding/`). On the frontend, components check which assets are available and swap in the custom versions, falling back to the built-in defaults when none are provided.
 
 ## Supported assets
 
@@ -41,7 +41,7 @@ All assets are optional. Only assets that are present in the directory will over
 3. Add the path to `app-config.local.yaml`:
 
    ```yaml
-   gs:
+   app:
      branding:
        assetsPath: ./branding-assets
    ```
@@ -114,9 +114,9 @@ base64 -w0 favicon-32x32.png
 
 ## Configuration reference
 
-| Key                      | Default                | Description                                                 |
-| ------------------------ | ---------------------- | ----------------------------------------------------------- |
-| `gs.branding.assetsPath` | `/app/branding-assets` | Filesystem path where the backend looks for branding assets |
+| Key                       | Default                | Description                                                 |
+| ------------------------- | ---------------------- | ----------------------------------------------------------- |
+| `app.branding.assetsPath` | `/app/branding-assets` | Filesystem path where the backend looks for branding assets |
 
 ### Helm values
 
@@ -128,13 +128,13 @@ base64 -w0 favicon-32x32.png
 
 ## How it works
 
-1. On startup, the `gs-backend` plugin scans the configured `assetsPath` directory and registers a `/branding/manifest` endpoint that lists the available files, plus an `express.static` handler that serves them. If the directory does not exist, the manifest returns an empty list and no errors are logged.
+1. On startup, the `branding` backend plugin scans the configured `assetsPath` directory and registers a `/api/branding/manifest` endpoint that lists the available files, plus an `express.static` handler that serves them at `/api/branding/<filename>`. If the directory does not exist, the manifest returns an empty list and no errors are logged.
 
 2. On the frontend, the `useBranding()` hook fetches the manifest once and caches it. The `LogoFull`, `LogoIcon`, and `HomeLogo` components check whether a matching asset exists and render an `<img>` tag pointing at the backend URL, or fall back to the built-in inline SVG.
 
 3. The `BrandingFavicon` component (mounted at the app root) updates the `<link>` tags in `<head>` to point at any available favicon assets, leaving unmatched tags unchanged.
 
-4. The `/branding/*` routes are served without authentication so that `<img>` and `<link>` tags (which cannot include auth headers) work correctly.
+4. The `/api/branding/*` routes are served without authentication so that `<img>` and `<link>` tags (which cannot include auth headers) work correctly.
 
 ## Design notes
 

--- a/helm/backstage/README.md
+++ b/helm/backstage/README.md
@@ -78,7 +78,7 @@ Backstage app provided by Giant Swarm
 | database.postgresql.clusterNameSuffix | string | `"cnpg"` | Suffix appended to the chart name to form the CNPG cluster resource name |
 | database.postgresql.storageSize | string | `"5Gi"` | Persistent volume size for the PostgreSQL CNPG cluster |
 | database.postgresql.image | string | `"giantswarm/postgresql-cnpg:18.0@sha256:7c998e8352408ff5dbb74bcd945c3ef6578b7185c97aca9b89e4cc9fcbdf4716"` | PostgreSQL container image for the CNPG cluster (registry.domain is prepended) |
-| branding | object | `{"assetsPath":"/app/branding-assets","enabled":false,"volume":{"configMap":{}}}` | Custom branding/UI asset settings (logos served by the gs-backend plugin) |
+| branding | object | `{"assetsPath":"/app/branding-assets","enabled":false,"volume":{"configMap":{}}}` | Custom branding/UI asset settings (logos and favicons served by the branding backend plugin) |
 | branding.enabled | bool | `false` | Enable serving custom branding assets (logos) from a mounted volume |
 | branding.assetsPath | string | `"/app/branding-assets"` | Filesystem path inside the container where branding assets are mounted |
 | branding.volume | object | `{"configMap":{}}` | Volume source for the branding assets. Currently only the `configMap` source is supported; the volume `name` is supplied by the chart. |

--- a/helm/backstage/templates/configmaps.yaml
+++ b/helm/backstage/templates/configmaps.yaml
@@ -38,7 +38,7 @@ metadata:
     {{- include "labels.backstage" $ | nindent 4 }}
 data:
   app-config-branding.yaml: |
-    gs:
+    app:
       branding:
         assetsPath: {{ .Values.branding.assetsPath | quote }}
 {{- end }}

--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -124,7 +124,7 @@
             "additionalProperties": false
         },
         "branding": {
-            "description": "Custom branding/UI asset settings (logos served by the gs-backend plugin)",
+            "description": "Custom branding/UI asset settings (logos and favicons served by the branding backend plugin)",
             "type": "object",
             "properties": {
                 "assetsPath": {

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -194,7 +194,7 @@ database:
     # -- PostgreSQL container image for the CNPG cluster (registry.domain is prepended)
     image: giantswarm/postgresql-cnpg:18.0@sha256:7c998e8352408ff5dbb74bcd945c3ef6578b7185c97aca9b89e4cc9fcbdf4716
 
-# -- Custom branding/UI asset settings (logos served by the gs-backend plugin)
+# -- Custom branding/UI asset settings (logos and favicons served by the branding backend plugin)
 branding:
   # @schema type:boolean
   # -- Enable serving custom branding assets (logos) from a mounted volume

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -1,5 +1,14 @@
 export interface Config {
   app: {
+    branding?: {
+      /**
+       * Filesystem path where custom branding assets (logos, favicons) are stored.
+       * Assets in this directory are served at /api/branding/<filename>.
+       * @visibility backend
+       */
+      assetsPath?: string;
+    };
+
     /**
      * @deepVisibility frontend
      */

--- a/packages/app/src/modules/branding/useBranding.ts
+++ b/packages/app/src/modules/branding/useBranding.ts
@@ -15,9 +15,9 @@ let cachedPromise: Promise<ManifestResult> | null = null;
 let cachedResult: ManifestResult | null = null;
 
 /**
- * Hook that provides access to custom branding assets served by the gs-backend
- * plugin. Returns helpers to check for and resolve asset URLs, with graceful
- * fallback when no custom assets are configured.
+ * Hook that provides access to custom branding assets served by the branding
+ * backend plugin. Returns helpers to check for and resolve asset URLs, with
+ * graceful fallback when no custom assets are configured.
  */
 export function useBranding() {
   const discoveryApi = useApi(discoveryApiRef);
@@ -34,9 +34,9 @@ export function useBranding() {
 
     if (!cachedPromise) {
       cachedPromise = (async (): Promise<ManifestResult> => {
-        const baseUrl = await discoveryApi.getBaseUrl('gs');
+        const baseUrl = await discoveryApi.getBaseUrl('branding');
         try {
-          const response = await fetchApi.fetch(`${baseUrl}/branding/manifest`);
+          const response = await fetchApi.fetch(`${baseUrl}/manifest`);
           if (response.ok) {
             const data = await response.json();
             return { assets: data.assets ?? {}, baseUrl };
@@ -70,7 +70,7 @@ export function useBranding() {
   const getAssetUrl = useCallback(
     (filename: string) => {
       if (!result?.baseUrl || !result.assets[filename]) return undefined;
-      return `${result.baseUrl}/branding/${filename}`;
+      return `${result.baseUrl}/${filename}`;
     },
     [result],
   );

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@aws/aws-core-plugin-for-backstage-scaffolder-actions": "^0.6.0",
     "@backstage/backend-defaults": "backstage:^",
+    "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/plugin-app-backend": "backstage:^",
     "@backstage/plugin-auth-backend": "backstage:^",
     "@backstage/plugin-auth-backend-module-github-provider": "backstage:^",
@@ -66,7 +67,10 @@
     "pg": "^8.10.0"
   },
   "devDependencies": {
-    "@backstage/cli": "backstage:^"
+    "@backstage/backend-test-utils": "backstage:^",
+    "@backstage/cli": "backstage:^",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "dist"

--- a/packages/backend/src/branding/index.ts
+++ b/packages/backend/src/branding/index.ts
@@ -1,0 +1,1 @@
+export { brandingPlugin } from './plugin';

--- a/packages/backend/src/branding/plugin.ts
+++ b/packages/backend/src/branding/plugin.ts
@@ -1,0 +1,26 @@
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { createRouter } from './router';
+
+export const brandingPlugin = createBackendPlugin({
+  pluginId: 'branding',
+  register(env) {
+    env.registerInit({
+      deps: {
+        httpRouter: coreServices.httpRouter,
+        logger: coreServices.logger,
+        config: coreServices.rootConfig,
+      },
+      async init({ httpRouter, logger, config }) {
+        httpRouter.use(await createRouter({ config, logger }));
+
+        httpRouter.addAuthPolicy({
+          path: '/',
+          allow: 'unauthenticated',
+        });
+      },
+    });
+  },
+});

--- a/packages/backend/src/branding/router.test.ts
+++ b/packages/backend/src/branding/router.test.ts
@@ -1,35 +1,25 @@
 import { mockServices } from '@backstage/backend-test-utils';
+import express from 'express';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import request from 'supertest';
-import express from 'express';
 import { createRouter } from './router';
-
-// Stubs for dependencies that the branding routes do not exercise.
-const noopGithubCredentialsProvider = {
-  getCredentials: jest.fn(),
-} as any;
-const noopContainerRegistry = {} as any;
-const noopMimir = {} as any;
 
 async function buildApp(assetsPath: string | undefined) {
   const config = mockServices.rootConfig({
-    data: assetsPath ? { gs: { branding: { assetsPath } } } : {},
+    data: assetsPath ? { app: { branding: { assetsPath } } } : {},
   });
   const router = await createRouter({
     config,
     logger: mockServices.logger.mock(),
-    containerRegistry: noopContainerRegistry,
-    mimir: noopMimir,
-    githubCredentialsProvider: noopGithubCredentialsProvider,
   });
   const app = express();
   app.use(router);
   return app;
 }
 
-describe('gs-backend router branding routes', () => {
+describe('branding router', () => {
   let assetsDir: string;
 
   beforeEach(() => {
@@ -48,7 +38,7 @@ describe('gs-backend router branding routes', () => {
     writeFileSync(join(assetsDir, 'logo-icon.png'), 'binary-data');
 
     const app = await buildApp(assetsDir);
-    const res = await request(app).get('/branding/manifest');
+    const res = await request(app).get('/manifest');
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -66,7 +56,7 @@ describe('gs-backend router branding routes', () => {
     const app = await buildApp(assetsDir);
     // superagent has no default parser for image/svg+xml, so buffer manually.
     const res = await request(app)
-      .get('/branding/logo-full.svg')
+      .get('/logo-full.svg')
       .buffer(true)
       .parse((response, cb) => {
         let data = '';
@@ -86,7 +76,7 @@ describe('gs-backend router branding routes', () => {
     const missing = join(assetsDir, 'does-not-exist');
     const app = await buildApp(missing);
 
-    const res = await request(app).get('/branding/manifest');
+    const res = await request(app).get('/manifest');
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ assets: {} });
@@ -96,7 +86,7 @@ describe('gs-backend router branding routes', () => {
     const missing = join(assetsDir, 'does-not-exist');
     const app = await buildApp(missing);
 
-    const res = await request(app).get('/branding/logo-full.svg');
+    const res = await request(app).get('/logo-full.svg');
 
     expect(res.status).toBe(404);
   });

--- a/packages/backend/src/branding/router.ts
+++ b/packages/backend/src/branding/router.ts
@@ -1,0 +1,55 @@
+import {
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
+import express from 'express';
+import Router from 'express-promise-router';
+import { existsSync, readdirSync } from 'fs';
+import { resolve } from 'path';
+
+export async function createRouter({
+  config,
+  logger,
+}: {
+  config: RootConfigService;
+  logger: LoggerService;
+}): Promise<express.Router> {
+  const router = Router();
+
+  const assetsPath =
+    config.getOptionalString('app.branding.assetsPath') ??
+    '/app/branding-assets';
+  const resolvedAssetsPath = resolve(assetsPath);
+
+  if (existsSync(resolvedAssetsPath)) {
+    const files = readdirSync(resolvedAssetsPath);
+    const assets: Record<string, boolean> = {};
+    for (const file of files) {
+      assets[file] = true;
+    }
+
+    router.get('/manifest', (_req, res) => {
+      res.json({ assets });
+    });
+
+    router.use(
+      express.static(resolvedAssetsPath, {
+        maxAge: '1d',
+      }),
+    );
+
+    logger.info(
+      `Serving ${files.length} branding asset(s) from ${resolvedAssetsPath}`,
+    );
+  } else {
+    router.get('/manifest', (_req, res) => {
+      res.json({ assets: {} });
+    });
+
+    logger.info(
+      `Branding assets directory not found at ${resolvedAssetsPath}, serving defaults`,
+    );
+  }
+
+  return router;
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -4,6 +4,7 @@ import {
   customHttpAuthServiceFactory,
   rootLogger,
 } from '@internal/backend-common';
+import { brandingPlugin } from './branding';
 
 const backend = createBackend();
 
@@ -74,6 +75,9 @@ backend.add(import('@backstage/plugin-kubernetes-backend'));
 // notifications and signals plugins
 backend.add(import('@backstage/plugin-notifications-backend'));
 backend.add(import('@backstage/plugin-signals-backend'));
+
+// branding plugin (decoupled from gs so it works in deployments without gs)
+backend.add(brandingPlugin);
 
 // giantswarm plugin
 backend.add(import('@giantswarm/backstage-plugin-gs-backend'));

--- a/plugins/gs-backend/config.d.ts
+++ b/plugins/gs-backend/config.d.ts
@@ -1,13 +1,5 @@
 export interface Config {
   gs?: {
-    branding?: {
-      /**
-       * Filesystem path where custom branding assets (logos, backgrounds) are stored.
-       * Assets in this directory are served at /api/gs/branding/<filename>.
-       * @visibility backend
-       */
-      assetsPath?: string;
-    };
     containerRegistry?: {
       registries?: {
         /**

--- a/plugins/gs-backend/src/plugin.ts
+++ b/plugins/gs-backend/src/plugin.ts
@@ -43,18 +43,11 @@ export const gsPlugin = createBackendPlugin({
 
         httpRouter.use(
           await createRouter({
-            config,
-            logger,
             containerRegistry,
             mimir,
             githubCredentialsProvider,
           }),
         );
-
-        httpRouter.addAuthPolicy({
-          path: '/branding',
-          allow: 'unauthenticated',
-        });
 
         registerMcpActions(
           actionsRegistry,

--- a/plugins/gs-backend/src/router.ts
+++ b/plugins/gs-backend/src/router.ts
@@ -1,70 +1,23 @@
 import { InputError } from '@backstage/errors';
 import { GithubCredentialsProvider } from '@backstage/integration';
-import {
-  LoggerService,
-  RootConfigService,
-} from '@backstage/backend-plugin-api';
 import { z } from 'zod/v3';
 import express from 'express';
 import Router from 'express-promise-router';
-import { existsSync, readdirSync } from 'fs';
-import { resolve } from 'path';
 import { fetchGitHubRawContent } from './githubRawContent';
 import { containerRegistryServiceRef } from './services/ContainerRegistryService';
 import { mimirServiceRef } from './services/MimirService';
 
 export async function createRouter({
-  config,
-  logger,
   containerRegistry,
   mimir,
   githubCredentialsProvider,
 }: {
-  config: RootConfigService;
-  logger: LoggerService;
   containerRegistry: typeof containerRegistryServiceRef.T;
   mimir: typeof mimirServiceRef.T;
   githubCredentialsProvider: GithubCredentialsProvider;
 }): Promise<express.Router> {
   const router = Router();
   router.use(express.json());
-
-  // --- Branding asset routes ---
-  const assetsPath =
-    config.getOptionalString('gs.branding.assetsPath') ??
-    '/app/branding-assets';
-  const resolvedAssetsPath = resolve(assetsPath);
-
-  if (existsSync(resolvedAssetsPath)) {
-    const files = readdirSync(resolvedAssetsPath);
-    const assets: Record<string, boolean> = {};
-    for (const file of files) {
-      assets[file] = true;
-    }
-
-    router.get('/branding/manifest', (_req, res) => {
-      res.json({ assets });
-    });
-
-    router.use(
-      '/branding',
-      express.static(resolvedAssetsPath, {
-        maxAge: '1d',
-      }),
-    );
-
-    logger.info(
-      `Serving ${files.length} branding asset(s) from ${resolvedAssetsPath}`,
-    );
-  } else {
-    router.get('/branding/manifest', (_req, res) => {
-      res.json({ assets: {} });
-    });
-
-    logger.info(
-      `Branding assets directory not found at ${resolvedAssetsPath}, serving defaults`,
-    );
-  }
 
   /**
    * GET /container-registry/tags

--- a/yarn.lock
+++ b/yarn.lock
@@ -23930,6 +23930,8 @@ __metadata:
   dependencies:
     "@aws/aws-core-plugin-for-backstage-scaffolder-actions": "npm:^0.6.0"
     "@backstage/backend-defaults": "backstage:^"
+    "@backstage/backend-plugin-api": "backstage:^"
+    "@backstage/backend-test-utils": "backstage:^"
     "@backstage/cli": "backstage:^"
     "@backstage/plugin-app-backend": "backstage:^"
     "@backstage/plugin-auth-backend": "backstage:^"
@@ -23970,6 +23972,7 @@ __metadata:
     "@internal/backend-common": "workspace:^"
     "@roadiehq/scaffolder-backend-module-utils": "npm:^4.1.1"
     "@terasky/backstage-plugin-catalog-mcp-backend": "npm:^0.8.0"
+    "@types/supertest": "npm:^2.0.12"
     app: "link:../app"
     better-sqlite3: "npm:^12.0.0"
     express: "npm:^5.0.0"
@@ -23977,6 +23980,7 @@ __metadata:
     global-agent: "npm:^3.0.0"
     node-gyp: "npm:^11.0.0"
     pg: "npm:^8.10.0"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does this PR do?

Moves custom branding asset serving out of the `gs-backend` plugin into a dedicated `branding` backend plugin colocated under `packages/backend/src/branding/`. Renames the app-config key from `gs.branding.assetsPath` to `app.branding.assetsPath` so that deployments which do not configure the `gs:` block can still enable branding.

The frontend code under `packages/app/src/modules/branding/` was already self-contained — no imports from the gs frontend plugin — so the only frontend change is the discovery prefix used by `useBranding` (`gs` → `branding`) and dropping the `/branding/` segment from the URL since the plugin ID now provides it.

### Any background context you can provide?

The branding feature was introduced in v0.124 (#1552, #1555). Backend serving and the config schema landed in `gs-backend`, which couples a generic UI feature to a gs-specific namespace. This PR splits that coupling.

### Do the docs need to be updated?

Updated in this PR: `docs/branding.md` (config example, "How it works" section, configuration reference table) and `helm/backstage/README.md` / `values.yaml` / `values.schema.json` descriptions.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))