### PR TITLE
Improve markdown table rendering in AI chat

### DIFF
--- a/.changeset/ancient-falcon-whisper.md
+++ b/.changeset/ancient-falcon-whisper.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+Improve markdown table rendering: wrap tables in a horizontally scrollable container and adjust cell padding and line-height for better readability.

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/MarkdownText.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/MarkdownText.tsx
@@ -50,12 +50,19 @@ export const useMarkdownStyles = makeStyles((theme: Theme) =>
       fontStyle: 'italic',
       color: theme.palette.text.secondary,
     },
-    table: {
+    tableContainer: {
       margin: theme.spacing(2, 0),
+      overflowX: 'auto',
+      position: 'relative',
+    },
+    table: {
       animation: '$fadeInUp 0.3s ease-out',
     },
     tableCell: {
       borderBottom: `1px solid ${theme.palette.divider}`,
+      lineHeight: 1.6,
+      wordBreak: 'initial',
+      padding: theme.spacing(1, 1),
     },
     list: {
       marginLeft: theme.spacing(1),
@@ -217,9 +224,9 @@ export const createMarkdownComponents = (
     li: ({ children }) => <li>{children}</li>,
     hr: () => <hr className={classes.hr} />,
     table: ({ children }) => (
-      <Table size="small" className={classes.table}>
-        {children}
-      </Table>
+      <div className={classes.tableContainer}>
+        <Table className={classes.table}>{children}</Table>
+      </div>
     ),
     thead: ({ children }) => <TableHead>{children}</TableHead>,
     tbody: ({ children }) => <TableBody>{children}</TableBody>,


### PR DESCRIPTION
### What does this PR do?

Improves how markdown tables render in the AI chat:

- Wraps tables in a horizontally scrollable container so wide tables no longer overflow the chat panel.
- Adjusts cell padding and line-height for better readability.
- Removes the default `size="small"` on `Table` so spacing matches the new cell padding.

### How does it look like?

Before:
<img width="378" height="312" alt="Screenshot 2026-04-27 at 16 14 30" src="https://github.com/user-attachments/assets/04036985-bdef-4316-9c2b-f0ecb2bc137b" />

After:
<img width="378" height="339" alt="Screenshot 2026-04-27 at 16 15 00" src="https://github.com/user-attachments/assets/115fe9b0-01f8-434d-9daf-d10fd6adcd47" />


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))