### PR TITLE
fix(muster): make auth provider resolution config frontend-visible

### DIFF
--- a/.changeset/muster-auth-config-visibility.md
+++ b/.changeset/muster-auth-config-visibility.md
@@ -1,0 +1,17 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': patch
+'@giantswarm/backstage-plugin-muster': patch
+'@giantswarm/backstage-plugin-muster-backend': patch
+---
+
+Fix the muster Workflows page failing with 401 ("requires a user token for
+auth provider ... but the request did not include one") when the muster MCP
+server uses per-user auth.
+
+The muster frontend resolves the server's `authProvider` by matching the
+`aiChat.mcp` entry by `name`, but `name` was not declared frontend-visible in
+the config schema, so the browser never saw it, never resolved the auth
+provider, and never sent the auth header. `aiChat.mcp[].name` is now
+`@visibility frontend`, and `muster.serverName` is declared frontend-visible
+in the muster frontend plugin's own config schema so overriding the entry
+name also works in the browser.

--- a/plugins/ai-chat/config.d.ts
+++ b/plugins/ai-chat/config.d.ts
@@ -25,6 +25,12 @@ export interface Config {
     /** Optional: MCP servers configuration */
     mcp?: Array<{
       /**
+       * Name of the MCP server entry. Frontend-visible so plugins can look
+       * up an entry's auth provider by name (e.g. the muster plugin).
+       * @visibility frontend
+       */
+      name?: string;
+      /**
        * Optional: Auth provider name to use for this MCP server
        * @visibility frontend
        */

--- a/plugins/muster/config.d.ts
+++ b/plugins/muster/config.d.ts
@@ -3,7 +3,8 @@ export interface Config {
   muster?: {
     /**
      * Name of the entry in the `aiChat.mcp` server list that points at the
-     * muster MCP server. Defaults to `muster`.
+     * muster MCP server. Defaults to `muster`. Frontend-visible because the
+     * frontend resolves the entry's auth provider by this name.
      * @visibility frontend
      */
     serverName?: string;

--- a/plugins/muster/package.json
+++ b/plugins/muster/package.json
@@ -51,6 +51,8 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
## Summary

The muster Workflows page fails with 401 ("The muster MCP server requires a user token for auth provider 'mcp-muster', but the request did not include one") on deployments where the muster MCP server uses per-user auth (e.g. graveler devportal).

Root cause: the muster frontend resolves the server's `authProvider` by matching the `aiChat.mcp` entry by `name` (`MusterApiClient.resolveAuthProvider()`), but `aiChat.mcp[].name` was not declared `@visibility frontend` in the ai-chat config schema, and `muster.serverName` was `@visibility backend` in a backend-only package. The browser-filtered config therefore contained `aiChat.mcp` entries without `name`, the match never succeeded, no OAuth login was attempted, no `backstage-muster-authorization` header was sent, and the muster-backend proxy correctly rejected the request. The backend sees the full config, hence the asymmetry. The ai-chat plugin is unaffected because it never matches by name (`useChatSetup.ts` collects all `authProvider` values).

Changes:

- `plugins/ai-chat/config.d.ts`: declare `aiChat.mcp[].name` as `@visibility frontend` (server names are not secrets; URLs stay backend-only)
- `plugins/muster/config.d.ts` (new) + `configSchema` in `package.json`: declare `muster.serverName` frontend-visible from the frontend plugin so it is part of the app config schema
- `plugins/muster-backend/config.d.ts`: align `muster.serverName` visibility to `frontend`

Unit tests did not catch this because mock ConfigApis do not apply visibility filtering.

## Test plan

- [ ] CI green
- [ ] After release: on graveler devportal, /muster prompts for the `mcp-muster` OAuth login and then lists workflows instead of failing with 401

Made with [Cursor](https://cursor.com)