### PR TITLE
feat(ai-chat): forward main Dex ID token for MCP servers without a dedicated auth provider

### DIFF
--- a/.changeset/mcp-auth-main-id-token-forwarding.md
+++ b/.changeset/mcp-auth-main-id-token-forwarding.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-ai-chat': minor
+'@giantswarm/backstage-plugin-muster': minor
+---
+
+Forward the main Dex ID token as the MCP bearer token when an MCP server's `authProvider` has no dedicated `auth.providers` entry. `MCPAuthProviders` and `MusterAuthProviders` accept an optional main auth API (wired to `gsAuthProvidersApi.getMainAuthApi()` in the app) and fall back to its ID token, enabling single sign-on for muster via its trusted-audiences validation. Deployments enable this by removing the `mcp-muster` provider from `auth.providers`, which also removes the separate PKCE login from the user settings page; dedicated providers keep taking precedence while still configured.

--- a/packages/app/src/modules/ai-chat/AiChatApiOverride.ts
+++ b/packages/app/src/modules/ai-chat/AiChatApiOverride.ts
@@ -4,6 +4,7 @@ import {
   MCPAuthProviders,
 } from '@giantswarm/backstage-plugin-ai-chat';
 import { gsAuthProvidersApiRef } from '@giantswarm/backstage-plugin-gs';
+import { getOptionalMainAuthApi } from '../auth/getOptionalMainAuthApi';
 
 export const AiChatApiOverride = ApiBlueprint.make({
   name: 'mcp-auth-providers',
@@ -13,7 +14,12 @@ export const AiChatApiOverride = ApiBlueprint.make({
       deps: { gsAuthProvidersApi: gsAuthProvidersApiRef },
       factory: ({ gsAuthProvidersApi }) => {
         const authProviders = gsAuthProvidersApi.getMCPAuthApis();
-        return new MCPAuthProviders(authProviders);
+        // MCP servers whose authProvider has no dedicated `auth.providers`
+        // entry get the main Dex ID token forwarded instead (single
+        // sign-on via muster's trusted-audiences validation), so no
+        // separate PKCE login is needed.
+        const mainAuthApi = getOptionalMainAuthApi(gsAuthProvidersApi);
+        return new MCPAuthProviders(authProviders, mainAuthApi);
       },
     }),
 });

--- a/packages/app/src/modules/auth/getOptionalMainAuthApi.ts
+++ b/packages/app/src/modules/auth/getOptionalMainAuthApi.ts
@@ -1,0 +1,16 @@
+import { gsAuthProvidersApiRef } from '@giantswarm/backstage-plugin-gs';
+
+/**
+ * Resolves the main auth API, or undefined when no main auth provider is
+ * configured (`gs.authProvider` unset), in which case MCP servers require
+ * dedicated auth providers.
+ */
+export function getOptionalMainAuthApi(
+  gsAuthProvidersApi: typeof gsAuthProvidersApiRef.T,
+) {
+  try {
+    return gsAuthProvidersApi.getMainAuthApi();
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/app/src/modules/muster/MusterApiOverride.ts
+++ b/packages/app/src/modules/muster/MusterApiOverride.ts
@@ -4,6 +4,7 @@ import {
   MusterAuthProviders,
 } from '@giantswarm/backstage-plugin-muster';
 import { gsAuthProvidersApiRef } from '@giantswarm/backstage-plugin-gs';
+import { getOptionalMainAuthApi } from '../auth/getOptionalMainAuthApi';
 
 export const MusterApiOverride = ApiBlueprint.make({
   name: 'auth-providers',
@@ -13,7 +14,11 @@ export const MusterApiOverride = ApiBlueprint.make({
       deps: { gsAuthProvidersApi: gsAuthProvidersApiRef },
       factory: ({ gsAuthProvidersApi }) => {
         const authProviders = gsAuthProvidersApi.getMCPAuthApis();
-        return new MusterAuthProviders(authProviders);
+        // Same single sign-on fallback as the ai-chat MCP auth providers:
+        // without a dedicated provider entry, the main Dex ID token is
+        // forwarded as the muster bearer token.
+        const mainAuthApi = getOptionalMainAuthApi(gsAuthProvidersApi);
+        return new MusterAuthProviders(authProviders, mainAuthApi);
       },
     }),
 });

--- a/plugins/ai-chat/src/api/MCPAuthProviders.test.ts
+++ b/plugins/ai-chat/src/api/MCPAuthProviders.test.ts
@@ -1,0 +1,68 @@
+import { OAuthApi, OpenIdConnectApi } from '@backstage/core-plugin-api';
+import { MCPAuthProviders } from './MCPAuthProviders';
+
+const oauthApi = (token: string): OAuthApi => ({
+  getAccessToken: jest.fn().mockResolvedValue(token),
+});
+
+const oidcApi = (idToken: string): OpenIdConnectApi => ({
+  getIdToken: jest.fn().mockResolvedValue(idToken),
+});
+
+describe('MCPAuthProviders', () => {
+  it('returns the access token from a dedicated provider', async () => {
+    const providers = new MCPAuthProviders({
+      'mcp-muster': oauthApi('access-token'),
+    });
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'access-token',
+    });
+  });
+
+  it('falls back to the main auth ID token for unknown providers', async () => {
+    const providers = new MCPAuthProviders({}, oidcApi('main-id-token'));
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'main-id-token',
+    });
+  });
+
+  it('prefers a dedicated provider over the main auth fallback', async () => {
+    const main = oidcApi('main-id-token');
+    const providers = new MCPAuthProviders(
+      { 'mcp-muster': oauthApi('access-token') },
+      main,
+    );
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'access-token',
+    });
+    expect(main.getIdToken).not.toHaveBeenCalled();
+  });
+
+  it('returns empty credentials without a matching provider or main auth', async () => {
+    const providers = new MCPAuthProviders();
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+  });
+
+  it('returns empty credentials when the dedicated provider fails', async () => {
+    const providers = new MCPAuthProviders({
+      'mcp-muster': {
+        getAccessToken: jest.fn().mockRejectedValue(new Error('boom')),
+      },
+    });
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+  });
+
+  it('returns empty credentials when the main auth fallback fails', async () => {
+    const providers = new MCPAuthProviders(
+      {},
+      { getIdToken: jest.fn().mockRejectedValue(new Error('boom')) },
+    );
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+  });
+});

