### PR TITLE
Add date tool to AI agent

### DIFF
--- a/.changeset/ai-chat-date-tool.md
+++ b/.changeset/ai-chat-date-tool.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+---
+
+Add a `date` tool to the AI agent that returns the current date and time as an ISO 8601 string with seconds and UTC timezone offset.

--- a/.changeset/ai-chat-date-tool.md
+++ b/.changeset/ai-chat-date-tool.md
@@ -2,4 +2,4 @@
 '@giantswarm/backstage-plugin-ai-chat-backend': minor
 ---
 
-Add a `date` tool to the AI agent that returns the current date and time as an ISO 8601 string with seconds and UTC timezone offset.
+Add a `getDate` tool to the AI agent that returns the current date and time as an ISO 8601 string with seconds and UTC timezone offset.

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -28,6 +28,7 @@ import { frontendTools } from './frontendTools';
 import {
   listSkills,
   getSkill,
+  date,
   createUserTools,
   createResourceTools,
   createContextUsageTool,
@@ -325,6 +326,7 @@ export async function createRouter(
         ...mcpResourceTools,
         listSkills,
         getSkill,
+        date,
         ...userTools,
         ...contextUsageTools,
       };

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -28,7 +28,7 @@ import { frontendTools } from './frontendTools';
 import {
   listSkills,
   getSkill,
-  date,
+  getDate,
   createUserTools,
   createResourceTools,
   createContextUsageTool,
@@ -326,7 +326,7 @@ export async function createRouter(
         ...mcpResourceTools,
         listSkills,
         getSkill,
-        date,
+        getDate,
         ...userTools,
         ...contextUsageTools,
       };

--- a/plugins/ai-chat-backend/src/tools/dateTools.ts
+++ b/plugins/ai-chat-backend/src/tools/dateTools.ts
@@ -1,0 +1,13 @@
+import { tool } from 'ai';
+import { z } from 'zod/v3';
+
+export const date = tool({
+  description:
+    'Returns the current date and time as an ISO 8601 string with seconds and timezone offset. Use this whenever you need to know what time it is now.',
+  inputSchema: z.object({}),
+  execute: async () => {
+    return {
+      now: new Date().toISOString(),
+    };
+  },
+});

--- a/plugins/ai-chat-backend/src/tools/dateTools.ts
+++ b/plugins/ai-chat-backend/src/tools/dateTools.ts
@@ -1,7 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod/v3';
 
-export const date = tool({
+export const getDate = tool({
   description:
     'Returns the current date and time as an ISO 8601 string with seconds and timezone offset. Use this whenever you need to know what time it is now.',
   inputSchema: z.object({}),

--- a/plugins/ai-chat-backend/src/tools/index.ts
+++ b/plugins/ai-chat-backend/src/tools/index.ts
@@ -1,4 +1,5 @@
 export { listSkills, getSkill } from './skillTools';
+export { date } from './dateTools';
 export { createUserTools } from './userTools';
 export { createResourceTools } from './resourceTools';
 export { createContextUsageTool, recordUsage } from './contextUsageTools';

--- a/plugins/ai-chat-backend/src/tools/index.ts
+++ b/plugins/ai-chat-backend/src/tools/index.ts
@@ -1,5 +1,5 @@
 export { listSkills, getSkill } from './skillTools';
-export { date } from './dateTools';
+export { getDate } from './dateTools';
 export { createUserTools } from './userTools';
 export { createResourceTools } from './resourceTools';
 export { createContextUsageTool, recordUsage } from './contextUsageTools';


### PR DESCRIPTION
## Summary

- Adds a new local tool `getDate` to the AI agent backend that returns the current date and time as an ISO 8601 string in UTC (e.g. `2026-04-28T14:30:45.123Z`).
- Lets the agent answer "what time is it now" and reason about recency without guessing or relying on training-cutoff timestamps.
- Follows the existing pattern from `skillTools.ts` / `userTools.ts`: a small `dateTools.ts` file, re-exported via `tools/index.ts`, and registered in `router.ts`'s tool set.

## Preview

<img width="810" height="333" alt="image" src="https://github.com/user-attachments/assets/97b113d7-4e87-4fcc-846d-00c924446fbb" />

## Test plan

- [x] Start the backend (`yarn start backend`) and confirm it boots without errors.
- [x] In the AI chat, ask "what's the current date and time?" and verify the agent calls the `getDate` tool and reports a fresh ISO 8601 UTC timestamp.
- [x] Confirm the tool appears in the debug metadata when the chat debug header is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)