### PR TITLE
Remove @terasky/backstage-plugin-catalog-mcp-backend

### DIFF
--- a/.changeset/soft-planet-nestle.md
+++ b/.changeset/soft-planet-nestle.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Remove `@terasky/backstage-plugin-catalog-mcp-backend` in favor of the built-in `catalog.query-catalog-entities` action from `@backstage/plugin-mcp-actions-backend`. The built-in action covers all `catalog-mcp.*` use cases via predicate filters, logical operators (`$all`, `$any`, `$not`), value operators (`$in`, `$exists`, `$contains`, `$hasPrefix`), field selection, sorting, and pagination.

--- a/app-config.local.yaml.example
+++ b/app-config.local.yaml.example
@@ -9,7 +9,6 @@ backend:
   actions:
     pluginSources:
       - catalog
-      - catalog-mcp
       - gs
   baseUrl: https://localhost:7007
   listen:
@@ -28,7 +27,6 @@ backend:
         accessRestrictions:
           - plugin: mcp-actions
           - plugin: catalog
-          - plugin: catalog-mcp
           - plugin: gs
 
 auth:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -107,7 +107,7 @@ backend:
     pluginSources:
       - auth
       - catalog
-      - scaffolder
+      - gs
 
   cache:
     store: memory

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -57,7 +57,6 @@
     "@giantswarm/backstage-plugin-techdocs-backend-module-gs": "^0.10.0",
     "@internal/backend-common": "workspace:^",
     "@roadiehq/scaffolder-backend-module-utils": "^4.1.1",
-    "@terasky/backstage-plugin-catalog-mcp-backend": "^0.8.0",
     "app": "link:../app",
     "better-sqlite3": "^12.0.0",
     "express": "^5.0.0",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -87,6 +87,5 @@ backend.add(import('@giantswarm/backstage-plugin-ai-chat-backend'));
 
 // mcp actions plugin
 backend.add(import('@backstage/plugin-mcp-actions-backend'));
-backend.add(import('@terasky/backstage-plugin-catalog-mcp-backend'));
 
 backend.start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -20862,21 +20862,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terasky/backstage-plugin-catalog-mcp-backend@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@terasky/backstage-plugin-catalog-mcp-backend@npm:0.8.0"
-  dependencies:
-    "@backstage/backend-defaults": "npm:^0.17.0"
-    "@backstage/backend-plugin-api": "npm:^1.9.0"
-    "@backstage/errors": "npm:^1.3.0"
-    "@backstage/types": "npm:^1.2.2"
-    express: "npm:^4.17.1"
-    express-promise-router: "npm:^4.1.0"
-    zod: "npm:^3.25.76"
-  checksum: 10c0/fcd51c7dd4396c6fd395964f3abf79ba4b92cee7d86a6630200c4fa927229e1cd9c4fbfd3fd83b195000d13e361f6f08763c2d22db4dc77b1645d196e7eaf776
-  languageName: node
-  linkType: hard
-
 "@testing-library/dom@npm:^10.0.0":
   version: 10.4.1
   resolution: "@testing-library/dom@npm:10.4.1"
@@ -24023,7 +24008,6 @@ __metadata:
     "@giantswarm/backstage-plugin-techdocs-backend-module-gs": "npm:^0.10.0"
     "@internal/backend-common": "workspace:^"
     "@roadiehq/scaffolder-backend-module-utils": "npm:^4.1.1"
-    "@terasky/backstage-plugin-catalog-mcp-backend": "npm:^0.8.0"
     "@types/supertest": "npm:^2.0.12"
     app: "link:../app"
     better-sqlite3: "npm:^12.0.0"


### PR DESCRIPTION
### What does this PR do?

Removes the third-party `@terasky/backstage-plugin-catalog-mcp-backend` plugin, which is now redundant with the built-in `catalog.query-catalog-entities` action shipped in `@backstage/plugin-mcp-actions-backend` since Backstage 1.49.0.

The built-in action covers all `catalog-mcp.*` use cases via predicate filters, logical operators (`$all`, `$any`, `$not`), value operators (`$in`, `$exists`, `$contains`, `$hasPrefix`), field selection, sorting, and pagination.

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/4272

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))