### PR TITLE
fix(ai-chat): always log network diagnostics for "Network error" triage

### DIFF
--- a/.changeset/ai-chat-network-instrumentation.md
+++ b/.changeset/ai-chat-network-instrumentation.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+AI chat: always log network-level diagnostics (request URL, response status / headers, fetch errors, SSE stream lifecycle including premature termination) to the browser console so a "Network error" banner can be triaged from a user report without requiring the `ai-chat-verbose-debugging` feature flag. Verbose payload-level logging (messages, system prompt, tool schemas, per-event SSE detail) remains gated on the feature flag in non-production builds.

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -1,122 +1,410 @@
 /* eslint-disable no-console */
 
 /**
- * Creates a fetch wrapper that logs outgoing requests and incoming SSE
- * stream events to the browser console.  Designed to be passed as the
- * `fetch` option of `AssistantChatTransport` when the
- * `ai-chat-verbose-debugging` feature flag is active.
+ * Creates a fetch wrapper for the AI chat `AssistantChatTransport`.
  *
- * All logging is wrapped in try/catch so it can never break the chat.
+ * Two tiers of instrumentation are layered on top of `globalThis.fetch`:
+ *
+ * 1. **Always-on, non-sensitive network diagnostics.** Whenever the wrapper
+ *    runs (it is installed unconditionally by `useChatSetup`) it logs the
+ *    request URL, the response status and headers, fetch-level errors
+ *    (`TypeError: Failed to fetch`, `AbortError`, TLS errors, etc.) and SSE
+ *    stream lifecycle events, including premature termination without a
+ *    `finish` event. None of this leaks the system prompt, message content,
+ *    tool schemas, or any other backend internal -- it is safe to ship to
+ *    production users so a "Network error" banner can be diagnosed by
+ *    inspecting the browser console.
+ *
+ * 2. **Verbose mode**, gated by the `ai-chat-verbose-debugging` feature flag
+ *    in non-production builds, additionally logs the request body
+ *    (messages, frontend tools, other transport fields), the backend's
+ *    `X-AI-Chat-Debug-Meta` payload (model, provider, system prompt, tool
+ *    list, MCP servers) and a per-event categorised SSE log. This is the
+ *    behaviour the previous `createDebugFetch()` had and continues to be
+ *    useful when working on prompt or tool-call regressions.
+ *
+ * All logging is wrapped in try/catch -- diagnostics must never break the
+ * chat.
  */
