### PR TITLE
fix(ai-chat): bound MCP server loading with timeouts and fix SSE interop hang

### DIFF
--- a/.changeset/ai-chat-mcp-timeout-sse-interop.md
+++ b/.changeset/ai-chat-mcp-timeout-sse-interop.md
@@ -1,0 +1,10 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+'@giantswarm/backstage-plugin-muster-backend': patch
+'@giantswarm/backstage-plugin-gs-node': patch
+---
+
+Fix AI chat hanging forever when an MCP server is slow or its responses are dropped by the transport.
+
+- MCP servers are now connected in parallel and each connection/tool-load is bounded by a timeout (15s default, configurable per server via `aiChat.mcp[].timeoutMs`). A hanging server is reported as failed and the chat continues with the remaining servers' tools.
+- Patch `@ai-sdk/mcp` to treat SSE events without an explicit `event:` field as `message` events, per the SSE specification. MCP servers behind agentgateway emit bare `data:` frames, which the unpatched client silently dropped — leaving the request promise pending forever and hanging the whole chat request.

--- a/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch
+++ b/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch
@@ -1,0 +1,62 @@
+diff --git a/dist/index.js b/dist/index.js
+index 973f16ed6bbe752f46dc417dd4be08c78526fcfb..6a6ef2412c0044ffd898110254897626857c6238 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1222,7 +1222,7 @@ var SseMCPTransport = class {
+                   }
+                   this.connected = true;
+                   resolve();
+-                } else if (event === "message") {
++                } else if ((event === void 0 || event === "message")) {
+                   try {
+                     const message = await parseJSONRPCMessage(data);
+                     (_a4 = this.onmessage) == null ? void 0 : _a4.call(this, message);
+@@ -1497,7 +1497,7 @@ var HttpMCPTransport = class {
+                 const { done, value } = await reader.read();
+                 if (done) return;
+                 const { event, data } = value;
+-                if (event === "message") {
++                if ((event === void 0 || event === "message")) {
+                   try {
+                     const msg = await parseJSONRPCMessage(data);
+                     (_a4 = this.onmessage) == null ? void 0 : _a4.call(this, msg);
+@@ -1624,7 +1624,7 @@ var HttpMCPTransport = class {
+             if (id) {
+               this.lastInboundEventId = id;
+             }
+-            if (event === "message") {
++            if ((event === void 0 || event === "message")) {
+               try {
+                 const msg = await parseJSONRPCMessage(data);
+                 (_a4 = this.onmessage) == null ? void 0 : _a4.call(this, msg);
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 2b80c31413f15377f1bfa76a520a914655d720d0..7298ad5e561e1847047afda222221f216144d57a 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1192,7 +1192,7 @@ var SseMCPTransport = class {
+                   }
+                   this.connected = true;
+                   resolve();
+-                } else if (event === "message") {
++                } else if ((event === void 0 || event === "message")) {
+                   try {
+                     const message = await parseJSONRPCMessage(data);
+                     (_a4 = this.onmessage) == null ? void 0 : _a4.call(this, message);
+@@ -1471,7 +1471,7 @@ var HttpMCPTransport = class {
+                 const { done, value } = await reader.read();
+                 if (done) return;
+                 const { event, data } = value;
+-                if (event === "message") {
++                if ((event === void 0 || event === "message")) {
+                   try {
+                     const msg = await parseJSONRPCMessage(data);
+                     (_a4 = this.onmessage) == null ? void 0 : _a4.call(this, msg);
+@@ -1598,7 +1598,7 @@ var HttpMCPTransport = class {
+             if (id) {
+               this.lastInboundEventId = id;
+             }
+-            if (event === "message") {
++            if ((event === void 0 || event === "message")) {
+               try {
+                 const msg = await parseJSONRPCMessage(data);
+                 (_a4 = this.onmessage) == null ? void 0 : _a4.call(this, msg);

--- a/plugins/ai-chat-backend/package.json
+++ b/plugins/ai-chat-backend/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.76",
     "@ai-sdk/azure": "^3.0.64",
-    "@ai-sdk/mcp": "^1.0.41",
+    "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch",
     "@ai-sdk/openai": "^3.0.63",
     "@ai-sdk/openai-compatible": "^2.0.47",
     "@backstage/backend-defaults": "backstage:^",

--- a/plugins/ai-chat-backend/src/getMcpTools.test.ts
+++ b/plugins/ai-chat-backend/src/getMcpTools.test.ts
@@ -1,0 +1,202 @@
+import { ConfigReader } from '@backstage/config';
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { McpClientCache } from '@giantswarm/backstage-plugin-gs-node';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { getMcpTools } from './getMcpTools';
+
+jest.mock('@ai-sdk/mcp', () => ({
+  experimental_createMCPClient: jest.fn(),
+}));
+
+const createMCPClientMock = createMCPClient as jest.Mock;
+
+function mockLogger(): LoggerService {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as LoggerService;
+}
+
+function makeGoodClient() {
+  return {
+    listResources: jest
+      .fn()
+      .mockRejectedValue(new Error('does not support resources')),
+    tools: jest.fn().mockResolvedValue({
+      my_tool: {
+        description: 'A test tool',
+        execute: async () => 'ok',
+      },
+    }),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('getMcpTools', () => {
+  let clientCache: McpClientCache;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clientCache = new McpClientCache(mockLogger());
+  });
+
+  afterEach(async () => {
+    // Don't await dispose: it may wait on never-resolving client promises
+    // that the hanging-server tests intentionally leave behind.
+    void clientCache.dispose().catch(() => {});
+  });
+
+  it('loads tools from a responsive MCP server', async () => {
+    createMCPClientMock.mockImplementation(() =>
+      Promise.resolve(makeGoodClient()),
+    );
+
+    const config = new ConfigReader({
+      aiChat: {
+        mcp: [{ name: 'good', url: 'http://good.example.com/mcp' }],
+      },
+    });
+
+    const result = await getMcpTools(
+      config,
+      {},
+      undefined,
+      mockLogger(),
+      clientCache,
+    );
+
+    expect(result.connectedServers).toEqual(['good']);
+    expect(result.failedServers).toEqual([]);
+    expect(Object.keys(result.tools)).toEqual(['my_tool']);
+  });
+
+  it('does not hang the chat request when an MCP server never completes the connection handshake', async () => {
+    createMCPClientMock.mockImplementation(({ name }: { name: string }) => {
+      if (name === 'hanging') {
+        // Simulates a server whose initialize response is never delivered
+        // to the client (observed in production with muster behind
+        // agentgateway): the promise never settles.
+        return new Promise(() => {});
+      }
+      return Promise.resolve(makeGoodClient());
+    });
+
+    const config = new ConfigReader({
+      aiChat: {
+        mcp: [
+          { name: 'good', url: 'http://good.example.com/mcp' },
+          {
+            name: 'hanging',
+            url: 'http://hanging.example.com/mcp',
+            timeoutMs: 250,
+          },
+        ],
+      },
+    });
+
+    const result = await getMcpTools(
+      config,
+      {},
+      undefined,
+      mockLogger(),
+      clientCache,
+    );
+
+    expect(result.connectedServers).toEqual(['good']);
+    expect(result.failedServers).toHaveLength(1);
+    expect(result.failedServers[0].name).toBe('hanging');
+    expect(result.failedServers[0].error).toMatch(/timed out/i);
+    // Tools from the healthy server are still available.
+    expect(Object.keys(result.tools)).toEqual(['my_tool']);
+  }, 5000);
+
+  it('does not hang the chat request when tools/list never returns', async () => {
+    createMCPClientMock.mockImplementation(({ name }: { name: string }) => {
+      if (name === 'hanging-tools') {
+        return Promise.resolve({
+          listResources: jest
+            .fn()
+            .mockRejectedValue(new Error('does not support resources')),
+          // tools/list response never arrives
+          tools: jest.fn().mockReturnValue(new Promise(() => {})),
+          close: jest.fn().mockResolvedValue(undefined),
+        });
+      }
+      return Promise.resolve(makeGoodClient());
+    });
+
+    const config = new ConfigReader({
+      aiChat: {
+        mcp: [
+          {
+            name: 'hanging-tools',
+            url: 'http://hanging.example.com/mcp',
+            timeoutMs: 250,
+          },
+          { name: 'good', url: 'http://good.example.com/mcp' },
+        ],
+      },
+    });
+
+    const result = await getMcpTools(
+      config,
+      {},
+      undefined,
+      mockLogger(),
+      clientCache,
+    );
+
+    expect(result.connectedServers).toEqual(['good']);
+    expect(result.failedServers).toHaveLength(1);
+    expect(result.failedServers[0].name).toBe('hanging-tools');
+    expect(result.failedServers[0].error).toMatch(/timed out/i);
+    expect(Object.keys(result.tools)).toEqual(['my_tool']);
+  }, 5000);
+
+  it('evicts a timed-out server from the cache so the next request retries', async () => {
+    let callCount = 0;
+    createMCPClientMock.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Promise(() => {});
+      }
+      return Promise.resolve(makeGoodClient());
+    });
+
+    const config = new ConfigReader({
+      aiChat: {
+        mcp: [
+          {
+            name: 'flaky',
+            url: 'http://flaky.example.com/mcp',
+            timeoutMs: 250,
+          },
+        ],
+      },
+    });
+
+    const first = await getMcpTools(
+      config,
+      {},
+      undefined,
+      mockLogger(),
+      clientCache,
+    );
+    expect(first.failedServers).toHaveLength(1);
+
+    const second = await getMcpTools(
+      config,
+      {},
+      undefined,
+      mockLogger(),
+      clientCache,
+    );
+    expect(second.connectedServers).toEqual(['flaky']);
+    expect(second.failedServers).toEqual([]);
+  }, 5000);
+});

--- a/plugins/ai-chat-backend/src/getMcpTools.ts
+++ b/plugins/ai-chat-backend/src/getMcpTools.ts
@@ -16,7 +16,17 @@ interface McpServerConfig {
   headers?: Record<string, string>;
   installation?: string;
   authToken?: string;
+  timeoutMs?: number;
 }
+
+/**
+ * Upper bound for connecting to an MCP server and loading its resources
+ * and tools. Without it a single unresponsive server hangs the whole chat
+ * request forever (observed in production when an MCP server's responses
+ * were silently dropped by the transport). Override per server with
+ * `aiChat.mcp[].timeoutMs`.
+ */
+const DEFAULT_MCP_SERVER_TIMEOUT_MS = 15_000;
 
 export interface BackstageUserContext {
   userEntityRef: string;
@@ -52,6 +62,7 @@ function readMcpServersFromConfig(
     const name = mcp.getString('name');
     const url = mcp.getString('url');
     const installation = mcp.getOptionalString('installation');
+    const timeoutMs = mcp.getOptionalNumber('timeoutMs');
 
     // Rule 1: Forward a Backstage token minted on behalf of the calling
     // user, scoped to the built-in `mcp-actions` plugin. Use this for
@@ -75,6 +86,7 @@ function readMcpServersFromConfig(
         // Stable per-user cache key so the cache survives across
         // requests despite the Authorization token being minted fresh.
         authToken: `bs-user:${backstageUser.userEntityRef}`,
+        timeoutMs,
       };
 
       continue;
@@ -93,6 +105,7 @@ function readMcpServersFromConfig(
         headers: { Authorization: `Bearer ${token}` },
         installation,
         authToken: token,
+        timeoutMs,
       };
 
       continue;
@@ -101,12 +114,12 @@ function readMcpServersFromConfig(
     // Rule 3: If headers configured, add server with those headers
     const headers = getMcpServerHeaders(mcp);
     if (headers) {
-      mcpServers[name] = { url, headers, installation };
+      mcpServers[name] = { url, headers, installation, timeoutMs };
       continue;
     }
 
     // Rule 4: No headers and no authProvider, just add server
-    mcpServers[name] = { url, installation };
+    mcpServers[name] = { url, installation, timeoutMs };
   }
 
   return mcpServers;
@@ -267,6 +280,77 @@ export interface McpToolsResult {
   connectedServers: string[];
 }
 
+interface ServerLoadResult {
+  serverName: string;
+  tools?: ToolSet;
+  resources?: { [resourceName: string]: string };
+  error?: string;
+}
+
+async function loadServer(
+  serverName: string,
+  server: McpServerConfig,
+  logger: LoggerService,
+  clientCache: McpClientCache,
+): Promise<ServerLoadResult> {
+  const cacheKey = McpClientCache.buildKey(serverName, server.authToken);
+  const timeoutMs = server.timeoutMs ?? DEFAULT_MCP_SERVER_TIMEOUT_MS;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `Timed out after ${timeoutMs}ms waiting for MCP server '${serverName}'`,
+          ),
+        ),
+      timeoutMs,
+    );
+    timer.unref?.();
+  });
+
+  try {
+    const load = (async () => {
+      const mcpClient = await clientCache.getOrCreate(cacheKey, () =>
+        createMCPClient({
+          name: serverName,
+          transport: {
+            type: 'http',
+            url: server.url,
+            headers: server.headers,
+          },
+        }),
+      );
+
+      const serverResources = await getResources(mcpClient, serverName, logger);
+      const serverTools = await getTools(
+        mcpClient,
+        serverName,
+        logger,
+        () => clientCache.markDead(cacheKey),
+        server.installation,
+      );
+
+      return { serverName, tools: serverTools, resources: serverResources };
+    })();
+
+    return await Promise.race([load, timeout]);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(
+      `Failed to connect to MCP server '${serverName}' at ${server.url}: ${errorMessage}`,
+    );
+    // Evict the broken session so the next request retries. Not awaited:
+    // invalidate awaits the cached client promise before closing it, which
+    // may itself never settle when the server is hanging.
+    void clientCache.invalidate(cacheKey).catch(() => {});
+    return { serverName, error: errorMessage };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export async function getMcpTools(
   config: Config,
   authTokens: AuthTokens,
@@ -285,42 +369,23 @@ export async function getMcpTools(
   const failedServers: Array<{ name: string; error: string }> = [];
   const connectedServers: string[] = [];
 
-  for (const [serverName, server] of Object.entries(mcpServers)) {
-    const cacheKey = McpClientCache.buildKey(serverName, server.authToken);
+  // Load all servers in parallel; each is individually bounded by its
+  // timeout so one slow or hanging server neither delays nor blocks the
+  // others. Results are merged in config order to keep tool precedence
+  // deterministic.
+  const results = await Promise.all(
+    Object.entries(mcpServers).map(([serverName, server]) =>
+      loadServer(serverName, server, logger, clientCache),
+    ),
+  );
 
-    try {
-      const mcpClient = await clientCache.getOrCreate(cacheKey, () =>
-        createMCPClient({
-          name: serverName,
-          transport: {
-            type: 'http',
-            url: server.url,
-            headers: server.headers,
-          },
-        }),
-      );
-
-      const serverResources = await getResources(mcpClient, serverName, logger);
-      Object.assign(resources, serverResources);
-
-      const serverTools = await getTools(
-        mcpClient,
-        serverName,
-        logger,
-        () => clientCache.markDead(cacheKey),
-        server.installation,
-      );
-      Object.assign(tools, serverTools);
-      connectedServers.push(serverName);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      logger.error(
-        `Failed to connect to MCP server '${serverName}' at ${server.url}: ${errorMessage}`,
-      );
-      failedServers.push({ name: serverName, error: errorMessage });
-      // Evict broken session so the next request retries
-      await clientCache.invalidate(cacheKey);
+  for (const result of results) {
+    if (result.error !== undefined) {
+      failedServers.push({ name: result.serverName, error: result.error });
+    } else {
+      Object.assign(resources, result.resources);
+      Object.assign(tools, result.tools);
+      connectedServers.push(result.serverName);
     }
   }
 

--- a/plugins/ai-chat-backend/src/mcpSseInterop.test.ts
+++ b/plugins/ai-chat-backend/src/mcpSseInterop.test.ts
@@ -1,0 +1,141 @@
+import http from 'http';
+import { AddressInfo } from 'net';
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+
+/**
+ * Regression test for the production AI chat hang (2026-06-11).
+ *
+ * MCP servers behind agentgateway answer streamable-HTTP POSTs with
+ * `Content-Type: text/event-stream` bodies whose events carry no explicit
+ * `event:` field — only `data:` lines. Per the SSE specification, an event
+ * without an `event:` field defaults to the type "message", so a compliant
+ * client must process it. @ai-sdk/mcp 1.0.x compared the parsed event type
+ * strictly against the string "message" (`event === 'message'`), dropping
+ * bare-data events and leaving the request promise pending forever, which
+ * hung the whole chat request.
+ *
+ * This test runs the real @ai-sdk/mcp client against a minimal MCP server
+ * that mimics agentgateway's SSE framing. It fails (times out) without the
+ * @ai-sdk/mcp patch and passes with it.
+ */
+describe('MCP client interop with bare-data SSE responses (agentgateway framing)', () => {
+  let server: http.Server;
+  let url: string;
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      if (req.method === 'GET') {
+        // No standalone inbound SSE stream; clients must tolerate this.
+        res.writeHead(405).end();
+        return;
+      }
+      if (req.method === 'DELETE') {
+        res.writeHead(200).end();
+        return;
+      }
+
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        const message = JSON.parse(body);
+
+        // Notifications get an empty 202, like agentgateway/mcp-go.
+        if (!('id' in message)) {
+          res.writeHead(202).end();
+          return;
+        }
+
+        let result: unknown;
+        switch (message.method) {
+          case 'initialize':
+            result = {
+              protocolVersion: message.params.protocolVersion,
+              capabilities: { tools: { listChanged: true } },
+              serverInfo: { name: 'fake-agentgateway', version: '0.0.1' },
+            };
+            break;
+          case 'tools/list':
+            result = {
+              tools: [
+                {
+                  name: 'echo',
+                  description: 'Echoes the input',
+                  inputSchema: {
+                    type: 'object',
+                    properties: { text: { type: 'string' } },
+                  },
+                },
+              ],
+            };
+            break;
+          default:
+            res.writeHead(200, {
+              'Content-Type': 'text/event-stream',
+              'mcp-session-id': 'test-session',
+            });
+            res.end(
+              `data: ${JSON.stringify({
+                jsonrpc: '2.0',
+                id: message.id,
+                error: { code: -32601, message: 'Method not found' },
+              })}\n\n`,
+            );
+            return;
+        }
+
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'mcp-session-id': 'test-session',
+        });
+        // Crucially: no `event: message` line, only `data:` — this is the
+        // framing agentgateway produces.
+        res.end(
+          `data: ${JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result,
+          })}\n\n`,
+        );
+      });
+    });
+
+    await new Promise<void>(resolve => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const { address, port } = server.address() as AddressInfo;
+    url = `http://${address}:${port}/mcp`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>(resolve => {
+      server.close(() => resolve());
+    });
+  });
+
+  it('initializes and lists tools when SSE events have no explicit event field', async () => {
+    const guard = (label: string) =>
+      new Promise<never>((_, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`${label} did not complete within 3s`)),
+          3000,
+        );
+        timer.unref();
+      });
+
+    const client = await Promise.race([
+      createMCPClient({
+        name: 'bare-data-sse-server',
+        transport: { type: 'http', url },
+      }),
+      guard('initialize'),
+    ]);
+
+    const tools = await Promise.race([client.tools(), guard('tools/list')]);
+
+    expect(Object.keys(tools)).toContain('echo');
+
+    await client.close();
+  }, 10000);
+});

--- a/plugins/gs-node/package.json
+++ b/plugins/gs-node/package.json
@@ -24,7 +24,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@ai-sdk/mcp": "^1.0.41",
+    "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/errors": "backstage:^",
     "@backstage/types": "backstage:^",

--- a/plugins/muster-backend/package.json
+++ b/plugins/muster-backend/package.json
@@ -25,7 +25,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@ai-sdk/mcp": "^1.0.41",
+    "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/config": "backstage:^",
     "@backstage/errors": "backstage:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,7 +100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/mcp@npm:^1.0.41":
+"@ai-sdk/mcp@npm:1.0.46":
   version: 1.0.46
   resolution: "@ai-sdk/mcp@npm:1.0.46"
   dependencies:
@@ -110,6 +110,19 @@ __metadata:
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
   checksum: 10c0/e1c8e0cf6fc8ec9e6f5af974f70cee9000c3a2ca479e8bb7201a6a146b4bf3319652bce19e81c3fc7d7296d9ba57e22782392bffe6731e62d88981d59472de0c
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/mcp@patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch":
+  version: 1.0.46
+  resolution: "@ai-sdk/mcp@patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch::version=1.0.46&hash=0cae29"
+  dependencies:
+    "@ai-sdk/provider": "npm:3.0.10"
+    "@ai-sdk/provider-utils": "npm:4.0.27"
+    pkce-challenge: "npm:^5.0.0"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/d20fc5b7b9b763b8dcc95fcbb714e140ce14d1b886e725c626e8769a4f1ee18b0e95e57dcc96ce5dcc4870a6b95da7e221e27c9bfcb45e5f37cd0f27c37f7f52
   languageName: node
   linkType: hard
 
@@ -10639,7 +10652,7 @@ __metadata:
   dependencies:
     "@ai-sdk/anthropic": "npm:^3.0.76"
     "@ai-sdk/azure": "npm:^3.0.64"
-    "@ai-sdk/mcp": "npm:^1.0.41"
+    "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch"
     "@ai-sdk/openai": "npm:^3.0.63"
     "@ai-sdk/openai-compatible": "npm:^2.0.47"
     "@backstage/backend-defaults": "backstage:^"
@@ -10880,7 +10893,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@giantswarm/backstage-plugin-gs-node@workspace:plugins/gs-node"
   dependencies:
-    "@ai-sdk/mcp": "npm:^1.0.41"
+    "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch"
     "@backstage/backend-plugin-api": "backstage:^"
     "@backstage/backend-test-utils": "backstage:^"
     "@backstage/cli": "backstage:^"
@@ -11007,7 +11020,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@giantswarm/backstage-plugin-muster-backend@workspace:plugins/muster-backend"
   dependencies:
-    "@ai-sdk/mcp": "npm:^1.0.41"
+    "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch"
     "@backstage/backend-defaults": "backstage:^"
     "@backstage/backend-plugin-api": "backstage:^"
     "@backstage/backend-test-utils": "backstage:^"


### PR DESCRIPTION
## Summary

Production AI chat on the dev portal hung forever on every request after the muster MCP server started participating in chat (#1735 populated its auth token for the first time). Two compounding bugs:

- **No timeout / no isolation**: `getMcpTools` loaded MCP servers serially with no time bound, so one hanging server blocked the whole `/chat` request indefinitely.
- **SSE interop bug**: `@ai-sdk/mcp` only processes SSE events whose `event:` field is literally `message`. MCP responses proxied through agentgateway are SSE frames with bare `data:` lines (no `event:` field), which per the SSE spec default to the `message` type. The client silently dropped every response — initialize/tools-list promises never settled, with no error on either side.

## Changes

- Load MCP servers in parallel; each server's connect + resource + tool loading is bounded by a timeout (15s default, configurable per server via `aiChat.mcp[].timeoutMs`). Timed-out servers land in `failedServers` (already surfaced to the system prompt) and their cache entry is evicted so the next request retries.
- `yarn patch` for `@ai-sdk/mcp@1.0.46`: treat SSE events without an explicit `event:` field as `message` events (SSE spec § interpretation of omitted event type). Will be dropped once fixed upstream.

## Tests (written first, red → green)

- `getMcpTools.test.ts`: hanging initialize, hanging tools/list, cache eviction after timeout, healthy-server baseline — all hung before the fix.
- `mcpSseInterop.test.ts`: real `@ai-sdk/mcp` client against a minimal MCP server that mimics agentgateway's bare-`data:` SSE framing — timed out before the patch, passes with it.
- Verified against the live muster endpoint: initialize + listResources + tools/list complete in ~0.4s with the patched client (previously hung forever).

## Test plan

- [ ] CI green
- [ ] After deploy: AI chat on the dev portal responds and muster tools are listed in the chat debug metadata

Made with [Cursor](https://cursor.com)