### PR TITLE
Add LatestReleaseProcessor for GitHub release annotations

### DIFF
--- a/.changeset/dark-grape-persist.md
+++ b/.changeset/dark-grape-persist.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-catalog-backend-module-gs': minor
+---
+
+Add `LatestReleaseProcessor` that annotates Component entities carrying a `github.com/project-slug` annotation with `giantswarm.io/latest-release-tag` and `giantswarm.io/latest-release-date` by querying GitHub Releases. Defaults to `/releases/latest`, or matches by tag prefix when `giantswarm.io/release-tag-prefix` is set (for monorepos with prefixed per-subproject tags). Results are cached in-memory per `(owner/repo, prefix)` with a configurable TTL. Gated behind `catalog.processors.latestRelease.enabled`.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -217,6 +217,13 @@ catalog:
   #     # and pagerduty.com/user-id by querying the PagerDuty REST API. Requires
   #     # pagerDuty.apiToken to be set; otherwise the processor stays inactive.
   #     enabled: true
+  #   latestRelease:
+  #     # Annotates Component entities that have github.com/project-slug with
+  #     # giantswarm.io/latest-release-tag and giantswarm.io/latest-release-date.
+  #     # Defaults to GitHub's canonical /releases/latest, or matches by tag
+  #     # prefix when giantswarm.io/release-tag-prefix is set (monorepos).
+  #     enabled: true
+  #     cacheTtlSeconds: 3600
 
 grafana:
   domain: https://example.com

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -58,9 +58,19 @@ An annotation we set on component entities in rare cases to provide a link from 
 
 Specifies the date and time of the latest release (as in a new tagged release in the revision control system) of a component entity. Value must be a string in ISO 8601 format.
 
+Can be set manually, or populated automatically by the `LatestReleaseProcessor` (see `giantswarm.io/release-tag-prefix` and `github.com/project-slug`).
+
 ### giantswarm.io/latest-release-tag
 
 The version tag of the latest release (as in a revision control system) of a component entity.
+
+Can be set manually, or populated automatically by the `LatestReleaseProcessor` (see `giantswarm.io/release-tag-prefix` and `github.com/project-slug`).
+
+### giantswarm.io/release-tag-prefix
+
+Used on component entities that map to a subproject of a monorepo whose releases are tagged with a per-subproject prefix (for example `sre/v0.1.5`). When set together with `github.com/project-slug`, the `LatestReleaseProcessor` paginates the repository's GitHub releases and picks the most recent non-draft release whose `tag_name` starts with this prefix, then writes the resulting tag and date into `giantswarm.io/latest-release-tag` and `giantswarm.io/latest-release-date`.
+
+When the annotation is absent, the processor falls back to GitHub's canonical `/releases/latest` endpoint (newest non-draft, non-prerelease release across the whole repository).
 
 ### github.com/project-slug
 

--- a/plugins/catalog-backend-module-gs/package.json
+++ b/plugins/catalog-backend-module-gs/package.json
@@ -31,6 +31,7 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "backstage:^",
     "@backstage/cli": "backstage:^",
     "@types/js-yaml": "^4"
   },

