### PR TITLE
Pin ai package version to fix MCP tool validation error

### DIFF
--- a/.changeset/ancient-beach-climb.md
+++ b/.changeset/ancient-beach-climb.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Pin `ai` to a single version via root yarn resolution to fix `AI_TypeValidationError` when invoking MCP tools. The backend's `ai@6.0.177` emitted `tool-input-available` chunks with a new `toolMetadata` field that the client's older nested `ai@6.0.168` (pinned by `@ai-sdk/react`) rejected as an unrecognized key.

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "@lezer/common": "1.5.2",
     "@lezer/highlight": "1.2.3",
     "codemirror-json-schema": "0.8.1",
-    "@assistant-ui/tap": "0.5.10"
+    "@assistant-ui/tap": "0.5.10",
+    "ai": "6.0.177"
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,32 +87,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/gateway@npm:3.0.104":
-  version: 3.0.104
-  resolution: "@ai-sdk/gateway@npm:3.0.104"
-  dependencies:
-    "@ai-sdk/provider": "npm:3.0.8"
-    "@ai-sdk/provider-utils": "npm:4.0.23"
-    "@vercel/oidc": "npm:3.2.0"
-  peerDependencies:
-    zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/caf6f8061b8b7f35e051422a5f35f2da05fa2a103cfd98e2210bb9f8e05d08b216c4baca70e1cb7f1368853bb0e1b7359efaaafcded816577880c970635381d8
-  languageName: node
-  linkType: hard
-
-"@ai-sdk/gateway@npm:3.0.105":
-  version: 3.0.105
-  resolution: "@ai-sdk/gateway@npm:3.0.105"
-  dependencies:
-    "@ai-sdk/provider": "npm:3.0.9"
-    "@ai-sdk/provider-utils": "npm:4.0.24"
-    "@vercel/oidc": "npm:3.2.0"
-  peerDependencies:
-    zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/5fd95080ed1e9056aba46bbffc8d5fd1e871eda9d99f3cc2c86628353851cfd47a6c162898558186b2c0f8b53bbb665949922781ce231f46e53195ff1732294b
-  languageName: node
-  linkType: hard
-
 "@ai-sdk/gateway@npm:3.0.112":
   version: 3.0.112
   resolution: "@ai-sdk/gateway@npm:3.0.112"
@@ -176,19 +150,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:4.0.24":
-  version: 4.0.24
-  resolution: "@ai-sdk/provider-utils@npm:4.0.24"
-  dependencies:
-    "@ai-sdk/provider": "npm:3.0.9"
-    "@standard-schema/spec": "npm:^1.1.0"
-    eventsource-parser: "npm:^3.0.8"
-  peerDependencies:
-    zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/43473a865313118bcafbe8d4b5ab37e5c10036da8ba975af9808f2d1b8dfac5747a5ec8da06788fc135eeb045ef51f3e068293f4cefe53ce8eb98db514e68915
-  languageName: node
-  linkType: hard
-
 "@ai-sdk/provider-utils@npm:4.0.27":
   version: 4.0.27
   resolution: "@ai-sdk/provider-utils@npm:4.0.27"
@@ -217,15 +178,6 @@ __metadata:
   dependencies:
     json-schema: "npm:^0.4.0"
   checksum: 10c0/c68637c0139a6ce8af17bac1d7d539f531860026237c5c971dcecda2daa8b1e42d8c05e1e664ece60c15edb325c0253fd5b091ee54d32f870a750a493acbb0b7
-  languageName: node
-  linkType: hard
-
-"@ai-sdk/provider@npm:3.0.9":
-  version: 3.0.9
-  resolution: "@ai-sdk/provider@npm:3.0.9"
-  dependencies:
-    json-schema: "npm:^0.4.0"
-  checksum: 10c0/507b30f2b15392ed4718efe2e618ee571fdea4eabbc09f38da8e2d6f839137d0d521b77ca279f55c349fe12f2a069abb4f320ebf87249c881b634f32997ae65c
   languageName: node
   linkType: hard
 
@@ -24609,35 +24561,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ai@npm:6.0.168":
-  version: 6.0.168
-  resolution: "ai@npm:6.0.168"
-  dependencies:
-    "@ai-sdk/gateway": "npm:3.0.104"
-    "@ai-sdk/provider": "npm:3.0.8"
-    "@ai-sdk/provider-utils": "npm:4.0.23"
-    "@opentelemetry/api": "npm:1.9.0"
-  peerDependencies:
-    zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/600a4693885f31f1873e742533f11070aeec5a23541704c71e625d31d47bb6702f99bfda7d3d21c7170b2c831fd57696299762afab7e1682a4fad2bcd8b4abcf
-  languageName: node
-  linkType: hard
-
-"ai@npm:^6.0.168":
-  version: 6.0.170
-  resolution: "ai@npm:6.0.170"
-  dependencies:
-    "@ai-sdk/gateway": "npm:3.0.105"
-    "@ai-sdk/provider": "npm:3.0.9"
-    "@ai-sdk/provider-utils": "npm:4.0.24"
-    "@opentelemetry/api": "npm:1.9.0"
-  peerDependencies:
-    zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/529a71efffba24eb3ce1ffa3062f355f4c140df25605bbe5818ce84619961e19c5e9f3ff62dbb91d554a45bf3dd399e924561d9ee4cd129e7eabe077054e53ce
-  languageName: node
-  linkType: hard
-
-"ai@npm:^6.0.176":
+"ai@npm:6.0.177":
   version: 6.0.177
   resolution: "ai@npm:6.0.177"
   dependencies:


### PR DESCRIPTION
### What does this PR do?

Pins the `ai` package to `6.0.177` via a root `package.json` `resolutions` entry. The repo had three nested copies of `ai` installed (`6.0.168`, `6.0.170`, `6.0.177`) because `@ai-sdk/react@3.0.170` and `@assistant-ui/react-ai-sdk` carry their own older copies. After this change, only one `ai@6.0.177` is installed and the lockfile is correspondingly smaller.

### What is the effect of this change to users?

Fixes `AI_TypeValidationError` thrown in the AI chat the moment an MCP tool is invoked (e.g. `query-catalog-entities` from the in-process `backstage-actions` MCP server).

Root cause: `ai@6.0.176` added a new optional `toolMetadata` field to the `tool-input-available` stream chunk. `@ai-sdk/mcp` started populating it (`toolMetadata: { clientName: "..." }`) so the backend (root `ai@6.0.177`) emits chunks with that key. The chat UI validates incoming chunks against `uiMessageChunkSchema` from `@ai-sdk/react`'s nested `ai@6.0.168`, which is a `z.strictObject` that doesn't know `toolMetadata` and rejects the chunk as having unrecognized keys — producing the long Zod union error covering every variant of the union. `@ai-sdk/react@3.0.170` pins `ai@6.0.168` *exactly* (not caret), so a yarn resolution is the only way to dedupe.

### How does it look like?

Before, invoking any MCP-backed tool in the chat surfaced an error from the SDK transport similar to:

```
Type validation failed: Value: {"type":"tool-input-available","toolCallId":"...","toolName":"query-catalog-entities","input":{...},"toolMetadata":{"clientName":"backstage-actions"},"dynamic":true,"title":"..."} ...
```

After, the chunk validates and the tool call proceeds normally.

### Any background context you can provide?

`ai` 7.0.0-canary.125 changelog entry: *"feat(ai): add toolMetadata for tool specific metdata"* (backported into the 6.0.x line as 6.0.176).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))