### PR TITLE
Strip past reasoning from AI chat history

### DIFF
--- a/.changeset/ai-chat-strip-past-reasoning.md
+++ b/.changeset/ai-chat-strip-past-reasoning.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+---
+
+Strip reasoning content parts from assistant messages older than the last two user turns before sending them to the model. Past thinking blocks don't need to round-trip per Anthropic guidance, and removing them reclaims up to ~10K tokens per past turn for Claude conversations. The current turn (and the one before it) keeps reasoning intact so Anthropic extended thinking + tool_use mid-loop continues to work.

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -40,6 +40,7 @@ import {
   sanitizeMessages,
   stripStaleLargeToolResults,
   pruneOldToolResults,
+  stripPastReasoning,
 } from './utils';
 import { ConversationStore } from './services/ConversationStore';
 import { createConversationRoutes } from './routes/conversationRoutes';
@@ -356,6 +357,19 @@ export async function createRouter(
         });
       }
 
+      // Strip reasoning content parts from assistant messages older than the
+      // last two user turns. Anthropic guidance: thinking blocks from
+      // completed turns don't need to round-trip; only the in-progress
+      // tool_use turn must preserve its thinking block.
+      const { messages: dereasonedMessages, stats: reasoningStats } =
+        stripPastReasoning(prunedMessages);
+      if (reasoningStats.strippedCount > 0) {
+        chatLogger.debug('Stripped past reasoning from history', {
+          strippedCount: reasoningStats.strippedCount,
+          approxTokensSaved: reasoningStats.approxTokensSaved,
+        });
+      }
+
       // For Anthropic models, prepend system message with cache control
       // to enable prompt caching for the system prompt.
       // See: https://ai-sdk.dev/providers/ai-sdk-providers/anthropic#cache-control