--- a/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.test.ts
+++ b/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.test.ts
@@ -1,0 +1,333 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import type { Entity } from '@backstage/catalog-model';
+import type { GithubCredentialsProvider } from '@backstage/integration';
+import { LatestReleaseProcessor } from './LatestReleaseProcessor';
+
+const dummyLocation = { type: 'url', target: 'https://example.com' };
+const dummyEmit = jest.fn();
+const dummyCache = { get: jest.fn(), set: jest.fn() } as any;
+
+const credentialsProvider: GithubCredentialsProvider = {
+  getCredentials: jest.fn().mockResolvedValue({ token: 'fake-token' }),
+} as unknown as GithubCredentialsProvider;
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+function component(
+  name: string,
+  annotations: Record<string, string> = {},
+): Entity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name, namespace: 'default', annotations },
+    spec: { type: 'service', lifecycle: 'production', owner: 'team-x' },
+  };
+}
+
+function makeProcessor(fetchImpl: jest.Mock, cacheTtlMs = 60_000) {
+  return new LatestReleaseProcessor({
+    logger: mockServices.logger.mock(),
+    credentialsProvider,
+    cacheTtlMs,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+describe('LatestReleaseProcessor', () => {
+  it('annotates a Component with a project-slug using GitHub /releases/latest', async () => {
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.endsWith('/repos/giantswarm/backstage/releases/latest')) {
+        return jsonResponse({
+          tag_name: 'v0.115.0',
+          published_at: '2026-03-23T13:53:07Z',
+          draft: false,
+          prerelease: false,
+        });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+    const processor = makeProcessor(fetchImpl);
+
+    const entity = component('backstage', {
+      'github.com/project-slug': 'giantswarm/backstage',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(result.metadata.annotations).toMatchObject({
+      'giantswarm.io/latest-release-tag': 'v0.115.0',
+      'giantswarm.io/latest-release-date': '2026-03-23T13:53:07Z',
+    });
+  });
+
+  it('uses release-tag-prefix to match a monorepo child', async () => {
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.includes('/releases?')) {
+        return jsonResponse([
+          {
+            tag_name: 'sre/v0.1.5',
+            published_at: '2026-05-04T12:00:00Z',
+            draft: false,
+            prerelease: false,
+          },
+          {
+            tag_name: 'other/v1.0.0',
+            published_at: '2026-05-05T12:00:00Z',
+            draft: false,
+            prerelease: false,
+          },
+        ]);
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+    const processor = makeProcessor(fetchImpl);
+
+    const entity = component('klaus-personality-sre', {
+      'github.com/project-slug': 'giantswarm/klaus-personalities',
+      'giantswarm.io/release-tag-prefix': 'sre/',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(result.metadata.annotations).toMatchObject({
+      'giantswarm.io/latest-release-tag': 'sre/v0.1.5',
+      'giantswarm.io/latest-release-date': '2026-05-04T12:00:00Z',
+    });
+  });
+
+  it('leaves the entity untouched when /releases/latest returns 404', async () => {
+    const fetchImpl = jest.fn(
+      async () => new Response('not found', { status: 404 }),
+    );
+    const processor = makeProcessor(fetchImpl);
+
+    const entity = component('no-releases', {
+      'github.com/project-slug': 'giantswarm/no-releases',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(
+      result.metadata.annotations?.['giantswarm.io/latest-release-tag'],
+    ).toBeUndefined();
+  });
+
+  it('leaves the entity untouched when no tag matches the prefix', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse([
+        {
+          tag_name: 'other/v1.0.0',
+          published_at: '2026-05-05T12:00:00Z',
+          draft: false,
+          prerelease: false,
+        },
+      ]),
+    );
+    const processor = makeProcessor(fetchImpl);
+
+    const entity = component('klaus-personality-sre', {
+      'github.com/project-slug': 'giantswarm/klaus-personalities',
+      'giantswarm.io/release-tag-prefix': 'sre/',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(
+      result.metadata.annotations?.['giantswarm.io/latest-release-tag'],
+    ).toBeUndefined();
+  });
+
+  it('overwrites existing latest-release annotations with fresh values', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse({
+        tag_name: 'v0.115.0',
+        published_at: '2026-03-23T13:53:07Z',
+        draft: false,
+        prerelease: false,
+      }),
+    );
+    const processor = makeProcessor(fetchImpl);
+
+    const entity = component('backstage', {
+      'github.com/project-slug': 'giantswarm/backstage',
+      'giantswarm.io/latest-release-tag': 'stale-tag',
+      'giantswarm.io/latest-release-date': '2020-01-01T00:00:00Z',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(result.metadata.annotations).toMatchObject({
+      'giantswarm.io/latest-release-tag': 'v0.115.0',
+      'giantswarm.io/latest-release-date': '2026-03-23T13:53:07Z',
+    });
+  });
+
+  it('skips non-Component kinds', async () => {
+    const fetchImpl = jest.fn();
+    const processor = makeProcessor(fetchImpl);
+
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'System',
+      metadata: {
+        name: 'klaus',
+        annotations: { 'github.com/project-slug': 'giantswarm/klaus' },
+      },
+      spec: { owner: 'team-x' },
+    };
+    await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('skips entities without github.com/project-slug', async () => {
+    const fetchImpl = jest.fn();
+    const processor = makeProcessor(fetchImpl);
+
+    await processor.preProcessEntity(
+      component('no-slug'),
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('caches per (owner/repo, prefix) and only calls GitHub once within the TTL', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse({
+        tag_name: 'v0.115.0',
+        published_at: '2026-03-23T13:53:07Z',
+        draft: false,
+        prerelease: false,
+      }),
+    );
+    const processor = makeProcessor(fetchImpl);
+
+    const entity = component('backstage', {
+      'github.com/project-slug': 'giantswarm/backstage',
+    });
+
+    await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+    await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent fills for the same cache key', async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    const fetchImpl = jest.fn(
+      () =>
+        new Promise<Response>(resolve => {
+          resolveFetch = resolve;
+        }),
+    );
+    const processor = makeProcessor(fetchImpl as unknown as jest.Mock);
+
+    const entity = component('backstage', {
+      'github.com/project-slug': 'giantswarm/backstage',
+    });
+
+    const p1 = processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+    const p2 = processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+    // Let credentialsProvider + fetchImpl invocation actually happen before
+    // resolving — the inflight dedupe is between getCacheEntry calls, not
+    // between fetchImpl invocations.
+    await new Promise(resolve => setImmediate(resolve));
+    resolveFetch(
+      jsonResponse({
+        tag_name: 'v0.115.0',
+        published_at: '2026-03-23T13:53:07Z',
+        draft: false,
+        prerelease: false,
+      }),
+    );
+    await Promise.all([p1, p2]);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the original entity when the GitHub fetch fails', async () => {
+    const fetchImpl = jest.fn(
+      async () => new Response('forbidden', { status: 403 }),
+    );
+    const processor = makeProcessor(fetchImpl);
+
+    const entity = component('backstage', {
+      'github.com/project-slug': 'giantswarm/backstage',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(result).toBe(entity);
+  });
+});

--- a/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.ts
+++ b/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.ts
@@ -1,0 +1,213 @@
+import type { Entity } from '@backstage/catalog-model';
+import type {
+  CatalogProcessor,
+  CatalogProcessorCache,
+  CatalogProcessorEmit,
+} from '@backstage/plugin-catalog-node';
+import type { LocationSpec } from '@backstage/plugin-catalog-common';
+import type {
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
+import {
+  DefaultGithubCredentialsProvider,
+  type GithubCredentialsProvider,
+  ScmIntegrations,
+} from '@backstage/integration';
+import {
+  getLatestStableRelease,
+  type LatestRelease,
+  listLatestReleasesByPrefix,
+} from '../util/githubReleases';
+
+const PROJECT_SLUG_ANNOTATION = 'github.com/project-slug';
+const RELEASE_TAG_PREFIX_ANNOTATION = 'giantswarm.io/release-tag-prefix';
+const LATEST_RELEASE_TAG_ANNOTATION = 'giantswarm.io/latest-release-tag';
+const LATEST_RELEASE_DATE_ANNOTATION = 'giantswarm.io/latest-release-date';
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000;
+
+type CacheEntry = {
+  release: LatestRelease | undefined;
+  fetchedAt: number;
+};
+
+type FetchFn = typeof fetch;
+
+export class LatestReleaseProcessor implements CatalogProcessor {
+  private readonly logger: LoggerService;
+  private readonly credentialsProvider: GithubCredentialsProvider;
+  private readonly cacheTtlMs: number;
+  private readonly fetchImpl: FetchFn;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inflight = new Map<string, Promise<CacheEntry>>();
+
+  static fromConfig(options: {
+    config: RootConfigService;
+    logger: LoggerService;
+    fetchImpl?: FetchFn;
+  }): LatestReleaseProcessor {
+    const { config, logger, fetchImpl } = options;
+    const integrations = ScmIntegrations.fromConfig(config);
+    const credentialsProvider =
+      DefaultGithubCredentialsProvider.fromIntegrations(integrations);
+    const cacheTtlSeconds = config.getOptionalNumber(
+      'catalog.processors.latestRelease.cacheTtlSeconds',
+    );
+    return new LatestReleaseProcessor({
+      logger,
+      credentialsProvider,
+      cacheTtlMs:
+        cacheTtlSeconds !== undefined
+          ? cacheTtlSeconds * 1000
+          : DEFAULT_CACHE_TTL_MS,
+      fetchImpl,
+    });
+  }
+
+  constructor(options: {
+    logger: LoggerService;
+    credentialsProvider: GithubCredentialsProvider;
+    cacheTtlMs?: number;
+    fetchImpl?: FetchFn;
+  }) {
+    this.logger = options.logger;
+    this.credentialsProvider = options.credentialsProvider;
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  getProcessorName(): string {
+    return 'LatestReleaseProcessor';
+  }
+
+  async preProcessEntity(
+    entity: Entity,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+    _originLocation: LocationSpec,
+    _cache: CatalogProcessorCache,
+  ): Promise<Entity> {
+    if (entity.kind !== 'Component') {
+      return entity;
+    }
+
+    const annotations = entity.metadata.annotations ?? {};
+    const slug = annotations[PROJECT_SLUG_ANNOTATION];
+    if (!slug) {
+      return entity;
+    }
+    const parsed = parseSlug(slug);
+    if (!parsed) {
+      return entity;
+    }
+    const prefix = annotations[RELEASE_TAG_PREFIX_ANNOTATION];
+
+    let entry: CacheEntry;
+    try {
+      entry = await this.getCacheEntry(parsed.owner, parsed.repo, prefix);
+    } catch (error) {
+      this.logger.warn(
+        `LatestReleaseProcessor: failed to fetch release for ${slug}${
+          prefix ? ` (prefix "${prefix}")` : ''
+        }: ${error}`,
+      );
+      return entity;
+    }
+
+    if (!entry.release) {
+      return entity;
+    }
+
+    return withReleaseAnnotations(entity, entry.release);
+  }
+
+  private async getCacheEntry(
+    owner: string,
+    repo: string,
+    prefix: string | undefined,
+  ): Promise<CacheEntry> {
+    const key = `${owner}/${repo}|${prefix ?? ''}`;
+    const now = Date.now();
+    const cached = this.cache.get(key);
+    if (cached && now - cached.fetchedAt < this.cacheTtlMs) {
+      return cached;
+    }
+    const existing = this.inflight.get(key);
+    if (existing) {
+      return existing;
+    }
+    const fill = this.fillCache(owner, repo, prefix)
+      .then(release => {
+        const fresh: CacheEntry = { release, fetchedAt: Date.now() };
+        this.cache.set(key, fresh);
+        return fresh;
+      })
+      .finally(() => {
+        this.inflight.delete(key);
+      });
+    this.inflight.set(key, fill);
+    return fill;
+  }
+
+  private async fillCache(
+    owner: string,
+    repo: string,
+    prefix: string | undefined,
+  ): Promise<LatestRelease | undefined> {
+    const repoUrl = `https://github.com/${owner}/${repo}`;
+    const { token } = await this.credentialsProvider.getCredentials({
+      url: repoUrl,
+    });
+    if (!token) {
+      throw new Error(`No GitHub credentials for ${repoUrl}`);
+    }
+    const label = `LatestReleaseProcessor: ${owner}/${repo}${
+      prefix ? ` prefix=${prefix}` : ''
+    }`;
+    if (prefix) {
+      const map = await listLatestReleasesByPrefix({
+        owner,
+        repo,
+        prefixes: [prefix],
+        token,
+        fetchImpl: this.fetchImpl,
+        logger: this.logger,
+        label,
+      });
+      return map.get(prefix);
+    }
+    return getLatestStableRelease({
+      owner,
+      repo,
+      token,
+      fetchImpl: this.fetchImpl,
+      logger: this.logger,
+      label,
+    });
+  }
+}
+
+function parseSlug(slug: string): { owner: string; repo: string } | undefined {
+  const segments = slug.split('/');
+  if (segments.length !== 2 || !segments[0] || !segments[1]) {
+    return undefined;
+  }
+  return { owner: segments[0], repo: segments[1] };
+}
+
+function withReleaseAnnotations(
+  entity: Entity,
+  release: LatestRelease,
+): Entity {
+  return {
+    ...entity,
+    metadata: {
+      ...entity.metadata,
+      annotations: {
+        ...(entity.metadata.annotations ?? {}),
+        [LATEST_RELEASE_TAG_ANNOTATION]: release.tag,
+        [LATEST_RELEASE_DATE_ANNOTATION]: release.publishedAt,
+      },
+    },
+  };
+}

--- a/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/index.ts
+++ b/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/index.ts
@@ -1,0 +1,1 @@
+export { LatestReleaseProcessor } from './LatestReleaseProcessor';

--- a/plugins/catalog-backend-module-gs/src/module.ts
+++ b/plugins/catalog-backend-module-gs/src/module.ts
@@ -7,6 +7,7 @@ import {
   catalogServiceRef,
 } from '@backstage/plugin-catalog-node';
 import { GiantSwarmLocationProcessor } from './GiantSwarmLocationProcessor';
+import { LatestReleaseProcessor } from './LatestReleaseProcessor';
 import { PagerDutyAnnotationProcessor } from './PagerDutyAnnotationProcessor';
 import { SbomDependencyProcessor } from './SbomDependencyProcessor';
 
@@ -64,6 +65,15 @@ export const catalogModuleGS = createBackendModule({
           if (pdProcessor) {
             catalog.addProcessor(pdProcessor);
           }
+        }
+
+        const latestReleaseEnabled = config.getOptionalBoolean(
+          'catalog.processors.latestRelease.enabled',
+        );
+        if (latestReleaseEnabled) {
+          catalog.addProcessor(
+            LatestReleaseProcessor.fromConfig({ config, logger }),
+          );
         }
       },
     });

--- a/plugins/catalog-backend-module-gs/src/util/githubReleases.test.ts
+++ b/plugins/catalog-backend-module-gs/src/util/githubReleases.test.ts
@@ -1,0 +1,190 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import {
+  getLatestStableRelease,
+  listLatestReleasesByPrefix,
+} from './githubReleases';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function release(
+  tag: string,
+  publishedAt: string,
+  overrides: { draft?: boolean; prerelease?: boolean } = {},
+) {
+  return {
+    tag_name: tag,
+    published_at: publishedAt,
+    draft: overrides.draft ?? false,
+    prerelease: overrides.prerelease ?? false,
+  };
+}
+
+describe('listLatestReleasesByPrefix', () => {
+  it('matches the first non-draft release per prefix', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse([
+        release('sre/v0.2.0', '2026-05-10T10:00:00Z', { draft: true }),
+        release('sre/v0.1.5', '2026-05-04T12:00:00Z'),
+        release('sre/v0.1.4', '2026-05-01T12:00:00Z'),
+        release('devops/v0.0.1-rc.1', '2026-04-30T09:00:00Z', {
+          prerelease: true,
+        }),
+        release('unrelated/v1.0.0', '2026-05-05T12:00:00Z'),
+      ]),
+    );
+
+    const result = await listLatestReleasesByPrefix({
+      owner: 'giantswarm',
+      repo: 'klaus-personalities',
+      prefixes: ['sre/', 'devops/'],
+      token: 'fake',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: mockServices.logger.mock(),
+      label: 'test',
+    });
+
+    expect(result.get('sre/')).toEqual({
+      tag: 'sre/v0.1.5',
+      publishedAt: '2026-05-04T12:00:00Z',
+    });
+    expect(result.get('devops/')).toEqual({
+      tag: 'devops/v0.0.1-rc.1',
+      publishedAt: '2026-04-30T09:00:00Z',
+    });
+  });
+
+  it('returns an empty map when prefixes is empty without calling fetch', async () => {
+    const fetchImpl = jest.fn();
+    const result = await listLatestReleasesByPrefix({
+      owner: 'giantswarm',
+      repo: 'klaus-personalities',
+      prefixes: [],
+      token: 'fake',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: mockServices.logger.mock(),
+      label: 'test',
+    });
+    expect(result.size).toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('paginates until every prefix is matched', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) =>
+      release(`other/v0.0.${i}`, '2026-01-01T00:00:00Z'),
+    );
+    const page2 = [
+      release('sre/v1.0.0', '2026-05-01T00:00:00Z'),
+      release('devops/v2.0.0', '2026-05-02T00:00:00Z'),
+    ];
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.includes('&page=1')) return jsonResponse(page1);
+      if (url.includes('&page=2')) return jsonResponse(page2);
+      return jsonResponse([]);
+    });
+
+    const result = await listLatestReleasesByPrefix({
+      owner: 'giantswarm',
+      repo: 'klaus-personalities',
+      prefixes: ['sre/', 'devops/'],
+      token: 'fake',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: mockServices.logger.mock(),
+      label: 'test',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.get('sre/')?.tag).toBe('sre/v1.0.0');
+    expect(result.get('devops/')?.tag).toBe('devops/v2.0.0');
+  });
+
+  it('stops paginating when a partial page is returned', async () => {
+    const fetchImpl = jest.fn(async () => jsonResponse([]));
+
+    const result = await listLatestReleasesByPrefix({
+      owner: 'giantswarm',
+      repo: 'klaus-personalities',
+      prefixes: ['sre/'],
+      token: 'fake',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: mockServices.logger.mock(),
+      label: 'test',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.size).toBe(0);
+  });
+
+  it('respects the maxPages cap', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) =>
+      release(`other/v0.0.${i}`, '2026-01-01T00:00:00Z'),
+    );
+    const fetchImpl = jest.fn(async () => jsonResponse(fullPage));
+
+    await listLatestReleasesByPrefix({
+      owner: 'giantswarm',
+      repo: 'klaus-personalities',
+      prefixes: ['sre/'],
+      token: 'fake',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: mockServices.logger.mock(),
+      label: 'test',
+      maxPages: 2,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getLatestStableRelease', () => {
+  it('returns the latest stable release', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse({
+        tag_name: 'v0.115.0',
+        published_at: '2026-03-23T13:53:07Z',
+        draft: false,
+        prerelease: false,
+      }),
+    );
+
+    const result = await getLatestStableRelease({
+      owner: 'giantswarm',
+      repo: 'backstage',
+      token: 'fake',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: mockServices.logger.mock(),
+      label: 'test',
+    });
+
+    expect(result).toEqual({
+      tag: 'v0.115.0',
+      publishedAt: '2026-03-23T13:53:07Z',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.github.com/repos/giantswarm/backstage/releases/latest',
+      expect.anything(),
+    );
+  });
+
+  it('returns undefined when no stable release exists (404)', async () => {
+    const fetchImpl = jest.fn(
+      async () => new Response('not found', { status: 404 }),
+    );
+
+    const result = await getLatestStableRelease({
+      owner: 'giantswarm',
+      repo: 'no-releases',
+      token: 'fake',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: mockServices.logger.mock(),
+      label: 'test',
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/plugins/catalog-backend-module-gs/src/util/githubReleases.ts
+++ b/plugins/catalog-backend-module-gs/src/util/githubReleases.ts
@@ -1,0 +1,221 @@
+import type { LoggerService } from '@backstage/backend-plugin-api';
+
+const MAX_RETRIES = 3;
+const DEFAULT_MAX_PAGES = 5;
+const PER_PAGE = 100;
+
+export interface LatestRelease {
+  tag: string;
+  publishedAt: string;
+}
+
+interface GithubRelease {
+  tag_name: string;
+  published_at: string | null;
+  created_at: string | null;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+/**
+ * For each prefix (e.g. `sre/`), finds the latest non-draft release in the
+ * given monorepo whose `tag_name` starts with that prefix. Prereleases are
+ * included. Paginates until every prefix is matched, pages are exhausted, or
+ * the page cap is hit. Returns a map keyed by prefix.
+ */
+export async function listLatestReleasesByPrefix(options: {
+  owner: string;
+  repo: string;
+  prefixes: string[];
+  token: string;
+  fetchImpl?: typeof fetch;
+  logger: LoggerService;
+  label: string;
+  maxPages?: number;
+}): Promise<Map<string, LatestRelease>> {
+  const {
+    owner,
+    repo,
+    prefixes,
+    token,
+    fetchImpl = fetch,
+    logger,
+    label,
+    maxPages = DEFAULT_MAX_PAGES,
+  } = options;
+
+  const result = new Map<string, LatestRelease>();
+  if (prefixes.length === 0) {
+    return result;
+  }
+
+  const pending = new Set(prefixes);
+
+  for (let page = 1; page <= maxPages; page++) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${PER_PAGE}&page=${page}`;
+    const response = await githubFetch({
+      url,
+      token,
+      fetchImpl,
+      logger,
+      label: `${label} releases page ${page}`,
+    });
+    const releases = (await response.json()) as GithubRelease[];
+    if (!Array.isArray(releases) || releases.length === 0) {
+      break;
+    }
+
+    for (const release of releases) {
+      if (release.draft) {
+        continue;
+      }
+      const tag = release.tag_name;
+      if (!tag) {
+        continue;
+      }
+      const matchedPrefix = findMatchingPrefix(tag, pending);
+      if (!matchedPrefix) {
+        continue;
+      }
+      const publishedAt = release.published_at ?? release.created_at;
+      if (!publishedAt) {
+        continue;
+      }
+      result.set(matchedPrefix, { tag, publishedAt });
+      pending.delete(matchedPrefix);
+    }
+
+    if (pending.size === 0) {
+      break;
+    }
+    if (releases.length < PER_PAGE) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Fetches the GitHub-canonical latest release (most recent non-draft,
+ * non-prerelease) for a repo via `/repos/{owner}/{repo}/releases/latest`.
+ * Returns undefined when the repo has no published stable releases.
+ */
+export async function getLatestStableRelease(options: {
+  owner: string;
+  repo: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+  logger: LoggerService;
+  label: string;
+}): Promise<LatestRelease | undefined> {
+  const { owner, repo, token, fetchImpl = fetch, logger, label } = options;
+
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
+  const response = await githubFetch({
+    url,
+    token,
+    fetchImpl,
+    logger,
+    label,
+    allowNotFound: true,
+  });
+  if (response.status === 404) {
+    return undefined;
+  }
+  const release = (await response.json()) as GithubRelease;
+  if (!release?.tag_name) {
+    return undefined;
+  }
+  const publishedAt = release.published_at ?? release.created_at;
+  if (!publishedAt) {
+    return undefined;
+  }
+  return { tag: release.tag_name, publishedAt };
+}
+
+function findMatchingPrefix(
+  tag: string,
+  prefixes: Set<string>,
+): string | undefined {
+  for (const prefix of prefixes) {
+    if (tag.startsWith(prefix)) {
+      return prefix;
+    }
+  }
+  return undefined;
+}
+
+async function githubFetch(options: {
+  url: string;
+  token: string;
+  fetchImpl: typeof fetch;
+  logger: LoggerService;
+  label: string;
+  allowNotFound?: boolean;
+}): Promise<Response> {
+  const {
+    url,
+    token,
+    fetchImpl,
+    logger,
+    label,
+    allowNotFound = false,
+  } = options;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (
+      response.status === 429 ||
+      (response.status >= 500 && response.status < 600)
+    ) {
+      if (attempt < MAX_RETRIES) {
+        const delayMs = getRetryDelayMs(response);
+        logger.info(
+          `${label} returned ${response.status}, retrying in ${Math.ceil(delayMs / 1000)}s (attempt ${attempt + 1}/${MAX_RETRIES})`,
+        );
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        continue;
+      }
+    }
+
+    if (allowNotFound && response.status === 404) {
+      return response;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `GitHub API ${url} returned ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    return response;
+  }
+
+  throw new Error(`GitHub API ${url} failed after ${MAX_RETRIES} retries`);
+}
+
+function getRetryDelayMs(response: Response): number {
+  const rateLimitReset = response.headers.get('x-ratelimit-reset');
+  if (rateLimitReset) {
+    const resetMs = parseInt(rateLimitReset, 10) * 1000;
+    const delayMs = resetMs - Date.now();
+    if (delayMs > 0) {
+      return delayMs;
+    }
+  }
+
+  const retryAfter = response.headers.get('retry-after');
+  if (retryAfter) {
+    return parseInt(retryAfter, 10) * 1000;
+  }
+
+  return 60_000;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10527,6 +10527,7 @@ __metadata:
   resolution: "@giantswarm/backstage-plugin-catalog-backend-module-gs@workspace:plugins/catalog-backend-module-gs"
   dependencies:
     "@backstage/backend-plugin-api": "backstage:^"
+    "@backstage/backend-test-utils": "backstage:^"
     "@backstage/catalog-model": "backstage:^"
     "@backstage/cli": "backstage:^"
     "@backstage/integration": "backstage:^"


### PR DESCRIPTION
### What does this PR do?

Adds a new `LatestReleaseProcessor` in `catalog-backend-module-gs`. For any `Component` entity carrying a `github.com/project-slug` annotation, the processor looks up the latest GitHub release and writes two annotations:

- `giantswarm.io/latest-release-tag`
- `giantswarm.io/latest-release-date`

Two modes:

- **Default**: queries GitHub's canonical `/repos/{owner}/{repo}/releases/latest` (newest non-draft, non-prerelease).
- **Monorepo / prefix mode**: when the entity also carries `giantswarm.io/release-tag-prefix` (e.g. `sre/`), the processor pages through `/releases` and picks the first non-draft release whose `tag_name` starts with that prefix. Prereleases are included in this mode (matches the existing monorepo-level annotation behavior).

Results are cached in-memory keyed by `(owner/repo, prefix)` with a configurable TTL. Concurrent cache fills for the same key are deduped via an inflight map so the first refresh after a TTL expiry doesn't fan out to multiple GitHub calls.

Disabled by default. Enable via:

```yaml
catalog:
  processors:
    latestRelease:
      enabled: true
      cacheTtlSeconds: 3600  # optional, defaults to 1h
```

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))