### PR TITLE
Make AI chat skills configurable per deployment

### DIFF
--- a/.changeset/vast-thunder-nestle.md
+++ b/.changeset/vast-thunder-nestle.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+---
+
+Make AI-chat skills configurable per deployment. The plugin still ships a default set of bundled skills, but deployments can now opt out via `aiChat.skills.bundled: false` and/or extend them with additional sources: `aiChat.skills.dir` (path to a directory of `*.md` files, e.g. mounted from a Kubernetes ConfigMap) and `aiChat.skills.inline` (an array of `{ name, content }` entries in `app-config`). Merge order is bundled → `dir` → `inline`, with later sources overriding earlier ones on name collision. When no skills end up loaded, the `listSkills` and `getSkill` tools are omitted from the toolset entirely.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -222,6 +222,23 @@ aiChat:
   # Model to use (default: gpt-4o-mini)
   model: gpt-4o-mini
 
+  # Expert-knowledge skills exposed to the model via `listSkills` /
+  # `getSkill` tools. The plugin ships a default set of bundled skills;
+  # deployments can opt out and/or extend them with extra sources.
+  # Merge order (later wins on name collision): bundled -> dir -> inline.
+  # skills:
+  #   # Set to false to opt out of the bundled skills.
+  #   bundled: true
+  #   # Optional directory of *.md files (e.g. mounted from a Kubernetes
+  #   # ConfigMap). Each file becomes a skill named after its basename.
+  #   dir: /etc/backstage/ai-skills
+  #   # Optional inline skills, defined directly in app-config.
+  #   inline:
+  #     - name: my-topic
+  #       content: |
+  #         # My topic
+  #         Expert knowledge about my topic...
+
   # Optional: override the context window size (in tokens) used to render
   # the context usage bar. When set, applies regardless of the model name.
   # When unset, a built-in lookup by model name prefix is used.

