### PR TITLE
Add Configure with AI button

### DIFF
--- a/.changeset/long-doors-refuse.md
+++ b/.changeset/long-doors-refuse.md
@@ -1,0 +1,7 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+'@giantswarm/backstage-plugin-ai-chat-react': minor
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Add "Configure with AI" button to App Deployment template

--- a/plugins/ai-chat-backend/skills/app-deployment-template.md
+++ b/plugins/ai-chat-backend/skills/app-deployment-template.md
@@ -1,0 +1,20 @@
+# App Deployment Template
+
+This template in the backstage portal allows the user to deploy an app (Helm chart) into a cluster. During this process, the user can call for your help. The message will likely start like this:
+
+> I'm in the App Deployment template to deploy a chart to a cluster. Please help me create the configuration values as a starting point.
+
+The message will include details like an OCI URL, version tag, and target cluster.
+
+When this happens, focus on helping to create valid Helm chart values YAML block. Apply these rules:
+
+- If the chart requires no confidential values (credentials), provide only one YAML block. Otherwise, provide two blocks and mark them clearly with sub headlines as "Non-confidential (ConfigMap)" and "Confidential (Secret)".
+- Focus on required values. Keep it minimal.
+- Avoid duplicating default values.
+- Prefer providing correct, usable values over guessed placeholders. Use your tools to retrieve correct values, like the cluster's base domain or the correct Gateway name.
+- When using placeholder values, add YAML comments like `# replace me` to draw the user's attention.
+- Prefer Gatway API over Ingress.
+- Do not provide manifests for any Kubernetes resources like ConfigMap, Secret, OCIRepository, HelmRelease etc.
+- Do not provide commands to create such Kubernetes resource.
+
+Finally, offer to refine the suggested config based on more detailed requirements.

--- a/plugins/ai-chat-backend/skills/backstage-catalog.md
+++ b/plugins/ai-chat-backend/skills/backstage-catalog.md
@@ -1,6 +1,6 @@
 # Backstage Catalog
 
-### Entity data and metadata
+## Entity data and metadata
 
 Annotations:
 

--- a/plugins/ai-chat-backend/systemPrompt.md
+++ b/plugins/ai-chat-backend/systemPrompt.md
@@ -82,6 +82,14 @@ The catalog in backstage is an important backbone of the portal.
 
 Use the `getSkill` tool to fetch information about `backstage-catalog` for more details.
 
+## App Deployment template
+
+This template in the backstage portal allows the user to deploy an app (Helm chart) into a cluster. During this process, the user can call for your help. The message will likely start like this:
+
+> I'm in the App Deployment template to deploy a chart to a cluster.
+
+In this case, use the `getSkill` tool to fetch information about `app-deployment-template`.
+
 ## Tools
 
 You have access to MCP (Model Context Protocol) tools and other tools.

--- a/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
+++ b/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
@@ -16,23 +16,36 @@ import { AIChatIcon } from '../../assets/icons';
 import { aiChatApiRef, aiChatDrawerApiRef } from '../../api';
 import { rootRouteRef } from '../../routes';
 
