### PR TITLE
Fix sqlite-persistence CI case to use connection.directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
+### Fixed
+
+- Make the sqlite-persistence CI test case (`ci-values-case3-sqlite-persistent.yaml`) inject a real `backend.database.connection.directory` override and update the surrounding comment so it reflects what current Backstage actually accepts. The previous comment suggested `connection: /var/lib/backstage/db.sqlite`, which the `Sqlite3Connector` rejects at runtime with `"connection.filename" is not supported for the base sqlite connection`.
+
 ## [0.126.0] - 2026-04-30
 
 ### Added

--- a/helm/backstage/ci/ci-values-case3-sqlite-persistent.yaml
+++ b/helm/backstage/ci/ci-values-case3-sqlite-persistent.yaml
@@ -51,9 +51,24 @@ backstage:
   args: []
   extraAppConfig: []
   extraEnvVars: []
-  # In a real deployment, override `backend.database.connection` to a path
-  # under the mounted PVC (e.g. /var/lib/backstage/db.sqlite). Omitted here
-  # because the chart's appConfig schema is currently closed.
+  # Point Backstage's base sqlite connection at the PVC mount. The current
+  # better-sqlite3 connector rejects `connection.filename` on the base
+  # config (it errors with "`connection.filename` is not supported for
+  # the base sqlite connection. Prefer `connection.directory` or provide
+  # a filename for the plugin connection instead."), so the supported
+  # shape is `connection.directory: <path>` -- Backstage then creates one
+  # `<plugin>.sqlite` file per plugin under that directory.
+  #
+  # The chart's `backstage.appConfig` schema disallows arbitrary nested
+  # keys when given as an object, but it also accepts a string, which is
+  # rendered verbatim into the app-config ConfigMap. Use the string form
+  # to inject the database override.
+  appConfig: |
+    backend:
+      database:
+        client: better-sqlite3
+        connection:
+          directory: /var/lib/backstage
   # fsGroupID handles ownership of the freshly provisioned volume; this
   # init container exists purely to assert the mount is readable from the
   # non-root user, and to demonstrate the new initContainers value.


### PR DESCRIPTION
## Summary

The CI fixture for `database.engine: sqlite` (`ci-values-case3-sqlite-persistent.yaml`) documented overriding the backend database connection with `/var/lib/backstage/db.sqlite` and then omitted the override entirely "because the chart's appConfig schema is currently closed". Both halves of that comment are wrong:

- The current `Sqlite3Connector` rejects `connection.filename` on the base sqlite connection at runtime with:

      "connection.filename" is not supported for the base sqlite connection.
      Prefer "connection.directory" or provide a filename for the plugin
      connection instead.

  Persistence requires `connection.directory: <path>` so Backstage creates one `<plugin>.sqlite` per plugin under the mounted PVC.

- `backstage.appConfig` accepts `["object", "string"]`. The object form is closed (no nested keys), but the string form is rendered verbatim into the app-config ConfigMap, which is exactly the documented escape hatch for overrides like this.

This PR injects the correct override into case 3 so the test actually exercises the supported persistence configuration, and replaces the comment with the rationale for the string form.

`helm template` against the updated fixture produces a `backstage-app-config-configmap` ConfigMap whose `app-config.yaml` contains:

```yaml
backend:
  database:
    client: better-sqlite3
    connection:
      directory: /var/lib/backstage
```

`helm lint` is clean.

## Discovery context

Hit while bringing up `bwi-backstage` on `spidertron`: chart `v0.126.0` wired up the SQLite persistence plumbing (`fsGroupID`, `strategy`, `initContainers`, `extraVolumes`/`extraVolumeMounts`), and the consumer (giantswarm/bwi#152) followed the comment in case 3 and set `connection: /var/lib/backstage/db.sqlite`. Backstage crashed on startup with the message above. Switching to `connection.directory` (giantswarm/bwi#155) fixed it. Updating the upstream CI fixture so the next consumer doesn't repeat the same investigation.

## Test plan

- [x] `helm dep update` + `helm template . -f ci/ci-values-case3-sqlite-persistent.yaml` renders cleanly and the rendered ConfigMap contains `connection.directory: /var/lib/backstage`.
- [x] `helm lint . -f ci/ci-values-case3-sqlite-persistent.yaml` -- 0 chart(s) failed.
- [ ] CI green.

Made with [Cursor](https://cursor.com)