### PR TITLE
ci: cache node_modules between buildjob runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,26 @@ jobs:
             node --version
             yarn --version
 
+      - restore_cache:
+          name: Restore node_modules
+          keys:
+            - v1-node-modules-{{ checksum "yarn.lock" }}
+
       - run:
           name: Install dependencies
-          command: yarn install --immutable
+          command: |
+            if [ -f .yarn/install-state.gz ]; then
+              echo "node_modules cache hit — skipping yarn install"
+            else
+              yarn install --immutable
+            fi
+
+      - save_cache:
+          name: Save node_modules
+          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+            - .yarn/install-state.gz
 
       - restore_cache:
           name: Restore TypeScript incremental build info


### PR DESCRIPTION
### What does this PR do?

Caches the root `node_modules` (plus Yarn's small `.yarn/install-state.gz`) between CircleCI runs, keyed strictly on `yarn.lock`'s checksum. On a cache hit, the install step is **skipped entirely** — the linked dependency tree and postinstall side effects (`patch-package`) are already baked into the restored `node_modules`.

### What is the effect of this change to users?

None directly — internal CI speedup. On lockfile-unchanged builds, install drops from ~2m46s to just the cache restore (~57s).

### How does it look like?

Strict cache key — no fallback:

- `v1-node-modules-{{ checksum "yarn.lock" }}` → exact match: install step is skipped (presence of `.yarn/install-state.gz` from the restored cache is the marker).
- No fallback key: if `yarn.lock` changes, a clean install runs and the resulting tree gets cached. This avoids merging a stale tree with a changed lockfile.

Bump the `v1-` prefix to bust the cache (e.g. after a Yarn major upgrade or a `patch-package` change that affects already-installed files — patches are baked into the cached tree).

### Any background context you can provide?

Replaces an earlier attempt in this branch that cached `~/.yarn/berry/cache` (the upstream archive cache). That version turned out to be ~no net benefit: it saved ~14s of network fetch but the bulk of `yarn install`'s ~2m45s is the extract + link step, which the archive cache doesn't help with.

Cold-run cost: ~40s extra for save_cache (3.2 GB → CircleCI cache store). Warm-run benefit: skips both the link step and Yarn's `--immutable` verification (~38s), so install time on a warm hit is just the cache restore.

Follow-up to #1634 (resource_class + `--noEmit`), #1636 (zod major unification), #1637 (tsbuildinfo cache).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.

CI-only change. No changeset needed.