### PR TITLE
fix(auth): send RFC 8707 resource parameter in MCP OAuth flows

### DIFF
--- a/.changeset/mcp-auth-resource-indicator.md
+++ b/.changeset/mcp-auth-resource-indicator.md
@@ -1,0 +1,18 @@
+---
+'@giantswarm/backstage-plugin-auth-backend-module-gs': patch
+---
+
+Add RFC 8707 resource indicator support to the MCP OAuth2 authenticator. When a `resource` option is configured on an `mcp-*` auth provider, it is sent in both the authorization request and every token request (including refresh grants), so the authorization server issues access tokens audience-bound to the target MCP server. This is required by the MCP authorization specification and by JWT-validating gateways in front of MCP servers (e.g. agentgateway), which reject tokens without the expected `aud` claim.
+
+Example configuration:
+
+```yaml
+auth:
+  providers:
+    mcp-muster:
+      production:
+        clientId: ...
+        authorizationUrl: ...
+        tokenUrl: ...
+        resource: https://muster.example.com/mcp
+```

--- a/plugins/auth-backend-module-gs/src/oauth2/authenticator.ts
+++ b/plugins/auth-backend-module-gs/src/oauth2/authenticator.ts
@@ -44,6 +44,10 @@ export const oauth2Authenticator = createOAuthAuthenticator({
     const authorizationUrl = config.getString('authorizationUrl');
     const tokenUrl = config.getString('tokenUrl');
     const includeBasicAuth = config.getOptionalBoolean('includeBasicAuth');
+    // RFC 8707 resource indicator. The MCP authorization spec requires
+    // clients to send this in both authorization and token requests so the
+    // issued access token is audience-bound to the target MCP server.
+    const resource = config.getOptionalString('resource');
 
     if (config.has('scope')) {
       throw new Error(
@@ -115,6 +119,12 @@ export const oauth2Authenticator = createOAuthAuthenticator({
         (strategy as any)._pendingCodeVerifier = null; // Clear after use
       }
 
+      // RFC 8707: bind the token to the target resource on every grant,
+      // including refresh_token grants which reuse this code path.
+      if (resource) {
+        params.resource = resource;
+      }
+
       return originalGetOAuthAccessToken(code, params, callback);
     };
 
@@ -123,6 +133,7 @@ export const oauth2Authenticator = createOAuthAuthenticator({
       clientId,
       authorizationUrl,
       callbackUrl,
+      resource,
     };
 
     return helperWithConfig;
@@ -161,6 +172,11 @@ export const oauth2Authenticator = createOAuthAuthenticator({
     authUrl.searchParams.set('code_challenge_method', pkce.codeChallengeMethod);
     authUrl.searchParams.set('access_type', 'offline');
     authUrl.searchParams.set('prompt', 'consent');
+
+    // RFC 8707: request a token audience-bound to the target resource
+    if (config.resource) {
+      authUrl.searchParams.set('resource', config.resource);
+    }
 
     // Add scopes - ensure they're included
     if (input.scope) {


### PR DESCRIPTION
### What does this PR do?

Adds RFC 8707 Resource Indicator support to the custom MCP OAuth2 authenticator. When a `resource` option is configured on an `mcp-*` auth provider, it is sent in:

- the authorization request (`start()`), and
- every token request, including `refresh_token` grants (via the existing `getOAuthAccessToken` override, which both grant types pass through).

Example configuration:

```yaml
auth:
  providers:
    mcp-muster:
      production:
        clientId: ...
        authorizationUrl: ...
        tokenUrl: ...
        resource: https://muster.example.com/mcp
```

### Any background context you can provide?

The [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization.md) requires MCP clients to send the RFC 8707 `resource` parameter in both authorization and token requests, so the issued access token is audience-bound to the target MCP server. Our authenticator never sent it, so muster (mcp-oauth in JWT mode) issued access tokens with an empty `aud` claim.

This broke the AI chat on the Giant Swarm dev portal: muster's `/mcp` endpoint is now fronted by an agentgateway with a strict JWT authentication policy that requires `aud` to equal muster's resource identifier. Tokens without it are rejected with `401 Error(InvalidAudience)`, and the chat reports the muster tool server as unavailable.

Note: existing sessions keep the unbound audience even across refresh grants (the authorization server preserves the original grant's audience), so users need one fresh login after the deployment config gains the `resource` option.

A complementary server-side fix (defaulting `aud` to the resource identifier) is being made in mcp-oauth.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.

Made with [Cursor](https://cursor.com)