-const useStyles = makeStyles(() => ({
-  button: {
-    textTransform: 'none',
-    paddingLeft: 11,
-    paddingRight: 11,
-  },
-  troubleshootButton: {
-    backgroundColor: '#9a2c28',
-    color: '#ffffff',
-    '&:hover': {
-      backgroundColor: '#7a2320',
+const useStyles = makeStyles(theme => {
+  const outlinedBorder =
+    theme.palette.type === 'light'
+      ? 'rgba(0, 0, 0, 0.23)'
+      : 'rgba(255, 255, 255, 0.23)';
+
+  return {
+    button: {
+      textTransform: 'none',
+      paddingLeft: 11,
+      paddingRight: 11,
     },
-  },
-  menuItem: {
-    minWidth: 200,
-  },
-}));
+    outlinedButton: {
+      border: `1px solid ${outlinedBorder}`,
+      '&:hover': {
+        border: `1px solid ${outlinedBorder}`,
+      },
+    },
+    troubleshootButton: {
+      backgroundColor: '#9a2c28',
+      color: '#ffffff',
+      '&:hover': {
+        backgroundColor: '#7a2320',
+      },
+    },
+    menuItem: {
+      minWidth: 200,
+    },
+  };
+});
 
 export type AIChatButtonItem = {
   label?: string;
@@ -50,6 +63,7 @@ type AIChatButtonProps = {
    * 'navigate' navigates to the AI chat page. Defaults to 'drawer' when the
    * drawer API is available, otherwise falls back to 'navigate'. */
   openMode?: AIChatButtonOpenMode;
+  variant?: 'text' | 'outlined' | 'contained';
 };
 
 type AIChatButtonInnerProps = AIChatButtonProps & {
@@ -63,6 +77,7 @@ const AIChatButtonInner = ({
   displayTooltip,
   troubleshoot,
   openMode,
+  variant,
 }: AIChatButtonInnerProps) => {
   const routeResolutionApi = useApi(routeResolutionApiRef);
   const chatPath = routeResolutionApi.resolve(rootRouteRef);
@@ -108,10 +123,12 @@ const AIChatButtonInner = ({
         <Button
           className={classNames(
             classes.button,
+            variant === 'outlined' && classes.outlinedButton,
             troubleshoot && classes.troubleshootButton,
           )}
           color="inherit"
           size="small"
+          variant={variant}
           startIcon={<AIChatIcon />}
           onClick={handleClick}
           aria-haspopup={items.length > 1 ? 'true' : undefined}
@@ -157,6 +174,7 @@ export const AIChatButton = ({
   label,
   troubleshoot,
   openMode,
+  variant,
 }: AIChatButtonProps) => {
   const apiHolder = useApiHolder();
   const aiChatApi = apiHolder.get(aiChatApiRef);
@@ -175,6 +193,7 @@ export const AIChatButton = ({
       label={label}
       troubleshoot={troubleshoot}
       openMode={openMode}
+      variant={variant}
       displayLabel={displayLabel}
       displayTooltip={displayTooltip}
     />

--- a/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
+++ b/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
@@ -16,36 +16,23 @@ import { AIChatIcon } from '../../assets/icons';
 import { aiChatApiRef, aiChatDrawerApiRef } from '../../api';
 import { rootRouteRef } from '../../routes';
 
-const useStyles = makeStyles(theme => {
-  const outlinedBorder =
-    theme.palette.type === 'light'
-      ? 'rgba(0, 0, 0, 0.23)'
-      : 'rgba(255, 255, 255, 0.23)';
-
-  return {
-    button: {
-      textTransform: 'none',
-      paddingLeft: 11,
-      paddingRight: 11,
+const useStyles = makeStyles(() => ({
+  button: {
+    textTransform: 'none',
+    paddingLeft: 11,
+    paddingRight: 11,
+  },
+  troubleshootButton: {
+    backgroundColor: '#9a2c28',
+    color: '#ffffff',
+    '&:hover': {
+      backgroundColor: '#7a2320',
     },
-    outlinedButton: {
-      border: `1px solid ${outlinedBorder}`,
-      '&:hover': {
-        border: `1px solid ${outlinedBorder}`,
-      },
-    },
-    troubleshootButton: {
-      backgroundColor: '#9a2c28',
-      color: '#ffffff',
-      '&:hover': {
-        backgroundColor: '#7a2320',
-      },
-    },
-    menuItem: {
-      minWidth: 200,
-    },
-  };
-});
+  },
+  menuItem: {
+    minWidth: 200,
+  },
+}));
 
 export type AIChatButtonItem = {
   label?: string;
@@ -64,6 +51,7 @@ type AIChatButtonProps = {
    * drawer API is available, otherwise falls back to 'navigate'. */
   openMode?: AIChatButtonOpenMode;
   variant?: 'text' | 'outlined' | 'contained';
+  color?: 'inherit' | 'primary' | 'secondary' | 'default';
 };
 
 type AIChatButtonInnerProps = AIChatButtonProps & {
@@ -78,6 +66,7 @@ const AIChatButtonInner = ({
   troubleshoot,
   openMode,
   variant,
+  color,
 }: AIChatButtonInnerProps) => {
   const routeResolutionApi = useApi(routeResolutionApiRef);
   const chatPath = routeResolutionApi.resolve(rootRouteRef);
@@ -123,12 +112,11 @@ const AIChatButtonInner = ({
         <Button
           className={classNames(
             classes.button,
-            variant === 'outlined' && classes.outlinedButton,
             troubleshoot && classes.troubleshootButton,
           )}
-          color="inherit"
           size="small"
           variant={variant}
+          color={color}
           startIcon={<AIChatIcon />}
           onClick={handleClick}
           aria-haspopup={items.length > 1 ? 'true' : undefined}
@@ -175,6 +163,7 @@ export const AIChatButton = ({
   troubleshoot,
   openMode,
   variant,
+  color,
 }: AIChatButtonProps) => {
   const apiHolder = useApiHolder();
   const aiChatApi = apiHolder.get(aiChatApiRef);
@@ -194,6 +183,7 @@ export const AIChatButton = ({
       troubleshoot={troubleshoot}
       openMode={openMode}
       variant={variant}
+      color={color}
       displayLabel={displayLabel}
       displayTooltip={displayTooltip}
     />

--- a/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
+++ b/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
@@ -168,6 +168,7 @@ export const ClusterLayout = ({ children }: ClusterLayoutProps) => {
               troubleshoot={
                 calculateClusterStatus(cluster) !== ClusterStatuses.Ready
               }
+              color="inherit"
               items={[
                 {
                   label: 'AI Chat',

--- a/plugins/gs/src/components/deployments/DeploymentLayout/DeploymentLayout.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentLayout/DeploymentLayout.tsx
@@ -232,6 +232,7 @@ export const DeploymentLayout = ({ children }: DeploymentLayoutProps) => {
               <Grid item className={classes.headerAction}>
                 <AIChatButton
                   troubleshoot={isTroubleshoot}
+                  color="inherit"
                   items={[{ label: 'AI Chat', message }]}
                 />
               </Grid>

--- a/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
@@ -1,0 +1,33 @@
+import { AIChatButton } from '@giantswarm/backstage-plugin-ai-chat-react';
+
+type ConfigureWithAiButtonProps = {
+  formData: Record<string, any>;
+};
+
+export const ConfigureWithAiButton = ({
+  formData,
+}: ConfigureWithAiButtonProps) => {
+  const chartRef = formData.chartRef;
+  const chartTag = formData.chartTag;
+  const installationName = formData.installation?.installationName;
+  const clusterName = formData.cluster?.clusterName;
+
+  const message = [
+    "I'm in the App Deployment template to deploy a chart to a cluster. Please help me create the configuration values as a starting point. Details:",
+    '',
+    `Chart: ${chartRef}`,
+    `Version: ${chartTag}`,
+    `Installation: ${installationName}`,
+    `Cluster: ${clusterName}`,
+    '',
+    'Please separate non-confidential values from confdidential values clearly.',
+  ].join('\n');
+
+  return (
+    <AIChatButton
+      label="Configure with AI"
+      variant="outlined"
+      items={[{ message }]}
+    />
+  );
+};

--- a/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
@@ -19,8 +19,6 @@ export const ConfigureWithAiButton = ({
     `Version: ${chartTag}`,
     `Installation: ${installationName}`,
     `Cluster: ${clusterName}`,
-    '',
-    'Please separate non-confidential values from confdidential values clearly.',
   ].join('\n');
 
   return (

--- a/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
@@ -1,16 +1,58 @@
 import { AIChatButton } from '@giantswarm/backstage-plugin-ai-chat-react';
+import { useValueFromOptions } from '../hooks/useValueFromOptions';
 
-type ConfigureWithAiButtonProps = {
-  formData: Record<string, any>;
+export type ConfigureWithAiButtonOptions = {
+  chartRef?: string;
+  chartRefField?: string;
+  chartTag?: string;
+  chartTagField?: string;
+  installationName?: string;
+  installationNameField?: string;
+  clusterName?: string;
+  clusterNameField?: string;
 };
 
 export const ConfigureWithAiButton = ({
-  formData,
-}: ConfigureWithAiButtonProps) => {
-  const chartRef = formData.chartRef;
-  const chartTag = formData.chartTag;
-  const installationName = formData.installation?.installationName;
-  const clusterName = formData.cluster?.clusterName;
+  configureWithAiOptions,
+  formContext,
+}: {
+  configureWithAiOptions: ConfigureWithAiButtonOptions;
+  formContext: any;
+}) => {
+  const {
+    chartRef: chartRefOption,
+    chartRefField: chartRefFieldOption,
+    chartTag: chartTagOption,
+    chartTagField: chartTagFieldOption,
+    installationName: installationNameOption,
+    installationNameField: installationNameFieldOption,
+    clusterName: clusterNameOption,
+    clusterNameField: clusterNameFieldOption,
+  } = configureWithAiOptions ?? {};
+
+  const chartRef = useValueFromOptions(
+    formContext,
+    chartRefOption,
+    chartRefFieldOption,
+  );
+
+  const chartTag = useValueFromOptions(
+    formContext,
+    chartTagOption,
+    chartTagFieldOption,
+  );
+
+  const installationName = useValueFromOptions(
+    formContext,
+    installationNameOption,
+    installationNameFieldOption,
+  );
+
+  const clusterName = useValueFromOptions(
+    formContext,
+    clusterNameOption,
+    clusterNameFieldOption,
+  );
 
   const message = [
     "I'm in the App Deployment template to deploy a chart to a cluster. Please help me create the configuration values as a starting point. Details:",

--- a/plugins/gs/src/components/scaffolder/StepLayout/StepLayout.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/StepLayout.tsx
@@ -20,7 +20,10 @@ import {
   ConfigurationDocs,
   ConfigurationDocsOptions,
 } from './ConfigurationDocs';
-import { ConfigureWithAiButton } from './ConfigureWithAiButton';
+import {
+  ConfigureWithAiButton,
+  ConfigureWithAiButtonOptions,
+} from './ConfigureWithAiButton';
 import { ReactNode, useState } from 'react';
 
 const useStyles = makeStyles(theme => ({
@@ -115,7 +118,7 @@ type UiOptions =
       formWidth?: number;
       note?: string;
       configurationDocs?: ConfigurationDocsOptions;
-      configureWithAi?: boolean;
+      configureWithAi?: ConfigureWithAiButtonOptions;
     }
   | undefined;
 
@@ -131,7 +134,7 @@ export const StepLayout: LayoutTemplate = ({
     formWidth,
     note: noteTemplate = '',
     configurationDocs: configurationDocsOptions,
-    configureWithAi,
+    configureWithAi: configureWithAiOptions,
   } = uiOptions ?? {};
 
   const showExtraContent = Boolean(configurationDocsOptions);
@@ -150,9 +153,12 @@ export const StepLayout: LayoutTemplate = ({
           </Grid>
         ),
       )}
-      {configureWithAi ? (
+      {configureWithAiOptions ? (
         <Grid item xs={12}>
-          <ConfigureWithAiButton formData={allFormData} />
+          <ConfigureWithAiButton
+            configureWithAiOptions={configureWithAiOptions}
+            formContext={formContext}
+          />
         </Grid>
       ) : null}
     </Grid>

--- a/plugins/gs/src/components/scaffolder/StepLayout/StepLayout.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/StepLayout.tsx
@@ -20,6 +20,7 @@ import {
   ConfigurationDocs,
   ConfigurationDocsOptions,
 } from './ConfigurationDocs';
+import { ConfigureWithAiButton } from './ConfigureWithAiButton';
 import { ReactNode, useState } from 'react';
 
 const useStyles = makeStyles(theme => ({
@@ -114,6 +115,7 @@ type UiOptions =
       formWidth?: number;
       note?: string;
       configurationDocs?: ConfigurationDocsOptions;
+      configureWithAi?: boolean;
     }
   | undefined;
 
@@ -129,6 +131,7 @@ export const StepLayout: LayoutTemplate = ({
     formWidth,
     note: noteTemplate = '',
     configurationDocs: configurationDocsOptions,
+    configureWithAi,
   } = uiOptions ?? {};
 
   const showExtraContent = Boolean(configurationDocsOptions);
@@ -147,6 +150,11 @@ export const StepLayout: LayoutTemplate = ({
           </Grid>
         ),
       )}
+      {configureWithAi ? (
+        <Grid item xs={12}>
+          <ConfigureWithAiButton formData={allFormData} />
+        </Grid>
+      ) : null}
     </Grid>
   );
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a "Configure with AI" button to the Configuration step in the App Deployment template.

### What is the effect of this change to users?

Users can ask the AI assistant for help. A message like this one will be submitted:

```
I'm in the App Deployment template to deploy a chart to a cluster. Please help me create the
configuration values as a starting point. Details:

Chart: gsoci.azurecr.io/charts/giantswarm/hello-world
Version: 3.0.2
Installation: graveler
Cluster: testcluster
```

### How does it look like?

<img width="1792" height="1215" alt="image" src="https://github.com/user-attachments/assets/89bcedea-b44f-4db6-a824-bcedad594bfa" />

### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/4264

Related:

- https://github.com/giantswarm/backstage-catalogs/pull/542

### Do the docs need to be updated?

Maybe

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
