### PR TITLE
Request token usage from vLLM streaming responses

### DIFF
--- a/.changeset/ai-chat-vllm-include-usage.md
+++ b/.changeset/ai-chat-vllm-include-usage.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Request token usage from OpenAI-compatible streaming responses (vLLM/KServe) so `getContextUsage` can report context size, output tokens, and cost. Sends `stream_options: { include_usage: true }` on the chat-completions path.

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -159,6 +159,12 @@ export async function createRouter(
     name: 'openai-compatible',
     baseURL: openaiBaseUrl ?? '',
     apiKey: openaiApiKey,
+    // Ask vLLM/KServe (and other OpenAI-compatible chat-completions
+    // servers) to include token usage in streaming responses by adding
+    // `stream_options: { include_usage: true }` to the request body.
+    // Without this, vLLM emits no usage chunk and `getContextUsage` has
+    // no data to show.
+    includeUsage: true,
   });
 
   const anthropic = createAnthropic({


### PR DESCRIPTION
### What does this PR do?

Adds `includeUsage: true` to the `@ai-sdk/openai-compatible` provider in `ai-chat-backend`. The SDK then attaches `stream_options: { include_usage: true }` to every chat-completions request body. With that flag, vLLM (and other OpenAI-compatible chat-completions servers) emit a final SSE chunk containing token usage; intermediate chunks still have `usage: null`.

### What is the effect of this change to users?

When the AI chat is configured against a KServe/vLLM-hosted model (`aiChat.openai.api: chat`), `getContextUsage` now reports real input/output token counts, cache details, and reasoning-token counts. Previously the tool returned "No usage data available yet" because the SDK's `onStepFinish` callback was firing with zeros.

Other paths are unaffected:
- Real OpenAI Responses API — already returns usage natively.
- Anthropic — already returns usage in `message_delta` events.
- Azure — uses a separate provider client.

### How does it look like?

No visual change to the UI. `ContextUsageDisplay` (which already exists) starts rendering token counts and a context-window progress bar instead of the fallback "no data" message when the user asks the chat about token usage.

### Any background context you can provide?

vLLM treats the `stream_options.include_usage` flag as a per-request opt-in. The runtime YAML doesn't need to change — it's a client-side request body field. The `@ai-sdk/openai-compatible` v2.0.41 SDK injects the flag automatically when the provider is constructed with `includeUsage: true` (see `node_modules/@ai-sdk/openai-compatible/dist/index.mjs:637`).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))