### PR TITLE
fix(ai-chat-backend): null-guard frontendTools so chat doesn't 500 when no client tools are sent

### DIFF
--- a/.changeset/ai-chat-frontend-tools-null-guard.md
+++ b/.changeset/ai-chat-frontend-tools-null-guard.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Fix AI chat backend crash on every chat send. The `tools` field in the request body is `z.any().optional()`, so it arrives as `undefined` whenever the frontend does not register any client-side tools (the default when the chat UI uses assistant-ui's `AssistantChatTransport`). The previous implementation called `Object.entries(tools)` unconditionally, which threw `TypeError: Cannot convert undefined or null to object`, returning a 500 from `POST /api/ai-chat/chat` on every request. The browser surfaced this as "network error" and the LLM never reached the tool-merge step, so MCP-provided tools (muster, prometheus, kubernetes, …), skill tools, `getDate`, and the context-usage tool were also unreachable from chat. `frontendTools` now accepts `null`/`undefined` and treats them as an empty registry.

--- a/plugins/ai-chat-backend/src/frontendTools.test.ts
+++ b/plugins/ai-chat-backend/src/frontendTools.test.ts
@@ -1,0 +1,33 @@
+import { frontendTools } from './frontendTools';
+
+describe('frontendTools', () => {
+  it('returns an empty object when tools is undefined', () => {
+    expect(frontendTools(undefined)).toEqual({});
+  });
+
+  it('returns an empty object when tools is null', () => {
+    expect(frontendTools(null)).toEqual({});
+  });
+
+  it('returns an empty object when tools is empty', () => {
+    expect(frontendTools({})).toEqual({});
+  });
+
+  it('converts tool entries and preserves descriptions', () => {
+    const result = frontendTools({
+      foo: {
+        description: 'foo tool',
+        parameters: { type: 'object', properties: {} },
+      },
+      bar: {
+        parameters: { type: 'object', properties: {} },
+      },
+    });
+
+    expect(Object.keys(result).sort()).toEqual(['bar', 'foo']);
+    expect(result.foo.description).toBe('foo tool');
+    expect(result.bar).not.toHaveProperty('description');
+    expect(result.foo.inputSchema).toBeDefined();
+    expect(result.bar.inputSchema).toBeDefined();
+  });
+});

--- a/plugins/ai-chat-backend/src/frontendTools.ts
+++ b/plugins/ai-chat-backend/src/frontendTools.ts
@@ -1,11 +1,19 @@
 import { jsonSchema } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 
+// `tools` is optional in the request schema (`z.any().optional()`), so it
+// arrives as `undefined` whenever the frontend does not register any
+// client-side tools (assistant-ui's default transport). Calling
+// `Object.entries(undefined)` would throw and surface to the user as a
+// generic 500 / "network error" on every chat send.
 export const frontendTools = (
-  tools: Record<string, { description?: string; parameters: JSONSchema7 }>,
+  tools:
+    | Record<string, { description?: string; parameters: JSONSchema7 }>
+    | null
+    | undefined,
 ) =>
   Object.fromEntries(
-    Object.entries(tools).map(([name, tool]) => [
+    Object.entries(tools ?? {}).map(([name, tool]) => [
       name,
       {
         ...(tool.description ? { description: tool.description } : undefined),


### PR DESCRIPTION
## Summary

Every `POST /api/ai-chat/chat` request was returning 500 with
`TypeError: Cannot convert undefined or null to object` whenever the
request body did not include a `tools` field.

The chat request schema marks `tools` as `z.any().optional()`, so it
arrives as `undefined` whenever the frontend has not registered any
client-side tools. That is the default for the assistant-ui
`AssistantChatTransport` the chat UI uses. `frontendTools` then called
`Object.entries(undefined)` and threw synchronously.

The throw happened **before** `mcpTools`, `mcpResourceTools`,
`skillTools`, `getDate`, and `contextUsageTools` were merged into the
tool catalog (`router.ts:418-425`). So one bug produced two parallel
user-visible symptoms:

- **Chat is broken.** The browser sees a JSON 500 response instead of
  the expected `text/event-stream`. The AI SDK's `useChat` reports it
  as "network error" on every send, which has been the persistent
  complaint on the demorack deployment.
- **Tools appear missing.** Because the throw is upstream of the tool
  merge, the LLM never sees muster / mcp-prometheus / mcp-kubernetes
  tools or the bundled skills tools either. The earlier "Backstage
  reports the prometheus tools are not available" report is the same
  bug.

## Reproduction (against demorack-lab-3-az, through Traefik)

```
POST /api/ai-chat/chat
{"messages":[...]}                         -> 500 TypeError (current bug)
{"messages":[...], "tools": {}}            -> 200 text/event-stream, full SSE response
```

Backend log (current, no `tools`):

```
"level":"error","message":"Error in chat endpoint Cannot convert undefined or null to object",
"stack":"TypeError ... at Object.entries (<anonymous>) at frontendTools (...)"
```

## Fix

`frontendTools` now accepts `null | undefined` and treats both as an
empty tool registry. The merged `allTools` then contains exactly the
MCP / skill / built-in tools as before, and streaming proceeds normally.

Added unit coverage in `plugins/ai-chat-backend/src/frontendTools.test.ts`
for `undefined`, `null`, `{}`, and a populated entry with and without
`description`.

## Test plan

- [x] Reproduced 500 against deployed `backstage:0.128.0` via Traefik on demorack-lab-3-az
- [x] Confirmed `tools: {}` returns a working SSE stream from the same deployment
- [x] `git diff` is a 1-line behaviour change + type widen; pre-existing TS errors are in unrelated `plugins/ai-chat/src/components/AiChat/...` files
- [ ] CI green
- [ ] After release: build a chart bump, roll out to demorack, verify chat works end-to-end in the browser and that muster/prometheus tools appear in tool catalog


Made with [Cursor](https://cursor.com)