### PR TITLE
Preserve line breaks in AI chat user messages

### DIFF
--- a/.changeset/ai-chat-user-message-line-breaks.md
+++ b/.changeset/ai-chat-user-message-line-breaks.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+AI chat: render user messages as plain text with preserved whitespace, so line breaks (shift+enter) appear consistently in the message bubble instead of being collapsed by markdown rendering.

--- a/plugins/ai-chat/src/components/AiChat/Thread.tsx
+++ b/plugins/ai-chat/src/components/AiChat/Thread.tsx
@@ -45,11 +45,11 @@ import { useStyles } from './styles';
 import {
   Reasoning,
   ReasoningGroup,
-  MarkdownText,
   StreamingMarkdownText,
   ToolFallback,
   ToolGroup,
   ContextUsageDisplay,
+  UserMessageText,
 } from './assistant-ui-components';
 import classNames from 'classnames';
 import { AnimateContext } from './AnimateContext';
@@ -201,7 +201,7 @@ const UserMessage = () => {
       >
         <MessagePrimitive.Content
           components={{
-            Text: MarkdownText,
+            Text: UserMessageText,
           }}
         />
       </div>

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/UserMessageText.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/UserMessageText.tsx
@@ -1,0 +1,20 @@
+import { memo } from 'react';
+import { useMessagePartText } from '@assistant-ui/react';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    root: {
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+    },
+  }),
+);
+
+const UserMessageTextImpl = () => {
+  const classes = useStyles();
+  const { text } = useMessagePartText();
+  return <span className={classes.root}>{text}</span>;
+};
+
+export const UserMessageText = memo(UserMessageTextImpl);

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/index.ts
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/index.ts
@@ -1,6 +1,7 @@
 export { MarkdownText } from './MarkdownText';
 export { MermaidDiagram } from './MermaidDiagram';
 export { StreamingMarkdownText } from './StreamingMarkdownText';
+export { UserMessageText } from './UserMessageText';
 export { Reasoning, ReasoningGroup } from './Reasoning';
 export { ToolGroup } from './ToolGroup';
 export { ToolFallback } from './ToolFallback';

--- a/plugins/ai-chat/src/components/AiChat/styles.ts
+++ b/plugins/ai-chat/src/components/AiChat/styles.ts
@@ -94,10 +94,6 @@ export const useStyles = makeStyles((theme: Theme) =>
       backgroundColor: 'var(--bui-bg-neutral-2)',
       padding: theme.spacing(1.5, 2),
       borderRadius: 'var(--bui-radius-3)',
-
-      '& p': {
-        margin: 0,
-      },
     },
     userMessageAnimate: {
       animation: '$fadeInUp 0.3s ease-out',


### PR DESCRIPTION
### What does this PR do?

Renders user messages in the AI chat as plain text with `white-space: pre-wrap` instead of through the markdown pipeline. A new `UserMessageText` component reads the message part text via `useMessagePartText` and renders it in a `<span>` with whitespace preservation. The `UserMessage` slot in `Thread.tsx` now uses this component instead of `MarkdownText`. The `& p { margin: 0 }` override in the `userMessage` style class is removed since user message bubbles no longer contain paragraphs.

### What is the effect of this change to users?

Line breaks typed with shift+enter in the chat composer are now preserved in the rendered user message bubble exactly as typed.

Before: a single newline collapsed into a space and a blank line became a paragraph break (markdown semantics), and the bubble would briefly render with no breaks at all before re-rendering once the assistant response started streaming.

After: every newline in the user's input is shown as a newline, consistently from the moment the message is submitted.

### How does it look like?

#### Before

<img width="779" height="98" alt="image" src="https://github.com/user-attachments/assets/42a6b2c3-9682-4b73-9685-2e6f96d0a4e5" />

#### With this PR

<img width="751" height="115" alt="image" src="https://github.com/user-attachments/assets/4ce0f4d2-35f9-42cf-a76a-97262e23f8a9" />

### Any background context you can provide?

User input in a chat composer is plain text, not markdown — the user expects WYSIWYG. Routing it through the markdown renderer collapsed single newlines and only honored blank lines as paragraph breaks. The interim "all on one line" render was an artifact of markdown component memoization re-evaluating once the assistant message streams in. Switching to plain text with `white-space: pre-wrap` removes both inconsistencies in one change.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))