### PR TITLE
ci: cache TypeScript incremental build info between buildjob runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,22 @@ jobs:
           name: Install dependencies
           command: yarn install --immutable
 
+      - restore_cache:
+          name: Restore TypeScript incremental build info
+          keys:
+            - v1-tsbuildinfo-{{ .Branch }}-{{ .Revision }}
+            - v1-tsbuildinfo-{{ .Branch }}-
+            - v1-tsbuildinfo-
+
       - run:
           name: Typecheck code using the TypeScript compiler
           command: NODE_OPTIONS="--max-old-space-size=6144" yarn run tsc --noEmit
+
+      - save_cache:
+          name: Save TypeScript incremental build info
+          key: v1-tsbuildinfo-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - dist-types/tsconfig.tsbuildinfo
 
       - run:
           name: Lint code using ESlint


### PR DESCRIPTION
### What does this PR do?

Persists `dist-types/tsconfig.tsbuildinfo` across CircleCI runs via `restore_cache` / `save_cache` so `tsc --incremental --noEmit` can reuse its prior state instead of typechecking the entire monorepo from scratch on every commit.

### What is the effect of this change to users?

None directly — internal CI speedup. PR builds with small changes will skip most of the typecheck work.

### How does it look like?

Local `tsc --noEmit` (no source changes between runs):

| Run | Time | Peak RSS |
| --- | --- | --- |
| Cold (no `.tsbuildinfo`) | 14.4 s | 2.15 GB |
| Warm (cached `.tsbuildinfo`) | 5.8 s | 1.48 GB |

So a typical PR commit that touches a handful of files saves ~9 s of typecheck and runs at ~30% lower memory peak. Re-runs of the same commit (CI retries) skip typechecking almost entirely.

### Any background context you can provide?

Cache key chain:

- `v1-tsbuildinfo-{{ .Branch }}-{{ .Revision }}` → exact match on retry
- `v1-tsbuildinfo-{{ .Branch }}-` → previous commit on the same branch
- `v1-tsbuildinfo-` → most recent build from any branch

Falling back to "any branch" is safe because `tsc --incremental` validates each file's content hash against the saved state and recomputes anything that has diverged. The fallback just gives us a warm starting point. Bump the `v1-` prefix to bust the cache after a TypeScript major upgrade.

`buildjob` is filtered off `main`, so there's no canonical cache to pre-warm — the first PR after this merges will cold-start, but every PR after that benefits from sibling-branch caches.

Follow-up to #1634 (resource_class bump + `--noEmit`) and #1636 (zod major unification).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.

CI-only change. No changeset needed.