### PR TITLE
Fall back to PAT when GitHub App has no access to a repo

### DIFF
--- a/.changeset/neat-apple-reflect.md
+++ b/.changeset/neat-apple-reflect.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-catalog-backend-module-gs': patch
+---
+
+Fall back to PAT or unauthenticated requests when the configured GitHub App has no access to a repo. Previously `LatestReleaseProcessor` and `SbomDependencyProcessor` failed with "No GitHub credentials" / "App does not have access to repository" for any repo not in the App's installation. They now try the credentials provider first, fall back to the integration's `token:` (PAT) when it throws or returns no token, and finally fall back to unauthenticated requests so public repos still work without any integration configured.

--- a/helm/backstage/README.md
+++ b/helm/backstage/README.md
@@ -61,6 +61,8 @@ Backstage app provided by Giant Swarm
 | githubAppCredentials.clientSecret | string | `""` | GitHub App OAuth client secret |
 | githubAppCredentials.webhookSecret | string | `""` | GitHub App webhook secret |
 | githubAppCredentials.privateKey | string | `""` | GitHub App private key (PEM format) |
+| github | object | `{"publicReadToken":""}` | GitHub integration settings (PAT used as fallback by catalog processors when the GitHub App lacks access to a repository) |
+| github.publicReadToken | string | `""` | GitHub personal access token with public read access (exposed as GITHUB_PUBLIC_READ_TOKEN env var) |
 | grafana | object | `{"apiToken":""}` | Grafana integration settings |
 | grafana.apiToken | string | `""` | Grafana API token for dashboard integration (exposed as GRAFANA_TOKEN env var) |
 | sentry | object | `{"app":{"dsn":""},"backend":{"dsn":""},"reportURI":""}` | Sentry error tracking settings |

--- a/helm/backstage/templates/secrets.yaml
+++ b/helm/backstage/templates/secrets.yaml
@@ -26,6 +26,9 @@ data:
   {{- if .Values.githubAuthCredentials.clientSecret }}
   GITHUB_OAUTH_CLIENT_SECRET: {{ .Values.githubAuthCredentials.clientSecret }}
   {{- end }}
+  {{- if .Values.github.publicReadToken }}
+  GITHUB_PUBLIC_READ_TOKEN: {{ .Values.github.publicReadToken }}
+  {{- end }}
   {{- if .Values.grafana.apiToken }}
   GRAFANA_TOKEN: {{ .Values.grafana.apiToken }}
   {{- end }}

--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -247,6 +247,17 @@
             ],
             "minimum": 0
         },