@@ -388,8 +402,8 @@ export async function createRouter(
       const result = streamText({
         model: selectedModel as any,
         messages: systemMessage
-          ? [systemMessage, ...prunedMessages]
-          : prunedMessages,
+          ? [systemMessage, ...dereasonedMessages]
+          : dereasonedMessages,
         system: isAnthropicModel ? undefined : effectiveSystemPrompt,
         abortSignal: req.socket ? undefined : undefined,
         stopWhen: stepCountIs(maxSteps),

--- a/plugins/ai-chat-backend/src/utils/index.ts
+++ b/plugins/ai-chat-backend/src/utils/index.ts
@@ -3,3 +3,4 @@ export { deduplicateToolCallIds } from './deduplicateToolCallIds';
 export { sanitizeMessages } from './sanitizeMessages';
 export { stripStaleLargeToolResults } from './stripStaleLargeToolResults';
 export { pruneOldToolResults } from './pruneOldToolResults';
+export { stripPastReasoning } from './stripPastReasoning';

--- a/plugins/ai-chat-backend/src/utils/stripPastReasoning.test.ts
+++ b/plugins/ai-chat-backend/src/utils/stripPastReasoning.test.ts
@@ -1,0 +1,222 @@
+import { ModelMessage } from 'ai';
+import { stripPastReasoning } from './stripPastReasoning';
+
+function userText(text: string): ModelMessage {
+  return { role: 'user', content: text };
+}
+
+function assistantWith(
+  parts: Array<
+    | { type: 'text'; text: string }
+    | { type: 'reasoning'; text: string }
+    | { type: 'tool-call'; toolCallId: string; toolName: string; input: any }
+  >,
+): ModelMessage {
+  return { role: 'assistant', content: parts as any };
+}
+
+function toolResult(
+  toolCallId: string,
+  toolName: string,
+  text: string,
+): ModelMessage {
+  return {
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId,
+        toolName,
+        output: { type: 'text', value: text },
+      },
+    ],
+  };
+}
+
+describe('stripPastReasoning', () => {
+  it('protects the last two user turns entirely', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantWith([
+        { type: 'reasoning', text: 'think 1' },
+        { type: 'text', text: 'answer 1' },
+      ]),
+      userText('q2'),
+      assistantWith([
+        { type: 'reasoning', text: 'think 2' },
+        { type: 'text', text: 'answer 2' },
+      ]),
+      userText('q3'),
+      assistantWith([
+        { type: 'reasoning', text: 'think 3' },
+        { type: 'text', text: 'answer 3' },
+      ]),
+    ];
+
+    const { messages: out, stats } = stripPastReasoning(messages);
+
+    // Turn 3 (current) and turn 2 (one back): reasoning kept.
+    expect((out[5] as any).content).toEqual([
+      { type: 'reasoning', text: 'think 3' },
+      { type: 'text', text: 'answer 3' },
+    ]);
+    expect((out[3] as any).content).toEqual([
+      { type: 'reasoning', text: 'think 2' },
+      { type: 'text', text: 'answer 2' },
+    ]);
+    // Turn 1: reasoning stripped, text retained.
+    expect((out[1] as any).content).toEqual([
+      { type: 'text', text: 'answer 1' },
+    ]);
+    expect(stats.strippedCount).toBe(1);
+    expect(stats.approxTokensSaved).toBeGreaterThan(0);
+  });
+
+  it('strips reasoning across multi-step assistant blocks within an old turn', () => {
+    // A turn with a tool call splits into multiple ModelMessage assistant
+    // blocks, each potentially carrying its own reasoning part.
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantWith([
+        { type: 'reasoning', text: 'pre-tool think' },
+        { type: 'tool-call', toolCallId: 'id-1', toolName: 'k_get', input: {} },
+      ]),
+      toolResult('id-1', 'k_get', 'tool output'),
+      assistantWith([
+        { type: 'reasoning', text: 'post-tool think' },
+        { type: 'text', text: 'final answer 1' },
+      ]),
+      userText('q2'),
+      assistantWith([{ type: 'text', text: 'answer 2' }]),
+      userText('q3'),
+      assistantWith([{ type: 'text', text: 'answer 3' }]),
+    ];
+
+    const { messages: out, stats } = stripPastReasoning(messages);
+
+    // Both old assistant blocks have reasoning stripped.
+    expect((out[1] as any).content).toEqual([
+      { type: 'tool-call', toolCallId: 'id-1', toolName: 'k_get', input: {} },
+    ]);
+    expect((out[3] as any).content).toEqual([
+      { type: 'text', text: 'final answer 1' },
+    ]);
+    expect(stats.strippedCount).toBe(2);
+  });
+
+  it('preserves tool-call parts and message order when reasoning is removed', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantWith([
+        { type: 'reasoning', text: 'think' },
+        { type: 'tool-call', toolCallId: 'id-1', toolName: 'k_get', input: {} },
+      ]),
+      toolResult('id-1', 'k_get', 'output'),
+      userText('q2'),
+      assistantWith([{ type: 'text', text: 'answer 2' }]),
+      userText('q3'),
+      assistantWith([{ type: 'text', text: 'answer 3' }]),
+    ];
+
+    const { messages: out } = stripPastReasoning(messages);
+
+    expect(out).toHaveLength(messages.length);
+    expect((out[1] as any).content).toEqual([
+      { type: 'tool-call', toolCallId: 'id-1', toolName: 'k_get', input: {} },
+    ]);
+    // Tool result message untouched.
+    expect(out[2]).toBe(messages[2]);
+  });
+
+  it('preserves reasoning in an in-progress tool-loop in the most recent turn', () => {
+    // Frontend auto-send fires while the assistant is mid-loop: the last
+    // message is a `tool` result, the prior `assistant` carries a reasoning
+    // block tied to the pending tool_use. Anthropic requires that block to
+    // round-trip with the next request — it must not be stripped.
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantWith([
+        { type: 'reasoning', text: 'old think' },
+        { type: 'text', text: 'old answer' },
+      ]),
+      userText('q2'),
+      assistantWith([
+        { type: 'reasoning', text: 'mid think' },
+        { type: 'text', text: 'mid answer' },
+      ]),
+      userText('q3'),
+      // In-progress tool loop in the current turn:
+      assistantWith([
+        { type: 'reasoning', text: 'active think' },
+        { type: 'tool-call', toolCallId: 'id-1', toolName: 'k_get', input: {} },
+      ]),
+      toolResult('id-1', 'k_get', 'tool output'),
+    ];
+
+    const { messages: out, stats } = stripPastReasoning(messages);
+
+    // Oldest turn: reasoning stripped.
+    expect((out[1] as any).content).toEqual([
+      { type: 'text', text: 'old answer' },
+    ]);
+    // One-back turn (still protected): reasoning kept.
+    expect((out[3] as any).content).toContainEqual({
+      type: 'reasoning',
+      text: 'mid think',
+    });
+    // In-progress tool-loop: reasoning preserved.
+    expect((out[5] as any).content).toContainEqual({
+      type: 'reasoning',
+      text: 'active think',
+    });
+    expect(stats.strippedCount).toBe(1);
+  });
+
+  it('returns identical reference when there is only one user turn', () => {
+    const messages: ModelMessage[] = [
+      userText('only turn'),
+      assistantWith([
+        { type: 'reasoning', text: 'think' },
+        { type: 'text', text: 'answer' },
+      ]),
+    ];
+
+    const { messages: out, stats } = stripPastReasoning(messages);
+
+    expect(out).toBe(messages);
+    expect(stats.strippedCount).toBe(0);
+    expect(stats.approxTokensSaved).toBe(0);
+  });
+
+  it('returns identical reference when there are no reasoning parts', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      assistantWith([{ type: 'text', text: 'answer 1' }]),
+      userText('q2'),
+      assistantWith([{ type: 'text', text: 'answer 2' }]),
+      userText('q3'),
+      assistantWith([{ type: 'text', text: 'answer 3' }]),
+    ];
+
+    const { messages: out, stats } = stripPastReasoning(messages);
+
+    expect(out).toBe(messages);
+    expect(stats.strippedCount).toBe(0);
+  });
+
+  it('leaves string-content assistant messages untouched', () => {
+    const messages: ModelMessage[] = [
+      userText('q1'),
+      { role: 'assistant', content: 'string answer 1' },
+      userText('q2'),
+      assistantWith([{ type: 'text', text: 'answer 2' }]),
+      userText('q3'),
+      assistantWith([{ type: 'text', text: 'answer 3' }]),
+    ];
+
+    const { messages: out, stats } = stripPastReasoning(messages);
+
+    expect(out).toBe(messages);
+    expect(stats.strippedCount).toBe(0);
+  });
+});

