### PR TITLE
Release v0.129.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
+## [0.129.2] - 2026-05-10
+
+### Fixed
+
+- AI chat instrumentation: render the SSE stream summary inline in the log message (`bytes=... events=... sawFinish=... lastEventType=...`) instead of attaching it as a trailing object argument, so it stays readable in browser-console consumers that flatten the args array (devtools-snapshotters, log shippers, the Cursor IDE browser, etc.) rather than collapsing to "[object Object]". Also classify a stream read error that arrives after a `finish` event was already parsed as a post-completion teardown (`console.warn`, message already committed) instead of a network failure (`console.error`); this matches the actual semantics of the AI SDK aborting the underlying fetch once it has finished consuming the stream.
+
+See [./docs/releases/v0.129.2-changelog.md](./docs/releases/v0.129.2-changelog.md) for more information.
+
 ## [0.129.1] - 2026-05-10
 
 ### Fixed
@@ -2447,7 +2455,8 @@ See [./docs/releases/v0.40.0-changelog.md](./docs/releases/v0.40.0-changelog.md)
 
 - Disable anonymous access.
 
-[Unreleased]: https://github.com/giantswarm/backstage/compare/v0.129.1...HEAD
+[Unreleased]: https://github.com/giantswarm/backstage/compare/v0.129.2...HEAD
+[0.129.2]: https://github.com/giantswarm/backstage/compare/v0.129.1...v0.129.2
 [0.129.1]: https://github.com/giantswarm/backstage/compare/v0.129.0...v0.129.1
 [0.129.0]: https://github.com/giantswarm/backstage/compare/v0.128.1...v0.129.0
 [0.128.1]: https://github.com/giantswarm/backstage/compare/v0.128.0...v0.128.1

