### PR TITLE
Release v0.129.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
+## [0.129.3] - 2026-05-10
+
+### Fixed
+
+- Stabilise the AI chat transport across React renders. `useChatSetup` constructed a fresh `AssistantChatTransport` on every render and handed it to `useChatRuntime`; when its identity changed mid-stream (e.g. as a side effect of a state update triggered by streamed `reasoning-delta` / `tool-input-delta` events), the runtime tore down the in-flight chat fetch with `TypeError: network error`. Envoy logged the symptom as `response_flags: DC` (downstream remote disconnect) against a healthy Backstage upstream while the SSE stream summary was `sawFinish=false`, last event `tool-input-delta`, surfacing in the UI as a "Network error" banner even though no real network outage occurred. The transport is now memoised on the resolved API URL and the stable `getHeaders` / `debugFetch` callbacks, so a single transport lives for the component's lifetime.
+- AI chat instrumentation: observe the caller's `AbortSignal` and log abort events with the reason inline (`ABORT signaled by client at <ms> -- reason: <name>: <message>`). Stream-outcome lines now annotate aborted streams with `[client-aborted at Nms reason="..."]` so a "Network error" banner can be classified as a deliberate client cancel (transport rebuild, unmount, manual stop) versus a real proxy / network failure (no abort signal fired, raw stream error). Read errors that fired after the caller aborted are now logged as `console.warn` ("cancelled by client AbortSignal") rather than `console.error` ("STREAM READ FAILED"), reserving the latter for the genuine pre-`finish`, non-aborted failure mode.
+
+See [./docs/releases/v0.129.3-changelog.md](./docs/releases/v0.129.3-changelog.md) for more information.
+
 ## [0.129.2] - 2026-05-10
 
 ### Fixed
@@ -2455,7 +2464,8 @@ See [./docs/releases/v0.40.0-changelog.md](./docs/releases/v0.40.0-changelog.md)
 
 - Disable anonymous access.
 
-[Unreleased]: https://github.com/giantswarm/backstage/compare/v0.129.2...HEAD
+[Unreleased]: https://github.com/giantswarm/backstage/compare/v0.129.3...HEAD
+[0.129.3]: https://github.com/giantswarm/backstage/compare/v0.129.2...v0.129.3
 [0.129.2]: https://github.com/giantswarm/backstage/compare/v0.129.1...v0.129.2
 [0.129.1]: https://github.com/giantswarm/backstage/compare/v0.129.0...v0.129.1
 [0.129.0]: https://github.com/giantswarm/backstage/compare/v0.128.1...v0.129.0

