### PR TITLE
chore(deps): unify zod major across backend plugins

### DIFF
--- a/plugins/ai-chat-backend/package.json
+++ b/plugins/ai-chat-backend/package.json
@@ -39,7 +39,7 @@
     "express": "^5.0.0",
     "express-promise-router": "^4.1.0",
     "knex": "^3.1.0",
-    "zod": "^3.25.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "backstage:^",

--- a/plugins/gs-backend/package.json
+++ b/plugins/gs-backend/package.json
@@ -35,7 +35,7 @@
     "express-promise-router": "^4.1.0",
     "node-fetch": "^3.3.2",
     "semver": "^7.7.3",
-    "zod": "^3.25.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "backstage:^",

--- a/plugins/scaffolder-backend-module-gs/package.json
+++ b/plugins/scaffolder-backend-module-gs/package.json
@@ -28,8 +28,7 @@
     "@backstage/config": "backstage:^",
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-scaffolder-node": "backstage:^",
-    "js-yaml": "^4.1.0",
-    "zod": "^3.25.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "backstage:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10135,7 +10135,7 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.1.0"
     supertest: "npm:^6.2.4"
-    zod: "npm:^3.25.0"
+    zod: "npm:^4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -10334,7 +10334,7 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     semver: "npm:^7.7.3"
     supertest: "npm:^6.2.4"
-    zod: "npm:^3.25.0"
+    zod: "npm:^4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -10469,7 +10469,6 @@ __metadata:
     "@backstage/plugin-scaffolder-node": "backstage:^"
     "@types/js-yaml": "npm:^4"
     js-yaml: "npm:^4.1.0"
-    zod: "npm:^3.25.0"
   languageName: unknown
   linkType: soft
 
@@ -47624,14 +47623,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.19.1, zod@npm:^3.22.4, zod@npm:^3.24.2, zod@npm:^3.25.0, zod@npm:^3.25.76":
+"zod@npm:^3.19.1, zod@npm:^3.22.4, zod@npm:^3.24.2, zod@npm:^3.25.76":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25 || ^4.0, zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.2.1, zod@npm:^4.3.6":
+"zod@npm:^3.25 || ^4.0, zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.2.1, zod@npm:^4.3.6, zod@npm:^4.4.3":
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3


### PR DESCRIPTION
### What does this PR do?

Bumps the three workspace plugins that were still on `zod ^3.25.0` to `^4.4.3`, matching `packages/app` and `plugins/ai-chat`. Also drops the unused `zod` dep from `scaffolder-backend-module-gs` (declared but never imported).

The two remaining backend plugins (`ai-chat-backend`, `gs-backend`) import zod via `import { z } from 'zod/v3'` — zod 4 ships a `zod/v3` compat sub-path, so no source changes are needed; runtime and types in those plugins are unchanged.

### What is the effect of this change to users?

None. Internal dep hygiene.

### How does it look like?

Cold-cache `tsc --noEmit` (post-#1634):

| Branch | Time | Peak RSS |
| --- | --- | --- |
| `main` (mixed zod 3.25 + 4.x) | 13.8 s | 2.39 GB |
| this PR (all 4.x) | 13.2 s | 2.09 GB |

So roughly a 300 MB / 12% RSS reduction on typecheck. Time is in the noise.

### Any background context you can provide?

Follow-up to #1634. The original theory was that mixed zod majors were the main driver of the AI-SDK typecheck blowup; in practice `--noEmit` did most of the work, and this unification is mostly hygiene. It is **not** sufficient on its own to drop the buildjob back to the medium resource class — the cold typecheck still peaks above the 2 GB headroom medium would leave us. If we want medium back, the next lever is caching `dist-types/tsconfig.tsbuildinfo` between CI runs, which would let the warm typecheck reuse incremental state.

`scaffolder-backend-module-gs`'s zod dep was added in cc6db5a9 with the original module but no source ever imported it; safe to drop.

Tests pass for all three affected plugins (`yarn test --coverage plugins/ai-chat-backend plugins/gs-backend plugins/scaffolder-backend-module-gs --forceExit`: 78/78).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.

All three affected plugins are `private: true`. No changeset needed.