### PR TITLE
feat(ai-chat-backend): make sampling parameters configurable per installation

### DIFF
--- a/.changeset/ai-chat-sampling-params.md
+++ b/.changeset/ai-chat-sampling-params.md
@@ -1,0 +1,21 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+---
+
+Make AI chat sampling parameters configurable per installation. The plugin previously called `streamText()` without `temperature`, `topP`, `topK`, `seed`, `minP`, or `maxOutputTokens`, so the server's defaults applied -- which for vLLM means `temperature=1.0, top_p=1.0, top_k=-1, seed=null`. That is far too loose for a tool-using agent backed by a reasoning model and was the dominant cause of token-cost variance in production agent loops (same prompt, fresh chat, observed total-token spread of 22k / 607k / 22k across three runs against the same Qwen3 endpoint).
+
+Config now accepts an `aiChat.sampling` block:
+
+```yaml
+aiChat:
+  model: <model>
+  sampling:
+    temperature: 0.6
+    topP: 0.95
+    topK: 20
+    minP: 0
+    # seed: 42
+    # maxOutputTokens: 4096
+```
+
+All fields are optional; default behaviour with no `sampling:` block is unchanged. `temperature`, `topP`, `topK`, `seed`, and `maxOutputTokens` are forwarded through the AI SDK to every provider that supports them. `minP` is spliced into the request body via the OpenAI-compatible provider's `transformRequestBody` hook, since vLLM accepts it as a top-level field but it is not part of the AI SDK call settings. The README documents recommended values per model family (Qwen3 thinking/non-thinking, Qwen3-Coder, GPT-4 / GPT-4o, Anthropic Claude).