+        "github": {
+            "description": "GitHub integration settings (PAT used as fallback by catalog processors when the GitHub App lacks access to a repository)",
+            "type": "object",
+            "properties": {
+                "publicReadToken": {
+                    "description": "GitHub personal access token with public read access (exposed as GITHUB_PUBLIC_READ_TOKEN env var)",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
         "githubAppCredentials": {
             "description": "GitHub App credentials for repository access and webhooks",
             "type": "object",

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -145,6 +145,12 @@ githubAppCredentials:
   # -- GitHub App private key (PEM format)
   privateKey: ''
 
+# -- GitHub integration settings (PAT used as fallback by catalog processors when the GitHub App lacks access to a repository)
+github:
+  # @schema type:string
+  # -- GitHub personal access token with public read access (exposed as GITHUB_PUBLIC_READ_TOKEN env var)
+  publicReadToken: ''
+
 # -- Grafana integration settings
 grafana:
   # @schema type:string

--- a/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.test.ts
+++ b/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.test.ts
@@ -1,6 +1,9 @@
 import { mockServices } from '@backstage/backend-test-utils';
 import type { Entity } from '@backstage/catalog-model';
-import type { GithubCredentialsProvider } from '@backstage/integration';
+import type {
+  GithubCredentialsProvider,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
 import { LatestReleaseProcessor } from './LatestReleaseProcessor';
 
 const dummyLocation = { type: 'url', target: 'https://example.com' };
@@ -10,6 +13,10 @@ const dummyCache = { get: jest.fn(), set: jest.fn() } as any;
 const credentialsProvider: GithubCredentialsProvider = {
   getCredentials: jest.fn().mockResolvedValue({ token: 'fake-token' }),
 } as unknown as GithubCredentialsProvider;
+
+const integrations = {
+  github: { byUrl: jest.fn().mockReturnValue(undefined) },
+} as unknown as ScmIntegrationRegistry;
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -31,10 +38,18 @@ function component(
   };
 }
 
-function makeProcessor(fetchImpl: jest.Mock, cacheTtlMs = 60_000) {
+function makeProcessor(
+  fetchImpl: jest.Mock,
+  cacheTtlMs = 60_000,
+  overrides: {
+    credentialsProvider?: GithubCredentialsProvider;
+    integrations?: ScmIntegrationRegistry;
+  } = {},
+) {
   return new LatestReleaseProcessor({
     logger: mockServices.logger.mock(),
-    credentialsProvider,
+    credentialsProvider: overrides.credentialsProvider ?? credentialsProvider,
+    integrations: overrides.integrations ?? integrations,
     cacheTtlMs,
     fetchImpl: fetchImpl as unknown as typeof fetch,
   });
@@ -309,6 +324,84 @@ describe('LatestReleaseProcessor', () => {
     await Promise.all([p1, p2]);
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the integration PAT when the credentials provider throws', async () => {
+    const throwingProvider = {
+      getCredentials: jest
+        .fn()
+        .mockRejectedValue(new Error('App has no access to repository athena')),
+    } as unknown as GithubCredentialsProvider;
+    const integrationsWithPat = {
+      github: {
+        byUrl: jest.fn().mockReturnValue({ config: { token: 'pat-fallback' } }),
+      },
+    } as unknown as ScmIntegrationRegistry;
+
+    const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => {
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer pat-fallback');
+      return jsonResponse({
+        tag_name: 'v1.0.0',
+        published_at: '2026-04-01T00:00:00Z',
+        draft: false,
+        prerelease: false,
+      });
+    });
+    const processor = makeProcessor(fetchImpl, 60_000, {
+      credentialsProvider: throwingProvider,
+      integrations: integrationsWithPat,
+    });
+
+    const entity = component('athena', {
+      'github.com/project-slug': 'giantswarm/athena',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(result.metadata.annotations).toMatchObject({
+      'giantswarm.io/latest-release-tag': 'v1.0.0',
+    });
+  });
+
+  it('issues an unauthenticated request when no token is available', async () => {
+    const emptyProvider = {
+      getCredentials: jest.fn().mockResolvedValue({ token: undefined }),
+    } as unknown as GithubCredentialsProvider;
+
+    const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => {
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBeUndefined();
+      return jsonResponse({
+        tag_name: 'v2.0.0',
+        published_at: '2026-04-02T00:00:00Z',
+        draft: false,
+        prerelease: false,
+      });
+    });
+    const processor = makeProcessor(fetchImpl, 60_000, {
+      credentialsProvider: emptyProvider,
+    });
+
+    const entity = component('public-repo', {
+      'github.com/project-slug': 'giantswarm/public-repo',
+    });
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache,
+    );
+
+    expect(result.metadata.annotations).toMatchObject({
+      'giantswarm.io/latest-release-tag': 'v2.0.0',
+    });
   });
 
   it('returns the original entity when the GitHub fetch fails', async () => {

--- a/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.ts
+++ b/plugins/catalog-backend-module-gs/src/LatestReleaseProcessor/LatestReleaseProcessor.ts
@@ -12,6 +12,7 @@ import type {
 import {
   DefaultGithubCredentialsProvider,
   type GithubCredentialsProvider,
+  type ScmIntegrationRegistry,
   ScmIntegrations,
 } from '@backstage/integration';
 import {
@@ -19,6 +20,7 @@ import {
   type LatestRelease,
   listLatestReleasesByPrefix,
 } from '../util/githubReleases';
+import { resolveGithubToken } from '../util/githubToken';
 
 const PROJECT_SLUG_ANNOTATION = 'github.com/project-slug';
 const RELEASE_TAG_PREFIX_ANNOTATION = 'giantswarm.io/release-tag-prefix';
@@ -36,6 +38,7 @@ type FetchFn = typeof fetch;
 export class LatestReleaseProcessor implements CatalogProcessor {
   private readonly logger: LoggerService;
   private readonly credentialsProvider: GithubCredentialsProvider;
+  private readonly integrations: ScmIntegrationRegistry;
   private readonly cacheTtlMs: number;
   private readonly fetchImpl: FetchFn;
   private readonly cache = new Map<string, CacheEntry>();
@@ -56,6 +59,7 @@ export class LatestReleaseProcessor implements CatalogProcessor {
     return new LatestReleaseProcessor({
       logger,
       credentialsProvider,
+      integrations,
       cacheTtlMs:
         cacheTtlSeconds !== undefined
           ? cacheTtlSeconds * 1000
@@ -67,11 +71,13 @@ export class LatestReleaseProcessor implements CatalogProcessor {
   constructor(options: {
     logger: LoggerService;
     credentialsProvider: GithubCredentialsProvider;
+    integrations: ScmIntegrationRegistry;
     cacheTtlMs?: number;
     fetchImpl?: FetchFn;
   }) {
     this.logger = options.logger;
     this.credentialsProvider = options.credentialsProvider;
+    this.integrations = options.integrations;
     this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
     this.fetchImpl = options.fetchImpl ?? fetch;
   }
@@ -155,12 +161,12 @@ export class LatestReleaseProcessor implements CatalogProcessor {
     prefix: string | undefined,
   ): Promise<LatestRelease | undefined> {
     const repoUrl = `https://github.com/${owner}/${repo}`;
-    const { token } = await this.credentialsProvider.getCredentials({
+    const token = await resolveGithubToken({
       url: repoUrl,
+      credentialsProvider: this.credentialsProvider,
+      integrations: this.integrations,
+      logger: this.logger,
     });
-    if (!token) {
-      throw new Error(`No GitHub credentials for ${repoUrl}`);
-    }
     const label = `LatestReleaseProcessor: ${owner}/${repo}${
       prefix ? ` prefix=${prefix}` : ''
     }`;

--- a/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/SbomDependencyProcessor.ts
+++ b/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/SbomDependencyProcessor.ts
@@ -69,6 +69,7 @@ export class SbomDependencyProcessor implements CatalogProcessor {
 
     await createSbomRefreshTask({
       credentialsProvider,
+      integrations,
       catalogApi,
       auth,
       db,

--- a/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/sbomScheduledTask.ts
+++ b/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/sbomScheduledTask.ts
@@ -5,8 +5,12 @@ import type {
   SchedulerServiceTaskScheduleDefinition,
 } from '@backstage/backend-plugin-api';
 import type { CatalogService } from '@backstage/plugin-catalog-node';
-import type { GithubCredentialsProvider } from '@backstage/integration';
+import type {
+  GithubCredentialsProvider,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
 import type { Knex } from 'knex';
+import { resolveGithubToken } from '../util/githubToken';
 
 const GITHUB_PROJECT_SLUG_ANNOTATION = 'github.com/project-slug';
 const GIANTSWARM_PURL_RE = /^pkg:golang\/github\.com\/giantswarm\/([^@/]+)/;
@@ -32,6 +36,7 @@ interface SbomApiResponse {
 
 export async function createSbomRefreshTask(options: {
   credentialsProvider: GithubCredentialsProvider;
+  integrations: ScmIntegrationRegistry;
   catalogApi: CatalogService;
   auth: AuthService;
   db: Knex;
@@ -39,8 +44,15 @@ export async function createSbomRefreshTask(options: {
   scheduler: SchedulerService;
   schedule?: SchedulerServiceTaskScheduleDefinition;
 }) {
-  const { credentialsProvider, catalogApi, auth, db, logger, scheduler } =
-    options;
+  const {
+    credentialsProvider,
+    integrations,
+    catalogApi,
+    auth,
+    db,
+    logger,
+    scheduler,
+  } = options;
   const schedule = options.schedule ?? DEFAULT_SCHEDULE;
 
   await scheduler.scheduleTask({
@@ -49,6 +61,7 @@ export async function createSbomRefreshTask(options: {
     fn: async () => {
       await refreshSbomDependencies({
         credentialsProvider,
+        integrations,
         catalogApi,
         auth,
         db,
@@ -60,12 +73,14 @@ export async function createSbomRefreshTask(options: {
 
 export async function refreshSbomDependencies(options: {
   credentialsProvider: GithubCredentialsProvider;
+  integrations: ScmIntegrationRegistry;
   catalogApi: CatalogService;
   auth: AuthService;
   db: Knex;
   logger: LoggerService;
 }) {
-  const { credentialsProvider, catalogApi, auth, db, logger } = options;
+  const { credentialsProvider, integrations, catalogApi, auth, db, logger } =
+    options;
 
   const { token } = await auth.getPluginRequestToken({
     onBehalfOf: await auth.getOwnServiceCredentials(),
@@ -101,6 +116,7 @@ export async function refreshSbomDependencies(options: {
         const dependencies = await fetchSbomDependencies(
           slug,
           credentialsProvider,
+          integrations,
           logger,
         );
 
@@ -177,27 +193,31 @@ function getRetryDelayMs(response: Response): number {
 async function fetchSbomDependencies(
   slug: string,
   credentialsProvider: GithubCredentialsProvider,
+  integrations: ScmIntegrationRegistry,
   logger: LoggerService,
 ): Promise<string[]> {
   const repoUrl = `https://github.com/${slug}`;
-  const { token } = await credentialsProvider.getCredentials({ url: repoUrl });
-
-  if (!token) {
-    throw new Error(`No GitHub credentials for ${repoUrl}`);
-  }
+  const token = await resolveGithubToken({
+    url: repoUrl,
+    credentialsProvider,
+    integrations,
+    logger,
+  });
 
   const [owner, repo] = slug.split('/');
+
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     const response = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/dependency-graph/sbom`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      },
+      { headers },
     );
 
     if (

--- a/plugins/catalog-backend-module-gs/src/util/githubReleases.ts
+++ b/plugins/catalog-backend-module-gs/src/util/githubReleases.ts
@@ -27,7 +27,7 @@ export async function listLatestReleasesByPrefix(options: {
   owner: string;
   repo: string;
   prefixes: string[];
-  token: string;
+  token?: string;
   fetchImpl?: typeof fetch;
   logger: LoggerService;
   label: string;
@@ -104,7 +104,7 @@ export async function listLatestReleasesByPrefix(options: {
 export async function getLatestStableRelease(options: {
   owner: string;
   repo: string;
-  token: string;
+  token?: string;
   fetchImpl?: typeof fetch;
   logger: LoggerService;
   label: string;
@@ -148,7 +148,7 @@ function findMatchingPrefix(
 
 async function githubFetch(options: {
   url: string;
-  token: string;
+  token?: string;
   fetchImpl: typeof fetch;
   logger: LoggerService;
   label: string;
@@ -163,14 +163,16 @@ async function githubFetch(options: {
     allowNotFound = false,
   } = options;
 
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const response = await fetchImpl(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    });
+    const response = await fetchImpl(url, { headers });
 
     if (
       response.status === 429 ||

--- a/plugins/catalog-backend-module-gs/src/util/githubToken.ts
+++ b/plugins/catalog-backend-module-gs/src/util/githubToken.ts
@@ -1,0 +1,41 @@
+import type { LoggerService } from '@backstage/backend-plugin-api';
+import type {
+  GithubCredentialsProvider,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
+
+/**
+ * Resolves a GitHub token for the given URL with fallbacks:
+ *
+ * 1. `GithubCredentialsProvider` — typically a GitHub App installation token
+ *    when an app is installed for the URL's owner.
+ * 2. Integration `token` (PAT) — used when the credentials provider throws or
+ *    returns no token. This covers the case where a GitHub App is installed
+ *    for the owner but the requested repo is not part of the installation's
+ *    selected repositories: Backstage's provider throws rather than falling
+ *    back to the PAT itself.
+ * 3. `undefined` — no token available (no integration configured, or PAT
+ *    omitted). Caller should issue an unauthenticated request, which works
+ *    for public repos at GitHub's anonymous rate limit (60/hr/IP).
+ */
+export async function resolveGithubToken(options: {
+  url: string;
+  credentialsProvider: GithubCredentialsProvider;
+  integrations: ScmIntegrationRegistry;
+  logger: LoggerService;
+}): Promise<string | undefined> {
+  const { url, credentialsProvider, integrations, logger } = options;
+
+  try {
+    const { token } = await credentialsProvider.getCredentials({ url });
+    if (token) {
+      return token;
+    }
+  } catch (error) {
+    logger.debug(
+      `GitHub credentials provider failed for ${url}, falling back to PAT: ${error}`,
+    );
+  }
+
+  return integrations.github.byUrl(url)?.config.token;
+}


### PR DESCRIPTION
### What does this PR do?

Updates `LatestReleaseProcessor` and `SbomDependencyProcessor` to gracefully handle the case where the configured GitHub App has no access to a given repository.

Previously these processors hard-failed with messages like:

```
LatestReleaseProcessor: failed to fetch release for giantswarm/athena:
  Error: No GitHub credentials for https://github.com/giantswarm/athena
```

or

```
The Backstage GitHub application used in the giantswarm organization
does not have access to a repository with the name athena
```

Backstage's `SingleInstanceGithubCredentialsProvider` only falls back to the integration `token:` (PAT) when **no** App installation matches the URL's owner. If a GitHub App is installed in the org but the requested repo is not in its selected-repositories list, the provider tries to mint a repo-scoped installation token and throws — the PAT never gets a chance.

A new helper `resolveGithubToken` is introduced to bridge that gap:

1. Try the credentials provider (returns the App's installation token for repos in the installation).
2. On throw / `{ token: undefined }`, fall back to the integration's `token:` (PAT).
3. If still nothing, return `undefined` so the caller issues an unauthenticated request.

The `Authorization` header is omitted entirely when no token is available, so unauthenticated requests work (subject to GitHub's 60/hr/IP anonymous rate limit).

### What is the effect of this change to users?

`LatestReleaseProcessor` and `SbomDependencyProcessor` now work for public repositories outside the GitHub App's installation, as long as a PAT (or no integration at all, for low-volume cases) is configured. Recommended setup for production:

```yaml
integrations:
  github:
    - host: github.com
      token: ${GITHUB_PUBLIC_READ_PAT}   # fine-grained PAT with "Public Repositories (read-only)"
      apps:
        - appId: ${GITHUB_APP_ID}
          # ...existing app for private repo access
```

### Any background context you can provide?

The current resolution order in Backstage's GitHub credentials provider is App-first, with no fallback when the App-scoped token request itself fails. This change works around that without modifying upstream Backstage.


- [x] A changeset describing the change and affected packages was added.