--- a/plugins/ai-chat/src/api/MCPAuthProviders.ts
+++ b/plugins/ai-chat/src/api/MCPAuthProviders.ts
@@ -1,21 +1,49 @@
-import { OAuthApi } from '@backstage/core-plugin-api';
+import { OAuthApi, OpenIdConnectApi } from '@backstage/core-plugin-api';
 import { MCPAuthProvidersApi, MCPAuthCredentials } from './types';
 
 export class MCPAuthProviders implements MCPAuthProvidersApi {
   private readonly authProviders: { [providerName: string]: OAuthApi };
+  private readonly mainAuthApi?: OpenIdConnectApi;
 
-  constructor(authProviders: { [providerName: string]: OAuthApi } = {}) {
+  /**
+   * @param authProviders - Dedicated OAuth providers, keyed by the
+   *   `authProvider` name used in `aiChat.mcp` config. Each yields its own
+   *   access token (legacy per-server PKCE login).
+   * @param mainAuthApi - Optional fallback for provider names without a
+   *   dedicated entry: the user's main identity provider, whose ID token is
+   *   forwarded as the MCP bearer token. This enables single sign-on for MCP
+   *   servers (e.g. muster) that trust the main issuer, without a separate
+   *   login.
+   */
+  constructor(
+    authProviders: { [providerName: string]: OAuthApi } = {},
+    mainAuthApi?: OpenIdConnectApi,
+  ) {
     this.authProviders = authProviders;
+    this.mainAuthApi = mainAuthApi;
   }
 
   async getCredentials(authProvider: string): Promise<MCPAuthCredentials> {
     const authApi = this.authProviders[authProvider];
     if (!authApi) {
-      return {};
+      return this.getMainCredentials();
     }
 
     try {
       const token = await authApi.getAccessToken();
+      return { token };
+    } catch {
+      return {};
+    }
+  }
+
+  private async getMainCredentials(): Promise<MCPAuthCredentials> {
+    if (!this.mainAuthApi) {
+      return {};
+    }
+
+    try {
+      const token = await this.mainAuthApi.getIdToken();
       return { token };
     } catch {
       return {};

--- a/plugins/muster/src/apis/MusterAuthProviders.test.ts
+++ b/plugins/muster/src/apis/MusterAuthProviders.test.ts
@@ -1,0 +1,58 @@
+import { OAuthApi, OpenIdConnectApi } from '@backstage/core-plugin-api';
+import { MusterAuthProviders } from './MusterAuthProviders';
+
+const oauthApi = (token: string): OAuthApi => ({
+  getAccessToken: jest.fn().mockResolvedValue(token),
+});
+
+const oidcApi = (idToken: string): OpenIdConnectApi => ({
+  getIdToken: jest.fn().mockResolvedValue(idToken),
+});
+
+describe('MusterAuthProviders', () => {
+  it('returns the access token from a dedicated provider', async () => {
+    const providers = new MusterAuthProviders({
+      'mcp-muster': oauthApi('access-token'),
+    });
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'access-token',
+    });
+  });
+
+  it('falls back to the main auth ID token for unknown providers', async () => {
+    const providers = new MusterAuthProviders({}, oidcApi('main-id-token'));
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'main-id-token',
+    });
+  });
+
+  it('prefers a dedicated provider over the main auth fallback', async () => {
+    const main = oidcApi('main-id-token');
+    const providers = new MusterAuthProviders(
+      { 'mcp-muster': oauthApi('access-token') },
+      main,
+    );
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'access-token',
+    });
+    expect(main.getIdToken).not.toHaveBeenCalled();
+  });
+
+  it('returns empty credentials without a matching provider or main auth', async () => {
+    const providers = new MusterAuthProviders();
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+  });
+
+  it('returns empty credentials when the main auth fallback fails', async () => {
+    const providers = new MusterAuthProviders(
+      {},
+      { getIdToken: jest.fn().mockRejectedValue(new Error('boom')) },
+    );
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+  });
+});

