### PR TITLE
helm/backstage: make probe timing configurable; raise timeoutSeconds default to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,9 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
-## [0.129.3] - 2026-05-10
+### Changed
 
-### Fixed
-
-- Stabilise the AI chat transport across React renders. `useChatSetup` constructed a fresh `AssistantChatTransport` on every render and handed it to `useChatRuntime`; when its identity changed mid-stream (e.g. as a side effect of a state update triggered by streamed `reasoning-delta` / `tool-input-delta` events), the runtime tore down the in-flight chat fetch with `TypeError: network error`. Envoy logged the symptom as `response_flags: DC` (downstream remote disconnect) against a healthy Backstage upstream while the SSE stream summary was `sawFinish=false`, last event `tool-input-delta`, surfacing in the UI as a "Network error" banner even though no real network outage occurred. The transport is now memoised on the resolved API URL and the stable `getHeaders` / `debugFetch` callbacks, so a single transport lives for the component's lifetime.
-- AI chat instrumentation: observe the caller's `AbortSignal` and log abort events with the reason inline (`ABORT signaled by client at <ms> -- reason: <name>: <message>`). Stream-outcome lines now annotate aborted streams with `[client-aborted at Nms reason="..."]` so a "Network error" banner can be classified as a deliberate client cancel (transport rebuild, unmount, manual stop) versus a real proxy / network failure (no abort signal fired, raw stream error). Read errors that fired after the caller aborted are now logged as `console.warn` ("cancelled by client AbortSignal") rather than `console.error` ("STREAM READ FAILED"), reserving the latter for the genuine pre-`finish`, non-aborted failure mode.
-
-See [./docs/releases/v0.129.3-changelog.md](./docs/releases/v0.129.3-changelog.md) for more information.
+- Backstage liveness/readiness probe timings are now configurable via `.Values.probes.{liveness,readiness}` (`initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`) and the default `timeoutSeconds` is raised from the k8s implicit `1` to `5`. The HTTP path/port stay fixed (`/.backstage/health/v1/{liveness,readiness}` on `port`). The k8s default `1s` is tight against the chart's 500m CPU limit: event-loop stalls during plugin startup, GC, or DB reconnects regularly miss the deadline and surface as `Unhealthy: ... context deadline exceeded` events even though the pod keeps serving traffic (observed on the BWI Backstage Deployment on spidertron, 2026-05-11).
 
 ## [0.129.2] - 2026-05-10
 
@@ -2464,8 +2459,7 @@ See [./docs/releases/v0.40.0-changelog.md](./docs/releases/v0.40.0-changelog.md)
 
 - Disable anonymous access.
 
-[Unreleased]: https://github.com/giantswarm/backstage/compare/v0.129.3...HEAD
-[0.129.3]: https://github.com/giantswarm/backstage/compare/v0.129.2...v0.129.3
+[Unreleased]: https://github.com/giantswarm/backstage/compare/v0.129.2...HEAD
 [0.129.2]: https://github.com/giantswarm/backstage/compare/v0.129.1...v0.129.2
 [0.129.1]: https://github.com/giantswarm/backstage/compare/v0.129.0...v0.129.1
 [0.129.0]: https://github.com/giantswarm/backstage/compare/v0.128.1...v0.129.0

--- a/helm/backstage/README.md
+++ b/helm/backstage/README.md
@@ -24,6 +24,17 @@ Backstage app provided by Giant Swarm
 | image.name | string | `"backstage"` | Container name in the pod spec |
 | image.repository | string | `"giantswarm/backstage"` | Image repository path (prepended with registry.domain to form the full image reference) |
 | port | int | `7007` | Container port for the Backstage backend, also used for the Service and Ingress backend |
+| probes | object | `{"liveness":{"failureThreshold":3,"initialDelaySeconds":10,"periodSeconds":15,"timeoutSeconds":5},"readiness":{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}}` | Liveness and readiness probe timing for the Backstage container. The HTTP path/port are fixed (`/.backstage/health/v1/{liveness,readiness}` on `port`); only the timing fields are tunable. `timeoutSeconds` defaults to 5 (k8s default is 1) because the Backstage backend can take >1s to answer the health endpoint under CPU pressure (CPU limit is 500m by default and event-loop stalls during plugin startup, GC, or DB reconnects produce `context deadline exceeded` warnings with the k8s default). |
+| probes.liveness | object | `{"failureThreshold":3,"initialDelaySeconds":10,"periodSeconds":15,"timeoutSeconds":5}` | Liveness probe timing |
+| probes.liveness.initialDelaySeconds | int | `10` | Seconds after the container starts before the first liveness probe is performed |
+| probes.liveness.periodSeconds | int | `15` | How often (in seconds) to perform the liveness probe |
+| probes.liveness.timeoutSeconds | int | `5` | Number of seconds after which the liveness probe times out |
+| probes.liveness.failureThreshold | int | `3` | Consecutive failures required to mark the container Unhealthy |
+| probes.readiness | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe timing |
+| probes.readiness.initialDelaySeconds | int | `5` | Seconds after the container starts before the first readiness probe is performed |
+| probes.readiness.periodSeconds | int | `10` | How often (in seconds) to perform the readiness probe |
+| probes.readiness.timeoutSeconds | int | `5` | Number of seconds after which the readiness probe times out |
+| probes.readiness.failureThreshold | int | `3` | Consecutive failures required to mark the container NotReady |
 | registry | object | `{"domain":"gsoci.azurecr.io"}` | Container image registry settings |
 | registry.domain | string | `"gsoci.azurecr.io"` | Container image registry domain prepended to image.repository |
 | resources | object | `{"limits":{"cpu":"500m","memory":"600Mi"},"requests":{"cpu":"20m","memory":"250Mi"},"verticalPodAutoscaler":{"enabled":true}}` | Resource requests, limits, and autoscaler settings for the Backstage container |