--- a/plugins/ai-chat-backend/README.md
+++ b/plugins/ai-chat-backend/README.md
@@ -19,6 +19,82 @@ const backend = createBackend();
 backend.add(import('@giantswarm/backstage-plugin-ai-chat-backend'));
 ```
 
+## Sampling
+
+The Vercel AI SDK omits `temperature`, `topP`, `topK`, `seed`, `minP`, and
+`maxOutputTokens` from the request whenever they are not set, so the
+**server's defaults** apply. For vLLM that means `temperature=1.0,
+top_p=1.0, top_k=-1, seed=null` -- far too loose for a tool-using agent,
+and the dominant cause of token-cost variance in production agent loops
+(same prompt, fresh chat, observed total-token spread of 22k - 607k - 22k
+across three runs against the same Qwen3 endpoint).
+
+Configure sampling per installation:
+
+```yaml
+aiChat:
+  model: <model name>
+  # ... provider config (openai / anthropic / azure) ...
+  sampling:
+    temperature: 0.6
+    topP: 0.95
+    topK: 20
+    minP: 0
+    # seed: 42        # optional, for evaluation/regression-test deployments only
+    # maxOutputTokens: 4096
+```
+
+All fields are optional; when unset the SDK / provider defaults apply.
+`temperature`, `topP`, `topK`, `seed`, and `maxOutputTokens` are forwarded
+through the AI SDK to every provider that supports them. `minP` is not
+part of the SDK call settings; the plugin splices it into the outgoing
+request body for the OpenAI-compatible (vLLM) provider, where it is most
+useful.
+
+### Recommended values per model family
+
+| Model family | temperature | topP | topK | minP | notes |
+|---|---|---|---|---|---|
+| Qwen3 thinking-mode | 0.6 | 0.95 | 20 | 0 | Qwen team's official recipe; do **not** use greedy decoding -- the Qwen team explicitly warns it leads to performance degradation and endless repetitions |
+| Qwen3 non-thinking | 0.7 | 0.8 | 20 | 0 | Qwen team's official recipe |
+| Qwen3-Coder | 0.7 | -- | -- | -- | |
+| GPT-4 / GPT-4o (tool use) | 0.0 - 0.3 | -- | -- | -- | greedy is fine here |
+| Anthropic Claude (tool use) | 0.0 - 0.3 | -- | -- | -- | greedy is fine here |
+
+### Examples
+
+vLLM-served Qwen3 thinking-mode (recommended):
+
+```yaml
+aiChat:
+  model: Qwen/Qwen3-30B-A3B
+  openai:
+    baseUrl: http://<vllm-svc>/v1
+    apiKey: not-needed
+    api: chat
+  sampling:
+    temperature: 0.6
+    topP: 0.95
+    topK: 20
+    minP: 0
+```
+
+Real-OpenAI / Anthropic Claude tool-use deployment:
+
+```yaml
+aiChat:
+  model: gpt-4o
+  openai:
+    apiKey: ${OPENAI_API_KEY}
+  sampling:
+    temperature: 0
+```
+
+For evaluation / regression-test deployments where bit-identical responses
+across runs are desired, combine `temperature: 0` with a fixed `seed`. Do
+**not** ship a fixed seed to production -- users would see the same
+deterministic answer to ambiguous questions.
+
 ## Development
 
 This plugin backend can be started in a standalone mode from directly in this

--- a/plugins/ai-chat-backend/README.md
+++ b/plugins/ai-chat-backend/README.md
@@ -53,13 +53,13 @@ useful.
 
 ### Recommended values per model family
 
-| Model family | temperature | topP | topK | minP | notes |
-|---|---|---|---|---|---|
-| Qwen3 thinking-mode | 0.6 | 0.95 | 20 | 0 | Qwen team's official recipe; do **not** use greedy decoding -- the Qwen team explicitly warns it leads to performance degradation and endless repetitions |
-| Qwen3 non-thinking | 0.7 | 0.8 | 20 | 0 | Qwen team's official recipe |
-| Qwen3-Coder | 0.7 | -- | -- | -- | |
-| GPT-4 / GPT-4o (tool use) | 0.0 - 0.3 | -- | -- | -- | greedy is fine here |
-| Anthropic Claude (tool use) | 0.0 - 0.3 | -- | -- | -- | greedy is fine here |
+| Model family                | temperature | topP | topK | minP | notes                                                                                                                                                     |
+| --------------------------- | ----------- | ---- | ---- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Qwen3 thinking-mode         | 0.6         | 0.95 | 20   | 0    | Qwen team's official recipe; do **not** use greedy decoding -- the Qwen team explicitly warns it leads to performance degradation and endless repetitions |
+| Qwen3 non-thinking          | 0.7         | 0.8  | 20   | 0    | Qwen team's official recipe                                                                                                                               |
+| Qwen3-Coder                 | 0.7         | --   | --   | --   |                                                                                                                                                           |
+| GPT-4 / GPT-4o (tool use)   | 0.0 - 0.3   | --   | --   | --   | greedy is fine here                                                                                                                                       |
+| Anthropic Claude (tool use) | 0.0 - 0.3   | --   | --   | --   | greedy is fine here                                                                                                                                       |
 
 ### Examples
 

--- a/plugins/ai-chat-backend/config.d.ts
+++ b/plugins/ai-chat-backend/config.d.ts
@@ -82,6 +82,61 @@ export interface Config {
     maxSteps?: number;
 
     /**
+     * Sampling parameters passed through to the underlying provider via
+     * the Vercel AI SDK's `streamText` call. All fields are optional; when
+     * unset, the provider/server defaults apply (e.g. vLLM defaults to
+     * `temperature=1.0, top_p=1.0, top_k=-1, seed=null`, which is far too
+     * loose for tool-using agents and the dominant cause of token-cost
+     * variance in production agent loops).
+     *
+     * Recommended values are model-specific -- see the model card for the
+     * model `aiChat.model` points at. The README has a "Sampling" section
+     * with recipes for common model families (Qwen3 thinking-mode, Qwen3
+     * non-thinking, GPT-4 / GPT-4o, Anthropic Claude).
+     */
+    sampling?: {
+      /**
+       * `0.0` = greedy decoding, `> 0` = sample. Provider/server default
+       * applies if unset. NOTE: Do not use greedy (`0`) for thinking-mode
+       * models like Qwen3 -- the Qwen team explicitly warns it leads to
+       * performance degradation and endless repetitions.
+       * @visibility backend
+       */
+      temperature?: number;
+      /**
+       * Nucleus sampling cutoff in `(0, 1]`.
+       * @visibility backend
+       */
+      topP?: number;
+      /**
+       * Top-K sampling cutoff. Not supported by all providers; the AI SDK
+       * routes it through provider options where applicable.
+       * @visibility backend
+       */
+      topK?: number;
+      /**
+       * Min-P sampling cutoff in `[0, 1)`. Not supported by all providers;
+       * the AI SDK routes it through provider options where applicable.
+       * @visibility backend
+       */
+      minP?: number;
+      /**
+       * Fixed seed. Combined with `temperature: 0`, makes single-turn
+       * responses bit-identical across runs. Recommended ONLY for
+       * evaluation / regression-test deployments; omit in production so
+       * users don't see the same deterministic answer to ambiguous
+       * questions.
+       * @visibility backend
+       */
+      seed?: number;
+      /**
+       * Optional maximum number of output tokens per step.
+       * @visibility backend
+       */
+      maxOutputTokens?: number;
+    };
+
+    /**
      * Sources of expert-knowledge skills exposed to the model via the
      * `listSkills` and `getSkill` tools. The plugin ships a default set
      * of bundled skills; deployments can opt out and/or extend them with

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -134,7 +134,10 @@ export async function createRouter(
     if (maxOutputTokens !== undefined)
       samplingParams.maxOutputTokens = maxOutputTokens;
     samplingMinP = samplingConfig.getOptionalNumber('minP');
-    const all = { ...samplingParams, ...(samplingMinP !== undefined ? { minP: samplingMinP } : {}) };
+    const all = {
+      ...samplingParams,
+      ...(samplingMinP !== undefined ? { minP: samplingMinP } : {}),
+    };
     if (Object.keys(all).length > 0) {
       logger.info('AI chat sampling parameters configured', all);
     }

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -101,6 +101,45 @@ export async function createRouter(
   // first tool call, before the model ever sees the tool result.
   const maxSteps = config.getOptionalNumber('aiChat.maxSteps') ?? 20;
 
+  // Sampling parameters passed through to streamText. All optional; when
+  // unset the SDK / provider defaults apply (vLLM defaults to
+  // temperature=1.0 which is the dominant cause of token-cost variance
+  // in tool-using agent loops). Recommended values are model-specific --
+  // see the README for recipes.
+  //
+  // `temperature`, `topP`, `topK`, `seed`, `maxOutputTokens` are top-level
+  // CallSettings on `streamText` and are forwarded to every provider that
+  // supports them. `minP` is not part of the SDK CallSettings; for
+  // OpenAI-compatible servers (notably vLLM) we splice it into the request
+  // body via the provider's `transformRequestBody` hook below.
+  const samplingConfig = config.getOptionalConfig('aiChat.sampling');
+  const samplingParams: {
+    temperature?: number;
+    topP?: number;
+    topK?: number;
+    seed?: number;
+    maxOutputTokens?: number;
+  } = {};
+  let samplingMinP: number | undefined;
+  if (samplingConfig) {
+    const temperature = samplingConfig.getOptionalNumber('temperature');
+    if (temperature !== undefined) samplingParams.temperature = temperature;
+    const topP = samplingConfig.getOptionalNumber('topP');
+    if (topP !== undefined) samplingParams.topP = topP;
+    const topK = samplingConfig.getOptionalNumber('topK');
+    if (topK !== undefined) samplingParams.topK = topK;
+    const seed = samplingConfig.getOptionalNumber('seed');
+    if (seed !== undefined) samplingParams.seed = seed;
+    const maxOutputTokens = samplingConfig.getOptionalNumber('maxOutputTokens');
+    if (maxOutputTokens !== undefined)
+      samplingParams.maxOutputTokens = maxOutputTokens;
+    samplingMinP = samplingConfig.getOptionalNumber('minP');
+    const all = { ...samplingParams, ...(samplingMinP !== undefined ? { minP: samplingMinP } : {}) };
+    if (Object.keys(all).length > 0) {
+      logger.info('AI chat sampling parameters configured', all);
+    }
+  }
+
   // Continuous tool-result pruning. After every turn, older tool outputs
   // beyond a recent budget are replaced with a placeholder so the model
   // doesn't carry their full payload forever. Mirrors OpenCode's prune.
@@ -184,6 +223,15 @@ export async function createRouter(
     // Without this, vLLM emits no usage chunk and `getContextUsage` has
     // no data to show.
     includeUsage: true,
+    // `min_p` is not part of the AI SDK CallSettings, but vLLM accepts it
+    // as a top-level field on `/v1/chat/completions`. When configured
+    // under `aiChat.sampling.minP`, splice it into the outgoing request
+    // body. Recommended for Qwen3 thinking-mode (Qwen team's recipe is
+    // `temperature=0.6, topP=0.95, topK=20, minP=0`).
+    transformRequestBody:
+      samplingMinP !== undefined
+        ? args => ({ ...args, min_p: samplingMinP })
+        : undefined,
   });
 
   const anthropic = createAnthropic({
@@ -433,6 +481,7 @@ export async function createRouter(
         abortSignal: req.socket ? undefined : undefined,
         stopWhen: stepCountIs(maxSteps),
         tools: allTools as ToolSet,
+        ...samplingParams,
         providerOptions: isAnthropicModel
           ? {
               anthropic: {


### PR DESCRIPTION
Closes #1651.

## Summary

`streamText()` was called with no `temperature`, `topP`, `topK`, `seed`, `minP`, or `maxOutputTokens`, so the **server's defaults** applied. For vLLM that means `temperature=1.0, top_p=1.0, top_k=-1, seed=null` -- far too loose for a tool-using agent backed by a reasoning model and the dominant cause of token-cost variance in production agent loops (same prompt, fresh chat, observed 22k / 607k / 22k total-token spread across three runs against the same Qwen3 endpoint).

This PR adds an `aiChat.sampling` config block:

```yaml
aiChat:
  model: <model>
  sampling:
    temperature: 0.6
    topP: 0.95
    topK: 20
    minP: 0
    # seed: 42                # for evaluation/regression-test deployments only
    # maxOutputTokens: 4096