--- a/plugins/ai-chat-backend/config.d.ts
+++ b/plugins/ai-chat-backend/config.d.ts
@@ -81,6 +81,46 @@ export interface Config {
      */
     maxSteps?: number;
 
+    /**
+     * Sources of expert-knowledge skills exposed to the model via the
+     * `listSkills` and `getSkill` tools. The plugin ships a default set
+     * of bundled skills; deployments can opt out and/or extend them with
+     * additional sources. If no skills end up loaded, the tools are
+     * omitted from the toolset entirely.
+     *
+     * Merge order (later wins on name collision): bundled → `dir` → `inline`.
+     */
+    skills?: {
+      /**
+       * Whether to load the skills bundled with the plugin. Defaults to
+       * `true`. Set to `false` to opt out and rely solely on `dir` and/or
+       * `inline`.
+       * @visibility backend
+       */
+      bundled?: boolean;
+
+      /**
+       * Absolute path to a directory of `*.md` files. Each file becomes a
+       * skill named after its basename (e.g. `grafana.md` → `grafana`).
+       * Loaded once at backend startup. Entries override bundled skills
+       * with the same name.
+       * @visibility backend
+       */
+      dir?: string;
+
+      /**
+       * Inline skills. Entries override bundled and `dir` skills with the
+       * same name.
+       * @visibility backend
+       */
+      inline?: Array<{
+        /** Topic name (lowercase-with-hyphens recommended). */
+        name: string;
+        /** Markdown content of the skill. */
+        content: string;
+      }>;
+    };
+
     /** Optional: MCP servers configuration */
     mcp?: Array<{
       /** Name of the MCP server */

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -26,8 +26,7 @@ import { getMcpTools } from './getMcpTools';
 import { McpClientCache } from './McpClientCache';
 import { frontendTools } from './frontendTools';
 import {
-  listSkills,
-  getSkill,
+  createSkillTools,
   getDate,
   createResourceTools,
   createContextUsageTool,
@@ -77,6 +76,8 @@ export async function createRouter(
   const { auth, httpAuth, logger, config, conversationStore } = options;
 
   const mcpClientCache = new McpClientCache(logger);
+
+  const skillTools = createSkillTools(config, logger);
 
   const router = Router();
   router.use(express.json({ limit: '2mb' }));
@@ -418,8 +419,7 @@ export async function createRouter(
         ...frontendTools(tools),
         ...mcpTools,
         ...mcpResourceTools,
-        listSkills,
-        getSkill,
+        ...skillTools,
         getDate,
         ...contextUsageTools,
       };

--- a/plugins/ai-chat-backend/src/tools/index.ts
+++ b/plugins/ai-chat-backend/src/tools/index.ts
@@ -1,4 +1,4 @@
-export { listSkills, getSkill } from './skillTools';
+export { createSkillTools } from './skillTools';
 export { getDate } from './dateTools';
 export { createResourceTools } from './resourceTools';
 export { createContextUsageTool, recordUsage } from './contextUsageTools';

--- a/plugins/ai-chat-backend/src/tools/skillTools.test.ts
+++ b/plugins/ai-chat-backend/src/tools/skillTools.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ConfigReader } from '@backstage/config';
+import { mockServices } from '@backstage/backend-test-utils';
+import { createSkillTools } from './skillTools';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'ai-skills-test-'));
+}
+
+describe('createSkillTools', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads bundled skills by default', async () => {
+    const config = new ConfigReader({});
+    const { listSkills } = createSkillTools(config, mockServices.logger.mock());
+
+    const list = (await listSkills!.execute!({}, {} as any)) as {
+      availableTopics: string[];
+    };
+    expect(list.availableTopics).toContain('grafana');
+  });
+
+  it('returns no tools when bundled is opted out and nothing else is configured', () => {
+    const config = new ConfigReader({
+      aiChat: { skills: { bundled: false } },
+    });
+    const tools = createSkillTools(config, mockServices.logger.mock());
+    expect(tools).toEqual({});
+  });
+
+  it('returns no tools when bundled is opted out, dir is missing and inline is empty', () => {
+    tmpDir = makeTmpDir();
+    const missing = join(tmpDir, 'does-not-exist');
+    const logger = mockServices.logger.mock();
+
+    const config = new ConfigReader({
+      aiChat: { skills: { bundled: false, dir: missing } },
+    });
+    const tools = createSkillTools(config, logger);
+    expect(tools).toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(missing));
+  });
+
+  it('loads *.md files from a configured directory', async () => {
+    tmpDir = makeTmpDir();
+    writeFileSync(join(tmpDir, 'foo.md'), '# Foo\n\nFoo content.\n');
+    writeFileSync(join(tmpDir, 'bar.md'), '# Bar\n');
+    writeFileSync(join(tmpDir, 'ignored.txt'), 'not a skill');
+
+    const config = new ConfigReader({
+      aiChat: { skills: { bundled: false, dir: tmpDir } },
+    });
+    const { listSkills, getSkill } = createSkillTools(
+      config,
+      mockServices.logger.mock(),
+    );
+
+    const list = (await listSkills!.execute!({}, {} as any)) as {
+      availableTopics: string[];
+    };
+    expect(list.availableTopics.sort()).toEqual(['bar', 'foo']);
+
+    const hit = (await getSkill!.execute!({ topic: 'foo' }, {} as any)) as {
+      topic: string;
+      content: string;
+    };
+    expect(hit.topic).toBe('foo');
+    expect(hit.content).toBe('# Foo\n\nFoo content.');
+  });
+
+  it('loads inline skills', async () => {
+    const config = new ConfigReader({
+      aiChat: {
+        skills: {
+          bundled: false,
+          inline: [
+            { name: 'alpha', content: 'alpha content' },
+            { name: 'beta', content: '   beta content   ' },
+          ],
+        },
+      },
+    });
+    const { listSkills, getSkill } = createSkillTools(
+      config,
+      mockServices.logger.mock(),
+    );
+
+    const list = (await listSkills!.execute!({}, {} as any)) as {
+      availableTopics: string[];
+    };
+    expect(list.availableTopics.sort()).toEqual(['alpha', 'beta']);
+
+    const beta = (await getSkill!.execute!({ topic: 'beta' }, {} as any)) as {
+      content: string;
+    };
+    expect(beta.content).toBe('beta content');
+  });
+
+  it('dir entries override bundled skills with the same name', async () => {
+    tmpDir = makeTmpDir();
+    writeFileSync(join(tmpDir, 'grafana.md'), 'from-dir');
+
+    const config = new ConfigReader({
+      aiChat: { skills: { dir: tmpDir } },
+    });
+    const { getSkill } = createSkillTools(config, mockServices.logger.mock());
+
+    const result = (await getSkill!.execute!(
+      { topic: 'grafana' },
+      {} as any,
+    )) as { content: string };
+    expect(result.content).toBe('from-dir');
+  });
+
+  it('inline entries override bundled skills with the same name', async () => {
+    const config = new ConfigReader({
+      aiChat: {
+        skills: {
+          inline: [{ name: 'grafana', content: 'from-config' }],
+        },
+      },
+    });
+    const { getSkill } = createSkillTools(config, mockServices.logger.mock());
+
+    const result = (await getSkill!.execute!(
+      { topic: 'grafana' },
+      {} as any,
+    )) as { content: string };
+    expect(result.content).toBe('from-config');
+  });
+
+  it('inline skills override directory entries with the same name', async () => {
+    tmpDir = makeTmpDir();
+    writeFileSync(join(tmpDir, 'grafana.md'), 'from-disk');
+
+    const config = new ConfigReader({
+      aiChat: {
+        skills: {
+          bundled: false,
+          dir: tmpDir,
+          inline: [{ name: 'grafana', content: 'from-config' }],
+        },
+      },
+    });
+    const { getSkill } = createSkillTools(config, mockServices.logger.mock());
+
+    const result = (await getSkill!.execute!(
+      { topic: 'grafana' },
+      {} as any,
+    )) as { content: string };
+    expect(result.content).toBe('from-config');
+  });
+
+  it('skips subdirectories', async () => {
+    tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, 'nested.md'));
+    writeFileSync(join(tmpDir, 'real.md'), 'real');
+
+    const config = new ConfigReader({
+      aiChat: { skills: { bundled: false, dir: tmpDir } },
+    });
+    const { listSkills } = createSkillTools(config, mockServices.logger.mock());
+
+    const list = (await listSkills!.execute!({}, {} as any)) as {
+      availableTopics: string[];
+    };
+    expect(list.availableTopics).toEqual(['real']);
+  });
+});

