### PR TITLE
chore(app): migrate grafana plugin to @backstage-community/plugin-grafana

### DIFF
--- a/.changeset/migrate-grafana-community-plugin.md
+++ b/.changeset/migrate-grafana-community-plugin.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Migrate the Grafana plugin from `@k-phoen/backstage-plugin-grafana` to the actively maintained `@backstage-community/plugin-grafana` (v0.20.0). The exported symbols (`grafanaPlugin`, `EntityGrafanaDashboardsCard`, `isDashboardSelectorAvailable`) and the `grafana.domain` configuration are unchanged, so this is a drop-in replacement with no behavior change.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@backstage-community/plugin-github-actions": "^0.23.0",
+    "@backstage-community/plugin-grafana": "^0.20.0",
     "@backstage/app-defaults": "backstage:^",
     "@backstage/catalog-model": "backstage:^",
     "@backstage/cli": "backstage:^",
@@ -58,7 +59,6 @@
     "@giantswarm/backstage-plugin-flux-react": "workspace:^",
     "@giantswarm/backstage-plugin-gs": "workspace:^",
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^",
-    "@k-phoen/backstage-plugin-grafana": "^0.1.22",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@pagerduty/backstage-plugin": "^0.19.0",

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -42,7 +42,7 @@ import {
   gsAuthApiRef,
 } from '@giantswarm/backstage-plugin-gs';
 import { errorReporterApiRef } from '@giantswarm/backstage-plugin-error-reporter-react';