--- a/plugins/muster/src/apis/MusterAuthProviders.ts
+++ b/plugins/muster/src/apis/MusterAuthProviders.ts
@@ -1,4 +1,8 @@
-import { createApiRef, OAuthApi } from '@backstage/core-plugin-api';
+import {
+  createApiRef,
+  OAuthApi,
+  OpenIdConnectApi,
+} from '@backstage/core-plugin-api';
 import { MusterAuthCredentials, MusterAuthProvidersApi } from './types';
 
 export const musterAuthProvidersApiRef = createApiRef<MusterAuthProvidersApi>({
@@ -8,23 +12,48 @@ export const musterAuthProvidersApiRef = createApiRef<MusterAuthProvidersApi>({
 /**
  * Maps auth provider names to OAuthApi instances, mirroring ai-chat's
  * MCPAuthProviders. The app wires this up with the gs auth providers'
- * MCP auth APIs.
+ * MCP auth APIs and main auth API.
  */
 export class MusterAuthProviders implements MusterAuthProvidersApi {
   private readonly authProviders: { [providerName: string]: OAuthApi };
+  private readonly mainAuthApi?: OpenIdConnectApi;
 
-  constructor(authProviders: { [providerName: string]: OAuthApi } = {}) {
+  /**
+   * @param authProviders - Dedicated OAuth providers, keyed by `authProvider`
+   *   name. Each yields its own access token (legacy per-server PKCE login).
+   * @param mainAuthApi - Optional fallback for provider names without a
+   *   dedicated entry: the user's main identity provider, whose ID token is
+   *   forwarded as the bearer token (single sign-on, no separate login).
+   */
+  constructor(
+    authProviders: { [providerName: string]: OAuthApi } = {},
+    mainAuthApi?: OpenIdConnectApi,
+  ) {
     this.authProviders = authProviders;
+    this.mainAuthApi = mainAuthApi;
   }
 
   async getCredentials(authProvider: string): Promise<MusterAuthCredentials> {
     const authApi = this.authProviders[authProvider];
     if (!authApi) {
-      return {};
+      return this.getMainCredentials();
     }
 
     try {
       const token = await authApi.getAccessToken();
+      return { token };
+    } catch {
+      return {};
+    }
+  }
+
+  private async getMainCredentials(): Promise<MusterAuthCredentials> {
+    if (!this.mainAuthApi) {
+      return {};
+    }
+
+    try {
+      const token = await this.mainAuthApi.getIdToken();
       return { token };
     } catch {
       return {};


### PR DESCRIPTION
## Summary

- `MCPAuthProviders` (ai-chat) and `MusterAuthProviders` (muster) accept an optional main auth API and fall back to its **ID token** when an MCP server's `authProvider` has no dedicated entry; the app wires this to `gsAuthProvidersApi.getMainAuthApi()`.
- Dedicated providers keep taking precedence, so current deployments are unaffected. Once muster trusts the main Dex issuer (giantswarm/muster#831), deployments migrate by dropping the `mcp-muster` provider from `auth.providers` — that flips both AI chat and the muster Workflows page to forwarded main-token auth and removes the separate PKCE login from the user settings page (its `ProviderSettings` entry is derived from the same config), with no further code or backend changes (`extractMcpAuthTokens`/`getMcpTools` and the muster-backend proxy forward the header unchanged).
- New unit tests cover precedence, fallback, and failure paths for both provider classes.

Part of #1737 (AI chat token forwarding, part 1). Epic: giantswarm/giantswarm#36840.

## Test plan

- [x] Unit tests for `MCPAuthProviders` and `MusterAuthProviders` (precedence, fallback, no-provider, error paths)
- [x] `yarn tsc`, package lint, and prettier clean
- [ ] After giantswarm/muster#831 is deployed: drop `auth.providers.mcp-muster` on a test portal and verify AI chat + Workflows page authenticate via the forwarded main Dex ID token with no `mcp-muster` login prompt

Made with [Cursor](https://cursor.com)