### PR TITLE
Prune old tool results from AI chat history

### DIFF
--- a/.changeset/ai-chat-prune-old-tool-results.md
+++ b/.changeset/ai-chat-prune-old-tool-results.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+---
+
+Replace older tool outputs in the AI chat with `[Old tool result content cleared]` once cumulative tool I/O past the most recent two user turns exceeds a budget. Mirrors OpenCode's continuous prune. Tunable via `aiChat.pruning.reservedTokens` (default 20000) and `aiChat.pruning.minimumSavingsTokens` (default 10000); `getSkill` results stay verbatim.

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -39,11 +39,17 @@ import {
   deduplicateToolCallIds,
   sanitizeMessages,
   stripStaleLargeToolResults,
+  pruneOldToolResults,
 } from './utils';
 import { ConversationStore } from './services/ConversationStore';
 import { createConversationRoutes } from './routes/conversationRoutes';
 
 const STALE_TOOL_RESULT_STRIP_LIST = ['list_tools', 'list_core_tools'];
+
+// Tool names whose results stay verbatim across the whole conversation,
+// even when older tool I/O is pruned to reclaim context. Skill content is
+// authoritative and the system prompt steers the model toward it.
+const PRUNE_PROTECTED_TOOLS = ['getSkill'];
 
 const systemPromptPath = resolvePackagePath(
   '@giantswarm/backstage-plugin-ai-chat-backend',
@@ -93,6 +99,14 @@ export async function createRouter(
   // and would otherwise terminate the assistant turn immediately after the
   // first tool call, before the model ever sees the tool result.
   const maxSteps = config.getOptionalNumber('aiChat.maxSteps') ?? 20;
+
+  // Continuous tool-result pruning. After every turn, older tool outputs
+  // beyond a recent budget are replaced with a placeholder so the model
+  // doesn't carry their full payload forever. Mirrors OpenCode's prune.
+  const pruneReservedTokens =
+    config.getOptionalNumber('aiChat.pruning.reservedTokens') ?? 20000;
+  const pruneMinimumSavingsTokens =
+    config.getOptionalNumber('aiChat.pruning.minimumSavingsTokens') ?? 10000;
 
   // Get OpenAI configuration
   const openaiApiKey = config.getOptionalString('aiChat.openai.apiKey');
@@ -309,7 +323,7 @@ export async function createRouter(
       // muster MCP servers, which can weigh ~20K tokens) with a short
       // placeholder so they are not resent on every turn. The most recent
       // result for each listed tool is kept intact.
-      const { messages: prunedMessages, stats: stripStats } =
+      const { messages: strippedMessages, stats: stripStats } =
         stripStaleLargeToolResults(sanitizedMessages, {
           toolNames: STALE_TOOL_RESULT_STRIP_LIST,
         });
@@ -317,6 +331,28 @@ export async function createRouter(
         chatLogger.info('Stripped stale tool results from history', {
           strippedCount: stripStats.strippedCount,
           approxBytesSaved: stripStats.approxBytesSaved,
+        });
+      }
+
+      // General-purpose continuous prune: protect the most recent user turn
+      // and a budget of recent tool output, replace older tool results with
+      // a placeholder. Catches large tool I/O (Kubernetes, metrics, ...)
+      // that the name-allowlist strip above can't anticipate.
+      const { messages: prunedMessages, stats: pruneStats } =
+        pruneOldToolResults(strippedMessages, {
+          reservedTokens: pruneReservedTokens,
+          minimumSavingsTokens: pruneMinimumSavingsTokens,
+          protectedTools: PRUNE_PROTECTED_TOOLS,
+        });
+      if (pruneStats.prunedCount > 0) {
+        chatLogger.info('Pruned old tool results from history', {
+          prunedCount: pruneStats.prunedCount,
+          approxTokensSaved: pruneStats.prunableTokens,
+        });
+      } else if (pruneStats.prunableTokens > 0) {
+        chatLogger.debug('Pruning skipped: savings below threshold', {
+          prunableTokens: pruneStats.prunableTokens,
+          minimumSavingsTokens: pruneMinimumSavingsTokens,
         });
       }
 

--- a/plugins/ai-chat-backend/src/utils/index.ts
+++ b/plugins/ai-chat-backend/src/utils/index.ts
@@ -2,3 +2,4 @@ export { extractMcpAuthTokens, type AuthTokens } from './extractMcpAuthTokens';
 export { deduplicateToolCallIds } from './deduplicateToolCallIds';
 export { sanitizeMessages } from './sanitizeMessages';
 export { stripStaleLargeToolResults } from './stripStaleLargeToolResults';
+export { pruneOldToolResults } from './pruneOldToolResults';

--- a/plugins/ai-chat-backend/src/utils/pruneOldToolResults.test.ts
+++ b/plugins/ai-chat-backend/src/utils/pruneOldToolResults.test.ts
@@ -1,0 +1,204 @@
+import { ModelMessage } from 'ai';
+import { pruneOldToolResults } from './pruneOldToolResults';
+
+function assistantToolCall(toolCallId: string, toolName: string): ModelMessage {
+  return {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId,
+        toolName,
+        input: {},
+      },
+    ],
+  };
+}
+
+function toolResult(
+  toolCallId: string,
+  toolName: string,
+  text: string,
+): ModelMessage {
+  return {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId,
+        toolName,
+        output: { type: 'text', value: text },
+      },
+    ],
+  };
+}
+
+function userText(text: string): ModelMessage {
+  return { role: 'user', content: text };
+}
+
+function assistantText(text: string): ModelMessage {
+  return { role: 'assistant', content: text };
+}
+
+// 1 token ≈ 4 chars, so 200_000 chars ≈ 50_000 tokens.
+const HUGE = 'x'.repeat(200_000);
+// 1 token ≈ 4 chars, so 60_000 chars ≈ 15_000 tokens.
+const MEDIUM = 'x'.repeat(60_000);
+// 1 token ≈ 4 chars, so 4_000 chars ≈ 1_000 tokens.
+const SMALL = 'x'.repeat(4_000);
+
+describe('pruneOldToolResults', () => {
+  it('protects the last two user turns entirely', () => {
+    // Pruning kicks in only from the third-most-recent user turn back.
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantToolCall('id-1', 'k_get'),
+      toolResult('id-1', 'k_get', HUGE), // turn 1 — eligible
+      userText('q2'),
+      assistantToolCall('id-2', 'k_get'),
+      toolResult('id-2', 'k_get', HUGE), // turn 2 — protected
+      userText('q3'),
+      assistantToolCall('id-3', 'k_get'),
+      toolResult('id-3', 'k_get', HUGE), // turn 3 (current) — protected
+    ];
+
+    const { messages: out, stats } = pruneOldToolResults(messages, {
+      reservedTokens: 1_000,
+      minimumSavingsTokens: 1_000,
+    });
+
+    // Two most recent turns: untouched.
+    expect((out[8] as any).content[0].output.value).toBe(HUGE);
+    expect((out[5] as any).content[0].output.value).toBe(HUGE);
+    // Oldest turn: pruned, since its 50k tokens blow past the 1k budget.
+    expect((out[2] as any).content[0].output.value).toBe(
+      '[Old tool result content cleared]',
+    );
+    expect(stats.prunedCount).toBe(1);
+  });
+
+  it('keeps tool results within reservedTokens of the most recent', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantToolCall('id-1', 'k_get'),
+      toolResult('id-1', 'k_get', HUGE), // ~50k — outside 40k budget
+      userText('q2'),
+      assistantToolCall('id-2', 'k_get'),
+      toolResult('id-2', 'k_get', MEDIUM), // ~15k — inside 40k budget
+      userText('q3'),
+      assistantToolCall('id-3', 'k_get'),
+      toolResult('id-3', 'k_get', SMALL), // current — protected
+      userText('q4'),
+      assistantText('answer'), // current — protected
+    ];
+
+    const { messages: out } = pruneOldToolResults(messages, {
+      reservedTokens: 40_000,
+      minimumSavingsTokens: 1_000,
+    });
+
+    expect((out[8] as any).content[0].output.value).toBe(SMALL); // protected window
+    expect((out[5] as any).content[0].output.value).toBe(MEDIUM); // within budget
+    expect((out[2] as any).content[0].output.value).toBe(
+      '[Old tool result content cleared]',
+    );
+  });
+
+  it('does nothing if savings are below minimumSavingsTokens', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantToolCall('id-1', 'k_get'),
+      toolResult('id-1', 'k_get', SMALL), // ~1k tokens — eligible but tiny
+      userText('q2'),
+      assistantToolCall('id-2', 'k_get'),
+      toolResult('id-2', 'k_get', SMALL),
+      userText('q3'),
+      assistantText('answer'),
+    ];
+
+    const { messages: out, stats } = pruneOldToolResults(messages, {
+      reservedTokens: 0, // everything past protected window is prunable…
+      minimumSavingsTokens: 100_000, // …but only if savings ≥ 100k tokens
+    });
+
+    expect(out).toBe(messages);
+    expect(stats.prunedCount).toBe(0);
+    // Near-miss reporting: prunable count is still surfaced so the caller
+    // can log that something was eligible but held back by the gate.
+    expect(stats.prunableTokens).toBeGreaterThan(0);
+  });
+
+  it('never prunes results from protectedTools', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantToolCall('id-1', 'getSkill'),
+      toolResult('id-1', 'getSkill', HUGE),
+      assistantToolCall('id-2', 'k_get'),
+      toolResult('id-2', 'k_get', HUGE),
+      userText('q2'),
+      assistantText('answer 2'),
+      userText('q3'),
+      assistantText('answer 3'),
+    ];
+
+    const { messages: out, stats } = pruneOldToolResults(messages, {
+      reservedTokens: 1_000,
+      minimumSavingsTokens: 1_000,
+      protectedTools: ['getSkill'],
+    });
+
+    // getSkill survives unchanged.
+    expect((out[2] as any).content[0].output.value).toBe(HUGE);
+    // Other tool result gets pruned.
+    expect((out[4] as any).content[0].output.value).toBe(
+      '[Old tool result content cleared]',
+    );
+    expect(stats.prunedCount).toBe(1);
+  });
+
+  it('preserves toolCallId, toolName, and assistant tool-call on pruned parts', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantToolCall('id-1', 'k_get'),
+      toolResult('id-1', 'k_get', HUGE),
+      userText('q2'),
+      assistantText('answer 2'),
+      userText('q3'),
+      assistantText('answer 3'),
+    ];
+
+    const { messages: out } = pruneOldToolResults(messages, {
+      reservedTokens: 1_000,
+      minimumSavingsTokens: 1_000,
+    });
+
+    const stripped = (out[2] as any).content[0];
+    expect(stripped.type).toBe('tool-result');
+    expect(stripped.toolCallId).toBe('id-1');
+    expect(stripped.toolName).toBe('k_get');
+
+    // Assistant tool-call message untouched.
+    expect((out[1] as any).content[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'id-1',
+      toolName: 'k_get',
+    });
+  });
+
+  it('returns identical messages when there is only one user turn', () => {
+    const messages: ModelMessage[] = [
+      userText('only turn'),
+      assistantToolCall('id-1', 'k_get'),
+      toolResult('id-1', 'k_get', HUGE),
+    ];
+
+    const { messages: out, stats } = pruneOldToolResults(messages, {
+      reservedTokens: 1_000,
+      minimumSavingsTokens: 1_000,
+    });
+
+    expect(out).toBe(messages);
+    expect(stats.prunedCount).toBe(0);
+  });
+});

