### PR TITLE
fix(ai-chat): log missing OpenAI key at info to avoid Sentry noise

### DIFF
--- a/.changeset/ai-chat-openai-key-log-level.md
+++ b/.changeset/ai-chat-openai-key-log-level.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Log the "no OpenAI API key configured" message at `info` instead of `warn`. This is the expected state when a customer hasn't set up the AI chat feature, so it should no longer be forwarded to Sentry as an error-level event.

--- a/plugins/ai-chat-backend/src/router.test.ts
+++ b/plugins/ai-chat-backend/src/router.test.ts
@@ -1,0 +1,56 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import type { JsonObject } from '@backstage/types';
+import type { ConversationStore } from './services/ConversationStore';
+import { createRouter } from './router';
+
+function buildRouter(configData: JsonObject) {
+  const logger = mockServices.logger.mock();
+  const config = mockServices.rootConfig({ data: configData });
+  return createRouter({
+    auth: mockServices.auth(),
+    httpAuth: mockServices.httpAuth(),
+    logger,
+    config,
+    conversationStore: {} as ConversationStore,
+  }).then(() => logger);
+}
+
+function messagesFor(mock: jest.Mock): string[] {
+  return mock.mock.calls.map(call => String(call[0]));
+}
+
+describe('createRouter provider configuration logging', () => {
+  it('logs the missing OpenAI key at info (not warn) so it is not forwarded to Sentry', async () => {
+    // Default model (gpt-4o-mini) selects the OpenAI provider; no key is set.
+    // This is the expected state for customers who never enabled AI chat, so
+    // it must stay below the Sentry transport threshold (warn).
+    const logger = await buildRouter({});
+
+    const infoMessages = messagesFor(logger.info as jest.Mock);
+    const warnMessages = messagesFor(logger.warn as jest.Mock);
+
+    expect(infoMessages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('no OpenAI API key configured'),
+      ]),
+    );
+    expect(warnMessages).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('OpenAI API key')]),
+    );
+  });
+
+  it('still warns when an explicitly selected Anthropic model has no key', async () => {
+    // A genuine misconfiguration (operator chose a claude model but set no
+    // key) should remain a warning and reach Sentry.
+    const logger = await buildRouter({
+      aiChat: { model: 'claude-sonnet-4-5' },
+    });
+
+    const warnMessages = messagesFor(logger.warn as jest.Mock);
+    expect(warnMessages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('No Anthropic API key configured'),
+      ]),
+    );
+  });
+});

--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -200,8 +200,12 @@ export async function createRouter(
   }
 
   if (!isAnthropicModel && !isAzureConfigured && !openaiApiKey) {
-    logger.warn(
-      'No OpenAI API key configured for OpenAI model. Set aiChat.openai.apiKey in app-config.yaml',
+    // Expected when a customer hasn't set up the AI chat feature: the default
+    // model (gpt-4o-mini) selects the OpenAI provider, but no key is set. This
+    // is benign, so log at `info` — `warn` (and above) is forwarded to Sentry
+    // by the root logger and would otherwise create noise on every restart.
+    logger.info(
+      'AI chat: no OpenAI API key configured (aiChat.openai.apiKey); the AI chat feature is unavailable until a provider is configured.',
     );
   }
 


### PR DESCRIPTION
### What does this PR do?

The ai-chat backend logged `No OpenAI API key configured for OpenAI model` at `warn` when no OpenAI key was set. The root logger (`packages/backend-common/src/rootLogger.ts`) forwards everything at `warn` and above to Sentry, so this message became a Sentry event.

For customers who never set up the AI chat feature, the default model (`gpt-4o-mini`) selects the OpenAI provider with no key configured — so this expected, benign condition was reported to Sentry on every backend restart (40–76 events each across 8 non-OpenAI deployments).

This PR logs that specific case at `info` instead. The message is now also reworded to read as the expected "feature not configured" state rather than a directive.

The Anthropic and Azure "no key" cases stay at `warn`, since they only fire when an operator has explicitly opted into those providers (a genuine misconfiguration worth surfacing in Sentry).

> Note: the message was already `warn`, not `error` as the issue assumed — and it is logged once at startup, not per request. The actual reason it reached Sentry is the `warn`-level Sentry transport, so lowering it below `warn` is the correct fix.

### What is the effect of this change to users?

No user-facing change. Operators of installations without AI chat configured will no longer see this benign message reported as a Sentry error.

### How does it look like?

Startup log now reads (at `info` level, not forwarded to Sentry):

```
AI chat: no OpenAI API key configured (aiChat.openai.apiKey); the AI chat feature is unavailable until a provider is configured.
```

### Any background context you can provide?

Closes giantswarm/giantswarm#36763

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))