```

All fields are optional; default behaviour with no `sampling:` block is unchanged.

## Implementation

- `temperature`, `topP`, `topK`, `seed`, and `maxOutputTokens` are top-level `CallSettings` on `streamText` and are forwarded through the AI SDK to every provider that supports them (OpenAI, Anthropic, Azure, openai-compatible/vLLM).
- `minP` is **not** part of the AI SDK `CallSettings`. It is spliced into the outgoing `/v1/chat/completions` request body via the `@ai-sdk/openai-compatible` provider's `transformRequestBody` hook. vLLM accepts `min_p` as a top-level field, and the Qwen team's official recipe for Qwen3 thinking-mode is `temperature=0.6, topP=0.95, topK=20, minP=0` -- all four are needed.

## Documentation

`plugins/ai-chat-backend/README.md` grows a **Sampling** section with:

- Background on why this matters (the variance problem against vLLM defaults).
- Recommended values per model family: Qwen3 thinking-mode (`0.6 / 0.95 / 20 / 0` -- Qwen team's official recipe; do **not** use greedy decoding), Qwen3 non-thinking, Qwen3-Coder, GPT-4 / GPT-4o tool-use, Anthropic Claude tool-use.
- Example `app-config.yaml` snippets for a vLLM-Qwen3 deployment and a real-OpenAI / Claude deployment.
- A note that fixed-seed regression-test deployments should not ship to production.

`config.d.ts` is updated with `@visibility backend` tags so the values surface in the Backstage config snapshot.

## Acceptance criteria (from #1651)

- [x] `aiChat.sampling.{temperature,topP,topK,minP,seed,maxOutputTokens}` are honoured by the `streamText` call in `router.ts` (`temperature/topP/topK/seed/maxOutputTokens` via top-level CallSettings, `minP` via `transformRequestBody`).
- [x] Default behaviour with no `sampling:` block is unchanged (config block is fully optional and only the explicitly-set fields are forwarded).
- [x] README documents the Qwen3 thinking-mode recipe and a tool-using GPT/Claude recipe.
- [x] `config.d.ts` updated with descriptive `@visibility` tags.
- [ ] Order-of-magnitude variance reduction on a "run the same prompt 5x" microbenchmark -- to be validated against a deployed vLLM-Qwen3 instance after release.

## Test plan

- [x] `yarn workspace @giantswarm/backstage-plugin-ai-chat-backend lint` passes.
- [x] `yarn workspace @giantswarm/backstage-plugin-ai-chat-backend test` -- 37 tests pass; 3 pre-existing test-suite load failures from `@backstage/backend-test-utils` are unrelated to this change.
- [x] `yarn tsc` shows zero errors in `plugins/ai-chat-backend/` (the 3 unrelated tsc errors in `plugins/ai-chat/` are pre-existing).
- [ ] Validate against a vLLM-Qwen3 deployment that the recommended sampling block reduces median total-token-per-agent-turn variance by ≥ an order of magnitude. Tracked via the deployment-side rollout, not blocking on this PR.

Made with [Cursor](https://cursor.com)