--- a/plugins/ai-chat-backend/src/utils/pruneOldToolResults.ts
+++ b/plugins/ai-chat-backend/src/utils/pruneOldToolResults.ts
@@ -1,0 +1,115 @@
+import { ModelMessage } from 'ai';
+
+const CHARS_PER_TOKEN = 4;
+const PLACEHOLDER_TEXT = '[Old tool result content cleared]';
+
+export interface PruneStats {
+  prunedCount: number;
+  /**
+   * Total tokens of tool output eligible for pruning past the protected
+   * window. Populated whether or not the prune was committed, so callers
+   * can detect near-misses (eligible content held back by the savings gate).
+   */
+  prunableTokens: number;
+}
+
+export interface PruneOptions {
+  /**
+   * How many tokens of recent tool output to keep verbatim, beyond the
+   * always-protected window of the most recent user turn. Older tool
+   * results past this cumulative budget are replaced with a placeholder.
+   */
+  reservedTokens: number;
+  /**
+   * Minimum tokens that pruning would need to save in order to commit
+   * the prune. Avoids flicker for trivial prunes.
+   */
+  minimumSavingsTokens: number;
+  /**
+   * Tool names whose results are never pruned — for tools whose output is
+   * meant to remain authoritative across the whole conversation.
+   */
+  protectedTools?: string[];
+}
+
+function estimateTokens(value: unknown): number {
+  const text =
+    typeof value === 'string' ? value : (JSON.stringify(value) ?? '');
+  return Math.max(0, Math.round(text.length / CHARS_PER_TOKEN));
+}
+
+/**
+ * Replaces the `output` of older tool-result parts with a short placeholder
+ * once cumulative tool output exceeds `reservedTokens` past the most recent
+ * user turn. Mirrors OpenCode's `compaction.prune`: the most recent user turn
+ * (and everything after it) is fully protected; further back, results within
+ * a `reservedTokens` budget are kept; older ones are cleared.
+ *
+ * Stateless — recomputed on every request from the messages provided by the
+ * frontend.
+ */
+export function pruneOldToolResults(
+  messages: ModelMessage[],
+  options: PruneOptions,
+): { messages: ModelMessage[]; stats: PruneStats } {
+  const protectedTools = new Set(options.protectedTools ?? []);
+
+  const toPrune = new Set<string>();
+  let userTurnsSeen = 0;
+  let cumulativeTokens = 0;
+  let prunableTokens = 0;
+
+  for (let m = messages.length - 1; m >= 0; m--) {
+    const message = messages[m];
+    if (message.role === 'user') {
+      userTurnsSeen++;
+    }
+    if (userTurnsSeen < 2) continue;
+
+    if (message.role !== 'tool' || !Array.isArray(message.content)) continue;
+
+    for (let p = 0; p < message.content.length; p++) {
+      const part = message.content[p];
+      if (part.type !== 'tool-result') continue;
+      if (typeof part.toolName !== 'string') continue;
+      if (protectedTools.has(part.toolName)) continue;
+
+      const tokens = estimateTokens(part.output);
+      cumulativeTokens += tokens;
+      if (cumulativeTokens > options.reservedTokens) {
+        toPrune.add(`${m}:${p}`);
+        prunableTokens += tokens;
+      }
+    }
+  }
+
+  if (prunableTokens < options.minimumSavingsTokens) {
+    return { messages, stats: { prunedCount: 0, prunableTokens } };
+  }
+
+  const newMessages = messages.map((message, m) => {
+    if (message.role !== 'tool' || !Array.isArray(message.content)) {
+      return message;
+    }
+
+    let changed = false;
+    const newContent = message.content.map((part, p) => {
+      if (!toPrune.has(`${m}:${p}`)) return part;
+      changed = true;
+      return {
+        ...part,
+        output: { type: 'text' as const, value: PLACEHOLDER_TEXT },
+      };
+    });
+
+    return changed ? { ...message, content: newContent } : message;
+  });
+
+  return {
+    messages: newMessages,
+    stats: {
+      prunedCount: toPrune.size,
+      prunableTokens,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Continuously replace older tool outputs in the AI chat with `[Old tool result content cleared]` once cumulative tool I/O past the most recent two user turns exceeds a budget. Mirrors OpenCode's `compaction.prune`.
- Stateless port: re-derived on every request from the messages the frontend sends. No persistence layer needed.
- Layered with the existing `stripStaleLargeToolResults` (name-allowlist for `list_tools`/`list_core_tools`): the new `pruneOldToolResults` runs after it as a general backstop for large MCP tool I/O (Kubernetes, metrics, …).
- Tunable via `app-config.yaml`:
  - `aiChat.pruning.reservedTokens` (default 20000) — recent tool-output budget kept verbatim past the protected window.
  - `aiChat.pruning.minimumSavingsTokens` (default 10000) — savings gate; smaller prunes are held back.
- `getSkill` results stay verbatim across the conversation (skills are authoritative).
- Logs:
  - INFO `Pruned old tool results from history` when a prune commits, with `prunedCount` and `approxTokensSaved`.
  - DEBUG `Pruning skipped: savings below threshold` near-miss diagnostic for tuning.

Refs giantswarm/giantswarm#36358 — implements one slice of the OpenCode-inspired context-management work.

## Test plan

- [x] Unit tests cover protected window, budget cliff, savings-gate near-miss, protected tools, tool-call/result pairing preservation, single-turn no-op (6 new tests; 45/45 in `plugins/ai-chat-backend` pass).
- [x] `yarn tsc` clean.
- [x] `yarn lint plugins/ai-chat-backend` clean.
- [x] Manual smoke: open the AI chat, run a multi-turn conversation involving large MCP tool calls (e.g. `kubernetes_list helmreleases`), and verify backend logs show prune events on later turns. Expect older tool results to be replaced with `[Old tool result content cleared]` from the model's perspective while the frontend keeps the full transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)