### PR TITLE
Fix Helm charts column showing "Yes (0)" for entities without charts

### DIFF
--- a/.changeset/jolly-heart-nestle.md
+++ b/.changeset/jolly-heart-nestle.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fix Helm charts column in the catalog showing "Yes (0)" for entities without charts.

--- a/plugins/gs/src/components/catalog/columns.tsx
+++ b/plugins/gs/src/components/catalog/columns.tsx
@@ -151,7 +151,7 @@ export const columnFactories = Object.freeze({
       render: ({ entity }) => {
         const helmCharts = getHelmChartsFromEntity(entity);
 
-        if (!helmCharts) {
+        if (helmCharts.length === 0) {
           return undefined;
         }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the Helm charts column in the catalog table showing "Yes (0)" for entities that do not have any Helm charts attached.

`getHelmChartsFromEntity` always returns an array (never `null`/`undefined`), so the previous `if (!helmCharts)` check never short-circuited and the column rendered `Yes (0)` instead of being empty.

### What is the effect of this change to users?

Entities without Helm charts now render as empty in the Helm charts column instead of showing the misleading "Yes (0)" badge.

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))