### PR TITLE
Improvements to Configure with AI button

### DIFF
--- a/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
+++ b/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
@@ -16,36 +16,23 @@ import { AIChatIcon } from '../../assets/icons';
 import { aiChatApiRef, aiChatDrawerApiRef } from '../../api';
 import { rootRouteRef } from '../../routes';
 
-const useStyles = makeStyles(theme => {
-  const outlinedBorder =
-    theme.palette.type === 'light'
-      ? 'rgba(0, 0, 0, 0.23)'
-      : 'rgba(255, 255, 255, 0.23)';
-
-  return {
-    button: {
-      textTransform: 'none',
-      paddingLeft: 11,
-      paddingRight: 11,
+const useStyles = makeStyles(() => ({
+  button: {
+    textTransform: 'none',
+    paddingLeft: 11,
+    paddingRight: 11,
+  },
+  troubleshootButton: {
+    backgroundColor: '#9a2c28',
+    color: '#ffffff',
+    '&:hover': {
+      backgroundColor: '#7a2320',
     },
-    outlinedButton: {
-      border: `1px solid ${outlinedBorder}`,
-      '&:hover': {
-        border: `1px solid ${outlinedBorder}`,
-      },
-    },
-    troubleshootButton: {
-      backgroundColor: '#9a2c28',
-      color: '#ffffff',
-      '&:hover': {
-        backgroundColor: '#7a2320',
-      },
-    },
-    menuItem: {
-      minWidth: 200,
-    },
-  };
-});
+  },
+  menuItem: {
+    minWidth: 200,
+  },
+}));
 
 export type AIChatButtonItem = {
   label?: string;
@@ -123,10 +110,8 @@ const AIChatButtonInner = ({
         <Button
           className={classNames(
             classes.button,
-            variant === 'outlined' && classes.outlinedButton,
             troubleshoot && classes.troubleshootButton,
           )}
-          color="inherit"
           size="small"
           variant={variant}
           startIcon={<AIChatIcon />}

--- a/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
+++ b/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
@@ -51,6 +51,7 @@ type AIChatButtonProps = {
    * drawer API is available, otherwise falls back to 'navigate'. */
   openMode?: AIChatButtonOpenMode;
   variant?: 'text' | 'outlined' | 'contained';
+  color?: 'inherit' | 'primary' | 'secondary' | 'default';
 };
 
 type AIChatButtonInnerProps = AIChatButtonProps & {
@@ -65,6 +66,7 @@ const AIChatButtonInner = ({
   troubleshoot,
   openMode,
   variant,
+  color,
 }: AIChatButtonInnerProps) => {
   const routeResolutionApi = useApi(routeResolutionApiRef);
   const chatPath = routeResolutionApi.resolve(rootRouteRef);
@@ -114,6 +116,7 @@ const AIChatButtonInner = ({
           )}
           size="small"
           variant={variant}
+          color={color}
           startIcon={<AIChatIcon />}
           onClick={handleClick}
           aria-haspopup={items.length > 1 ? 'true' : undefined}
@@ -160,6 +163,7 @@ export const AIChatButton = ({
   troubleshoot,
   openMode,
   variant,
+  color,
 }: AIChatButtonProps) => {
   const apiHolder = useApiHolder();
   const aiChatApi = apiHolder.get(aiChatApiRef);
@@ -179,6 +183,7 @@ export const AIChatButton = ({
       troubleshoot={troubleshoot}
       openMode={openMode}
       variant={variant}
+      color={color}
       displayLabel={displayLabel}
       displayTooltip={displayTooltip}
     />

--- a/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
+++ b/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
@@ -168,6 +168,7 @@ export const ClusterLayout = ({ children }: ClusterLayoutProps) => {
               troubleshoot={
                 calculateClusterStatus(cluster) !== ClusterStatuses.Ready
               }
+              color="inherit"
               items={[
                 {
                   label: 'AI Chat',

--- a/plugins/gs/src/components/deployments/DeploymentLayout/DeploymentLayout.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentLayout/DeploymentLayout.tsx
@@ -232,6 +232,7 @@ export const DeploymentLayout = ({ children }: DeploymentLayoutProps) => {
               <Grid item className={classes.headerAction}>
                 <AIChatButton
                   troubleshoot={isTroubleshoot}
+                  color="inherit"
                   items={[{ label: 'AI Chat', message }]}
                 />
               </Grid>

--- a/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
@@ -1,16 +1,58 @@
 import { AIChatButton } from '@giantswarm/backstage-plugin-ai-chat-react';
+import { useValueFromOptions } from '../hooks/useValueFromOptions';
 
-type ConfigureWithAiButtonProps = {
-  formData: Record<string, any>;
+export type ConfigureWithAiButtonOptions = {
+  chartRef?: string;
+  chartRefField?: string;
+  chartTag?: string;
+  chartTagField?: string;
+  installationName?: string;
+  installationNameField?: string;
+  clusterName?: string;
+  clusterNameField?: string;
 };
 
 export const ConfigureWithAiButton = ({
-  formData,
-}: ConfigureWithAiButtonProps) => {
-  const chartRef = formData.chartRef;
-  const chartTag = formData.chartTag;
-  const installationName = formData.installation?.installationName;
-  const clusterName = formData.cluster?.clusterName;
+  configureWithAiOptions,
+  formContext,
+}: {
+  configureWithAiOptions: ConfigureWithAiButtonOptions;
+  formContext: any;
+}) => {
+  const {
+    chartRef: chartRefOption,
+    chartRefField: chartRefFieldOption,
+    chartTag: chartTagOption,
+    chartTagField: chartTagFieldOption,
+    installationName: installationNameOption,
+    installationNameField: installationNameFieldOption,
+    clusterName: clusterNameOption,
+    clusterNameField: clusterNameFieldOption,
+  } = configureWithAiOptions ?? {};
+
+  const chartRef = useValueFromOptions(
+    formContext,
+    chartRefOption,
+    chartRefFieldOption,
+  );
+
+  const chartTag = useValueFromOptions(
+    formContext,
+    chartTagOption,
+    chartTagFieldOption,
+  );
+
+  const installationName = useValueFromOptions(
+    formContext,
+    installationNameOption,
+    installationNameFieldOption,
+  );
+
+  const clusterName = useValueFromOptions(
+    formContext,
+    clusterNameOption,
+    clusterNameFieldOption,
+  );
 
   const message = [
     "I'm in the App Deployment template to deploy a chart to a cluster. Please help me create the configuration values as a starting point. Details:",

--- a/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/ConfigureWithAiButton.tsx
@@ -20,7 +20,7 @@ export const ConfigureWithAiButton = ({
     `Installation: ${installationName}`,
     `Cluster: ${clusterName}`,
     '',
-    'Please separate non-confidential values from confdidential values clearly.',
+    'Please separate non-confidential values from confidential values clearly.',
   ].join('\n');
 
   return (

--- a/plugins/gs/src/components/scaffolder/StepLayout/StepLayout.tsx
+++ b/plugins/gs/src/components/scaffolder/StepLayout/StepLayout.tsx
@@ -20,7 +20,10 @@ import {
   ConfigurationDocs,
   ConfigurationDocsOptions,
 } from './ConfigurationDocs';
-import { ConfigureWithAiButton } from './ConfigureWithAiButton';
+import {
+  ConfigureWithAiButton,
+  ConfigureWithAiButtonOptions,
+} from './ConfigureWithAiButton';
 import { ReactNode, useState } from 'react';
 
 const useStyles = makeStyles(theme => ({
@@ -115,7 +118,7 @@ type UiOptions =
       formWidth?: number;
       note?: string;
       configurationDocs?: ConfigurationDocsOptions;
-      configureWithAi?: boolean;
+      configureWithAi?: ConfigureWithAiButtonOptions;
     }
   | undefined;
 
@@ -131,7 +134,7 @@ export const StepLayout: LayoutTemplate = ({
     formWidth,
     note: noteTemplate = '',
     configurationDocs: configurationDocsOptions,
-    configureWithAi,
+    configureWithAi: configureWithAiOptions,
   } = uiOptions ?? {};
 
   const showExtraContent = Boolean(configurationDocsOptions);
@@ -150,9 +153,12 @@ export const StepLayout: LayoutTemplate = ({
           </Grid>
         ),
       )}
-      {configureWithAi ? (
+      {configureWithAiOptions ? (
         <Grid item xs={12}>
-          <ConfigureWithAiButton formData={allFormData} />
+          <ConfigureWithAiButton
+            configureWithAiOptions={configureWithAiOptions}
+            formContext={formContext}
+          />
         </Grid>
       ) : null}
     </Grid>


### PR DESCRIPTION
### What does this PR do?

Refines the "Configure with AI" button on the App Deployment template introduced in the base branch:

- Makes the button configurable via `ui:options` — it now accepts literal values or `*Field` references that are resolved against the form context, instead of being hardcoded to specific form-data field names.
- Adds a `color` prop to `AIChatButton` and removes the custom `outlinedButton` styling so the button uses Material-UI's default outlined appearance.
- Sets `color="inherit"` on the existing usages in `ClusterLayout` and `DeploymentLayout` to preserve their previous look.
- Fixes a typo in the prompt message ("confdidential" → "confidential").

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))