--- a/docs/releases/v0.129.2-changelog.md
+++ b/docs/releases/v0.129.2-changelog.md
@@ -1,0 +1,7 @@
+# Release v0.129.2
+
+## @giantswarm/backstage-plugin-ai-chat@0.13.4
+
+### Patch Changes
+
+- AI chat instrumentation: render the SSE stream summary inline in the log message (`bytes=... events=... sawFinish=... lastEventType=...`) instead of attaching it as a trailing object argument, so it stays readable in browser-console consumers that flatten the args array (devtools-snapshotters, log shippers, the Cursor IDE browser, etc.) rather than collapsing to "[object Object]". Also classify a stream read error that arrives after a `finish` event was already parsed as a post-completion teardown (`console.warn`, message already committed) instead of a network failure (`console.error`); this matches the actual semantics of the AI SDK aborting the underlying fetch once it has finished consuming the stream.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.129.1",
+  "version": "0.129.2",
   "private": true,
   "engines": {
     "node": "22 || 24"

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -447,71 +447,104 @@ function reportStreamOutcome(args: {
   const duration = (args.totalDurationMs / 1000).toFixed(1);
   const conv = args.conversationId ? ` (conv ${args.conversationId})` : '';
 
-  const summary = {
-    bytes: counters.totalBytes,
-    events: counters.totalEvents,
-    textDeltaChars: counters.textDeltaChars,
-    toolCalls: counters.toolCalls,
-    reasoningDeltas: counters.reasoningDeltas,
-    steps: counters.steps,
-    finishReason: counters.lastFinishReason,
-    firstByteMs: counters.firstByteAtMs?.toFixed(0),
-    lastEventMs: counters.lastEventAtMs?.toFixed(0),
-    lastEventType: counters.lastEventType,
-  };
+  // Render the structured summary inline as a single JSON-shaped string so
+  // it survives consumers that flatten the args[] array (Cursor's IDE
+  // browser, log shippers that .join() the args, ...). Passing an object
+  // as a trailing `console.error` argument renders nicely in Chrome
+  // devtools but collapses to "[object Object]" everywhere else.
+  const summaryStr =
+    `summary={` +
+    [
+      `bytes=${counters.totalBytes}`,
+      `events=${counters.totalEvents}`,
+      `textDeltaChars=${counters.textDeltaChars}`,
+      `reasoningDeltas=${counters.reasoningDeltas}`,
+      `steps=${counters.steps}`,
+      `toolCalls=[${counters.toolCalls.join(', ')}]`,
+      `sawFinish=${counters.sawFinish}`,
+      `finishReason=${counters.lastFinishReason ?? 'n/a'}`,
+      `firstByteMs=${counters.firstByteAtMs?.toFixed(0) ?? 'n/a'}`,
+      `lastEventMs=${counters.lastEventAtMs?.toFixed(0) ?? 'n/a'}`,
+      `lastEventType=${counters.lastEventType ?? 'none'}`,
+    ].join(' ') +
+    `}`;
 
   if (args.readError) {
     const e = args.readError as { name?: string; message?: string };
+    const errName = e?.name ?? typeof args.readError;
+    const errMsg = e?.message ?? String(args.readError);
+
+    if (counters.sawFinish) {
+      // The stream emitted a `finish` event before the read errored, so
+      // the assistant message was committed successfully. The teardown
+      // error is then a post-completion artifact -- typically the AI
+      // SDK aborting the underlying fetch to release the body once it
+      // has finished consuming. Log informationally so it isn't
+      // mistaken for a real network failure.
+      console.warn(
+        '%c[AI Chat]%c %s SSE stream torn down AFTER `finish` (post-completion teardown, message already committed) in %ss%s -- %s: %s %s',
+        PREFIX_STYLE,
+        RESET_STYLE,
+        args.requestId,
+        duration,
+        conv,
+        errName,
+        errMsg,
+        summaryStr,
+      );
+      return;
+    }
+
     console.error(
-      '%c[AI Chat]%c %s SSE STREAM READ FAILED after %ss%s -- %s: %s',
+      '%c[AI Chat]%c %s SSE STREAM READ FAILED after %ss%s -- %s: %s %s',
       PREFIX_STYLE,
       RESET_STYLE,
       args.requestId,
       duration,
       conv,
-      e?.name ?? typeof args.readError,
-      e?.message ?? String(args.readError),
-      summary,
+      errName,
+      errMsg,
+      summaryStr,
     );
     return;
   }
 
   if (counters.sawErrorEvent) {
     console.error(
-      '%c[AI Chat]%c %s SSE stream contained an `error` event after %ss%s',
+      '%c[AI Chat]%c %s SSE stream contained an `error` event after %ss%s %s',
       PREFIX_STYLE,
       RESET_STYLE,
       args.requestId,
       duration,
       conv,
-      summary,
+      summaryStr,
     );
     return;
   }
 
   if (!counters.sawFinish && counters.totalEvents > 0) {
     console.warn(
-      '%c[AI Chat]%c %s SSE stream ended WITHOUT a `finish` event after %ss%s -- last event was `%s` -- this is the typical fingerprint of a proxy / gateway stream timeout or upstream disconnect',
+      '%c[AI Chat]%c %s SSE stream ended WITHOUT a `finish` event after %ss%s -- last event was `%s` -- this is the typical fingerprint of a proxy / gateway stream timeout or upstream disconnect %s',
       PREFIX_STYLE,
       RESET_STYLE,
       args.requestId,
       duration,
       conv,
       counters.lastEventType ?? 'none',
-      summary,
+      summaryStr,
     );
     return;
   }
 
   if (counters.totalEvents === 0) {
     console.warn(
-      '%c[AI Chat]%c %s SSE stream produced no events after %ss%s -- response body closed without any data',
+      '%c[AI Chat]%c %s SSE stream produced no events after %ss%s -- response body closed without any data %s',
       PREFIX_STYLE,
       RESET_STYLE,
       args.requestId,
       duration,
       conv,
-      summary,
+      summaryStr,
     );
     return;
   }

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -452,22 +452,20 @@ function reportStreamOutcome(args: {
   // browser, log shippers that .join() the args, ...). Passing an object
   // as a trailing `console.error` argument renders nicely in Chrome
   // devtools but collapses to "[object Object]" everywhere else.
-  const summaryStr =
-    `summary={` +
-    [
-      `bytes=${counters.totalBytes}`,
-      `events=${counters.totalEvents}`,
-      `textDeltaChars=${counters.textDeltaChars}`,
-      `reasoningDeltas=${counters.reasoningDeltas}`,
-      `steps=${counters.steps}`,
-      `toolCalls=[${counters.toolCalls.join(', ')}]`,
-      `sawFinish=${counters.sawFinish}`,
-      `finishReason=${counters.lastFinishReason ?? 'n/a'}`,
-      `firstByteMs=${counters.firstByteAtMs?.toFixed(0) ?? 'n/a'}`,
-      `lastEventMs=${counters.lastEventAtMs?.toFixed(0) ?? 'n/a'}`,
-      `lastEventType=${counters.lastEventType ?? 'none'}`,
-    ].join(' ') +
-    `}`;
+  const summaryFields = [
+    `bytes=${counters.totalBytes}`,
+    `events=${counters.totalEvents}`,
+    `textDeltaChars=${counters.textDeltaChars}`,
+    `reasoningDeltas=${counters.reasoningDeltas}`,
+    `steps=${counters.steps}`,
+    `toolCalls=[${counters.toolCalls.join(', ')}]`,
+    `sawFinish=${counters.sawFinish}`,
+    `finishReason=${counters.lastFinishReason ?? 'n/a'}`,
+    `firstByteMs=${counters.firstByteAtMs?.toFixed(0) ?? 'n/a'}`,
+    `lastEventMs=${counters.lastEventAtMs?.toFixed(0) ?? 'n/a'}`,
+    `lastEventType=${counters.lastEventType ?? 'none'}`,
+  ].join(' ');
+  const summaryStr = `summary={${summaryFields}}`;
 
   if (args.readError) {
     const e = args.readError as { name?: string; message?: string };


### PR DESCRIPTION
## Summary

Two follow-up fixes to the v0.129.1 ai-chat network instrumentation, bundled with the version bump so we don't pay for two PR round-trips:

- **Inline summary in the log line**. The SSE stream summary (`bytes=... events=... sawFinish=... lastEventType=...`) is now part of the format string itself rather than a trailing object argument. Passing an object as the last printf-style arg renders nicely in Chrome devtools but consumers that flatten the `args[]` (the Cursor IDE-browser console reader, log shippers, devtools snapshotters) collapse it to `[object Object]` and the structured detail is lost. Today's reproduction needed a re-read of the actual reader to recover the counters.
- **Classify post-`finish` read errors as teardown, not failure**. The 14:12:30Z reproduction on spidertron showed Envoy logging `response_flags: DC` (downstream remote disconnect) at the exact instant my cloned reader tripped on `TypeError: network error`, while the assistant message was already fully rendered with Copy/Regenerate buttons. That is the AI SDK aborting the underlying fetch to release the body once it has finished consuming -- the cloned tee branch then sees the source error, but no real network outage occurred. We now split the two cases: read errors after a `finish` event was already parsed log as `console.warn` ("stream torn down AFTER `finish`, message already committed"); only read errors with no preceding `finish` log as `console.error`.

## Test plan

- [x] `tsc --noEmit` clean (via the same build path as v0.129.1)
- [x] `prettier --check` clean
- [ ] Once shipped on spidertron: reproduce a "Network error" and confirm the summary string is now readable in the cursor-ide-browser console output (no more `[object Object]`), and that the post-`finish` teardown is logged as a warn rather than as an error.


Made with [Cursor](https://cursor.com)