### PR TITLE
Fix AI chat input freeze on dead-key composition

### DIFF
--- a/.changeset/gentle-apple-travel.md
+++ b/.changeset/gentle-apple-travel.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+Fix AI chat input freezing after typing dead keys (e.g., backtick on German keyboard) by replacing the upstream `ComposerPrimitive.Input` with a controlled `TextField` bound directly to the assistant runtime.

--- a/plugins/ai-chat/package.json
+++ b/plugins/ai-chat/package.json
@@ -29,6 +29,7 @@
     "@assistant-ui/react-ai-sdk": "^1.3.1",
     "@assistant-ui/react-devtools": "^1.0.0",
     "@assistant-ui/react-markdown": "^0.12.0",
+    "@assistant-ui/tap": "^0.5.10",
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/errors": "backstage:^",

--- a/plugins/ai-chat/src/components/AiChat/Thread.tsx
+++ b/plugins/ai-chat/src/components/AiChat/Thread.tsx
@@ -6,6 +6,8 @@ import {
   useEffect,
   useRef,
   type CSSProperties,
+  type ChangeEvent,
+  type KeyboardEvent,
 } from 'react';
 import {
   ThreadPrimitive,
@@ -19,6 +21,7 @@ import {
   useThreadViewportStore,
   useAuiEvent,
 } from '@assistant-ui/react';
+import { flushResourcesSync } from '@assistant-ui/tap';
 import {
   useApi,
   configApiRef,
@@ -259,22 +262,59 @@ const AssistantMessage = () => {
   );
 };
 
+// Bypass ComposerPrimitive.Input: its compositionRef can get stuck on dead-key layouts (e.g. German backtick) and freeze the input.
+const useComposerInputBinding = () => {
+  const api = useAssistantApi();
+  const text = useAssistantState(({ composer }) => composer.text);
+  const isDisabled = useAssistantState(
+    ({ thread, composer }) =>
+      thread.isDisabled || Boolean(composer.dictation?.inputDisabled),
+  );
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      // Flush synchronously so the controlled TextField stays in sync with
+      // fast keystrokes — without this the store update is scheduled on a
+      // macrotask and React drops characters between renders.
+      flushResourcesSync(() => {
+        api.composer().setText(e.target.value);
+      });
+    },
+    [api],
+  );
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Enter' || e.shiftKey) return;
+    if (e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    const target = e.target as HTMLElement;
+    target.closest('form')?.requestSubmit();
+  }, []);
+
+  return { value: text, disabled: isDisabled, handleChange, handleKeyDown };
+};
+
 const EditComposer = () => {
   const classes = useStyles();
+  const { value, disabled, handleChange, handleKeyDown } =
+    useComposerInputBinding();
 
   return (
     <ComposerPrimitive.Root className={classes.composerForm}>
-      <ComposerPrimitive.Input asChild addAttachmentOnPaste={false}>
-        <TextField
-          variant="outlined"
-          size="small"
-          fullWidth
-          multiline
-          maxRows={4}
-          placeholder="Edit message..."
-          className={classes.composerInput}
-        />
-      </ComposerPrimitive.Input>
+      <TextField
+        name="input"
+        variant="outlined"
+        size="small"
+        fullWidth
+        multiline
+        maxRows={4}
+        placeholder="Edit message..."
+        className={classes.composerInput}
+        value={value}
+        disabled={disabled}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+      />
       <ComposerPrimitive.Cancel asChild>
         <Button variant="outlined" size="small">
           Cancel
@@ -291,6 +331,8 @@ const EditComposer = () => {
 
 const Composer = ({ isSticky = true }: { isSticky?: boolean }) => {
   const classes = useStyles();
+  const { value, disabled, handleChange, handleKeyDown } =
+    useComposerInputBinding();
 
   return (
     <div
@@ -306,19 +348,22 @@ const Composer = ({ isSticky = true }: { isSticky?: boolean }) => {
         )}
       >
         <ComposerPrimitive.Root className={classes.composerForm}>
-          <ComposerPrimitive.Input asChild addAttachmentOnPaste={false}>
-            <TextField
-              variant="outlined"
-              // eslint-disable-next-line jsx-a11y/no-autofocus
-              autoFocus
-              size="small"
-              fullWidth
-              multiline
-              maxRows={4}
-              placeholder="Ask a question..."
-              className={classes.composerInput}
-            />
-          </ComposerPrimitive.Input>
+          <TextField
+            name="input"
+            variant="outlined"
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            size="small"
+            fullWidth
+            multiline
+            maxRows={4}
+            placeholder="Ask a question..."
+            className={classes.composerInput}
+            value={value}
+            disabled={disabled}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+          />
 
           <ThreadPrimitive.If running={false}>
             <ComposerPrimitive.Send asChild>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10073,6 +10073,7 @@ __metadata:
     "@assistant-ui/react-ai-sdk": "npm:^1.3.1"
     "@assistant-ui/react-devtools": "npm:^1.0.0"
     "@assistant-ui/react-markdown": "npm:^0.12.0"
+    "@assistant-ui/tap": "npm:^0.5.10"
     "@backstage/cli": "backstage:^"
     "@backstage/core-app-api": "backstage:^"
     "@backstage/core-components": "backstage:^"


### PR DESCRIPTION
### What does this PR do?

Fixes the AI chat composer freezing after typing a dead-key character (most reproducibly the backtick on a German keyboard, but also affects U.S. International, French AZERTY, Spanish ISO, etc.).

Upstream `@assistant-ui/react`'s `ComposerPrimitive.Input` tracks IME composition with a ref and short-circuits `onChange` while composing. On dead-key layouts Chrome occasionally drops the matching `compositionend`, the ref stays stuck at `true`, and every subsequent keystroke is silently ignored — the input still has focus but no longer accepts text.

This PR replaces the primitive with a controlled MUI `TextField` bound directly to the assistant runtime via `useAssistantApi()` / `useAssistantState()`. Composition is only consulted at the `Enter`→send keybinding (a per-event check on `e.nativeEvent.isComposing`), so CJK users keep correct submit behavior and there is no longer any stateful flag that can get stuck. `setText` is wrapped in `flushResourcesSync` so the controlled input stays in sync with fast keystrokes.

### Any background context you can provide?

Upstream issue - https://github.com/assistant-ui/assistant-ui/issues/3923

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))