### PR TITLE
feat(ai-chat): model-aware Anthropic thinking config

### DIFF
--- a/.changeset/nice-loops-allow.md
+++ b/.changeset/nice-loops-allow.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+---
+
+add Opus 4.8 context window info

--- a/.changeset/quick-pugs-think.md
+++ b/.changeset/quick-pugs-think.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': minor
+---
+
+AI chat: make the Anthropic thinking config model-aware. Adaptive-thinking Claude models (Opus 4.5+, Sonnet 4.6) now use `thinking: { type: 'adaptive' }` plus `effort` (configurable via `aiChat.anthropic.effort`, default `high`) instead of the legacy `thinking: { type: 'enabled', budgetTokens }` shape, which those models reject with a 400 ("thinking.type.enabled is not supported for this model"). Older Claude models keep the legacy budget-based interface, and non-Claude models are unaffected. For adaptive-thinking models, `temperature`/`topP`/`topK` from `aiChat.sampling` are dropped (with a warning) since those models also reject them.

--- a/plugins/ai-chat-backend/config.d.ts
+++ b/plugins/ai-chat-backend/config.d.ts
@@ -12,6 +12,13 @@ export interface Config {
        * @visibility backend
        */
       baseUrl?: string;
+      /**
+       * Thinking effort for adaptive-thinking Claude models (Opus 4.5+,
+       * Sonnet 4.6). Maps to output_config.effort. Ignored by older Claude
+       * models, which use a fixed thinking budget instead. Defaults to 'high'.
+       * @visibility backend
+       */
+      effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
     };
 
     openai?: {

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -39,6 +39,8 @@ import {
   stripStaleLargeToolResults,
   pruneOldToolResults,
   stripPastReasoning,
+  usesAdaptiveThinking,
+  buildAnthropicProviderOptions,
 } from './utils';
 import { ConversationStore } from './services/ConversationStore';
 import { createConversationRoutes } from './routes/conversationRoutes';
@@ -201,6 +203,35 @@ export async function createRouter(
       'No OpenAI API key configured for OpenAI model. Set aiChat.openai.apiKey in app-config.yaml',
     );
   }