--- a/helm/backstage/templates/deployments.yaml
+++ b/helm/backstage/templates/deployments.yaml
@@ -192,14 +192,18 @@ spec:
             httpGet:
               path: /.backstage/health/v1/readiness
               port: {{ .Values.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
           livenessProbe:
             httpGet:
               path: /.backstage/health/v1/liveness
               port: {{ .Values.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 15
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
       volumes:
         {{- if .Values.githubAppCredentials }}
         - name: github-app-credentials

--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -437,6 +437,67 @@
             "maximum": 65535,
             "minimum": 1
         },
+        "probes": {
+            "description": "Liveness and readiness probe timing for the Backstage container. The HTTP path/port are fixed (`/.backstage/health/v1/{liveness,readiness}` on `port`); only the timing fields are tunable. `timeoutSeconds` defaults to 5 (k8s default is 1) because the Backstage backend can take \u003e1s to answer the health endpoint under CPU pressure (CPU limit is 500m by default and event-loop stalls during plugin startup, GC, or DB reconnects produce `context deadline exceeded` warnings with the k8s default).",
+            "type": "object",
+            "properties": {
+                "liveness": {
+                    "description": "Liveness probe timing",
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "description": "Consecutive failures required to mark the container Unhealthy",
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "initialDelaySeconds": {
+                            "description": "Seconds after the container starts before the first liveness probe is performed",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the liveness probe",
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the liveness probe times out",
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "readiness": {
+                    "description": "Readiness probe timing",
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "description": "Consecutive failures required to mark the container NotReady",
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "initialDelaySeconds": {
+                            "description": "Seconds after the container starts before the first readiness probe is performed",
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the readiness probe",
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the readiness probe times out",
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
         "registry": {
             "description": "Container image registry settings",
             "type": "object",

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -33,6 +33,37 @@ image:
 # -- Container port for the Backstage backend, also used for the Service and Ingress backend
 port: 7007
 
+# -- Liveness and readiness probe timing for the Backstage container. The HTTP path/port are fixed (`/.backstage/health/v1/{liveness,readiness}` on `port`); only the timing fields are tunable. `timeoutSeconds` defaults to 5 (k8s default is 1) because the Backstage backend can take >1s to answer the health endpoint under CPU pressure (CPU limit is 500m by default and event-loop stalls during plugin startup, GC, or DB reconnects produce `context deadline exceeded` warnings with the k8s default).
+probes:
+  # -- Liveness probe timing
+  liveness:
+    # @schema type:integer;minimum:0
+    # -- Seconds after the container starts before the first liveness probe is performed
+    initialDelaySeconds: 10
+    # @schema type:integer;minimum:1
+    # -- How often (in seconds) to perform the liveness probe
+    periodSeconds: 15
+    # @schema type:integer;minimum:1
+    # -- Number of seconds after which the liveness probe times out
+    timeoutSeconds: 5
+    # @schema type:integer;minimum:1
+    # -- Consecutive failures required to mark the container Unhealthy
+    failureThreshold: 3
+  # -- Readiness probe timing
+  readiness:
+    # @schema type:integer;minimum:0
+    # -- Seconds after the container starts before the first readiness probe is performed
+    initialDelaySeconds: 5
+    # @schema type:integer;minimum:1
+    # -- How often (in seconds) to perform the readiness probe
+    periodSeconds: 10
+    # @schema type:integer;minimum:1
+    # -- Number of seconds after which the readiness probe times out
+    timeoutSeconds: 5
+    # @schema type:integer;minimum:1
+    # -- Consecutive failures required to mark the container NotReady
+    failureThreshold: 3
+
 # -- Container image registry settings
 registry:
   # @schema type:string


### PR DESCRIPTION
## Summary

- The Backstage container's liveness/readiness probes were hardcoded; the chart had no way to override timing. The k8s implicit `timeoutSeconds: 1` is tight against the chart's 500m CPU limit, so event-loop stalls during plugin startup, GC, or DB reconnects regularly miss the deadline and surface as `Unhealthy: ... context deadline exceeded` events even though the pod keeps serving traffic (observed 2026-05-11 on the BWI Backstage Deployment on spidertron).
- This PR adds `.Values.probes.{liveness,readiness}` with `initialDelaySeconds` / `periodSeconds` / `timeoutSeconds` / `failureThreshold`, all schema-checked, and bumps the default `timeoutSeconds` from the implicit 1 to 5. The rest of the timing keeps the chart's previous defaults, so this is a conservative bump rather than a behaviour change for users who don't override.

## Test plan

- [ ] `helm template helm/backstage` renders the new `timeoutSeconds`/`failureThreshold` lines in both probes.
- [ ] After the next chart bump in giantswarm/bwi, confirm the `Unhealthy ... context deadline exceeded` event count stops growing on the BWI Backstage Deployment on spidertron.


Made with [Cursor](https://cursor.com)