### PR TITLE
fix(ai-chat-backend): rebuild MCPClient when cached transport is closed; null-guard frontendTools

### DIFF
--- a/.changeset/ai-chat-frontend-tools-null-guard.md
+++ b/.changeset/ai-chat-frontend-tools-null-guard.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Fix AI chat backend crash on every chat send. The `tools` field in the request body is `z.any().optional()`, so it arrives as `undefined` whenever the frontend does not register any client-side tools (the default when the chat UI uses assistant-ui's `AssistantChatTransport`). The previous implementation called `Object.entries(tools)` unconditionally, which threw `TypeError: Cannot convert undefined or null to object`, returning a 500 from `POST /api/ai-chat/chat` on every request. The browser surfaced this as "network error" and the LLM never reached the tool-merge step, so MCP-provided tools (muster, prometheus, kubernetes, …), skill tools, `getDate`, and the context-usage tool were also unreachable from chat. `frontendTools` now accepts `null`/`undefined` and treats them as an empty registry.

--- a/.changeset/ai-chat-mcp-cache-liveness.md
+++ b/.changeset/ai-chat-mcp-cache-liveness.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Rebuild MCP clients when the underlying transport closes. The AI chat backend caches one `MCPClient` per server for 30 minutes, but the cache was holding on to clients whose StreamableHTTP transport had already been torn down by muster (idle timeout, server reset, …). Tool calls then failed with `MCPClientError: Attempted to send a request from a closed client` until the TTL expired, surfacing in the browser as a "network error" banner. The cache now chains into the transport's `onclose` callback and evicts the entry as soon as the connection drops, so the next request rebuilds the client cleanly. Tool execution also detects the same SDK error eagerly and marks the entry dead so a single failure -- not a 30-minute window -- triggers reconnection.

--- a/plugins/ai-chat-backend/src/McpClientCache.test.ts
+++ b/plugins/ai-chat-backend/src/McpClientCache.test.ts
@@ -1,0 +1,133 @@
+import { McpClientCache, isClosedClientError } from './McpClientCache';
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+} as any;
+
+interface FakeTransport {
+  onclose?: (...args: unknown[]) => void;
+}
+
+interface FakeClient {
+  id: number;
+  transport: FakeTransport;
+  close: jest.Mock;
+}
+
+function makeFakeClient(id: number): FakeClient {
+  const transport: FakeTransport = {};
+  return {
+    id,
+    transport,
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('isClosedClientError', () => {
+  it('detects the SDK closed-client error message', () => {
+    expect(
+      isClosedClientError(
+        new Error('Attempted to send a request from a closed client'),
+      ),
+    ).toBe(true);
+    expect(
+      isClosedClientError(
+        'wrapped: Attempted to send a request from a closed client (foo)',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isClosedClientError(undefined)).toBe(false);
+    expect(isClosedClientError(null)).toBe(false);
+    expect(isClosedClientError(new Error('network unreachable'))).toBe(false);
+  });
+});
+
+describe('McpClientCache', () => {
+  let cache: McpClientCache;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cache = new McpClientCache(mockLogger, {
+      ttlMs: 60_000,
+      sweepIntervalMs: 60_000,
+    });
+  });
+
+  afterEach(async () => {
+    await cache.dispose();
+  });
+
+  it('returns the same client for repeated getOrCreate while alive', async () => {
+    const factory = jest.fn(async () => makeFakeClient(1) as any);
+    const a = await cache.getOrCreate('k', factory);
+    const b = await cache.getOrCreate('k', factory);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it('rebuilds when the underlying transport fires onclose', async () => {
+    const clients = [makeFakeClient(1), makeFakeClient(2)];
+    const factory = jest
+      .fn()
+      .mockImplementationOnce(async () => clients[0] as any)
+      .mockImplementationOnce(async () => clients[1] as any);
+
+    const first = await cache.getOrCreate('k', factory);
+    expect(first).toBe(clients[0]);
+    expect(typeof clients[0].transport.onclose).toBe('function');
+
+    clients[0].transport.onclose!();
+
+    const second = await cache.getOrCreate('k', factory);
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(second).toBe(clients[1]);
+    expect(second).not.toBe(first);
+  });
+
+  it('chains an existing transport.onclose handler', async () => {
+    const previous = jest.fn();
+    const client = makeFakeClient(1);
+    client.transport.onclose = previous;
+    const factory = jest.fn(async () => client as any);
+
+    await cache.getOrCreate('k', factory);
+    client.transport.onclose!('arg');
+
+    expect(previous).toHaveBeenCalledWith('arg');
+  });
+
+  it('markDead forces a rebuild on the next getOrCreate', async () => {
+    const clients = [makeFakeClient(1), makeFakeClient(2)];
+    const factory = jest
+      .fn()
+      .mockImplementationOnce(async () => clients[0] as any)
+      .mockImplementationOnce(async () => clients[1] as any);
+
+    await cache.getOrCreate('k', factory);
+    cache.markDead('k');
+    const next = await cache.getOrCreate('k', factory);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(next).toBe(clients[1]);
+  });
+
+  it('removes the entry when the factory rejects so the next call retries', async () => {
+    const success = makeFakeClient(2);
+    const factory = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(success as any);
+
+    await expect(cache.getOrCreate('k', factory)).rejects.toThrow('boom');
+    const second = await cache.getOrCreate('k', factory);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(second).toBe(success);
+  });
+});

--- a/plugins/ai-chat-backend/src/McpClientCache.ts
+++ b/plugins/ai-chat-backend/src/McpClientCache.ts
@@ -27,8 +27,7 @@ const CLOSED_CLIENT_ERROR_FRAGMENT =
 
 export function isClosedClientError(error: unknown): boolean {
   if (!error) return false;
-  const message =
-    error instanceof Error ? error.message : String(error ?? '');
+  const message = error instanceof Error ? error.message : String(error ?? '');
   return message.includes(CLOSED_CLIENT_ERROR_FRAGMENT);
 }
 
@@ -95,9 +94,11 @@ export class McpClientCache {
           // the only practical way to detect closure without polling.
           // Cast through `unknown` to avoid lint complaints; runtime
           // shape is stable across the @ai-sdk/mcp 1.x line.
-          const transport = (client as unknown as {
-            transport?: { onclose?: (...args: unknown[]) => void };
-          }).transport;
+          const transport = (
+            client as unknown as {
+              transport?: { onclose?: (...args: unknown[]) => void };
+            }
+          ).transport;
           if (transport) {
             const previous = transport.onclose;
             transport.onclose = (...args: unknown[]) => {

--- a/plugins/ai-chat-backend/src/McpClientCache.ts
+++ b/plugins/ai-chat-backend/src/McpClientCache.ts
@@ -5,10 +5,32 @@ import { MCPClient } from '@ai-sdk/mcp';
 interface CacheEntry {
   clientPromise: Promise<MCPClient>;
   createdAt: number;
+  // Set to false when the underlying MCP transport invokes its `onclose`
+  // hook. The cache uses this to evict dead entries on the next access
+  // instead of handing the LLM a closed client (which would surface as
+  // `MCPClientError: Attempted to send a request from a closed client` on
+  // every subsequent tool call until the entry expires).
+  alive: boolean;
 }
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000; // 60 seconds
+
+// Match @ai-sdk/mcp's `MCPClientError({ message: 'Attempted to send a
+// request from a closed client' })` thrown from `request()` when
+// `isClosed` is set. The string is stable across versions of the SDK
+// since it's part of the public error surface used by docs / blog
+// posts; if it ever changes we'd just stop self-healing on this signal,
+// not crash.
+const CLOSED_CLIENT_ERROR_FRAGMENT =
+  'Attempted to send a request from a closed client';
+
+export function isClosedClientError(error: unknown): boolean {
+  if (!error) return false;
+  const message =
+    error instanceof Error ? error.message : String(error ?? '');
+  return message.includes(CLOSED_CLIENT_ERROR_FRAGMENT);
+}
 
 export class McpClientCache {
   private readonly cache = new Map<string, CacheEntry>();
@@ -41,17 +63,91 @@ export class McpClientCache {
   ): Promise<MCPClient> {
     const existing = this.cache.get(key);
     if (existing) {
-      return existing.clientPromise;
+      if (existing.alive) {
+        return existing.clientPromise;
+      }
+      // The transport's onclose fired since we last handed this entry
+      // out. Evict it so we recreate cleanly below; do NOT await
+      // invalidate's client.close() because the underlying transport
+      // is already gone.
+      this.logger.debug(
+        `McpClientCache: cached entry '${key}' is closed; recreating`,
+      );
+      this.cache.delete(key);
     }
 
-    const clientPromise = factory().catch(err => {
-      // On factory failure, remove the entry so the next request retries
-      this.cache.delete(key);
-      throw err;
-    });
+    const entry: CacheEntry = {
+      // Filled in below once factory resolves.
+      clientPromise: undefined as unknown as Promise<MCPClient>,
+      createdAt: Date.now(),
+      alive: true,
+    };
 
-    this.cache.set(key, { clientPromise, createdAt: Date.now() });
-    return clientPromise;
+    entry.clientPromise = factory()
+      .then(client => {
+        // Chain into the transport's onclose handler so we learn when
+        // the connection has been torn down (idle timeout from the
+        // server, network drop, server-side reset, ...). The MCPClient
+        // installs its own onclose during construction; we wrap it so
+        // both run, leaving the SDK's bookkeeping intact.
+        try {
+          // `transport` is private on MCPClient, but the chain hook is
+          // the only practical way to detect closure without polling.
+          // Cast through `unknown` to avoid lint complaints; runtime
+          // shape is stable across the @ai-sdk/mcp 1.x line.
+          const transport = (client as unknown as {
+            transport?: { onclose?: (...args: unknown[]) => void };
+          }).transport;
+          if (transport) {
+            const previous = transport.onclose;
+            transport.onclose = (...args: unknown[]) => {
+              entry.alive = false;
+              try {
+                previous?.(...args);
+              } catch (closeErr) {
+                // Don't let chaining surface as an unhandled rejection.
+                this.logger.debug(
+                  `McpClientCache: chained onclose for '${key}' threw: ${
+                    closeErr instanceof Error
+                      ? closeErr.message
+                      : String(closeErr)
+                  }`,
+                );
+              }
+            };
+          }
+        } catch (hookErr) {
+          // If the SDK shape changed and we can't install the hook,
+          // continue without close-detection rather than failing the
+          // whole request. The 30-minute TTL still bounds staleness.
+          this.logger.debug(
+            `McpClientCache: failed to install onclose hook for '${key}': ${
+              hookErr instanceof Error ? hookErr.message : String(hookErr)
+            }`,
+          );
+        }
+        return client;
+      })
+      .catch(err => {
+        this.cache.delete(key);
+        throw err;
+      });
+
+    this.cache.set(key, entry);
+    return entry.clientPromise;
+  }
+
+  /**
+   * Mark a cached entry dead without awaiting client.close(). Use this
+   * from a tool-execution catch block when the SDK reports the client
+   * is closed, so the very next chat request creates a fresh client
+   * instead of waiting for the TTL to evict the dead entry.
+   */
+  markDead(key: string): void {
+    const entry = this.cache.get(key);
+    if (entry) {
+      entry.alive = false;
+    }
   }
 
   async invalidate(key: string): Promise<void> {
@@ -76,8 +172,12 @@ export class McpClientCache {
   private sweep(): void {
     const now = Date.now();
     for (const [key, entry] of this.cache) {
-      if (now - entry.createdAt > this.ttlMs) {
-        this.logger.debug(`McpClientCache: evicting expired entry '${key}'`);
+      if (!entry.alive || now - entry.createdAt > this.ttlMs) {
+        this.logger.debug(
+          `McpClientCache: evicting ${
+            entry.alive ? 'expired' : 'closed'
+          } entry '${key}'`,
+        );
         this.invalidate(key).catch(() => {});
       }
     }

--- a/plugins/ai-chat-backend/src/frontendTools.test.ts
+++ b/plugins/ai-chat-backend/src/frontendTools.test.ts
@@ -1,0 +1,33 @@
+import { frontendTools } from './frontendTools';
+
+describe('frontendTools', () => {
+  it('returns an empty object when tools is undefined', () => {
+    expect(frontendTools(undefined)).toEqual({});
+  });
+
+  it('returns an empty object when tools is null', () => {
+    expect(frontendTools(null)).toEqual({});
+  });
+
+  it('returns an empty object when tools is empty', () => {
+    expect(frontendTools({})).toEqual({});
+  });
+
+  it('converts tool entries and preserves descriptions', () => {
+    const result = frontendTools({
+      foo: {
+        description: 'foo tool',
+        parameters: { type: 'object', properties: {} },
+      },
+      bar: {
+        parameters: { type: 'object', properties: {} },
+      },
+    });
+
+    expect(Object.keys(result).sort()).toEqual(['bar', 'foo']);
+    expect(result.foo.description).toBe('foo tool');
+    expect(result.bar).not.toHaveProperty('description');
+    expect(result.foo.inputSchema).toBeDefined();
+    expect(result.bar.inputSchema).toBeDefined();
+  });
+});

--- a/plugins/ai-chat-backend/src/frontendTools.ts
+++ b/plugins/ai-chat-backend/src/frontendTools.ts
@@ -1,11 +1,19 @@
 import { jsonSchema } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 
+// `tools` is optional in the request schema (`z.any().optional()`), so it
+// arrives as `undefined` whenever the frontend does not register any
+// client-side tools (assistant-ui's default transport). Calling
+// `Object.entries(undefined)` would throw and surface to the user as a
+// generic 500 / "network error" on every chat send.
 export const frontendTools = (
-  tools: Record<string, { description?: string; parameters: JSONSchema7 }>,
+  tools:
+    | Record<string, { description?: string; parameters: JSONSchema7 }>
+    | null
+    | undefined,
 ) =>
   Object.fromEntries(
-    Object.entries(tools).map(([name, tool]) => [
+    Object.entries(tools ?? {}).map(([name, tool]) => [
       name,
       {
         ...(tool.description ? { description: tool.description } : undefined),

--- a/plugins/ai-chat-backend/src/getMcpTools.ts
+++ b/plugins/ai-chat-backend/src/getMcpTools.ts
@@ -6,7 +6,7 @@ import {
   MCPClient,
 } from '@ai-sdk/mcp';
 import { AuthTokens } from './utils';
-import { McpClientCache } from './McpClientCache';
+import { isClosedClientError, McpClientCache } from './McpClientCache';
 import { createSessionAwareTransport } from './createSessionAwareTransport';
 
 interface McpServerConfig {
@@ -159,7 +159,52 @@ function sanitizeToolName(name: string): string {
     .substring(0, 128);
 }
 
-function collectTools(mcpClientTools: ToolSet, installation?: string): ToolSet {
+// Wrap a Tool's `execute` so a "closed client" error from the
+// underlying MCP transport eagerly marks the cache entry dead. This
+// turns a multi-turn retry loop ("I'm getting 'closed client' errors
+// from the Kubernetes MCP server, let me try once more...") into at
+// most one stale call followed by a clean reconnect on the next chat
+// request, while still surfacing the failure to the LLM for the
+// current turn so it can react.
+function wrapToolWithClosedClientDetection(
+  tool: Tool,
+  onClosedClientError: () => void,
+  logger: LoggerService,
+  serverName: string,
+  toolName: string,
+): Tool {
+  const original = (tool as { execute?: Function }).execute;
+  if (typeof original !== 'function') return tool;
+
+  return {
+    ...tool,
+    execute: async (...args: unknown[]) => {
+      try {
+        return await (original as Function).apply(tool, args);
+      } catch (err) {
+        if (isClosedClientError(err)) {
+          logger.warn(
+            `MCP tool '${toolName}' on server '${serverName}' returned a closed-client error; marking cache entry dead so the next request reconnects.`,
+          );
+          try {
+            onClosedClientError();
+          } catch {
+            // Don't let bookkeeping mask the real tool error.
+          }
+        }
+        throw err;
+      }
+    },
+  } as Tool;
+}
+
+function collectTools(
+  mcpClientTools: ToolSet,
+  installation: string | undefined,
+  serverName: string,
+  logger: LoggerService,
+  onClosedClientError: () => void,
+): ToolSet {
   const tools: ToolSet = {};
   Object.entries(mcpClientTools).forEach(([toolName, tool]) => {
     const toolInstance = tool as Tool;
@@ -167,9 +212,22 @@ function collectTools(mcpClientTools: ToolSet, installation?: string): ToolSet {
     if (installation) {
       toolInstance.description = `${toolInstance.description} (for installation: ${installation})`;
       const prefixedToolName = sanitizeToolName(`${installation}_${toolName}`);
-      tools[prefixedToolName] = toolInstance;
+      tools[prefixedToolName] = wrapToolWithClosedClientDetection(
+        toolInstance,
+        onClosedClientError,
+        logger,
+        serverName,
+        prefixedToolName,
+      );
     } else {
-      tools[sanitizeToolName(toolName)] = toolInstance;
+      const safeName = sanitizeToolName(toolName);
+      tools[safeName] = wrapToolWithClosedClientDetection(
+        toolInstance,
+        onClosedClientError,
+        logger,
+        serverName,
+        safeName,
+      );
     }
   });
   return tools;
@@ -179,11 +237,18 @@ async function getTools(
   mcpClient: MCPClient,
   serverName: string,
   logger: LoggerService,
+  onClosedClientError: () => void,
   installation?: string,
 ): Promise<ToolSet> {
   try {
     const mcpClientTools = (await mcpClient.tools()) as ToolSet;
-    const tools = collectTools(mcpClientTools, installation);
+    const tools = collectTools(
+      mcpClientTools,
+      installation,
+      serverName,
+      logger,
+      onClosedClientError,
+    );
     logger.debug(`Successfully loaded tools from MCP server: ${serverName}`);
     return tools;
   } catch (toolError) {
@@ -251,6 +316,7 @@ export async function getMcpTools(
         mcpClient,
         serverName,
         logger,
+        () => clientCache.markDead(cacheKey),
         server.installation,
       );
       Object.assign(tools, serverTools);


### PR DESCRIPTION
## Summary

Two related fixes in the AI chat backend, folded into one PR (closes #1645).

### 1. Rebuild MCP clients when the cached transport is closed

`McpClientCache` was caching one `MCPClient` per server for 30 minutes regardless of whether the underlying StreamableHTTP transport had been torn down by muster (idle timeout, server reset, network drop, ...). Tool calls then failed with

```
MCPClientError: Attempted to send a request from a closed client
```

until the TTL expired, surfacing in the browser as the "network error" banner on the demorack BWI deployment.

Two signals now keep the cache honest:

- The cache chains into `transport.onclose`, so the entry is marked dead the moment the connection drops. The next `getOrCreate` rebuilds.
- The tool wrapper in `getMcpTools` detects the SDK's closed-client error on tool execution and eagerly marks the entry dead, so a single stale call -- not a 30-minute window -- is enough to trigger reconnection on the very next request.

The chain wraps the SDK's existing `onclose` handler instead of replacing it, so `MCPClient.onClose()` bookkeeping still runs.

### 2. Null-guard `frontendTools` (originally #1645)

Every `POST /api/ai-chat/chat` request was returning 500 with `TypeError: Cannot convert undefined or null to object` whenever the request body did not include a `tools` field. The chat request schema marks `tools` as `z.any().optional()`, so it arrives as `undefined` whenever the frontend has not registered any client-side tools (the default for assistant-ui's `AssistantChatTransport`). `frontendTools` then called `Object.entries(undefined)` and threw.

The throw happened **before** `mcpTools`, `mcpResourceTools`, `skillTools`, `getDate`, and `contextUsageTools` were merged into the tool catalog, so one bug produced two parallel symptoms: the 500/network error banner and the LLM never seeing MCP-provided tools (muster / mcp-prometheus / mcp-kubernetes) or the bundled skills tools.

`frontendTools` now accepts `null | undefined` and treats both as an empty registry.

## Test plan

- [x] Reproduced the 500 against deployed `backstage:0.128.0` via Traefik on demorack-lab-3-az
- [x] Confirmed `tools: {}` returns a working SSE stream from the same deployment
- [x] Unit coverage:
  - `frontendTools.test.ts`: undefined / null / empty / populated entries with and without `description`
  - `McpClientCache.test.ts`: cached-while-alive reuse, onclose-driven rebuild, onclose chaining (previous handler still called), `markDead`, factory-failure cleanup
  - `isClosedClientError` recognises the SDK's stable error message and ignores unrelated errors
- [ ] CI green
- [ ] After release: bundle-bump in `giantswarm/bwi`, roll out to demorack via OCM/flux, verify the chat works end-to-end in the browser and that MCP tools surface in the catalog

Made with [Cursor](https://cursor.com)