+
+  // Anthropic thinking config is model-aware. Opus 4.5+/Sonnet 4.6 use the
+  // adaptive-thinking + `effort` interface; older Claude models use the legacy
+  // `thinking: { type: 'enabled', budgetTokens }` shape. `modelName` and
+  // `isAnthropicModel` are fixed for the router's lifetime, so the provider
+  // options are computed once here. See utils/anthropicProviderOptions.ts.
+  const anthropicEffort =
+    config.getOptionalString('aiChat.anthropic.effort') ?? 'high';
+
+  // Adaptive-thinking models (Opus 4.7+, etc.) reject temperature/top_p/top_k
+  // with a 400. Drop any configured under `aiChat.sampling` so they don't break
+  // Anthropic requests for those models.
+  if (isAnthropicModel && usesAdaptiveThinking(modelName)) {
+    const removed = (['temperature', 'topP', 'topK'] as const).filter(
+      k => samplingParams[k] !== undefined,
+    );
+    if (removed.length > 0) {
+      logger.warn(
+        `Ignoring sampling params not supported by ${modelName}: ${removed.join(', ')}`,
+      );
+      for (const k of removed) delete samplingParams[k];
+    }
+  }
+
+  const anthropicProviderOptions = buildAnthropicProviderOptions({
+    modelName,
+    isAnthropicModel,
+    effort: anthropicEffort,
+  });
 
   // Create provider clients
   const openai = createOpenAI({
@@ -485,12 +516,8 @@ export async function createRouter(
         stopWhen: stepCountIs(maxSteps),
         tools: allTools as ToolSet,
         ...samplingParams,
-        providerOptions: isAnthropicModel
-          ? {
-              anthropic: {
-                thinking: { type: 'enabled', budgetTokens: 10000 },
-              },
-            }
+        providerOptions: anthropicProviderOptions
+          ? { anthropic: anthropicProviderOptions }
           : undefined,
         onError({ error }) {
           chatLogger.error('Error during streaming:', error as Error);
@@ -546,9 +573,7 @@ export async function createRouter(
             connected: connectedServers,
             failed: failedServers.map(s => s.name),
           },
-          providerOptions: isAnthropicModel
-            ? { thinking: { type: 'enabled', budgetTokens: 10000 } }
-            : undefined,
+          providerOptions: anthropicProviderOptions,
           // Message transformations applied server-side (useful to spot
           // when the frontend's messages differ from what the LLM sees).
           messageCount: sanitizedMessages.length,

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -41,6 +41,7 @@ import {
   stripPastReasoning,
   usesAdaptiveThinking,
   buildAnthropicProviderOptions,
+  DEFAULT_ANTHROPIC_EFFORT,
 } from './utils';
 import { ConversationStore } from './services/ConversationStore';
 import { createConversationRoutes } from './routes/conversationRoutes';
@@ -210,7 +211,8 @@ export async function createRouter(
   // `isAnthropicModel` are fixed for the router's lifetime, so the provider
   // options are computed once here. See utils/anthropicProviderOptions.ts.
   const anthropicEffort =
-    config.getOptionalString('aiChat.anthropic.effort') ?? 'high';
+    config.getOptionalString('aiChat.anthropic.effort') ??
+    DEFAULT_ANTHROPIC_EFFORT;
 
   // Adaptive-thinking models (Opus 4.7+, etc.) reject temperature/top_p/top_k
   // with a 400. Drop any configured under `aiChat.sampling` so they don't break

--- a/plugins/ai-chat-backend/src/utils/anthropicProviderOptions.test.ts
+++ b/plugins/ai-chat-backend/src/utils/anthropicProviderOptions.test.ts
@@ -1,0 +1,94 @@
+import {
+  buildAnthropicProviderOptions,
+  usesAdaptiveThinking,
+  LEGACY_THINKING_BUDGET_TOKENS,
+} from './anthropicProviderOptions';
+
+describe('usesAdaptiveThinking', () => {
+  it.each([
+    'claude-opus-4-5',
+    'claude-opus-4-6',
+    'claude-opus-4-7',
+    'claude-opus-4-8',
+    'claude-sonnet-4-6',
+  ])('returns true for adaptive-thinking model %s', model => {
+    expect(usesAdaptiveThinking(model)).toBe(true);
+  });
+
+  it('matches date-suffixed IDs via the family prefix', () => {
+    expect(usesAdaptiveThinking('claude-opus-4-8-20260101')).toBe(true);
+  });
+
+  it.each([
+    'claude-sonnet-4-5',
+    'claude-haiku-4-5',
+    'claude-opus-4-1',
+    'claude-3-5-sonnet',
+    'claude-3-haiku',
+  ])('returns false for legacy Claude model %s', model => {
+    expect(usesAdaptiveThinking(model)).toBe(false);
+  });
+});
+
+describe('buildAnthropicProviderOptions', () => {
+  it('returns undefined for non-Anthropic models', () => {
+    expect(
+      buildAnthropicProviderOptions({
+        modelName: 'gpt-4o-mini',
+        isAnthropicModel: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('uses adaptive thinking with the default effort for Opus 4.8', () => {
+    expect(
+      buildAnthropicProviderOptions({
+        modelName: 'claude-opus-4-8',
+        isAnthropicModel: true,
+      }),
+    ).toEqual({ thinking: { type: 'adaptive' }, effort: 'high' });
+  });
+
+  it('honors an explicit effort for adaptive-thinking models', () => {
+    expect(
+      buildAnthropicProviderOptions({
+        modelName: 'claude-opus-4-8',
+        isAnthropicModel: true,
+        effort: 'max',
+      }),
+    ).toEqual({ thinking: { type: 'adaptive' }, effort: 'max' });
+  });
+
+  it.each(['claude-opus-4-5', 'claude-sonnet-4-6'])(
+    'uses adaptive thinking for %s',
+    model => {
+      expect(
+        buildAnthropicProviderOptions({
+          modelName: model,
+          isAnthropicModel: true,
+        }),
+      ).toEqual({ thinking: { type: 'adaptive' }, effort: 'high' });
+    },
+  );
+
+  it.each([
+    'claude-sonnet-4-5',
+    'claude-haiku-4-5',
+    'claude-opus-4-1',
+    'claude-3-5-sonnet',
+  ])('uses the legacy thinking budget for %s', model => {
+    expect(
+      buildAnthropicProviderOptions({
+        modelName: model,
+        isAnthropicModel: true,
+        // An effort value is ignored for legacy models.
+        effort: 'max',
+      }),
+    ).toEqual({
+      thinking: {
+        type: 'enabled',
+        budgetTokens: LEGACY_THINKING_BUDGET_TOKENS,
+      },
+    });
+  });
+});

--- a/plugins/ai-chat-backend/src/utils/anthropicProviderOptions.ts
+++ b/plugins/ai-chat-backend/src/utils/anthropicProviderOptions.ts
@@ -1,0 +1,76 @@
+// Claude models that use adaptive thinking + the `effort` parameter instead of
+// the legacy `thinking: { type: 'enabled', budgetTokens }` interface. On these
+// models the enabled+budgetTokens shape returns a 400:
+//   "thinking.type.enabled is not supported for this model. Use
+//    thinking.type.adaptive and output_config.effort to control thinking."
+// Opus 4.5+ and Sonnet 4.6 introduced adaptive thinking and `effort`; older
+// Claude models (Sonnet 4.5, Haiku 4.5, Opus 4.1, Claude 3.x) still require
+// enabled+budgetTokens and reject `effort`. Adaptive-thinking models also
+// reject temperature/top_p/top_k. Extend this list as new effort-generation
+// models ship (keep roughly in sync with ContextUsageDisplay.tsx).
+export const ADAPTIVE_THINKING_MODEL_PREFIXES = [
+  'claude-opus-4-5',
+  'claude-opus-4-6',
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+  'claude-sonnet-4-6',
+];
+
+// Thinking budget for legacy (pre-effort) Claude models.
+export const LEGACY_THINKING_BUDGET_TOKENS = 10000;
+
+// Default effort for adaptive-thinking models. `high` is the Opus 4.8 default
+// and the recommended minimum for intelligence-sensitive work.
+export const DEFAULT_ANTHROPIC_EFFORT = 'high';
+
+/**
+ * Whether a Claude model uses the adaptive-thinking + `effort` interface
+ * rather than the legacy `thinking: { type: 'enabled', budgetTokens }` shape.
+ *
+ * Uses `startsWith` so date-suffixed IDs (e.g. `claude-opus-4-5-20251101`)
+ * still match their family prefix.
+ */
+export function usesAdaptiveThinking(modelName: string): boolean {
+  return ADAPTIVE_THINKING_MODEL_PREFIXES.some(prefix =>
+    modelName.startsWith(prefix),
+  );
+}
+
+// Value passed under `providerOptions.anthropic`. Both shapes are JSON-safe so
+// the result is assignable to the AI SDK's `providerOptions`.
+export type AnthropicProviderOptions =
+  | { thinking: { type: 'adaptive' }; effort: string }
+  | { thinking: { type: 'enabled'; budgetTokens: number } };
+
+/**
+ * Build the value passed under `providerOptions.anthropic` for a given model.
+ *
+ * - Non-Anthropic models: `undefined` (no Anthropic provider options).
+ * - Adaptive-thinking models (Opus 4.5+, Sonnet 4.6): adaptive thinking plus
+ *   `effort` (`output_config.effort`), defaulting to `high`.
+ * - Older Claude models: the legacy fixed thinking budget; `effort` is omitted
+ *   because those models reject it.
+ */
+export function buildAnthropicProviderOptions(opts: {
+  modelName: string;
+  isAnthropicModel: boolean;
+  effort?: string;
+}): AnthropicProviderOptions | undefined {
+  const {
+    modelName,
+    isAnthropicModel,
+    effort = DEFAULT_ANTHROPIC_EFFORT,
+  } = opts;
+
+  if (!isAnthropicModel) {
+    return undefined;
+  }
+
+  if (usesAdaptiveThinking(modelName)) {
+    return { thinking: { type: 'adaptive' }, effort };
+  }
+
+  return {
+    thinking: { type: 'enabled', budgetTokens: LEGACY_THINKING_BUDGET_TOKENS },
+  };
+}

--- a/plugins/ai-chat-backend/src/utils/index.ts
+++ b/plugins/ai-chat-backend/src/utils/index.ts
@@ -4,3 +4,7 @@ export { sanitizeMessages } from './sanitizeMessages';
 export { stripStaleLargeToolResults } from './stripStaleLargeToolResults';
 export { pruneOldToolResults } from './pruneOldToolResults';
 export { stripPastReasoning } from './stripPastReasoning';
+export {
+  usesAdaptiveThinking,
+  buildAnthropicProviderOptions,
+} from './anthropicProviderOptions';

--- a/plugins/ai-chat-backend/src/utils/index.ts
+++ b/plugins/ai-chat-backend/src/utils/index.ts
@@ -7,4 +7,5 @@ export { stripPastReasoning } from './stripPastReasoning';
 export {
   usesAdaptiveThinking,
   buildAnthropicProviderOptions,
+  DEFAULT_ANTHROPIC_EFFORT,
 } from './anthropicProviderOptions';

--- a/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ContextUsageDisplay.tsx
+++ b/plugins/ai-chat/src/components/AiChat/assistant-ui-components/ContextUsageDisplay.tsx
@@ -81,10 +81,11 @@ function formatCost(cost: number): string {
 // Known context window sizes by model prefix
 // More specific prefixes must come before less specific ones (startsWith matching)
 const CONTEXT_WINDOWS: Record<string, number> = {
-  'claude-sonnet-4-6': 1_000_000,
   'claude-opus-4-6': 1_000_000,
   'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-8': 1_000_000,
   'claude-sonnet-4-5': 200_000,
+  'claude-sonnet-4-6': 1_000_000,
   'claude-sonnet-4': 200_000,
   'claude-opus-4': 200_000,
   'claude-3-7-sonnet': 200_000,


### PR DESCRIPTION
### What does this PR do?

Makes the AI chat backend's Anthropic thinking configuration **model-aware**.

Previously `router.ts` hardcoded `thinking: { type: 'enabled', budgetTokens: 10000 }` for every Anthropic model. The adaptive-thinking generation (Opus 4.5+, Sonnet 4.6) rejects that shape with a 400:

> "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.

The provider options are now built once at router setup based on the model ID:

- **Adaptive-thinking models** (Opus 4.5/4.6/4.7/4.8, Sonnet 4.6) → `{ thinking: { type: 'adaptive' }, effort }`, where `effort` is configurable via the new `aiChat.anthropic.effort` option (default `high`).
- **Older Claude models** (Sonnet 4.5, Haiku 4.5, Opus 4.1, Claude 3.x) → unchanged legacy `{ thinking: { type: 'enabled', budgetTokens: 10000 } }`.
- **Non-Claude models** → unchanged (`undefined`).

Adaptive-thinking models also reject `temperature`/`top_p`/`top_k`, so any of those configured under `aiChat.sampling` are dropped (with a warning) for those models to prevent the next 400.

The branching logic lives in a new pure helper (`utils/anthropicProviderOptions.ts`) with unit tests. The same options object is reused for both the `streamText` call and the debug-meta header (removing the duplicated literal).

This PR also folds in the Opus 4.8 context-window addition from #1697 (which can be closed once this lands).

### What is the effect of this change to users?

AI chat works when `aiChat.model` is set to Claude Opus 4.8 (or any Opus 4.5+/Sonnet 4.6) instead of failing on every message. Thinking depth on those models is tunable via `aiChat.anthropic.effort` (`low | medium | high | xhigh | max`).

### How does it look like?

No visual change. Behavior fix — chat messages stream normally on Opus 4.8 rather than erroring out.

### Any background context you can provide?

The `enabled + budgetTokens` thinking interface was removed on the newer Claude generation; they require `thinking.type=adaptive` + `output_config.effort` (exposed by `@ai-sdk/anthropic` as a top-level `effort` field). The prefix-list approach mirrors the manually-maintained model map already in `ContextUsageDisplay.tsx`.

### Do the docs need to be updated?

No (the new `aiChat.anthropic.effort` option is documented inline in `config.d.ts`).

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))