--- a/docs/releases/v0.129.3-changelog.md
+++ b/docs/releases/v0.129.3-changelog.md
@@ -1,0 +1,8 @@
+# Release v0.129.3
+
+## @giantswarm/backstage-plugin-ai-chat@0.13.5
+
+### Patch Changes
+
+- Stabilise the `AssistantChatTransport` across `useChatSetup` renders. Constructing a fresh transport on every render caused `useChatRuntime` to tear down in-flight chat fetches mid-stream when its identity changed (e.g. as a side effect of a React state update triggered by streamed `reasoning-delta` / `tool-input-delta` events), surfacing in the UI as a "Network error" banner. The transport is now memoised so a single instance lives for the component's lifetime.
+- Observe the caller's `AbortSignal` in the chat fetch wrapper and log abort events with reason inline. Stream-outcome lines now annotate aborted streams with `[client-aborted at Nms reason="..."]` so a "Network error" can be classified as a deliberate client cancel versus a real proxy / network failure. Read errors that fired after a client abort log as `console.warn` ("cancelled by client AbortSignal"), reserving `console.error` ("SSE STREAM READ FAILED") for the genuine pre-`finish`, non-aborted failure mode.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.129.2",
+  "version": "0.129.3",
   "private": true,
   "engines": {
     "node": "22 || 24"

--- a/plugins/ai-chat/src/hooks/createDebugFetch.ts
+++ b/plugins/ai-chat/src/hooks/createDebugFetch.ts
@@ -55,6 +55,38 @@ export function createDebugFetch(
     const method = (init?.method ?? 'GET').toUpperCase();
     const startedAt = performance.now();
     const conversationId = safeCall(getConversationId);
+    // Tracks whether the caller's AbortSignal fired during this fetch's
+    // lifetime, and what reason was attached. The AI SDK runtime
+    // typically wires its own AbortController.signal here; observing it
+    // tells us whether a stream that ended in `TypeError: network error`
+    // was canceled by the runtime (deliberate abort with a reason -- e.g.
+    // unmount, transport-rebuild, manual stop) or by a real network /
+    // proxy-side disconnect (signal never aborted).
+    const abortObservation: AbortObservation = {
+      aborted: init?.signal?.aborted === true,
+      reason: undefined,
+      atMs: undefined,
+    };
+    const abortListener = () => {
+      abortObservation.aborted = true;
+      abortObservation.reason = init?.signal?.reason;
+      abortObservation.atMs = performance.now() - startedAt;
+      try {
+        const reasonStr = formatAbortReason(init?.signal?.reason);
+        console.warn(
+          '%c[AI Chat]%c %s ABORT signaled by client at %sms%s -- reason: %s',
+          PREFIX_STYLE,
+          RESET_STYLE,
+          requestId,
+          abortObservation.atMs.toFixed(0),
+          conversationId ? ` (conv ${conversationId})` : '',
+          reasonStr,
+        );
+      } catch {
+        // Ignore logging errors
+      }
+    };
+    init?.signal?.addEventListener('abort', abortListener, { once: true });
 
     logRequestStart({ requestId, url, method, conversationId });
 
@@ -96,6 +128,7 @@ export function createDebugFetch(
         conversationId,
         response: cloned,
         verbose,
+        abortObservation,
       });
     } catch {
       // Cloning a streaming Response can fail in rare browser edge cases;
@@ -104,6 +137,25 @@ export function createDebugFetch(
 
     return response;
   };
+}
+
+interface AbortObservation {
+  aborted: boolean;
+  reason: unknown;
+  atMs: number | undefined;
+}
+
+function formatAbortReason(reason: unknown): string {
+  if (reason === undefined || reason === null) return 'no reason';
+  if (reason instanceof Error) {
+    return `${reason.name}: ${reason.message}`;
+  }
+  if (typeof reason === 'string') return reason;
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
 }
 
 function safeCall<T>(fn: (() => T) | undefined): T | undefined {
@@ -333,6 +385,7 @@ async function instrumentSSEStream(args: {
   conversationId: string | undefined;
   response: Response;
   verbose: boolean;
+  abortObservation: AbortObservation;
 }): Promise<void> {
   const body = args.response.body;
   if (!body) return;
@@ -399,6 +452,7 @@ async function instrumentSSEStream(args: {
     counters,
     totalDurationMs: totalDuration,
     readError,
+    abortObservation: args.abortObservation,
   });
 }
 
@@ -442,10 +496,14 @@ function reportStreamOutcome(args: {
   counters: StreamCounters;
   totalDurationMs: number;
   readError: unknown;
+  abortObservation: AbortObservation;
 }) {
   const { counters } = args;
   const duration = (args.totalDurationMs / 1000).toFixed(1);
   const conv = args.conversationId ? ` (conv ${args.conversationId})` : '';
+  const abortNote = args.abortObservation.aborted
+    ? ` [client-aborted at ${args.abortObservation.atMs?.toFixed(0) ?? '?'}ms reason="${formatAbortReason(args.abortObservation.reason)}"]`
+    : '';
 
   // Render the structured summary inline as a single JSON-shaped string so
   // it survives consumers that flatten the args[] array (Cursor's IDE
@@ -480,12 +538,34 @@ function reportStreamOutcome(args: {
       // has finished consuming. Log informationally so it isn't
       // mistaken for a real network failure.
       console.warn(
-        '%c[AI Chat]%c %s SSE stream torn down AFTER `finish` (post-completion teardown, message already committed) in %ss%s -- %s: %s %s',
+        '%c[AI Chat]%c %s SSE stream torn down AFTER `finish` (post-completion teardown, message already committed) in %ss%s%s -- %s: %s %s',
         PREFIX_STYLE,
         RESET_STYLE,
         args.requestId,
         duration,
         conv,
+        abortNote,
+        errName,
+        errMsg,
+        summaryStr,
+      );
+      return;
+    }
+
+    if (args.abortObservation.aborted) {
+      // The caller's AbortSignal fired before/while the stream was being
+      // read. That's a deliberate client-side cancel (transport rebuild,
+      // component unmount, manual stop, or a useChatRuntime that sees a
+      // dependency change). Distinguish from a real network outage so
+      // the banner can be classified correctly.
+      console.warn(
+        '%c[AI Chat]%c %s SSE stream cancelled by client AbortSignal after %ss%s%s -- %s: %s %s',
+        PREFIX_STYLE,
+        RESET_STYLE,
+        args.requestId,
+        duration,
+        conv,
+        abortNote,
         errName,
         errMsg,
         summaryStr,
@@ -494,12 +574,13 @@ function reportStreamOutcome(args: {
     }
 
     console.error(
-      '%c[AI Chat]%c %s SSE STREAM READ FAILED after %ss%s -- %s: %s %s',
+      '%c[AI Chat]%c %s SSE STREAM READ FAILED after %ss%s%s -- %s: %s %s',
       PREFIX_STYLE,
       RESET_STYLE,
       args.requestId,
       duration,
       conv,
+      abortNote,
       errName,
       errMsg,
       summaryStr,

--- a/plugins/ai-chat/src/hooks/useChatSetup.ts
+++ b/plugins/ai-chat/src/hooks/useChatSetup.ts
@@ -178,14 +178,30 @@ export function useChatSetup(options?: UseChatSetupOptions) {
     };
   }, [identityApi, getMCPAuthHeaders, verboseDebugging]);
 
+  // The transport must be stable across renders. `useChatRuntime` keeps an
+  // internal AbortController per in-flight stream and tears it down when the
+  // transport identity changes; constructing a new transport on every render
+  // (even with logically identical config) was observed to cancel
+  // mid-stream chat fetches with a `TypeError: network error` (Envoy logs
+  // `response_flags: DC` against the Backstage upstream while
+  // `sawFinish=false` and the model was actively emitting
+  // `reasoning-delta` / `tool-input-delta` events). Memoising on the
+  // resolved api URL and the stable `getHeaders` / `debugFetch` callbacks
+  // keeps a single transport for the lifetime of the component.
+  const transport = useMemo(
+    () =>
+      new AssistantChatTransport({
+        api: apiUrl,
+        headers: getHeaders,
+        fetch: debugFetch,
+      }),
+    [apiUrl, getHeaders, debugFetch],
+  );
+
   const runtime = useChatRuntime({
     messages: options?.initialMessages,
     sendAutomaticallyWhen: shouldSendAutomatically,
-    transport: new AssistantChatTransport({
-      api: apiUrl,
-      headers: getHeaders,
-      fetch: debugFetch,
-    }),
+    transport,
   });
 
   return {


### PR DESCRIPTION
## Summary

Two coupled fixes around the "Network error" reproduction on the spidertron BWI demo at 21:53:00Z 2026-05-10. The v0.129.2 instrumentation made the failure observable for the first time:

- `req-ij8m4s` ran for 2.9s, got 200 + `text/event-stream`, streamed 93 SSE events (85 `reasoning-delta` + 8 `tool-input-delta`) totalling 6.2 KB, then died with `TypeError: network error`.
- `sawFinish=false`, `lastEventType=tool-input-delta`.
- Envoy logged the same request as `response_flags: DC` (downstream remote disconnect) against a healthy Backstage upstream.

So the cut was client-side, mid-stream, while the model was actively emitting tool-call arguments. Two changes:

- **Stabilise the `AssistantChatTransport` across `useChatSetup` renders.** `useChatSetup` was constructing a fresh transport on every render and handing it to `useChatRuntime`. The runtime keeps an internal AbortController per in-flight stream and tears it down when transport identity changes; React state updates triggered by streamed deltas (each `reasoning-delta` / `tool-input-delta` is rendered into the thread) re-render the component, build a new transport, and the in-flight fetch is canceled. The transport is now memoised on the resolved API URL and the stable `getHeaders` / `debugFetch` callbacks.
- **Observe the caller's `AbortSignal` in `createDebugFetch`.** The wrapper now attaches an `abort` listener to `init.signal` and logs the abort reason at the moment it fires. Stream-outcome lines annotate aborted streams with `[client-aborted at Nms reason="..."]`. Read errors that fired after a client abort are downgraded to `console.warn`; `console.error` ("SSE STREAM READ FAILED") is reserved for the genuine pre-`finish`, non-aborted failure mode. This lets us prove on the next reproduction whether the transport-stability fix actually closed the symptom or whether there's a deeper abort path still in play.

## Test plan

- [x] tsc / prettier / eslint clean locally (validated through the same paths CI uses).
- [ ] Once shipped on spidertron: confirm "Network error" banner no longer fires on multi-turn chats with reasoning + tool-input streaming. If it does, the abort observation will pin the abort reason inline in the console, and we'll know whether to chase the SDK runtime, react-ai-sdk, or something else.


Made with [Cursor](https://cursor.com)