-export function createDebugFetch(): typeof globalThis.fetch {
+
+const PREFIX_STYLE = 'color:#7c3aed;font-weight:bold';
+const RESET_STYLE = 'color:inherit';
+
+interface CreateDebugFetchOptions {
+  /**
+   * When true, log message content, backend metadata and per-SSE-event
+   * detail. Should be false in production builds because these payloads
+   * include the system prompt and tool schemas.
+   */
+  verbose?: boolean;
+  /**
+   * Returns the current chat conversation id so log lines can be correlated
+   * with the backend's structured logs.
+   */
+  getConversationId?: () => string | undefined;
+}
+
+export function createDebugFetch(
+  options: CreateDebugFetchOptions = {},
+): typeof globalThis.fetch {
+  const { verbose = false, getConversationId } = options;
+
   return async (input, init) => {
-    // --- 1. Log the outgoing request ---
-    try {
-      if (init?.body) {
-        const body = JSON.parse(init.body as string);
-        const headers = init.headers as Record<string, string> | undefined;
-        const safeHeaders = headers
-          ? Object.fromEntries(
-              Object.entries(headers).map(([k, v]) =>
-                k.toLowerCase() === 'authorization' ||
-                k.toLowerCase() === 'x-backstage-token'
-                  ? [k, '[REDACTED]']
-                  : [k, v],
-              ),
-            )
-          : undefined;
+    const requestId = `req-${Math.random().toString(36).slice(2, 8)}`;
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const startedAt = performance.now();
+    const conversationId = safeCall(getConversationId);
 
-        console.groupCollapsed(
-          '%c[AI Chat Debug]%c Outgoing request',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
-        );
-        console.log('URL:', input);
-        if (safeHeaders) console.log('Headers:', safeHeaders);
-        console.log('Messages:', body.messages);
-        if (body.tools && Object.keys(body.tools).length > 0) {
-          console.log('Frontend tools:', body.tools);
-        }
-        // Log any extra body fields besides messages/tools
-        const { messages: _m, tools: _t, ...rest } = body;
-        if (Object.keys(rest).length > 0) {
-          console.log('Other body fields:', rest);
-        }
-        console.groupEnd();
-      }
-    } catch {
-      // Ignore logging errors
+    logRequestStart({ requestId, url, method, conversationId });
+
+    if (verbose) {
+      logVerboseRequestBody({ requestId, init });
     }
 
-    // --- 2. Execute the real fetch ---
-    const response = await globalThis.fetch(input, init);
-
-    // --- 3. Log backend debug metadata header ---
+    let response: Response;
     try {
-      const debugMeta = response.headers.get('X-AI-Chat-Debug-Meta');
-      if (debugMeta) {
-        // Decode base64 + utf-8 (needed for non-ASCII characters in the
-        // system prompt or tool descriptions).
-        const decoded = new TextDecoder('utf-8').decode(
-          Uint8Array.from(atob(debugMeta), c => c.charCodeAt(0)),
-        );
-        const meta = JSON.parse(decoded);
-        console.groupCollapsed(
-          '%c[AI Chat Debug]%c Backend metadata',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
-        );
-        console.log('Model:', meta.model);
-        console.log('Provider:', meta.provider);
-        if (typeof meta.systemPrompt === 'string') {
-          console.log(
-            `System prompt (${meta.systemPrompt.length} chars):\n${meta.systemPrompt}`,
-          );
-        }
-        console.log(`Tools (${meta.tools?.length ?? 0}):`, meta.tools);
-        console.log('MCP servers:', meta.mcpServers);
-        if (meta.providerOptions) {
-          console.log('Provider options:', meta.providerOptions);
-        }
-        console.log('Messages after sanitization:', meta.messageCount);
-        if (meta.hadUnsupportedContent) {
-          console.warn('Unsupported content was stripped from messages');
-        }
-        console.groupEnd();
-      }
-    } catch {
-      // Ignore parse/logging errors
+      response = await globalThis.fetch(input, init);
+    } catch (err) {
+      logFetchError({
+        requestId,
+        url,
+        method,
+        conversationId,
+        elapsedMs: performance.now() - startedAt,
+        err,
+        aborted: init?.signal?.aborted === true,
+      });
+      throw err;
     }
 
-    // --- 4. Clone response and consume the clone for SSE logging ---
+    logResponseHeaders({
+      requestId,
+      conversationId,
+      response,
+      elapsedMs: performance.now() - startedAt,
+    });
+
+    if (verbose) {
+      logVerboseBackendMetadata({ requestId, response });
+    }
+
     try {
       const cloned = response.clone();
-      consumeSSEStream(cloned).catch(() => {
-        // Ignore stream read errors
+      void instrumentSSEStream({
+        requestId,
+        conversationId,
+        response: cloned,
+        verbose,
       });
     } catch {
-      // Ignore clone errors
+      // Cloning a streaming Response can fail in rare browser edge cases;
+      // never surface that to the chat.
     }
 
     return response;
   };
 }
 
-/**
- * Reads an SSE response body from a cloned Response and logs each event.
- */
+function safeCall<T>(fn: (() => T) | undefined): T | undefined {
+  try {
+    return fn?.();
+  } catch {
+    return undefined;
+  }
+}
+
+function logRequestStart(args: {
+  requestId: string;
+  url: string;
+  method: string;
+  conversationId: string | undefined;
+}) {
+  try {
+    console.log(
+      '%c[AI Chat]%c %s %s %s%s',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+      args.method,
+      args.url,
+      args.conversationId ? ` (conv ${args.conversationId})` : '',
+    );
+  } catch {
+    // Ignore logging errors
+  }
+}
+
+function logVerboseRequestBody(args: {
+  requestId: string;
+  init: RequestInit | undefined;
+}) {
+  try {
+    if (!args.init?.body) return;
+    const body = JSON.parse(args.init.body as string);
+    const headers = args.init.headers as Record<string, string> | undefined;
+    const safeHeaders = headers
+      ? Object.fromEntries(
+          Object.entries(headers).map(([k, v]) =>
+            k.toLowerCase() === 'authorization' ||
+            k.toLowerCase() === 'x-backstage-token' ||
+            k.toLowerCase().startsWith('backstage-ai-chat-authorization-')
+              ? [k, '[REDACTED]']
+              : [k, v],
+          ),
+        )
+      : undefined;
+
+    console.groupCollapsed(
+      '%c[AI Chat Debug]%c %s outgoing body',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+    );
+    if (safeHeaders) console.log('Headers:', safeHeaders);
+    console.log('Messages:', body.messages);
+    if (body.tools && Object.keys(body.tools).length > 0) {
+      console.log('Frontend tools:', body.tools);
+    }
+    const { messages: _m, tools: _t, ...rest } = body;
+    if (Object.keys(rest).length > 0) {
+      console.log('Other body fields:', rest);
+    }
+    console.groupEnd();
+  } catch {
+    // Ignore logging errors
+  }
+}
+
+function logFetchError(args: {
+  requestId: string;
+  url: string;
+  method: string;
+  conversationId: string | undefined;
+  elapsedMs: number;
+  err: unknown;
+  aborted: boolean;
+}) {
+  try {
+    const elapsed = args.elapsedMs.toFixed(0);
+    const e = args.err as { name?: string; message?: string; stack?: string };
+    console.error(
+      '%c[AI Chat]%c %s FETCH FAILED after %sms %s %s%s\n  cause: %s: %s',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+      elapsed,
+      args.method,
+      args.url,
+      args.conversationId ? ` (conv ${args.conversationId})` : '',
+      e?.name ?? typeof args.err,
+      e?.message ?? String(args.err),
+    );
+    if (args.aborted) {
+      console.error(
+        '%c[AI Chat]%c %s aborted by client (user pressed Stop or component unmounted)',
+        PREFIX_STYLE,
+        RESET_STYLE,
+        args.requestId,
+      );
+    }
+    if (e?.stack) {
+      console.error('%c[AI Chat]%c %s stack:', PREFIX_STYLE, RESET_STYLE, args.requestId, e.stack);
+    }
+  } catch {
+    // Ignore logging errors
+  }
+}
+
+const HEADERS_TO_LOG = [
+  'content-type',
+  'transfer-encoding',
+  'cache-control',
+  'connection',
+  'x-conversation-id',
+  'x-envoy-upstream-service-time',
+  'x-envoy-attempt-count',
+  'x-envoy-decorator-operation',
+  'x-envoy-overloaded',
+  'x-request-id',
+  'server',
+];
+
+function logResponseHeaders(args: {
+  requestId: string;
+  conversationId: string | undefined;
+  response: Response;
+  elapsedMs: number;
+}) {
+  try {
+    const headers: Record<string, string> = {};
+    for (const name of HEADERS_TO_LOG) {
+      const value = args.response.headers.get(name);
+      if (value !== null) {
+        headers[name] = value;
+      }
+    }
+
+    const elapsed = args.elapsedMs.toFixed(0);
+    const isOk = args.response.ok;
+    const logger = isOk ? console.log : console.error;
+    logger(
+      '%c[AI Chat]%c %s response %d %s in %sms%s',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+      args.response.status,
+      args.response.statusText,
+      elapsed,
+      Object.keys(headers).length > 0
+        ? ` headers=${JSON.stringify(headers)}`
+        : '',
+    );
+  } catch {
+    // Ignore logging errors
+  }
+}
+
+function logVerboseBackendMetadata(args: {
+  requestId: string;
+  response: Response;
+}) {
+  try {
+    const debugMeta = args.response.headers.get('X-AI-Chat-Debug-Meta');
+    if (!debugMeta) return;
+
+    // Decode base64 + utf-8 (needed for non-ASCII characters in the
+    // system prompt or tool descriptions).
+    const decoded = new TextDecoder('utf-8').decode(
+      Uint8Array.from(atob(debugMeta), c => c.charCodeAt(0)),
+    );
+    const meta = JSON.parse(decoded);
+    console.groupCollapsed(
+      '%c[AI Chat Debug]%c %s backend metadata',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+    );
+    console.log('Model:', meta.model);
+    console.log('Provider:', meta.provider);
+    if (typeof meta.systemPrompt === 'string') {
+      console.log(
+        `System prompt (${meta.systemPrompt.length} chars):\n${meta.systemPrompt}`,
+      );
+    }
+    console.log(`Tools (${meta.tools?.length ?? 0}):`, meta.tools);
+    console.log('MCP servers:', meta.mcpServers);
+    if (meta.providerOptions) {
+      console.log('Provider options:', meta.providerOptions);
+    }
+    console.log('Messages after sanitization:', meta.messageCount);
+    if (meta.hadUnsupportedContent) {
+      console.warn('Unsupported content was stripped from messages');
+    }
+    console.groupEnd();
+  } catch {
+    // Ignore parse/logging errors
+  }
+}
+
 interface StreamCounters {
   totalEvents: number;
+  totalBytes: number;
   textDeltaChars: number;
   toolCalls: string[];
   reasoningDeltas: number;
   steps: number;
   lastFinishReason: string | undefined;
+  sawFinish: boolean;
+  sawErrorEvent: boolean;
+  firstByteAtMs: number | undefined;
+  lastEventAtMs: number | undefined;
+  lastEventType: string | undefined;
 }
 
-function handleEvent(parsed: any, counters: StreamCounters) {
+async function instrumentSSEStream(args: {
+  requestId: string;
+  conversationId: string | undefined;
+  response: Response;
+  verbose: boolean;
+}): Promise<void> {
+  const body = args.response.body;
+  if (!body) return;
+
+  const reader = body.pipeThrough(new TextDecoderStream()).getReader();
+  let buffer = '';
+  const startTime = performance.now();
+
+  const counters: StreamCounters = {
+    totalEvents: 0,
+    totalBytes: 0,
+    textDeltaChars: 0,
+    toolCalls: [],
+    reasoningDeltas: 0,
+    steps: 0,
+    lastFinishReason: undefined,
+    sawFinish: false,
+    sawErrorEvent: false,
+    firstByteAtMs: undefined,
+    lastEventAtMs: undefined,
+    lastEventType: undefined,
+  };
+
+  let readError: unknown = null;
+  try {
+    let result = await reader.read();
+    while (!result.done) {
+      if (counters.firstByteAtMs === undefined) {
+        counters.firstByteAtMs = performance.now() - startTime;
+      }
+      counters.totalBytes += result.value.length;
+      buffer += result.value;
+
+      let boundary = buffer.indexOf('\n\n');
+      while (boundary !== -1) {
+        const eventBlock = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+
+        processEventBlock(eventBlock, {
+          onEvent(parsed) {
+            handleEvent(parsed, counters, startTime, args.verbose);
+          },
+        });
+
+        boundary = buffer.indexOf('\n\n');
+      }
+
+      result = await reader.read();
+    }
+  } catch (err) {
+    readError = err;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Ignore lock release errors
+    }
+  }
+
+  const totalDuration = performance.now() - startTime;
+  reportStreamOutcome({
+    requestId: args.requestId,
+    conversationId: args.conversationId,
+    counters,
+    totalDurationMs: totalDuration,
+    readError,
+  });
+}
+
+function handleEvent(
+  parsed: any,
+  counters: StreamCounters,
+  startTime: number,
+  verbose: boolean,
+) {
   counters.totalEvents++;
-  categorizeEvent(parsed, {
+  counters.lastEventAtMs = performance.now() - startTime;
+  categorizeEvent(parsed, verbose, {
     onTextDelta(chars) {
       counters.textDeltaChars += chars;
     },
@@ -131,82 +419,111 @@ function handleEvent(parsed: any, counters: StreamCounters) {
     },
     onFinish(reason) {
       counters.lastFinishReason = reason;
+      counters.sawFinish = true;
+    },
+    onErrorEvent() {
+      counters.sawErrorEvent = true;
+    },
+    onTypeSeen(type) {
+      counters.lastEventType = type;
     },
   });
 }
 
-async function consumeSSEStream(response: Response): Promise<void> {
-  const body = response.body;
-  if (!body) return;
+function reportStreamOutcome(args: {
+  requestId: string;
+  conversationId: string | undefined;
+  counters: StreamCounters;
+  totalDurationMs: number;
+  readError: unknown;
+}) {
+  const { counters } = args;
+  const duration = (args.totalDurationMs / 1000).toFixed(1);
+  const conv = args.conversationId ? ` (conv ${args.conversationId})` : '';
 
-  const reader = body.pipeThrough(new TextDecoderStream()).getReader();
-  let buffer = '';
-  const startTime = performance.now();
-
-  const counters: StreamCounters = {
-    totalEvents: 0,
-    textDeltaChars: 0,
-    toolCalls: [],
-    reasoningDeltas: 0,
-    steps: 0,
-    lastFinishReason: undefined,
+  const summary = {
+    bytes: counters.totalBytes,
+    events: counters.totalEvents,
+    textDeltaChars: counters.textDeltaChars,
+    toolCalls: counters.toolCalls,
+    reasoningDeltas: counters.reasoningDeltas,
+    steps: counters.steps,
+    finishReason: counters.lastFinishReason,
+    firstByteMs: counters.firstByteAtMs?.toFixed(0),
+    lastEventMs: counters.lastEventAtMs?.toFixed(0),
+    lastEventType: counters.lastEventType,
   };
 
-  try {
-    let result = await reader.read();
-    while (!result.done) {
-      buffer += result.value;
-
-      // SSE events are separated by double newlines
-      let boundary = buffer.indexOf('\n\n');
-      while (boundary !== -1) {
-        const eventBlock = buffer.slice(0, boundary);
-        buffer = buffer.slice(boundary + 2);
-
-        processEventBlock(eventBlock, {
-          onEvent(parsed) {
-            handleEvent(parsed, counters);
-          },
-        });
-
-        boundary = buffer.indexOf('\n\n');
-      }
-
-      result = await reader.read();
-    }
-  } finally {
-    reader.releaseLock();
+  if (args.readError) {
+    const e = args.readError as { name?: string; message?: string };
+    console.error(
+      '%c[AI Chat]%c %s SSE STREAM READ FAILED after %ss%s -- %s: %s',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+      duration,
+      conv,
+      e?.name ?? typeof args.readError,
+      e?.message ?? String(args.readError),
+      summary,
+    );
+    return;
   }
 
-  // --- Summary ---
-  const duration = ((performance.now() - startTime) / 1000).toFixed(1);
-  console.groupCollapsed(
-    '%c[AI Chat Debug]%c Stream complete (%ss)',
-    'color:#7c3aed;font-weight:bold',
-    'color:inherit',
+  if (counters.sawErrorEvent) {
+    console.error(
+      '%c[AI Chat]%c %s SSE stream contained an `error` event after %ss%s',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+      duration,
+      conv,
+      summary,
+    );
+    return;
+  }
+
+  if (!counters.sawFinish && counters.totalEvents > 0) {
+    console.warn(
+      '%c[AI Chat]%c %s SSE stream ended WITHOUT a `finish` event after %ss%s -- last event was `%s` -- this is the typical fingerprint of a proxy / gateway stream timeout or upstream disconnect',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+      duration,
+      conv,
+      counters.lastEventType ?? 'none',
+      summary,
+    );
+    return;
+  }
+
+  if (counters.totalEvents === 0) {
+    console.warn(
+      '%c[AI Chat]%c %s SSE stream produced no events after %ss%s -- response body closed without any data',
+      PREFIX_STYLE,
+      RESET_STYLE,
+      args.requestId,
+      duration,
+      conv,
+      summary,
+    );
+    return;
+  }
+
+  console.log(
+    '%c[AI Chat]%c %s SSE stream complete in %ss%s finish=%s events=%d bytes=%d toolCalls=[%s]',
+    PREFIX_STYLE,
+    RESET_STYLE,
+    args.requestId,
     duration,
+    conv,
+    counters.lastFinishReason ?? 'n/a',
+    counters.totalEvents,
+    counters.totalBytes,
+    counters.toolCalls.join(', '),
   );
-  console.log(`Total events: ${counters.totalEvents}`);
-  console.log(`Text delta chars: ${counters.textDeltaChars}`);
-  if (counters.toolCalls.length > 0) {
-    console.log(`Tool calls: ${counters.toolCalls.join(', ')}`);
-  }
-  if (counters.reasoningDeltas > 0) {
-    console.log(`Reasoning deltas: ${counters.reasoningDeltas}`);
-  }
-  if (counters.steps > 0) {
-    console.log(`Steps: ${counters.steps}`);
-  }
-  if (counters.lastFinishReason) {
-    console.log(`Finish reason: ${counters.lastFinishReason}`);
-  }
-  console.groupEnd();
 }
 
-/**
- * Parses a single SSE event block (lines between double-newline boundaries)
- * and calls the callback with the parsed JSON data.
- */
 function processEventBlock(
   block: string,
   { onEvent }: { onEvent: (data: any) => void },
@@ -232,86 +549,102 @@ interface EventCallbacks {
   onReasoningDelta: () => void;
   onStepStart: () => void;
   onFinish: (reason: string) => void;
+  onErrorEvent: () => void;
+  onTypeSeen: (type: string) => void;
 }
 
-/**
- * Categorizes a parsed SSE event and updates counters.
- * Also logs the event to the console.
- */
-function categorizeEvent(event: any, callbacks: EventCallbacks) {
+function categorizeEvent(
+  event: any,
+  verbose: boolean,
+  callbacks: EventCallbacks,
+) {
   try {
     // The AI SDK UI message stream uses a type-based protocol.
     // Common types: text-delta, tool-call, tool-result, step-start,
     // step-finish, reasoning, finish, error
     const type = event.type ?? event.event ?? 'unknown';
+    callbacks.onTypeSeen(type);
 
     switch (type) {
       case 'text-delta':
         callbacks.onTextDelta(event.textDelta?.length ?? 0);
-        // Don't log every text delta to avoid flooding
         break;
       case 'tool-call':
         callbacks.onToolCall(event.toolName ?? event.name ?? 'unknown');
-        console.log(
-          '%c[AI Chat Debug]%c Tool call: %s',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
-          event.toolName ?? event.name,
-          event.args ?? event.arguments,
-        );
+        if (verbose) {
+          console.log(
+            '%c[AI Chat Debug]%c Tool call: %s',
+            PREFIX_STYLE,
+            RESET_STYLE,
+            event.toolName ?? event.name,
+            event.args ?? event.arguments,
+          );
+        }
         break;
       case 'tool-result':
-        console.log(
-          '%c[AI Chat Debug]%c Tool result: %s',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
-          event.toolName ?? event.toolCallId,
-          event.result,
-        );
+        if (verbose) {
+          console.log(
+            '%c[AI Chat Debug]%c Tool result: %s',
+            PREFIX_STYLE,
+            RESET_STYLE,
+            event.toolName ?? event.toolCallId,
+            event.result,
+          );
+        }
         break;
       case 'step-start':
         callbacks.onStepStart();
-        console.log(
-          '%c[AI Chat Debug]%c Step start',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
-        );
+        if (verbose) {
+          console.log(
+            '%c[AI Chat Debug]%c Step start',
+            PREFIX_STYLE,
+            RESET_STYLE,
+          );
+        }
         break;
       case 'step-finish':
       case 'finish':
         if (event.finishReason) {
           callbacks.onFinish(event.finishReason);
+        } else {
+          // The `step-finish` / `finish` envelope alone is enough to consider
+          // the stream cleanly terminated, even when the SDK omits a reason.
+          callbacks.onFinish('unspecified');
         }
-        console.log(
-          '%c[AI Chat Debug]%c %s (reason: %s)',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
-          type,
-          event.finishReason ?? 'n/a',
-          event.usage ?? '',
-        );
+        if (verbose) {
+          console.log(
+            '%c[AI Chat Debug]%c %s (reason: %s)',
+            PREFIX_STYLE,
+            RESET_STYLE,
+            type,
+            event.finishReason ?? 'n/a',
+            event.usage ?? '',
+          );
+        }
         break;
       case 'reasoning':
       case 'reasoning-delta':
         callbacks.onReasoningDelta();
-        // Don't log every reasoning delta to avoid flooding
         break;
       case 'error':
+        callbacks.onErrorEvent();
         console.error(
-          '%c[AI Chat Debug]%c Stream error:',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
+          '%c[AI Chat]%c SSE error event:',
+          PREFIX_STYLE,
+          RESET_STYLE,
           event,
         );
         break;
       default:
-        console.log(
-          '%c[AI Chat Debug]%c SSE event [%s]:',
-          'color:#7c3aed;font-weight:bold',
-          'color:inherit',
-          type,
-          event,
-        );
+        if (verbose) {
+          console.log(
+            '%c[AI Chat Debug]%c SSE event [%s]:',
+            PREFIX_STYLE,
+            RESET_STYLE,
+            type,
+            event,
+          );
+        }
         break;
     }
   } catch {

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -209,7 +209,13 @@ function logFetchError(args: {
       );
     }
     if (e?.stack) {
-      console.error('%c[AI Chat]%c %s stack:', PREFIX_STYLE, RESET_STYLE, args.requestId, e.stack);
+      console.error(
+        '%c[AI Chat]%c %s stack:',
+        PREFIX_STYLE,
+        RESET_STYLE,
+        args.requestId,
+        e.stack,
+      );
     }
   } catch {
     // Ignore logging errors

--- a/plugins/ai-chat/src/hooks/useChatSetup.ts
+++ b/plugins/ai-chat/src/hooks/useChatSetup.ts
@@ -91,14 +91,26 @@ export function useChatSetup(options?: UseChatSetupOptions) {
     }
   }, [isNewConversation, featureFlagsApi]);
 
-  // Verbose debugging is only enabled in non-production builds to avoid
-  // leaking backend internals (system prompt, tool schemas) to end users
-  // who toggle the feature flag in production.
+  // Verbose debugging adds payload-level inspection (request body, system
+  // prompt, tool schemas, per-event SSE log). It must stay gated on
+  // non-production builds because those payloads include the system prompt
+  // and tool descriptions; even with the feature flag toggled they should
+  // not leak to end users on a production deployment.
   const verboseDebugging =
     process.env.NODE_ENV !== 'production' &&
     featureFlagsApi.isActive('ai-chat-verbose-debugging');
+  // The lightweight network-diagnostic tier is always installed: it logs
+  // request URLs, response status / headers, fetch errors and SSE stream
+  // termination details (clean finish vs. premature close vs. error event)
+  // to the browser console. None of this exposes message content or backend
+  // internals -- it is the minimum needed to triage a "Network error"
+  // banner from a user report.
   const debugFetch = useMemo(
-    () => (verboseDebugging ? createDebugFetch() : undefined),
+    () =>
+      createDebugFetch({
+        verbose: verboseDebugging,
+        getConversationId: () => conversationIdRef.current,
+      }),
     [verboseDebugging],
   );
 


### PR DESCRIPTION
## Summary

When the AI chat shows a "Network error" banner the previous build had no always-on instrumentation: `createDebugFetch` was only installed in non-production builds with the `ai-chat-verbose-debugging` feature flag enabled, so a real user report had nothing actionable in the browser console.

This PR splits the wrapper into two tiers:

- **Always-on, prod-safe** -- request URL + method + conversation id, response status + a curated set of headers (`content-type`, `transfer-encoding`, `cache-control`, `connection`, `x-conversation-id`, the `x-envoy-*` set used to diagnose gateway timeouts, `x-request-id`, `server`), fetch-level errors (`TypeError` / `AbortError` / TLS) with stack and elapsed time, and explicit SSE stream outcome detection -- clean finish, error event, premature close without a finish event, zero-event close, and mid-stream read errors. None of these payloads expose message content or backend internals.
- **Verbose** (unchanged: gated on `ai-chat-verbose-debugging` feature flag in non-prod builds) -- request body, backend metadata, system prompt, per-event SSE log.

Per-request `req-XXXXXX` ids correlate every log line for one chat turn (including the verbose group entries when the flag is on) and align with the backend's `X-Conversation-Id` so a user-reported banner can be cross-referenced against `ai-chat-backend` structured logs.

## Test plan

- [x] `yarn workspace @giantswarm/backstage-plugin-ai-chat run lint`
- [x] `yarn workspace @giantswarm/backstage-plugin-ai-chat run build`
- [x] `yarn workspace @giantswarm/backstage-plugin-ai-chat run test`
- [ ] Reproduce a "Network error" banner against the running deployment and confirm the console logs identify whether the failure is a fetch error, an in-stream error event, or a premature close (with the last event type and `x-envoy-*` headers visible).

Made with [Cursor](https://cursor.com)