### PR TITLE
Context window: Add configuration, add Opus 4.7

### DIFF
--- a/.changeset/ai-chat-context-window-config.md
+++ b/.changeset/ai-chat-context-window-config.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+Allow overriding the context window size used by the context usage bar via `aiChat.contextWindow` in app-config. When set, this value is used regardless of the model name; otherwise the built-in model-prefix lookup applies.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -223,6 +223,11 @@ aiChat:
   # Model to use (default: gpt-4o-mini)
   model: gpt-4o-mini
 
+  # Optional: override the context window size (in tokens) used to render
+  # the context usage bar. When set, applies regardless of the model name.
+  # When unset, a built-in lookup by model name prefix is used.
+  # contextWindow: 128000
+
   # Optional: override the built-in system prompt. MCP-specific additions
   # (e.g. muster prompt, failed-server notes) are still appended.
   # Inline:

--- a/plugins/ai-chat/config.d.ts
+++ b/plugins/ai-chat/config.d.ts
@@ -30,5 +30,13 @@ export interface Config {
        */
       authProvider?: string;
     }>;
+
+    /**
+     * Optional: override the context window size (in tokens) used to render
+     * the context usage bar. When set, this value is used regardless of the
+     * model name. When unset, a built-in lookup by model name prefix is used.
+     * @visibility frontend
+     */
+    contextWindow?: number;
   };
 }

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ContextUsageDisplay.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ContextUsageDisplay.tsx
@@ -82,6 +82,7 @@ function formatCost(cost: number): string {
 const CONTEXT_WINDOWS: Record<string, number> = {
   'claude-sonnet-4-6': 1_000_000,
   'claude-opus-4-6': 1_000_000,
+  'claude-opus-4-7': 1_000_000,
   'claude-sonnet-4-5': 200_000,
   'claude-sonnet-4': 200_000,
   'claude-opus-4': 200_000,

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ContextUsageDisplay.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ContextUsageDisplay.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import type { ToolCallMessagePartComponent } from '@assistant-ui/react';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -162,6 +163,9 @@ const ContextUsageDisplayImpl: ToolCallMessagePartComponent<
   UsageResult
 > = ({ result }) => {
   const classes = useStyles();
+  const configApi = useApi(configApiRef);
+  const configuredContextWindow =
+    configApi.getOptionalNumber('aiChat.contextWindow') ?? null;
 
   if (!result || !result.available) {
     return (
@@ -173,9 +177,9 @@ const ContextUsageDisplayImpl: ToolCallMessagePartComponent<
     );
   }
 
-  const contextWindow = result.modelName
-    ? getContextWindow(result.modelName)
-    : null;
+  const contextWindow =
+    configuredContextWindow ??
+    (result.modelName ? getContextWindow(result.modelName) : null);
   const usagePercent =
     contextWindow && result.inputTokens
       ? Math.min((result.inputTokens / contextWindow) * 100, 100)


### PR DESCRIPTION
This PR makes the context window size for the LLM configurable, so we can display useful data in the getCurrentContext UI.

Also adding number for Opus 4.7.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