--- a/plugins/ai-chat-backend/src/utils/stripPastReasoning.ts
+++ b/plugins/ai-chat-backend/src/utils/stripPastReasoning.ts
@@ -1,0 +1,65 @@
+import { ModelMessage } from 'ai';
+
+const CHARS_PER_TOKEN = 4;
+
+export interface StripPastReasoningStats {
+  strippedCount: number;
+  approxTokensSaved: number;
+}
+
+/**
+ * Removes `reasoning` content parts from assistant messages older than the
+ * two most recent user turns. The most recent user turn (and the one before
+ * it) keeps reasoning intact, which is required for Anthropic extended
+ * thinking + tool_use mid-loop: the thinking block tied to a still-pending
+ * tool_use must round-trip with the next request.
+ *
+ * Stateless — recomputed on every request from the messages provided by the
+ * frontend.
+ */
+export function stripPastReasoning(messages: ModelMessage[]): {
+  messages: ModelMessage[];
+  stats: StripPastReasoningStats;
+} {
+  // Find the boundary: index of the second-most-recent user message.
+  // Messages at this index and later are protected.
+  let userTurnsSeen = 0;
+  let protectedFromIndex = -1;
+  for (let m = messages.length - 1; m >= 0; m--) {
+    if (messages[m].role === 'user') {
+      userTurnsSeen++;
+      if (userTurnsSeen === 2) {
+        protectedFromIndex = m;
+        break;
+      }
+    }
+  }
+  if (protectedFromIndex === -1) {
+    return { messages, stats: { strippedCount: 0, approxTokensSaved: 0 } };
+  }
+
+  let strippedCount = 0;
+  let approxTokensSaved = 0;
+  let changed = false;
+
+  const newMessages = messages.map((message, m) => {
+    if (m >= protectedFromIndex) return message;
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+      return message;
+    }
+    const filtered = message.content.filter(part => {
+      if (part.type !== 'reasoning') return true;
+      strippedCount++;
+      approxTokensSaved += Math.round(part.text.length / CHARS_PER_TOKEN);
+      return false;
+    });
+    if (filtered.length === message.content.length) return message;
+    changed = true;
+    return { ...message, content: filtered };
+  });
+
+  return {
+    messages: changed ? newMessages : messages,
+    stats: { strippedCount, approxTokensSaved },
+  };
+}


### PR DESCRIPTION
## Summary

- Remove `reasoning` content parts from assistant messages older than the last two user turns before they are sent to the model. Past thinking blocks don't need to round-trip per Anthropic guidance, and removing them reclaims up to ~10K tokens per past turn for Claude conversations.
- Mirrors the protected-window pattern from #1589: a stateless `stripPastReasoning` utility recomputed on every request, wired into `router.ts` after `pruneOldToolResults`.
- The current turn (and the one before it) keeps reasoning intact so Anthropic extended thinking + tool_use mid-loop continues to work — the in-progress thinking block tied to a still-pending `tool_use` round-trips correctly when the frontend auto-send fires with `…assistant(reasoning + tool_call) → tool_result`.
- No new config knobs: stripping past reasoning is unconditional and has no real tradeoff (savings are deterministic, the rule is safe).
- Logs `Stripped past reasoning from history` at DEBUG with `strippedCount` and `approxTokensSaved` when a strip commits.

Refs giantswarm/giantswarm#36358 — implements another slice of the OpenCode-inspired context-management work.

## Test plan

- [x] Unit tests cover protected window, multi-step assistant blocks across an old turn, in-progress tool-loop preservation, single-turn no-op, no-reasoning no-op, and string-content assistant messages (7 new tests; 52/52 in `plugins/ai-chat-backend` pass; 100% line/branch coverage on the new file).
- [x] `yarn tsc` clean.
- [x] `yarn lint plugins/ai-chat-backend` clean.
- [x] Manual smoke: open the AI chat with an Anthropic model (`claude-*`), run a multi-turn conversation with extended thinking enabled, and confirm backend logs show `Stripped past reasoning from history` from turn 3 onward while the chat continues to work mid-tool-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)