### PR TITLE
Avoid flashing default logo while branding manifest loads

### DIFF
--- a/.changeset/humble-maple-adapt.md
+++ b/.changeset/humble-maple-adapt.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Avoid flashing the default logo while the branding manifest is loading.

--- a/packages/app/src/modules/nav/LogoFull.tsx
+++ b/packages/app/src/modules/nav/LogoFull.tsx
@@ -21,7 +21,11 @@ export const LogoFull = () => {
   const imgHeight =
     configApi.getOptionalNumber('app.branding.logo.height') ?? 30;
   const classes = useStyles({ imgHeight });
-  const { hasAsset, getAssetUrl } = useBranding();
+  const { hasAsset, getAssetUrl, isLoading } = useBranding();
+
+  if (isLoading) {
+    return null;
+  }
 
   const customAsset =
     (hasAsset('logo-full.svg') && 'logo-full.svg') ||

--- a/packages/app/src/modules/nav/LogoIcon.tsx
+++ b/packages/app/src/modules/nav/LogoIcon.tsx
@@ -21,7 +21,11 @@ export const LogoIcon = () => {
   const imgHeight =
     configApi.getOptionalNumber('app.branding.logo.height') ?? 30;
   const classes = useStyles({ imgHeight });
-  const { hasAsset, getAssetUrl } = useBranding();
+  const { hasAsset, getAssetUrl, isLoading } = useBranding();
+
+  if (isLoading) {
+    return null;
+  }
 
   const customAsset =
     (hasAsset('logo-icon.svg') && 'logo-icon.svg') ||


### PR DESCRIPTION
### What does this PR do?

`LogoFull` and `LogoIcon` now render `null` while `useBranding` is fetching the assets manifest, instead of immediately rendering the default inline SVG.

### What is the effect of this change to users?

For installations that configure custom branding, the default Backstage logo no longer briefly flashes in the sidebar before the custom logo loads on first page load. The module-level cache in `useBranding` already prevented this on subsequent mounts; this fixes the first mount.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))