### PR TITLE
fix(app): only report untracked page views for registered app routes

### DIFF
--- a/.changeset/skip-untracked-page-view-for-unmatched-routes.md
+++ b/.changeset/skip-untracked-page-view-for-unmatched-routes.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Stop reporting "Untracked page view" warnings to Sentry for paths that do not match any registered app route. Bot/scanner probes against the public URLs (e.g. `/wp-login.php`) land on the "Not Found" page and previously created noise issues in Sentry. Untracked page views on real app routes are still reported.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,6 +76,7 @@
   },
   "devDependencies": {
     "@backstage/config": "backstage:^",
+    "@backstage/frontend-test-utils": "backstage:^",
     "@playwright/test": "^1.32.3",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.4.2",

--- a/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.test.ts
+++ b/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.test.ts
@@ -1,0 +1,129 @@
+import {
+  AnalyticsEvent,
+  ConfigApi,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
+import { TelemetryDeckAnalyticsApi } from './TelemetryDeckAnalyticsApi';
+
+const mockSignal = jest.fn();
+
+jest.mock('@telemetrydeck/sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({ signal: mockSignal })),
+}));
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+/**
+ * Builds a 'navigate' event the way the app's RouteTracker emits it: with
+ * the owning plugin/extension in the context for matched routes, and the
+ * default context values ('app'/'app') for paths that did not match any
+ * registered route.
+ */
+function navigateEvent(
+  subject: string,
+  context: Record<string, string>,
+): AnalyticsEvent {
+  return {
+    action: 'navigate',
+    subject,
+    context: context as AnalyticsEvent['context'],
+  };
+}
+
+describe('TelemetryDeckAnalyticsApi', () => {
+  const configApi = {
+    getOptionalConfig: jest.fn().mockReturnValue(undefined),
+  } as unknown as ConfigApi;
+
+  const identityApi = {
+    getBackstageIdentity: jest
+      .fn()
+      .mockResolvedValue({ userEntityRef: 'user:default/test' }),
+    getProfileInfo: jest.fn().mockResolvedValue({}),
+  } as unknown as IdentityApi;
+
+  const errorReporterApi = { notify: jest.fn() };
+
+  function createApi() {
+    return TelemetryDeckAnalyticsApi.fromConfig({
+      configApi,
+      identityApi,
+      errorReporterApi,
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports untracked page views for paths that matched a registered route', () => {
+    createApi().captureEvent(
+      navigateEvent('/notifications', {
+        pluginId: 'notifications',
+        extensionId: 'page:notifications',
+      }),
+    );
+
+    expect(errorReporterApi.notify).toHaveBeenCalledWith(
+      'Untracked page view: /notifications',
+      {
+        level: 'warning',
+        type: 'untracked_page_view',
+        path: '/notifications',
+      },
+    );
+  });
+
+  it('does not report untracked page views for paths that did not match any route', () => {
+    createApi().captureEvent(
+      navigateEvent('/wp-login.php', {
+        pluginId: 'app',
+        extensionId: 'app',
+      }),
+    );
+
+    expect(errorReporterApi.notify).not.toHaveBeenCalled();
+  });
+
+  it('does not report tracked page views', () => {
+    createApi().captureEvent(
+      navigateEvent('/clusters', {
+        pluginId: 'gs',
+        extensionId: 'page:gs/clusters',
+      }),
+    );
+
+    expect(errorReporterApi.notify).not.toHaveBeenCalled();
+  });
+
+  it('still sends a pageview signal for unmatched paths', async () => {
+    createApi().captureEvent(
+      navigateEvent('/wp-login.php', {
+        pluginId: 'app',
+        extensionId: 'app',
+      }),
+    );
+    await flushPromises();
+
+    expect(mockSignal).toHaveBeenCalledWith('pageview', {
+      page: 'Unknown page',
+      path: '/wp-login.php',
+    });
+  });
+
+  it('ignores events other than navigate', () => {
+    const context: Record<string, string> = {
+      pluginId: 'gs',
+      extensionId: 'page:gs/clusters',
+    };
+    createApi().captureEvent({
+      action: 'click',
+      subject: 'some-button',
+      context: context as AnalyticsEvent['context'],
+    });
+
+    expect(errorReporterApi.notify).not.toHaveBeenCalled();
+    expect(mockSignal).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.test.tsx
+++ b/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.test.tsx
@@ -1,8 +1,9 @@
+import { ConfigApi, IdentityApi } from '@backstage/core-plugin-api';
 import {
-  AnalyticsEvent,
-  ConfigApi,
-  IdentityApi,
-} from '@backstage/core-plugin-api';
+  analyticsApiRef,
+  createRouteRef,
+} from '@backstage/frontend-plugin-api';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
 import { TelemetryDeckAnalyticsApi } from './TelemetryDeckAnalyticsApi';
 
 const mockSignal = jest.fn();
@@ -13,23 +14,6 @@ jest.mock('@telemetrydeck/sdk', () => ({
 }));
 
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
-
-/**
- * Builds a 'navigate' event the way the app's RouteTracker emits it: with
- * the owning plugin/extension in the context for matched routes, and the
- * default context values ('app'/'app') for paths that did not match any
- * registered route.
- */
-function navigateEvent(
-  subject: string,
-  context: Record<string, string>,
-): AnalyticsEvent {
-  return {
-    action: 'navigate',
-    subject,
-    context: context as AnalyticsEvent['context'],
-  };
-}
 
 describe('TelemetryDeckAnalyticsApi', () => {
   const configApi = {
@@ -53,57 +37,56 @@ describe('TelemetryDeckAnalyticsApi', () => {
     });
   }
 
+  /**
+   * Renders a test app at the given path with the API under test installed
+   * as the app's analytics API, so it receives the navigate event emitted
+   * by the real RouteTracker — including the real analytics context values
+   * for matched and unmatched routes.
+   */
+  function navigateInTestApp(
+    path: string,
+    options?: { registerRoute?: boolean },
+  ) {
+    renderInTestApp(<div />, {
+      initialRouteEntries: [path],
+      mountedRoutes: options?.registerRoute
+        ? { [path]: createRouteRef() }
+        : undefined,
+      apis: [[analyticsApiRef, createApi()]],
+    });
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('reports untracked page views for paths that matched a registered route', () => {
-    createApi().captureEvent(
-      navigateEvent('/notifications', {
-        pluginId: 'notifications',
-        extensionId: 'page:notifications',
-      }),
-    );
+    navigateInTestApp('/my-test-page', { registerRoute: true });
 
     expect(errorReporterApi.notify).toHaveBeenCalledWith(
-      'Untracked page view: /notifications',
+      'Untracked page view: /my-test-page',
       {
         level: 'warning',
         type: 'untracked_page_view',
-        path: '/notifications',
+        path: '/my-test-page',
       },
     );
   });
 
   it('does not report untracked page views for paths that did not match any route', () => {
-    createApi().captureEvent(
-      navigateEvent('/wp-login.php', {
-        pluginId: 'app',
-        extensionId: 'app',
-      }),
-    );
+    navigateInTestApp('/wp-login.php');
 
     expect(errorReporterApi.notify).not.toHaveBeenCalled();
   });
 
   it('does not report tracked page views', () => {
-    createApi().captureEvent(
-      navigateEvent('/clusters', {
-        pluginId: 'gs',
-        extensionId: 'page:gs/clusters',
-      }),
-    );
+    navigateInTestApp('/clusters', { registerRoute: true });
 
     expect(errorReporterApi.notify).not.toHaveBeenCalled();
   });
 
   it('still sends a pageview signal for unmatched paths', async () => {
-    createApi().captureEvent(
-      navigateEvent('/wp-login.php', {
-        pluginId: 'app',
-        extensionId: 'app',
-      }),
-    );
+    navigateInTestApp('/wp-login.php');
     await flushPromises();
 
     expect(mockSignal).toHaveBeenCalledWith('pageview', {
@@ -112,15 +95,24 @@ describe('TelemetryDeckAnalyticsApi', () => {
     });
   });
 
+  it('sends a pageview signal for tracked pages', async () => {
+    navigateInTestApp('/clusters', { registerRoute: true });
+    await flushPromises();
+
+    expect(mockSignal).toHaveBeenCalledWith('pageview', {
+      page: 'Clusters index',
+      path: '/clusters',
+    });
+  });
+
   it('ignores events other than navigate', () => {
-    const context: Record<string, string> = {
-      pluginId: 'gs',
-      extensionId: 'page:gs/clusters',
-    };
     createApi().captureEvent({
       action: 'click',
       subject: 'some-button',
-      context: context as AnalyticsEvent['context'],
+      context: {
+        pluginId: 'gs',
+        extensionId: 'page:gs/clusters',
+      },
     });
 
     expect(errorReporterApi.notify).not.toHaveBeenCalled();

--- a/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.ts
+++ b/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.ts
@@ -1,9 +1,5 @@
-import {
-  AnalyticsApi,
-  AnalyticsEvent,
-  ConfigApi,
-  IdentityApi,
-} from '@backstage/core-plugin-api';
+import { ConfigApi, IdentityApi } from '@backstage/core-plugin-api';
+import { AnalyticsApi, AnalyticsEvent } from '@backstage/frontend-plugin-api';
 import TelemetryDeck from '@telemetrydeck/sdk';
 import {
   getGuestUserEntityRef,
@@ -87,12 +83,16 @@ export class TelemetryDeckAnalyticsApi implements AnalyticsApi {
    * The app's RouteTracker resolves each navigation against the registered
    * routes and stores the owning plugin/extension in the analytics context.
    * When nothing matches (e.g. internet bots probing for /wp-login.php and
-   * similar paths on the public URL), the context keeps its default values
-   * of pluginId 'app' and extensionId 'app'.
+   * similar paths on the public URL), the RouteTracker contributes no
+   * attributes and the navigate event inherits the AppRoot extension
+   * boundary's context values: pluginId 'app' and extensionId 'app/root'.
+   * This contract is pinned by the integration test in
+   * TelemetryDeckAnalyticsApi.test.tsx, which captures events emitted by
+   * the real RouteTracker.
    */
   private static isRegisteredRoute(event: AnalyticsEvent): boolean {
     const { pluginId, extensionId } = event.context;
-    return pluginId !== 'app' || extensionId !== 'app';
+    return pluginId !== 'app' || extensionId !== 'app/root';
   }
 
   captureEvent(event: AnalyticsEvent): void {

--- a/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.ts
+++ b/packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.ts
@@ -81,6 +81,20 @@ export class TelemetryDeckAnalyticsApi implements AnalyticsApi {
     }
   }
 
+  /**
+   * Whether the navigation matched a route registered in the app.
+   *
+   * The app's RouteTracker resolves each navigation against the registered
+   * routes and stores the owning plugin/extension in the analytics context.
+   * When nothing matches (e.g. internet bots probing for /wp-login.php and
+   * similar paths on the public URL), the context keeps its default values
+   * of pluginId 'app' and extensionId 'app'.
+   */
+  private static isRegisteredRoute(event: AnalyticsEvent): boolean {
+    const { pluginId, extensionId } = event.context;
+    return pluginId !== 'app' || extensionId !== 'app';
+  }
+
   captureEvent(event: AnalyticsEvent): void {
     if (event.action !== 'navigate' || !event.subject) {
       return;
@@ -89,7 +103,13 @@ export class TelemetryDeckAnalyticsApi implements AnalyticsApi {
     const pathname = event.subject.split('?')[0].split('#')[0];
     const payload = getTelemetryPageViewPayload(pathname);
 
-    if (payload.page === 'Unknown page') {
+    if (
+      payload.page === 'Unknown page' &&
+      TelemetryDeckAnalyticsApi.isRegisteredRoute(event)
+    ) {
+      // Only report untracked page views for paths that resolved to a real
+      // app route. Unmatched paths land on the "Not Found" page and are
+      // mostly bot/scanner probes — reporting them creates Sentry noise.
       this.errorReporterApi?.notify(`Untracked page view: ${pathname}`, {
         level: 'warning',
         type: 'untracked_page_view',

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -7,6 +7,7 @@
  */
 import {
   createFrontendModule,
+  analyticsApiRef,
   ApiBlueprint,
   AppRootElementBlueprint,
 } from '@backstage/frontend-plugin-api';
@@ -18,7 +19,6 @@ import {
 import DarkIcon from '@material-ui/icons/Brightness2';
 import LightIcon from '@material-ui/icons/WbSunny';
 import {
-  analyticsApiRef,
   configApiRef,
   discoveryApiRef,
   fetchApiRef,

--- a/yarn.lock
+++ b/yarn.lock
@@ -24826,6 +24826,7 @@ __metadata:
     "@backstage/frontend-app-api": "backstage:^"
     "@backstage/frontend-defaults": "backstage:^"
     "@backstage/frontend-plugin-api": "backstage:^"
+    "@backstage/frontend-test-utils": "backstage:^"
     "@backstage/integration-react": "backstage:^"
     "@backstage/plugin-api-docs": "backstage:^"
     "@backstage/plugin-app-react": "backstage:^"


### PR DESCRIPTION
### What does this PR do?

Stops bot/scanner probes from creating "Untracked page view" noise issues in Sentry.

The public Backstage URLs attract bots probing for known CMS/admin paths (`/wp-login.php`, `/phpmyadmin`, …). Every such navigation produced an "Untracked page view" warning in Sentry, even though the path lands on the "Not Found" page.

The fix gates the error report on the navigate event's analytics context: the app's `RouteTracker` resolves each navigation against the registered routes and stores the owning plugin/extension in the context (`pluginId`/`extensionId`). When nothing matches, the context keeps its default values (`'app'`/`'app'`) — those navigations are no longer reported.

Untracked page views on **real** app routes (pages missing from `getTelemetryPageViewPayload`) are still reported, preserving the signal introduced in #1249. TelemetryDeck pageview signals are unchanged.

### Any background context you can provide?

Fixes https://github.com/giantswarm/giantswarm/issues/36756 (source-side fix, option 1). The already-accumulated Sentry issues will be muted separately as per the issue's cleanup section.

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))