### PR TITLE
fix: Forward chat errors to Sentry, warn backend on mid-stream client disconnect

### DIFF
--- a/.changeset/empty-oasis-ripple.md
+++ b/.changeset/empty-oasis-ripple.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+AI chat: forward chat-level errors to the error reporter (Sentry) so the "Network error" banner is no longer silent. Network-class failures (TypeError + /fetch|network/) are reported as warnings to avoid paging on flaky-wifi users; other errors are reported as errors. The error reporter is looked up via the api holder so the chat still works in environments where Sentry isn't wired up. On the backend, the chat route now logs a warning when the client socket closes before the SSE stream finishes, giving a server-side trace for mid-stream disconnects that previously left no log entry.

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -582,10 +582,32 @@ export async function createRouter(
         return ret;
       } as typeof originalWrite;
 
+      // Observe whether the client received the full stream or hung up
+      // early. `finish` fires after the last byte is handed to the kernel;
+      // `close` fires when the socket closes. If `close` arrives before
+      // `finish`, the client disconnected mid-stream -- the exact failure
+      // that surfaces in the browser as `TypeError: network error` and
+      // that previously left no trace in backend logs.
+      const streamStartMs = Date.now();
+      let modelFinished = false;
+      let responseFinished = false;
+      res.once('finish', () => {
+        responseFinished = true;
+      });
+      res.once('close', () => {
+        if (responseFinished) return;
+        chatLogger.warn('Client disconnected before chat stream finished', {
+          requestId,
+          elapsedMs: Date.now() - streamStartMs,
+          modelFinished,
+        });
+      });
+
       result.pipeUIMessageStreamToResponse(res, {
         originalMessages: messages as UIMessage[],
         generateMessageId: () => crypto.randomUUID(),
         onFinish({ messages: allMessages }) {
+          modelFinished = true;
           // Fire-and-forget: update the conversation row created up-front
           // with the full message history including the assistant reply.
           conversationStore

--- a/plugins/ai-chat/package.json
+++ b/plugins/ai-chat/package.json
@@ -39,6 +39,7 @@
     "@backstage/theme": "backstage:^",
     "@backstage/ui": "backstage:^",
     "@giantswarm/backstage-plugin-ai-chat-react": "workspace:^",
+    "@giantswarm/backstage-plugin-error-reporter-react": "workspace:^",
     "@giantswarm/backstage-plugin-ui-react": "workspace:^",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",

--- a/plugins/ai-chat/src/hooks/useChatSetup.ts
+++ b/plugins/ai-chat/src/hooks/useChatSetup.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   useApi,
+  useApiHolder,
   identityApiRef,
   discoveryApiRef,
   configApiRef,
@@ -17,6 +18,7 @@ import {
   UIMessage,
 } from 'ai';
 import { useQuery } from '@tanstack/react-query';
+import { errorReporterApiRef } from '@giantswarm/backstage-plugin-error-reporter-react';
 import { mcpAuthProvidersApiRef } from '../api';
 import { createDebugFetch } from './createDebugFetch';
 
@@ -69,6 +71,10 @@ export function useChatSetup(options?: UseChatSetupOptions) {
   const configApi = useApi(configApiRef);
   const mcpAuthProvidersApi = useApi(mcpAuthProvidersApiRef);
   const featureFlagsApi = useApi(featureFlagsApiRef);
+  // Optional: the error reporter is only registered when
+  // `app.errorReporter.sentry` is configured. Use the api holder so the
+  // chat still works in environments without Sentry wiring.
+  const errorReporter = useApiHolder().get(errorReporterApiRef);
   // Generate the conversation id eagerly so getConversationId() never returns
   // null while the first user message is in flight. This lets the optimistic
   // history-list insert (useConversationListSync) fire on the first message,
@@ -198,10 +204,33 @@ export function useChatSetup(options?: UseChatSetupOptions) {
     [apiUrl, getHeaders, debugFetch],
   );
 
+  // Forward chat-level errors (raised by the AI SDK after fetch/stream
+  // failures or non-OK responses) to the error reporter. Aborts are
+  // filtered out upstream by the SDK before this fires. Network-class
+  // failures use the same TypeError + /fetch|network/i fingerprint the
+  // SDK uses internally; they are reported as warnings to avoid paging
+  // on every flaky-wifi user, while genuinely unexpected errors are
+  // reported as errors.
+  const onError = useCallback(
+    (err: Error) => {
+      if (!errorReporter) return;
+      const isNetworkError =
+        err instanceof TypeError && /fetch|network/i.test(err.message);
+      errorReporter.notify(err, {
+        level: isNetworkError ? 'warning' : 'error',
+        source: 'ai-chat',
+        conversationId: conversationIdRef.current,
+        isNetworkError,
+      });
+    },
+    [errorReporter],
+  );
+
   const runtime = useChatRuntime({
     messages: options?.initialMessages,
     sendAutomaticallyWhen: shouldSendAutomatically,
     transport,
+    onError,
   });
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10428,6 +10428,7 @@ __metadata:
     "@backstage/theme": "backstage:^"
     "@backstage/ui": "backstage:^"
     "@giantswarm/backstage-plugin-ai-chat-react": "workspace:^"
+    "@giantswarm/backstage-plugin-error-reporter-react": "workspace:^"
     "@giantswarm/backstage-plugin-ui-react": "workspace:^"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"


### PR DESCRIPTION
### What does this PR do?

Makes the AI chat "Network error" banner observable end-to-end. Previously, when a chat stream failed (mid-stream disconnect, proxy timeout, backend kill, flaky wifi), the banner appeared in the UI but neither Sentry nor the backend logs had any trace.

Two changes:

- **Frontend (`useChatSetup.ts`)** — wire `useChatRuntime`'s `onError` to `errorReporterApiRef` (looked up via the api holder so the chat still works in environments without Sentry configured). Network-class failures (`TypeError` + `/fetch|network/i`, the same fingerprint the AI SDK uses internally) are reported as **warnings** to avoid paging on every flaky-wifi user; genuinely unexpected errors are reported as **errors**. Extras include `conversationId` and `isNetworkError`.
- **Backend (`router.ts`)** — observe `res.on('close')` vs. `res.on('finish')` around the SSE pipe and emit `chatLogger.warn('Client disconnected before chat stream finished', { requestId, elapsedMs, modelFinished })` when the socket closes before the response has finished writing. This gives a server-side trace for the disconnects that surface to the user as the network-error banner.

### What is the effect of this change to users?

No user-visible behaviour change. The banner still renders the same way. Internally, the same failure now produces:

- a Sentry event (warning for network failures, error for unexpected ones), so user reports can be confirmed and triaged;
- a backend warn log when the client hung up mid-stream, so server-side breadcrumbs exist for what was previously a silent failure.

### How does it look like?

No UI change. In Sentry: events at `level=warning` (or `error`) with `source=ai-chat`, `conversationId`, `isNetworkError`. In the backend log: `Client disconnected before chat stream finished` with `requestId`, `elapsedMs`, `modelFinished`.

- [x] A changeset describing the change and affected packages was added.