-import { grafanaPlugin } from '@k-phoen/backstage-plugin-grafana';
+import { grafanaPlugin } from '@backstage-community/plugin-grafana';
 import { SentryErrorReporter } from '../../apis/errorReporter';
 import { TelemetryDeckAnalyticsApi } from '../../apis/analytics';
 import {

--- a/packages/app/src/modules/catalog/legacyEntityExtensions.tsx
+++ b/packages/app/src/modules/catalog/legacyEntityExtensions.tsx
@@ -17,7 +17,7 @@ import { EntityGithubPullRequestsContent } from '@roadiehq/backstage-plugin-gith
 import {
   EntityGrafanaDashboardsCard,
   isDashboardSelectorAvailable,
-} from '@k-phoen/backstage-plugin-grafana';
+} from '@backstage-community/plugin-grafana';
 
 export const GitHubPullRequestsEntityContent =
   convertLegacyEntityContentExtension(EntityGithubPullRequestsContent, {

--- a/packages/app/src/plugins.tsx
+++ b/packages/app/src/plugins.tsx
@@ -1,1 +1,1 @@
-export { grafanaPlugin } from '@k-phoen/backstage-plugin-grafana';
+export { grafanaPlugin } from '@backstage-community/plugin-grafana';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,6 +3502,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage-community/plugin-grafana@npm:^0.20.0":
+  version: 0.20.0
+  resolution: "@backstage-community/plugin-grafana@npm:0.20.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/core-components": "npm:^0.18.10"
+    "@backstage/core-plugin-api": "npm:^1.12.6"
+    "@backstage/frontend-plugin-api": "npm:^0.17.1"
+    "@backstage/plugin-catalog-react": "npm:^3.0.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    cross-fetch: "npm:^4.0.0"
+    jsep: "npm:^1.3.8"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: 10c0/128df34fe4e35d3bab92f3d0655c518ec6c8ed627e4d72e84fd0ece59f41f37ecbd7cc80cdcc57b11db2054f853aa421209c7c312c9ec6dff6b476177d974bc6
+  languageName: node
+  linkType: hard
+
 "@backstage/app-defaults@backstage:^::backstage=1.51.1&npm=1.7.8, @backstage/app-defaults@npm:^1.7.8":
   version: 1.7.8
   resolution: "@backstage/app-defaults@npm:1.7.8"
@@ -4112,7 +4134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.2.1, @backstage/catalog-model@npm:^1.4.5, @backstage/catalog-model@npm:^1.7.0":
+"@backstage/catalog-model@npm:^1.4.5, @backstage/catalog-model@npm:^1.7.0":
   version: 1.7.0
   resolution: "@backstage/catalog-model@npm:1.7.0"
   dependencies:
@@ -4724,7 +4746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:^1.0.7, @backstage/config@npm:^1.2.0":
+"@backstage/config@npm:^1.2.0":
   version: 1.2.0
   resolution: "@backstage/config@npm:1.2.0"
   dependencies:
@@ -4968,56 +4990,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/bbe1092ee5b005906c260e00b8b34f6394c395031f5f95d170d31d5c91d09022c268c67a98244e059ea65053259d369648d64069350e035c46425c1b2b4e1081
-  languageName: node
-  linkType: hard
-
-"@backstage/core-components@npm:^0.12.5":
-  version: 0.12.5
-  resolution: "@backstage/core-components@npm:0.12.5"
-  dependencies:
-    "@backstage/config": "npm:^1.0.7"
-    "@backstage/core-plugin-api": "npm:^1.5.0"
-    "@backstage/errors": "npm:^1.1.5"
-    "@backstage/theme": "npm:^0.2.18"
-    "@backstage/version-bridge": "npm:^1.0.3"
-    "@material-table/core": "npm:^3.1.0"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.57"
-    "@react-hookz/web": "npm:^20.0.0"
-    "@types/react-sparklines": "npm:^1.7.0"
-    "@types/react-text-truncate": "npm:^0.14.0"
-    ansi-regex: "npm:^6.0.1"
-    classnames: "npm:^2.2.6"
-    d3-selection: "npm:^3.0.0"
-    d3-shape: "npm:^3.0.0"
-    d3-zoom: "npm:^3.0.0"
-    dagre: "npm:^0.8.5"
-    history: "npm:^5.0.0"
-    immer: "npm:^9.0.1"
-    lodash: "npm:^4.17.21"
-    pluralize: "npm:^8.0.0"
-    prop-types: "npm:^15.7.2"
-    qs: "npm:^6.9.4"
-    rc-progress: "npm:3.4.1"
-    react-helmet: "npm:6.1.0"
-    react-hook-form: "npm:^7.12.2"
-    react-markdown: "npm:^8.0.0"
-    react-sparklines: "npm:^1.7.0"
-    react-syntax-highlighter: "npm:^15.4.5"
-    react-text-truncate: "npm:^0.19.0"
-    react-use: "npm:^17.3.2"
-    react-virtualized-auto-sizer: "npm:^1.0.6"
-    react-window: "npm:^1.8.6"
-    remark-gfm: "npm:^3.0.1"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:~3.18.0"
-  peerDependencies:
-    "@types/react": ^16.13.1 || ^17.0.0
-    react: ^16.13.1 || ^17.0.0
-    react-dom: ^16.13.1 || ^17.0.0
-    react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 10c0/fd8c960478cebc35b70786c29368810134558af86f54f4aeb86455b59eb880c0c2e7db09a9fa3fb144efba28d168b34702f74cf9cf4b58ac3382e8c02b2b4eb6
   languageName: node
   linkType: hard
 
@@ -5322,7 +5294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:^1.11.1, @backstage/core-plugin-api@npm:^1.12.1, @backstage/core-plugin-api@npm:^1.12.2, @backstage/core-plugin-api@npm:^1.12.4, @backstage/core-plugin-api@npm:^1.5.0, @backstage/core-plugin-api@npm:^1.9.2, @backstage/core-plugin-api@npm:^1.9.3":
+"@backstage/core-plugin-api@npm:^1.11.1, @backstage/core-plugin-api@npm:^1.12.1, @backstage/core-plugin-api@npm:^1.12.2, @backstage/core-plugin-api@npm:^1.12.4, @backstage/core-plugin-api@npm:^1.9.2, @backstage/core-plugin-api@npm:^1.9.3":
   version: 1.12.4
   resolution: "@backstage/core-plugin-api@npm:1.12.4"
   dependencies:
@@ -5421,7 +5393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.1.5, @backstage/errors@npm:^1.2.4":
+"@backstage/errors@npm:^1.2.4":
   version: 1.2.4
   resolution: "@backstage/errors@npm:1.2.4"
   dependencies:
@@ -6958,7 +6930,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:^1.11.3, @backstage/plugin-catalog-react@npm:^1.21.2, @backstage/plugin-catalog-react@npm:^1.21.6, @backstage/plugin-catalog-react@npm:^1.4.0":
+"@backstage/plugin-catalog-react@npm:^1.11.3, @backstage/plugin-catalog-react@npm:^1.21.2, @backstage/plugin-catalog-react@npm:^1.21.6":
   version: 1.21.6
   resolution: "@backstage/plugin-catalog-react@npm:1.21.6"
   dependencies:
@@ -9118,18 +9090,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:^0.2.18":
-  version: 0.2.19
-  resolution: "@backstage/theme@npm:0.2.19"
-  dependencies:
-    "@material-ui/core": "npm:^4.12.2"
-  peerDependencies:
-    react: ^16.13.1 || ^17.0.0
-    react-dom: ^16.13.1 || ^17.0.0
-  checksum: 10c0/3b40e3d7c4f6079d30c6c4bdfda903baea7507c63944602a2ea9a189773e8a8059afc5c5af06a8870471c757b701542077a01436e5f7144489671d01901c464c
-  languageName: node
-  linkType: hard
-
 "@backstage/theme@npm:^0.5.6":
   version: 0.5.7
   resolution: "@backstage/theme@npm:0.5.7"
@@ -9398,7 +9358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/version-bridge@npm:^1.0.3, @backstage/version-bridge@npm:^1.0.8":
+"@backstage/version-bridge@npm:^1.0.8":
   version: 1.0.9
   resolution: "@backstage/version-bridge@npm:1.0.9"
   dependencies:
@@ -12298,25 +12258,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@k-phoen/backstage-plugin-grafana@npm:^0.1.22":
-  version: 0.1.22
-  resolution: "@k-phoen/backstage-plugin-grafana@npm:0.1.22"
-  dependencies:
-    "@backstage/catalog-model": "npm:^1.2.1"
-    "@backstage/core-components": "npm:^0.12.5"
-    "@backstage/core-plugin-api": "npm:^1.5.0"
-    "@backstage/plugin-catalog-react": "npm:^1.4.0"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/lab": "npm:4.0.0-alpha.57"
-    jsep: "npm:^1.3.8"
-    react-use: "npm:^17.2.4"
-  peerDependencies:
-    react: ^16.13.1 || ^17.0.0
-    react-dom: ^16.13.1 || ^17.0.0
-  checksum: 10c0/ba0aca0afd21f7d6cf774d0c4240f18f1b7e8a2e812fdb1ef774040433ba3d297d715d91e2bd56bcff3195b7ff545355cb39e401d1c3c7a6dd3d0b3db6814b46
-  languageName: node
-  linkType: hard
-
 "@keyv/memcache@npm:^1.3.5":
   version: 1.4.1
   resolution: "@keyv/memcache@npm:1.4.1"
@@ -12671,27 +12612,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material-ui/lab@npm:4.0.0-alpha.57":
-  version: 4.0.0-alpha.57
-  resolution: "@material-ui/lab@npm:4.0.0-alpha.57"
-  dependencies:
-    "@babel/runtime": "npm:^7.4.4"
-    "@material-ui/utils": "npm:^4.11.2"
-    clsx: "npm:^1.0.4"
-    prop-types: "npm:^15.7.2"
-    react-is: "npm:^16.8.0 || ^17.0.0"
-  peerDependencies:
-    "@material-ui/core": ^4.9.10
-    "@types/react": ^16.8.6 || ^17.0.0
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/c167d93904b52189e33143b2db738cbe042e6dc266ce6d51ecb74e6cd79105c0c30310a98f215fa4accb3523b798947942ad60539bd3c131247ca59dcc468833
-  languageName: node
-  linkType: hard
-
 "@material-ui/lab@npm:4.0.0-alpha.61, @material-ui/lab@npm:^4.0.0-alpha.60, @material-ui/lab@npm:^4.0.0-alpha.61":
   version: 4.0.0-alpha.61
   resolution: "@material-ui/lab@npm:4.0.0-alpha.61"
@@ -12795,7 +12715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material-ui/utils@npm:^4.11.2, @material-ui/utils@npm:^4.11.3":
+"@material-ui/utils@npm:^4.11.3":
   version: 4.11.3
   resolution: "@material-ui/utils@npm:4.11.3"
   dependencies:
@@ -17358,22 +17278,6 @@ __metadata:
   version: 1.0.4
   resolution: "@react-hookz/deep-equal@npm:1.0.4"
   checksum: 10c0/f48774ccc63506e8de29eb6f3beff1204a5f51e481329f6b38b578bb43b35391eeacd9908f35a7fcca008e4c7e5144be7092103236042a8bcbbe4e7594ed4eb9
-  languageName: node
-  linkType: hard
-
-"@react-hookz/web@npm:^20.0.0":
-  version: 20.1.0
-  resolution: "@react-hookz/web@npm:20.1.0"
-  dependencies:
-    "@react-hookz/deep-equal": "npm:^1.0.4"
-  peerDependencies:
-    js-cookie: ^3.0.1
-    react: ^16.8 || ^17 || ^18
-    react-dom: ^16.8 || ^17 || ^18
-  peerDependenciesMeta:
-    js-cookie:
-      optional: true
-  checksum: 10c0/ae5fdf3e7d65d8eb3e90068aefdebb935f966af5aa47846b3fe570a2958699e9bcf229fae7f8f51fb65dac1d767a32ce8807aa884df9d4b6a4377e7a984000cb
   languageName: node
   linkType: hard
 
@@ -23710,15 +23614,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-text-truncate@npm:^0.14.0":
-  version: 0.14.4
-  resolution: "@types/react-text-truncate@npm:0.14.4"
-  dependencies:
-    "@types/react": "npm:*"
-  checksum: 10c0/423675e7c0fee22b13571dfaa1a092dde280b5bec915adbc71385d83a6f5aabf89bcf0b94fb5989eb53cec1060f7b270f7005453c65e0eacf2f431e0ec31853f
-  languageName: node
-  linkType: hard
-
 "@types/react-transition-group@npm:^4.2.0, @types/react-transition-group@npm:^4.4.10":
   version: 4.4.11
   resolution: "@types/react-transition-group@npm:4.4.11"
@@ -25149,6 +25044,7 @@ __metadata:
   resolution: "app@workspace:packages/app"
   dependencies:
     "@backstage-community/plugin-github-actions": "npm:^0.23.0"
+    "@backstage-community/plugin-grafana": "npm:^0.20.0"
     "@backstage/app-defaults": "backstage:^"
     "@backstage/catalog-model": "backstage:^"
     "@backstage/cli": "backstage:^"
@@ -25194,7 +25090,6 @@ __metadata:
     "@giantswarm/backstage-plugin-flux-react": "workspace:^"
     "@giantswarm/backstage-plugin-gs": "workspace:^"
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^"
-    "@k-phoen/backstage-plugin-grafana": "npm:^0.1.22"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@pagerduty/backstage-plugin": "npm:^0.19.0"
@@ -33639,7 +33534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:^9.0.1, immer@npm:^9.0.6, immer@npm:^9.0.7":
+"immer@npm:^9.0.6, immer@npm:^9.0.7":
   version: 9.0.21
   resolution: "immer@npm:9.0.21"
   checksum: 10c0/03ea3ed5d4d72e8bd428df4a38ad7e483ea8308e9a113d3b42e0ea2cc0cc38340eb0a6aca69592abbbf047c685dbda04e3d34bf2ff438ab57339ed0a34cc0a05
@@ -41691,7 +41586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.x, prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.5.7, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:15.x, prop-types@npm:^15.0.0, prop-types@npm:^15.5.10, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -42151,20 +42046,6 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: 10c0/981ebe65e1cee7230300d21ba6dcd8bd23ea81ef4ad2b167c0f62d93deba347f27921d330be848634baab3831cf9f38900af6082d6416c2e937fe612fa6a74ff
-  languageName: node
-  linkType: hard
-
-"rc-progress@npm:3.4.1":
-  version: 3.4.1
-  resolution: "rc-progress@npm:3.4.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.10.1"
-    classnames: "npm:^2.2.6"
-    rc-util: "npm:^5.16.1"
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 10c0/0a54feb6b878d25612fddc30f0eaef0a255e6454ee41deab2703781724f919c244b535d31f0d3b68646dd0e1cece721e3e96578d7492d11ce0c46393d50d035a
   languageName: node
   linkType: hard
 
@@ -43028,18 +42909,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-text-truncate@npm:^0.19.0":
-  version: 0.19.0
-  resolution: "react-text-truncate@npm:0.19.0"
-  dependencies:
-    prop-types: "npm:^15.5.7"
-  peerDependencies:
-    react: ^15.4.1 || ^16.0.0 || ^17.0.0 ||  || ^18.0.0
-    react-dom: ^15.4.1 || ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/0dbb3a949370d47e4e70cc58a9cc9058ffcb5a3e4e0e2027081a55d353dae0d28965cf2ed7d904974e449dfc5f0cee0a9d9024e3b476147aaa4a690b441d04de
-  languageName: node
-  linkType: hard
-
 "react-textarea-autosize@npm:^8.5.9":
   version: 8.5.9
   resolution: "react-textarea-autosize@npm:8.5.9"
@@ -43103,7 +42972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-virtualized-auto-sizer@npm:^1.0.11, react-virtualized-auto-sizer@npm:^1.0.6":
+"react-virtualized-auto-sizer@npm:^1.0.11":
   version: 1.0.24
   resolution: "react-virtualized-auto-sizer@npm:1.0.24"
   peerDependencies:
@@ -49124,13 +48993,6 @@ __metadata:
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
-  languageName: node
-  linkType: hard
-
-"zod@npm:~3.18.0":
-  version: 3.18.0
-  resolution: "zod@npm:3.18.0"
-  checksum: 10c0/35b2db00009663c88371c3658b6a83a68845d8dd601e6680c1bbf80cb4036d093e43d3423a38314189051e49507906fdacf366d20b7c9a3c37b0c497ed34940a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Migrates the Grafana frontend plugin from the original-author package `@k-phoen/backstage-plugin-grafana@^0.1.22` to the actively maintained community package `@backstage-community/plugin-grafana@^0.20.0`.

This is a minimal package swap. The community package exports the **same symbols** we use today (`grafanaPlugin`, `EntityGrafanaDashboardsCard`, `isDashboardSelectorAvailable`) from its main entry point, and the existing `convertLegacyEntityCardExtension` shim plus the manual `grafanaPlugin.getApis()` `ApiBlueprint` wiring are left untouched.

Changes:
- `packages/app/package.json` — dependency replaced
- `packages/app/src/modules/app/AppOverrides.tsx`, `modules/catalog/legacyEntityExtensions.tsx`, `plugins.tsx` — import sources repointed
- `yarn.lock` updated

### What is the effect of this change to users?

None. The `grafana.domain` configuration and the `grafana/dashboard-selector` annotation are read identically by the new package, so the Grafana Dashboards entity card behaves exactly as before. (The legacy `grafana.domain` key is now `@deprecated` in favor of multi-instance `grafana.hosts`, but remains fully supported — no config change required.)

### Any background context you can provide?

`v0.20.0` is the latest community release (built against Backstage 1.51.1, which this repo is already on, so peer-compat is exact). The `@k-phoen` repository has been superseded by the community-plugins monorepo.

Not included (possible follow-ups): adopting the package's native New Frontend System `/alpha` module, migrating `grafana.domain` → `grafana.hosts`, and removing the unused `plugins.tsx` re-export.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))