--- a/plugins/ai-chat-backend/src/tools/skillTools.ts
+++ b/plugins/ai-chat-backend/src/tools/skillTools.ts
@@ -1,64 +1,129 @@
-import { resolvePackagePath } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  resolvePackagePath,
+} from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
 import { tool } from 'ai';
 import { z } from 'zod/v3';
-import { readFileSync, readdirSync } from 'fs';
+import { readFileSync, readdirSync, statSync } from 'fs';
 import { join, basename } from 'path';
 
-// Load skills from markdown files in the skills directory
-const skillsDir = resolvePackagePath(
+const BUNDLED_SKILLS_DIR = resolvePackagePath(
   '@giantswarm/backstage-plugin-ai-chat-backend',
   'skills',
 );
 
-function loadSkills(): Record<string, string> {
-  const skills: Record<string, string> = {};
-  const files = readdirSync(skillsDir);
+function loadSkillsFromDir(
+  dir: string,
+  logger: LoggerService,
+): Map<string, string> {
+  const skills = new Map<string, string>();
 
-  for (const file of files) {
-    if (file.endsWith('.md')) {
-      const skillName = basename(file, '.md');
-      const filePath = join(skillsDir, file);
-      skills[skillName] = readFileSync(filePath, 'utf-8').trim();
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    logger.warn(
+      `aiChat.skills.dir "${dir}" could not be read: ${(err as Error).message}`,
+    );
+    return skills;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.md')) continue;
+    const filePath = join(dir, entry);
+    try {
+      if (!statSync(filePath).isFile()) continue;
+      const name = basename(entry, '.md');
+      skills.set(name, readFileSync(filePath, 'utf-8').trim());
+    } catch (err) {
+      logger.warn(
+        `Failed to load skill from "${filePath}": ${(err as Error).message}`,
+      );
     }
   }
 
   return skills;
 }
 
-const skills = loadSkills();
-const validTopics = Object.keys(skills);
+function resolveSkills(
+  config: Config,
+  logger: LoggerService,
+): Map<string, string> {
+  const skills = new Map<string, string>();
 
-export const listSkills = tool({
-  description:
-    'Lists all topics that have expert knowledge available. Call this first to see what expert knowledge can be queried.',
-  inputSchema: z.object({}),
-  execute: async () => {
-    return {
+  const useBundled = config.getOptionalBoolean('aiChat.skills.bundled') ?? true;
+  if (useBundled) {
+    for (const [name, content] of loadSkillsFromDir(
+      BUNDLED_SKILLS_DIR,
+      logger,
+    )) {
+      skills.set(name, content);
+    }
+  }
+
+  const dir = config.getOptionalString('aiChat.skills.dir');
+  if (dir) {
+    for (const [name, content] of loadSkillsFromDir(dir, logger)) {
+      skills.set(name, content);
+    }
+  }
+
+  const inline = config.getOptionalConfigArray('aiChat.skills.inline') ?? [];
+  for (const entry of inline) {
+    const name = entry.getString('name');
+    const content = entry.getString('content');
+    skills.set(name, content.trim());
+  }
+
+  return skills;
+}
+
+export function createSkillTools(config: Config, logger: LoggerService) {
+  const skills = resolveSkills(config, logger);
+  const validTopics = Array.from(skills.keys());
+
+  if (validTopics.length === 0) {
+    logger.info(
+      'No AI chat skills configured; listSkills/getSkill tools are disabled.',
+    );
+    return {};
+  }
+
+  logger.info(
+    `Loaded ${validTopics.length} AI chat skill(s): ${validTopics.join(', ')}`,
+  );
+
+  const listSkills = tool({
+    description:
+      'Lists all topics that have expert knowledge available. Call this first to see what expert knowledge can be queried.',
+    inputSchema: z.object({}),
+    execute: async () => ({
       availableTopics: validTopics,
       hint: 'Use getSkill with one of these topics to learn the expert knowledge.',
-    };
-  },
-});
+    }),
+  });
 
-export const getSkill = tool({
-  description:
-    'Retrieves expert knowledge about a specific topic. Only works for known topics. Use listSkills first if unsure what topics are available.',
-  inputSchema: z.object({
-    topic: z
-      .enum(validTopics as [string, ...string[]])
-      .describe('The topic to get expert knowledge about'),
-  }),
-  execute: async ({ topic }) => {
-    const content = skills[topic];
-    if (!content) {
+  const getSkill = tool({
+    description:
+      'Retrieves expert knowledge about a specific topic. Only works for known topics. Use listSkills first if unsure what topics are available.',
+    inputSchema: z.object({
+      topic: z.string().describe('The topic to get expert knowledge about'),
+    }),
+    execute: async ({ topic }) => {
+      const content = skills.get(topic);
+      if (!content) {
+        return {
+          error: `Unknown topic: ${topic}`,
+          availableTopics: validTopics,
+        };
+      }
       return {
-        error: `Unknown topic: ${topic}`,
-        availableTopics: validTopics,
+        topic,
+        content,
       };
-    }
-    return {
-      topic,
-      content,
-    };
-  },
-});
+    },
+  });
+
+  return { listSkills, getSkill };
+}


### PR DESCRIPTION
### What does this PR do?

Makes the set of expert-knowledge skills exposed to the AI chat agent configurable per deployment. The `ai-chat-backend` plugin still ships a default set of bundled skills and loads them by default, but deployments can now:

- **Opt out of the bundled set** with `aiChat.skills.bundled: false`.
- **Add a directory of skill files** with `aiChat.skills.dir: /path/to/skills` — each `*.md` file becomes a skill named after its basename. Useful for mounting a Kubernetes ConfigMap into the pod.
- **Inline skills directly in `app-config`** with `aiChat.skills.inline: [{ name, content }, ...]`.

Merge order is `bundled → dir → inline`, with later sources overriding earlier ones on name collision. When no skills end up loaded, the `listSkills` and `getSkill` tools are omitted from the toolset entirely.

### How does it look like?

Example `app-config` snippet:

```yaml
aiChat:
  skills:
    bundled: false
    inline:
      - name: grafana
        content: |
          # Grafana

          Giant Swarm provides Grafana in every management cluster...
```

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/36072.


- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))