### PR TITLE
Make sidebar logo height configurable

### DIFF
--- a/.changeset/zesty-maple-shine.md
+++ b/.changeset/zesty-maple-shine.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Make sidebar logo image height configurable via `app.branding.logo.height`.

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -7,6 +7,15 @@ export interface Config {
        * @visibility backend
        */
       assetsPath?: string;
+
+      logo?: {
+        /**
+         * Height (in pixels) for the sidebar logo image. Applied only when a
+         * custom branding logo asset is rendered.
+         * @visibility frontend
+         */
+        height?: number;
+      };
     };
 
     /**

--- a/packages/app/src/modules/nav/LogoFull.tsx
+++ b/packages/app/src/modules/nav/LogoFull.tsx
@@ -1,4 +1,5 @@
 import { makeStyles } from '@material-ui/core';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { useBranding } from '../branding';
 
 const useStyles = makeStyles({
@@ -8,7 +9,7 @@ const useStyles = makeStyles({
   },
   img: {
     width: 'auto',
-    height: 30,
+    height: ({ imgHeight }: { imgHeight: number }) => imgHeight,
   },
   path: {
     fill: '#7df3e1',
@@ -16,7 +17,10 @@ const useStyles = makeStyles({
 });
 
 export const LogoFull = () => {
-  const classes = useStyles();
+  const configApi = useApi(configApiRef);
+  const imgHeight =
+    configApi.getOptionalNumber('app.branding.logo.height') ?? 30;
+  const classes = useStyles({ imgHeight });
   const { hasAsset, getAssetUrl } = useBranding();
 
   const customAsset =

--- a/packages/app/src/modules/nav/LogoIcon.tsx
+++ b/packages/app/src/modules/nav/LogoIcon.tsx
@@ -1,4 +1,5 @@
 import { makeStyles } from '@material-ui/core';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { useBranding } from '../branding';
 
 const useStyles = makeStyles({
@@ -8,7 +9,7 @@ const useStyles = makeStyles({
   },
   img: {
     width: 'auto',
-    height: 30,
+    height: ({ imgHeight }: { imgHeight: number }) => imgHeight,
   },
   path: {
     fill: '#7df3e1',
@@ -16,7 +17,10 @@ const useStyles = makeStyles({
 });
 
 export const LogoIcon = () => {
-  const classes = useStyles();
+  const configApi = useApi(configApiRef);
+  const imgHeight =
+    configApi.getOptionalNumber('app.branding.logo.height') ?? 30;
+  const classes = useStyles({ imgHeight });
   const { hasAsset, getAssetUrl } = useBranding();
 
   const customAsset =


### PR DESCRIPTION
### What does this PR do?

Adds a new optional config value `app.branding.logo.height` that overrides the height (in pixels) of the custom branding logo image rendered in the sidebar's `LogoFull` and `LogoIcon` components.

The inline SVG fallbacks (Giant Swarm wordmark/icon) keep their existing hardcoded heights — the override applies only when a custom branding asset (`logo-full.svg/png`, `logo-icon.svg/png`) is present.

### What is the effect of this change to users?

Downstream deployments that ship custom branding assets via the branding module can now resize the sidebar logo without forking the components. With no config value set, behavior is identical to before.

Example:

```yaml
app:
  branding:
    logo:
      height: 48
```


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))