### PR TITLE
Allow customization of theme colors

### DIFF
--- a/.changeset/ripe-mirrors-melt.md
+++ b/.changeset/ripe-mirrors-melt.md
@@ -1,0 +1,5 @@
+---
+'app': minor
+---
+
+Allow customization of theme colors

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,6 +1,6 @@
 # Custom Branding
 
-The Dev Portal supports overriding the default sidebar logos, home page logo, and browser tab favicon with custom assets, without committing them to the source repository or loading them from external URLs.
+The Dev Portal supports overriding the default sidebar logos, home page logo, and browser tab favicon with custom assets, without committing them to the source repository or loading them from external URLs. It also supports overriding individual palette colors of the light and dark themes via app config, so deployments can match a customer's brand without rebuilding the frontend.
 
 Assets are placed into a directory on the backend's filesystem and served by the built-in `branding` backend plugin (defined in `packages/backend/src/branding/`). On the frontend, components check which assets are available and swap in the custom versions, falling back to the built-in defaults when none are provided.
 
@@ -112,11 +112,64 @@ Generate the base64 content with:
 base64 -w0 favicon-32x32.png
 ```
 
+## Theme colors
+
+Light and dark theme palette colors can be customized via `app.branding.theme.<variant>` in app config. Any unset key falls back to the Backstage default for that variant — overrides are merged on top of the built-in palette, not replacing it.
+
+```yaml
+app:
+  branding:
+    theme:
+      light:
+        primaryColor: '#1F5493'
+        secondaryColor: '#005B86'
+        backgroundColor: '#FFFFFF'
+        textColor: '#222222'
+        navigation:
+          background: '#171717'
+          indicator: '#9BF0E1'
+          color: '#FFFFFF'
+          selectedColor: '#FFFFFF'
+      dark:
+        primaryColor: '#9CC9FF'
+        secondaryColor: '#FF88B2'
+        backgroundColor: '#1A1A1A'
+        textColor: '#EEEEEE'
+        navigation:
+          background: '#424242'
+          indicator: '#9BF0E1'
+          color: '#B5B5B5'
+          selectedColor: '#FFFFFF'
+```
+
+`backgroundColor` sets the page background. It updates both the MUI `background.default` palette token (used by legacy components) and the `--bui-bg-app` CSS variable (used by `@backstage/ui` components) so the two stay in sync.
+
+`textColor` sets the default body text color. It updates both the MUI `text.primary` palette token and the `--bui-fg-primary` CSS variable.
+
+`neutralBackground1` through `neutralBackground4` set the four tiers of neutral surface backgrounds used by `@backstage/ui` components (cards, panels, hover surfaces). They map to the `--bui-bg-neutral-1` through `--bui-bg-neutral-4` CSS variables and have no MUI palette equivalent.
+
+The customization is wired into the New Frontend System: the built-in `theme:app/light` and `theme:app/dark` extensions are overridden in `packages/app/src/modules/app/AppOverrides.tsx`, and palette merging happens in `packages/app/src/modules/app/customThemes.tsx`. Theme variant `id`s match upstream so the theme switcher and persisted user selections continue to work.
+
+To preview overrides locally, drop a `theme:` block under `app.branding` in `app-config.local.yaml` and restart `yarn start`.
+
 ## Configuration reference
 
-| Key                       | Default                | Description                                                 |
-| ------------------------- | ---------------------- | ----------------------------------------------------------- |
-| `app.branding.assetsPath` | `/app/branding-assets` | Filesystem path where the backend looks for branding assets |
+| Key                                                 | Default                | Description                                                 |
+| --------------------------------------------------- | ---------------------- | ----------------------------------------------------------- |
+| `app.branding.assetsPath`                           | `/app/branding-assets` | Filesystem path where the backend looks for branding assets |
+| `app.branding.theme.light.primaryColor`             | Backstage default      | Primary brand color in the light theme                      |
+| `app.branding.theme.light.secondaryColor`           | Backstage default      | Secondary accent color in the light theme                   |
+| `app.branding.theme.light.backgroundColor`          | Backstage default      | Page background color in the light theme                    |
+| `app.branding.theme.light.textColor`                | Backstage default      | Default body text color in the light theme                  |
+| `app.branding.theme.light.neutralBackground1`       | Backstage default      | Tier 1 neutral surface background in the light theme        |
+| `app.branding.theme.light.neutralBackground2`       | Backstage default      | Tier 2 neutral surface background in the light theme        |
+| `app.branding.theme.light.neutralBackground3`       | Backstage default      | Tier 3 neutral surface background in the light theme        |
+| `app.branding.theme.light.neutralBackground4`       | Backstage default      | Tier 4 neutral surface background in the light theme        |
+| `app.branding.theme.light.navigation.background`    | Backstage default      | Sidebar background in the light theme                       |
+| `app.branding.theme.light.navigation.indicator`     | Backstage default      | Active-route indicator color in the light theme             |
+| `app.branding.theme.light.navigation.color`         | Backstage default      | Default nav item color in the light theme                   |
+| `app.branding.theme.light.navigation.selectedColor` | Backstage default      | Selected nav item color in the light theme                  |
+| `app.branding.theme.dark.*`                         | Backstage default      | Same keys as `light`, applied to the dark theme             |
 
 ### Helm values
 

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -16,6 +16,113 @@ export interface Config {
          */
         height?: number;
       };
+
+      /**
+       * Optional palette overrides applied on top of the built-in Backstage
+       * light/dark themes. Any key left unset falls back to the Backstage
+       * default for that variant.
+       * @deepVisibility frontend
+       */
+      theme?: {
+        light?: {
+          /** Brand color used for primary accents (buttons, links, etc.). */
+          primaryColor?: string;
+          /** Accent color used for secondary highlights. */
+          secondaryColor?: string;
+          /**
+           * Page background color. Sets both the MUI `background.default`
+           * palette token and the `--bui-bg-app` CSS variable used by
+           * `@backstage/ui` components.
+           */
+          backgroundColor?: string;
+          /**
+           * Default body text color. Sets both the MUI `text.primary`
+           * palette token and the `--bui-fg-primary` CSS variable used by
+           * `@backstage/ui` components.
+           */
+          textColor?: string;
+          /**
+           * Surface background tier 1. Sets the `--bui-bg-neutral-1` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground1?: string;
+          /**
+           * Surface background tier 2. Sets the `--bui-bg-neutral-2` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground2?: string;
+          /**
+           * Surface background tier 3. Sets the `--bui-bg-neutral-3` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground3?: string;
+          /**
+           * Surface background tier 4. Sets the `--bui-bg-neutral-4` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground4?: string;
+          /** Sidebar / navigation palette overrides. */
+          navigation?: {
+            /** Background color of the sidebar. */
+            background?: string;
+            /** Color of the active-route indicator strip. */
+            indicator?: string;
+            /** Default color of nav item icons and labels. */
+            color?: string;
+            /** Color used for the currently selected nav item. */
+            selectedColor?: string;
+          };
+        };
+        dark?: {
+          /** Brand color used for primary accents (buttons, links, etc.). */
+          primaryColor?: string;
+          /** Accent color used for secondary highlights. */
+          secondaryColor?: string;
+          /**
+           * Page background color. Sets both the MUI `background.default`
+           * palette token and the `--bui-bg-app` CSS variable used by
+           * `@backstage/ui` components.
+           */
+          backgroundColor?: string;
+          /**
+           * Default body text color. Sets both the MUI `text.primary`
+           * palette token and the `--bui-fg-primary` CSS variable used by
+           * `@backstage/ui` components.
+           */
+          textColor?: string;
+          /**
+           * Surface background tier 1. Sets the `--bui-bg-neutral-1` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground1?: string;
+          /**
+           * Surface background tier 2. Sets the `--bui-bg-neutral-2` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground2?: string;
+          /**
+           * Surface background tier 3. Sets the `--bui-bg-neutral-3` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground3?: string;
+          /**
+           * Surface background tier 4. Sets the `--bui-bg-neutral-4` CSS
+           * variable used by `@backstage/ui` components.
+           */
+          neutralBackground4?: string;
+          /** Sidebar / navigation palette overrides. */
+          navigation?: {
+            /** Background color of the sidebar. */
+            background?: string;
+            /** Color of the active-route indicator strip. */
+            indicator?: string;
+            /** Default color of nav item icons and labels. */
+            color?: string;
+            /** Color used for the currently selected nav item. */
+            selectedColor?: string;
+          };
+        };
+      };
     };
 
     /**

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,6 +73,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@backstage/config": "backstage:^",
     "@playwright/test": "^1.32.3",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.4.2",

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -13,7 +13,10 @@ import {
 import {
   IconBundleBlueprint,
   SignInPageBlueprint,
+  ThemeBlueprint,
 } from '@backstage/plugin-app-react';
+import DarkIcon from '@material-ui/icons/Brightness2';
+import LightIcon from '@material-ui/icons/WbSunny';
 import {
   analyticsApiRef,
   configApiRef,
@@ -49,6 +52,7 @@ import {
   GrafanaIcon,
 } from '../../assets/icons/CustomIcons';
 import { BrandingFavicon } from '../branding';
+import { DarkThemeProvider, LightThemeProvider } from './customThemes';
 
 // The Grafana plugin is a legacy plugin whose API factory is not
 // auto-registered in the NFS. Extract it and provide via ApiBlueprint.
@@ -175,6 +179,36 @@ export const appOverrides = createFrontendModule({
       name: 'branding-favicon',
       params: {
         element: <BrandingFavicon />,
+      },
+    }),
+    /**
+     * Override the built-in `theme:app/light` and `theme:app/dark` extensions
+     * so palette overrides under `app.branding.theme` in app-config take effect.
+     * The `id`/`title`/`variant` match upstream defaults so the theme switcher
+     * UI and persisted user selections continue to work unchanged.
+     */
+    ThemeBlueprint.make({
+      name: 'light',
+      params: {
+        theme: {
+          id: 'light',
+          title: 'Light Theme',
+          variant: 'light',
+          icon: <LightIcon />,
+          Provider: LightThemeProvider,
+        },
+      },
+    }),
+    ThemeBlueprint.make({
+      name: 'dark',
+      params: {
+        theme: {
+          id: 'dark',
+          title: 'Dark Theme',
+          variant: 'dark',
+          icon: <DarkIcon />,
+          Provider: DarkThemeProvider,
+        },
       },
     }),
     ApiBlueprint.make({

--- a/packages/app/src/modules/app/customThemes.test.ts
+++ b/packages/app/src/modules/app/customThemes.test.ts
@@ -1,0 +1,156 @@
+import { ConfigReader } from '@backstage/config';
+import { palettes } from '@backstage/theme';
+import { buildPalette, getCssVariableOverrides } from './customThemes';
+
+describe('buildPalette', () => {
+  it('returns the built-in palette unchanged when no overrides are configured', () => {
+    const config = new ConfigReader({});
+    expect(buildPalette(config, 'light')).toEqual(palettes.light);
+    expect(buildPalette(config, 'dark')).toEqual(palettes.dark);
+  });
+
+  it('overrides primary, secondary, background, text, and navigation colors when set', () => {
+    const config = new ConfigReader({
+      app: {
+        branding: {
+          theme: {
+            light: {
+              primaryColor: '#111111',
+              secondaryColor: '#222222',
+              backgroundColor: '#777777',
+              textColor: '#888888',
+              navigation: {
+                background: '#333333',
+                indicator: '#444444',
+                color: '#555555',
+                selectedColor: '#666666',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const palette = buildPalette(config, 'light') as ReturnType<
+      typeof buildPalette
+    > & { text: { primary: string } };
+
+    expect(palette.primary.main).toBe('#111111');
+    expect(palette.secondary.main).toBe('#222222');
+    expect(palette.background.default).toBe('#777777');
+    // background.paper is preserved from the built-in palette.
+    expect(palette.background.paper).toBe(palettes.light.background.paper);
+    expect(palette.text.primary).toBe('#888888');
+    expect(palette.navigation.background).toBe('#333333');
+    expect(palette.navigation.indicator).toBe('#444444');
+    expect(palette.navigation.color).toBe('#555555');
+    expect(palette.navigation.selectedColor).toBe('#666666');
+    // Untouched fields keep their built-in values.
+    expect(palette.navigation.navItem).toEqual(
+      palettes.light.navigation.navItem,
+    );
+  });
+
+  it('leaves background and text untouched when their keys are not set', () => {
+    const config = new ConfigReader({
+      app: {
+        branding: {
+          theme: {
+            dark: { primaryColor: '#abcdef' },
+          },
+        },
+      },
+    });
+
+    const palette = buildPalette(config, 'dark') as ReturnType<
+      typeof buildPalette
+    > & { text?: unknown };
+
+    expect(palette.background).toEqual(palettes.dark.background);
+    expect(palette.text).toBeUndefined();
+  });
+
+  it('only overrides the keys that are set, leaving others as built-in defaults', () => {
+    const config = new ConfigReader({
+      app: {
+        branding: {
+          theme: {
+            dark: {
+              primaryColor: '#abcdef',
+              navigation: {
+                indicator: '#fedcba',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const palette = buildPalette(config, 'dark');
+
+    expect(palette.primary.main).toBe('#abcdef');
+    expect(palette.secondary.main).toBe(palettes.dark.secondary.main);
+    expect(palette.navigation.indicator).toBe('#fedcba');
+    expect(palette.navigation.background).toBe(
+      palettes.dark.navigation.background,
+    );
+    expect(palette.navigation.color).toBe(palettes.dark.navigation.color);
+    expect(palette.navigation.selectedColor).toBe(
+      palettes.dark.navigation.selectedColor,
+    );
+  });
+
+  it('emits CSS variable overrides for backgroundColor, textColor, and neutralBackgrounds', () => {
+    const config = new ConfigReader({
+      app: {
+        branding: {
+          theme: {
+            dark: {
+              backgroundColor: '#101010',
+              textColor: '#eeeeee',
+              neutralBackground1: '#202020',
+              neutralBackground2: '#303030',
+              neutralBackground3: '#404040',
+              neutralBackground4: '#505050',
+            },
+            light: {},
+          },
+        },
+      },
+    });
+
+    const css = getCssVariableOverrides(config, 'dark');
+    expect(css).toContain("body[data-theme-mode='dark']");
+    expect(css).toContain('--bui-bg-app: #101010;');
+    expect(css).toContain('--bui-fg-primary: #eeeeee;');
+    expect(css).toContain('--bui-bg-neutral-1: #202020;');
+    expect(css).toContain('--bui-bg-neutral-2: #303030;');
+    expect(css).toContain('--bui-bg-neutral-3: #404040;');
+    expect(css).toContain('--bui-bg-neutral-4: #505050;');
+
+    // No declarations for an empty variant.
+    expect(getCssVariableOverrides(config, 'light')).toBeUndefined();
+
+    // No config at all yields undefined.
+    expect(
+      getCssVariableOverrides(new ConfigReader({}), 'dark'),
+    ).toBeUndefined();
+  });
+
+  it('isolates light and dark variants', () => {
+    const config = new ConfigReader({
+      app: {
+        branding: {
+          theme: {
+            light: { primaryColor: '#aaaaaa' },
+          },
+        },
+      },
+    });
+
+    expect(buildPalette(config, 'light').primary.main).toBe('#aaaaaa');
+    expect(buildPalette(config, 'dark').primary.main).toBe(
+      palettes.dark.primary.main,
+    );
+  });
+});

--- a/packages/app/src/modules/app/customThemes.tsx
+++ b/packages/app/src/modules/app/customThemes.tsx
@@ -1,0 +1,117 @@
+/**
+ * Custom theme providers that layer optional `app.branding.theme` palette
+ * overrides on top of Backstage's built-in light/dark palettes.
+ *
+ * Wired up in {@link AppOverrides} via `ThemeBlueprint.make({ name: 'light' })`
+ * and `name: 'dark'`, which override the built-in `theme:app/light` and
+ * `theme:app/dark` extensions provided by `@backstage/plugin-app`.
+ */
+import { ReactNode, useMemo } from 'react';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import {
+  createUnifiedTheme,
+  palettes,
+  UnifiedThemeProvider,
+} from '@backstage/theme';
+import type { Config } from '@backstage/config';
+
+type Variant = 'light' | 'dark';
+
+const CONFIG_KEY: Record<Variant, string> = {
+  light: 'app.branding.theme.light',
+  dark: 'app.branding.theme.dark',
+};
+
+export function buildPalette(configApi: Config, variant: Variant) {
+  const base = palettes[variant] as typeof palettes.dark;
+  const root = configApi.getOptionalConfig(CONFIG_KEY[variant]);
+  if (!root) {
+    return base;
+  }
+
+  const primary = root.getOptionalString('primaryColor');
+  const secondary = root.getOptionalString('secondaryColor');
+  const background = root.getOptionalString('backgroundColor');
+  const text = root.getOptionalString('textColor');
+  const nav = root.getOptionalConfig('navigation');
+  const navBackground = nav?.getOptionalString('background');
+  const navIndicator = nav?.getOptionalString('indicator');
+  const navColor = nav?.getOptionalString('color');
+  const navSelectedColor = nav?.getOptionalString('selectedColor');
+
+  const hasSecondary = base.secondary !== undefined || secondary !== undefined;
+
+  return {
+    ...base,
+    primary: { ...base.primary, ...(primary && { main: primary }) },
+    ...(hasSecondary && {
+      secondary: { ...base.secondary, ...(secondary && { main: secondary }) },
+    }),
+    ...(background && {
+      background: { ...base.background, default: background },
+    }),
+    ...(text && {
+      text: { ...(base as { text?: object }).text, primary: text },
+    }),
+    navigation: {
+      ...base.navigation,
+      ...(navBackground && { background: navBackground }),
+      ...(navIndicator && { indicator: navIndicator }),
+      ...(navColor && { color: navColor }),
+      ...(navSelectedColor && { selectedColor: navSelectedColor }),
+    },
+  };
+}
+
+export function getCssVariableOverrides(configApi: Config, variant: Variant) {
+  const root = configApi.getOptionalConfig(CONFIG_KEY[variant]);
+  if (!root) {
+    return undefined;
+  }
+  const backgroundColor = root.getOptionalString('backgroundColor');
+  const textColor = root.getOptionalString('textColor');
+  const neutralBackground1 = root.getOptionalString('neutralBackground1');
+  const neutralBackground2 = root.getOptionalString('neutralBackground2');
+  const neutralBackground3 = root.getOptionalString('neutralBackground3');
+  const neutralBackground4 = root.getOptionalString('neutralBackground4');
+  const declarations = [
+    backgroundColor && `--bui-bg-app: ${backgroundColor};`,
+    textColor && `--bui-fg-primary: ${textColor};`,
+    neutralBackground1 && `--bui-bg-neutral-1: ${neutralBackground1};`,
+    neutralBackground2 && `--bui-bg-neutral-2: ${neutralBackground2};`,
+    neutralBackground3 && `--bui-bg-neutral-3: ${neutralBackground3};`,
+    neutralBackground4 && `--bui-bg-neutral-4: ${neutralBackground4};`,
+  ].filter(Boolean);
+  return declarations.length
+    ? `body[data-theme-mode='${variant}'] { ${declarations.join(' ')} }`
+    : undefined;
+}
+
+function CustomThemeProvider({
+  variant,
+  children,
+}: {
+  variant: Variant;
+  children: ReactNode;
+}) {
+  const configApi = useApi(configApiRef);
+  const theme = useMemo(
+    () => createUnifiedTheme({ palette: buildPalette(configApi, variant) }),
+    [configApi, variant],
+  );
+  const cssOverrides = getCssVariableOverrides(configApi, variant);
+  return (
+    <UnifiedThemeProvider theme={theme}>
+      {cssOverrides && <style>{cssOverrides}</style>}
+      {children}
+    </UnifiedThemeProvider>
+  );
+}
+
+export const LightThemeProvider = ({ children }: { children: ReactNode }) => (
+  <CustomThemeProvider variant="light">{children}</CustomThemeProvider>
+);
+
+export const DarkThemeProvider = ({ children }: { children: ReactNode }) => (
+  <CustomThemeProvider variant="dark">{children}</CustomThemeProvider>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -23571,6 +23571,7 @@ __metadata:
     "@backstage/app-defaults": "backstage:^"
     "@backstage/catalog-model": "backstage:^"
     "@backstage/cli": "backstage:^"
+    "@backstage/config": "backstage:^"
     "@backstage/core-app-api": "backstage:^"
     "@backstage/core-compat-api": "backstage:^"
     "@backstage/core-components": "backstage:^"


### PR DESCRIPTION
### What does this PR do?

Adds the ability to customize theme colors.

### How does it look like?

<img width="1181" height="750" alt="image" src="https://github.com/user-attachments/assets/87524735-e383-47e6-936a-2c8e347c85d1" />


Screenshot for the following config:

```yaml
app:
  branding:
    theme:
      dark:
        primaryColor: '#f3ba37' # yellow
        secondaryColor: '#00FFAA' # mint
        backgroundColor: '#000000'
        textColor: '#f0f0f0'
        neutralBackground2: '#222'
        navigation:
          background: '#222'
          indicator: '#f3ba37' # yellow
          color: '#ddd'
          selectedColor: '#f3ba37' # yellow
```

### Any background context you can provide?

- https://github.com/giantswarm/giantswarm/issues/36072

### Do the docs need to be updated?

Done

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
