### PR TITLE
feat(auth): mint per-MC tokens silently via the muster token broker

### DIFF
--- a/.changeset/cluster-token-broker.md
+++ b/.changeset/cluster-token-broker.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-auth-backend-module-gs': minor
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Mint per-management-cluster tokens silently through the muster token broker instead of per-cluster OAuth popups. The auth backend module gains an authenticated `POST /api/auth/cluster-token/:installation` route that exchanges the user's main Dex ID token (forwarded in the `gs-subject-token` header) for a short-lived cluster token via RFC 8693 token exchange against the broker configured in `gs.clusterTokenBroker`, cached per (user, installation) with expiry-aware re-exchange. The frontend kubernetes auth connectors try this silent path in `refreshSession` before the cookie-based refresh, so broker-covered clusters never open a login popup; the legacy popup remains as fallback when the broker is unreachable or a cluster is not migrated. Installations marked with `gs.installations.<name>.clusterTokenAudience` are considered fully covered and their entries disappear from the provider settings page, collapsing it to the single main login.

--- a/plugins/auth-backend-module-gs/package.json
+++ b/plugins/auth-backend-module-gs/package.json
@@ -39,7 +39,9 @@
     "@backstage/backend-test-utils": "backstage:^",
     "@backstage/cli": "backstage:^",
     "@types/express": "^5.0.0",
-    "@types/passport-oauth2": "^1"
+    "@types/passport-oauth2": "^1",
+    "@types/supertest": "^2.0.12",
+    "supertest": "^6.2.4"
   },
   "files": [
     "dist"

--- a/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
@@ -1,0 +1,217 @@
+import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
+import { ConfigReader } from '@backstage/config';
+import express from 'express';
+import request from 'supertest';
+import { createClusterTokenRouter, SUBJECT_TOKEN_HEADER } from './router';
+
+const logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+} as unknown as LoggerService;
+
+const httpAuth = {
+  credentials: jest.fn().mockResolvedValue({
+    principal: { type: 'user', userEntityRef: 'user:default/mock' },
+  }),
+} as unknown as HttpAuthService;
+
+const BROKER_CONFIG = {
+  gs: {
+    clusterTokenBroker: {
+      tokenUrl: 'https://muster.example.com/oauth/token',
+      clientId: 'backstage',
+      clientSecret: 'secret',
+    },
+    installations: {
+      golem: {},
+      gaggle: {
+        clusterTokenAudience: 'gaggle-mc',
+      },
+    },
+  },
+};
+
+function buildApp(configData: object = BROKER_CONFIG) {
+  const router = createClusterTokenRouter({
+    config: new ConfigReader(configData),
+    logger,
+    httpAuth,
+  });
+  if (!router) {
+    return undefined;
+  }
+  const app = express();
+  app.use(router);
+  // Minimal error handler mirroring Backstage's middleware status mapping.
+  app.use(
+    (
+      err: Error & { name: string },
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      const statusByErrorName: Record<string, number> = {
+        NotFoundError: 404,
+        InputError: 400,
+      };
+      const status = statusByErrorName[err.name] ?? 500;
+      res.status(status).json({ error: err.message });
+    },
+  );
+  return app;
+}
+
+function mockBrokerResponse(
+  body: object,
+  init: { status?: number } = {},
+): jest.SpyInstance {
+  return jest.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: init.status ?? 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('createClusterTokenRouter', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns undefined when no broker is configured', () => {
+    expect(buildApp({ gs: {} })).toBeUndefined();
+  });
+
+  it('returns 404 for an unknown installation', async () => {
+    const res = await request(buildApp()!)
+      .post('/cluster-token/unknown')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when the subject token header is missing', async () => {
+    const res = await request(buildApp()!).post('/cluster-token/golem');
+    expect(res.status).toBe(400);
+  });
+
+  it('exchanges the subject token at the broker and returns the cluster token', async () => {
+    const fetchSpy = mockBrokerResponse({
+      access_token: 'mc-token',
+      token_type: 'Bearer',
+      expires_in: 1800,
+    });
+
+    const res = await request(buildApp()!)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ token: 'mc-token', expiresInSeconds: 1800 });
+    expect(res.headers['cache-control']).toBe('no-store');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://muster.example.com/oauth/token');
+    expect(init.headers.Authorization).toBe(
+      `Basic ${Buffer.from('backstage:secret').toString('base64')}`,
+    );
+    const params = new URLSearchParams(init.body);
+    expect(params.get('grant_type')).toBe(
+      'urn:ietf:params:oauth:grant-type:token-exchange',
+    );
+    expect(params.get('subject_token')).toBe('subject-token');
+    expect(params.get('subject_token_type')).toBe(
+      'urn:ietf:params:oauth:token-type:id_token',
+    );
+    expect(params.get('audience')).toBe('golem');
+    expect(params.get('scope')).toBeNull();
+  });
+
+  it('uses the configured audience override and scope', async () => {
+    const fetchSpy = mockBrokerResponse({
+      access_token: 'mc-token',
+      expires_in: 1800,
+    });
+
+    const configWithScope = JSON.parse(JSON.stringify(BROKER_CONFIG));
+    configWithScope.gs.clusterTokenBroker.scope =
+      'openid audience:server:client_id:dex-k8s-authenticator';
+
+    const res = await request(buildApp(configWithScope)!)
+      .post('/cluster-token/gaggle')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(200);
+    const params = new URLSearchParams(fetchSpy.mock.calls[0][1].body);
+    expect(params.get('audience')).toBe('gaggle-mc');
+    expect(params.get('scope')).toBe(
+      'openid audience:server:client_id:dex-k8s-authenticator',
+    );
+  });
+
+  it('serves cached tokens until close to expiry', async () => {
+    const fetchSpy = mockBrokerResponse({
+      access_token: 'mc-token',
+      expires_in: 1800,
+    });
+    const app = buildApp()!;
+
+    const first = await request(app)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+    const second = await request(app)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.token).toBe('mc-token');
+    expect(second.body.expiresInSeconds).toBeLessThanOrEqual(1800);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-exchanges when the cached token is close to expiry', async () => {
+    const fetchSpy = mockBrokerResponse({
+      access_token: 'short-lived',
+      expires_in: 60,
+    });
+    const app = buildApp()!;
+
+    await request(app)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+    await request(app)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps broker errors to 502 without leaking details', async () => {
+    mockBrokerResponse(
+      { error: 'invalid_target', error_description: 'unknown audience' },
+      { status: 400 },
+    );
+
+    const res = await request(buildApp()!)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ error: 'Token exchange failed' });
+  });
+
+  it('maps an unreachable broker to 502', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const res = await request(buildApp()!)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ error: 'Token broker is unreachable' });
+  });
+});

--- a/plugins/auth-backend-module-gs/src/clusterToken/router.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.ts
@@ -1,0 +1,192 @@
+import express from 'express';
+import Router from 'express-promise-router';
+import {
+  HttpAuthService,
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
+import { InputError, NotFoundError } from '@backstage/errors';
+
+/**
+ * Header used by the frontend to forward the user's main Dex ID token, which
+ * the broker exchanges for a per-management-cluster token. Backstage does not
+ * expose provider sessions server-side, so the token travels alongside the
+ * regular Backstage credentials (same pattern the AI chat uses for MCP auth).
+ */
+export const SUBJECT_TOKEN_HEADER = 'gs-subject-token';
+
+const TOKEN_EXCHANGE_GRANT_TYPE =
+  'urn:ietf:params:oauth:grant-type:token-exchange';
+const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
+
+/**
+ * Minimum remaining lifetime before a cached token is re-exchanged. Must be
+ * larger than the frontend's session refresh margin (3 minutes in OAuth2's
+ * sessionShouldRefresh), so a refresh-triggering request never gets a token
+ * that immediately triggers another refresh.
+ */
+const EXPIRY_SKEW_SECONDS = 240;
+
+/** Fallback lifetime when the broker response carries no expires_in. */
+const DEFAULT_EXPIRES_IN_SECONDS = 300;
+
+type CachedToken = {
+  token: string;
+  expiresAt: number;
+};
+
+export interface ClusterTokenRouterOptions {
+  config: RootConfigService;
+  logger: LoggerService;
+  httpAuth: HttpAuthService;
+}
+
+/**
+ * Creates the cluster token service router, exposed as
+ * `POST /api/auth/cluster-token/:installation`.
+ *
+ * Given the caller's authenticated Backstage session and their main Dex ID
+ * token (forwarded in the `gs-subject-token` header), it mints a short-lived
+ * per-management-cluster token through the muster token broker (RFC 8693
+ * token exchange) and caches it per (user, installation) with expiry-aware
+ * re-exchange. Exchanged tokens are returned to the frontend as short-lived
+ * credentials and are never persisted.
+ *
+ * Returns undefined when no broker is configured (`gs.clusterTokenBroker`).
+ */
+export function createClusterTokenRouter(
+  options: ClusterTokenRouterOptions,
+): express.Router | undefined {
+  const { config, logger, httpAuth } = options;
+
+  const brokerConfig = config.getOptionalConfig('gs.clusterTokenBroker');
+  if (!brokerConfig) {
+    return undefined;
+  }
+
+  const tokenUrl = brokerConfig.getString('tokenUrl');
+  const clientId = brokerConfig.getString('clientId');
+  const clientSecret = brokerConfig.getString('clientSecret');
+  const scope = brokerConfig.getOptionalString('scope');
+
+  const tokenCache = new Map<string, CachedToken>();
+
+  const pruneExpired = (now: number) => {
+    for (const [key, value] of tokenCache) {
+      if (value.expiresAt <= now) {
+        tokenCache.delete(key);
+      }
+    }
+  };
+
+  const router = Router();
+
+  router.post(
+    '/cluster-token/:installation',
+    async (req: express.Request, res: express.Response) => {
+      const credentials = await httpAuth.credentials(req, { allow: ['user'] });
+      const userEntityRef = credentials.principal.userEntityRef;
+
+      const { installation } = req.params;
+      if (typeof installation !== 'string') {
+        throw new InputError('Invalid installation parameter');
+      }
+      const installationsConfig = config.getOptionalConfig('gs.installations');
+      if (!installationsConfig || !installationsConfig.has(installation)) {
+        throw new NotFoundError(`Unknown installation "${installation}"`);
+      }
+      const audience =
+        installationsConfig
+          .getConfig(installation)
+          .getOptionalString('clusterTokenAudience') ?? installation;
+
+      const subjectToken = req.header(SUBJECT_TOKEN_HEADER);
+      if (!subjectToken) {
+        throw new InputError(`Missing ${SUBJECT_TOKEN_HEADER} header`);
+      }
+
+      res.setHeader('Cache-Control', 'no-store');
+
+      const now = Date.now();
+      pruneExpired(now);
+
+      const cacheKey = `${userEntityRef}:${installation}`;
+      const cached = tokenCache.get(cacheKey);
+      if (cached && cached.expiresAt - now > EXPIRY_SKEW_SECONDS * 1000) {
+        res.json({
+          token: cached.token,
+          expiresInSeconds: Math.floor((cached.expiresAt - now) / 1000),
+        });
+        return;
+      }
+
+      const params = new URLSearchParams({
+        grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+        subject_token: subjectToken,
+        subject_token_type: ID_TOKEN_TYPE,
+        audience,
+      });
+      if (scope) {
+        params.set('scope', scope);
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(tokenUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Basic ${Buffer.from(
+              `${clientId}:${clientSecret}`,
+            ).toString('base64')}`,
+          },
+          body: params.toString(),
+        });
+      } catch (error) {
+        logger.warn(
+          `Cluster token exchange for installation "${installation}" failed: broker unreachable`,
+          error as Error,
+        );
+        res.status(502).json({ error: 'Token broker is unreachable' });
+        return;
+      }
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        logger.warn(
+          `Cluster token exchange for installation "${installation}" failed with status ${response.status}: ${body}`,
+        );
+        tokenCache.delete(cacheKey);
+        res.status(502).json({ error: 'Token exchange failed' });
+        return;
+      }
+
+      const tokenResponse = (await response.json()) as {
+        access_token?: string;
+        expires_in?: number;
+      };
+      if (!tokenResponse.access_token) {
+        logger.warn(
+          `Cluster token exchange for installation "${installation}" returned no access_token`,
+        );
+        res.status(502).json({ error: 'Token exchange failed' });
+        return;
+      }
+
+      const expiresInSeconds =
+        tokenResponse.expires_in ?? DEFAULT_EXPIRES_IN_SECONDS;
+      tokenCache.set(cacheKey, {
+        token: tokenResponse.access_token,
+        expiresAt: now + expiresInSeconds * 1000,
+      });
+
+      logger.debug(
+        `Minted cluster token for ${userEntityRef} on installation "${installation}" (audience "${audience}", expires in ${expiresInSeconds}s)`,
+      );
+
+      res.json({ token: tokenResponse.access_token, expiresInSeconds });
+    },
+  );
+
+  return router;
+}

--- a/plugins/auth-backend-module-gs/src/module.ts
+++ b/plugins/auth-backend-module-gs/src/module.ts
@@ -16,6 +16,7 @@ import {
 } from '@backstage/plugin-auth-backend-module-oidc-provider';
 import { oauth2Authenticator } from './oauth2/authenticator';
 import { createCimdRouter } from './oauth2/cimdRouter';
+import { createClusterTokenRouter } from './clusterToken/router';
 
 const OIDC_PROVIDER_NAME_PREFIX = 'oidc-';
 const MCP_PROVIDER_NAME_PREFIX = 'mcp-';
@@ -90,8 +91,15 @@ export const authModuleGsProviders = createBackendModule({
         config: coreServices.rootConfig,
         logger: coreServices.rootLogger,
         httpRouter: coreServices.httpRouter,
+        httpAuth: coreServices.httpAuth,
       },
-      async init({ providersExtensionPoint, config, logger, httpRouter }) {
+      async init({
+        providersExtensionPoint,
+        config,
+        logger,
+        httpRouter,
+        httpAuth,
+      }) {
         const baseUrl = config.getString('backend.baseUrl');
         const providersConfig = config.getConfig('auth.providers');
         const configuredProviders: string[] = providersConfig?.keys() || [];
@@ -161,6 +169,18 @@ export const authModuleGsProviders = createBackendModule({
               authenticator: oauth2Authenticator,
             }),
           });
+        }
+
+        const clusterTokenRouter = createClusterTokenRouter({
+          config,
+          logger,
+          httpAuth,
+        });
+        if (clusterTokenRouter) {
+          logger.info(
+            'Cluster token broker is configured, registering cluster token route',
+          );
+          httpRouter.use(clusterTokenRouter);
         }
       },
     });

--- a/plugins/gs/config.d.ts
+++ b/plugins/gs/config.d.ts
@@ -7,6 +7,35 @@ export interface Config {
     /** @visibility frontend */
     authProvider: string;
 
+    /**
+     * Cluster token broker (muster) used to silently mint per-management-cluster
+     * tokens from the user's main Dex session, replacing the per-cluster OAuth
+     * popups for covered installations.
+     */
+    clusterTokenBroker?: {
+      /**
+       * OAuth token endpoint of the broker, e.g. https://muster.example.com/oauth/token.
+       * Its presence enables the silent broker path in the frontend.
+       * @visibility frontend
+       */
+      tokenUrl: string;
+      /**
+       * Confidential client ID registered with the broker.
+       * @visibility backend
+       */
+      clientId: string;
+      /**
+       * @visibility secret
+       */
+      clientSecret: string;
+      /**
+       * Optional scope sent with the RFC 8693 exchange request. Usually unset:
+       * the broker's per-audience configuration owns the scope set.
+       * @visibility backend
+       */
+      scope?: string;
+    };
+
     /** @deepVisibility frontend */
     clusterDetails?: {
       resources?: {
@@ -42,6 +71,13 @@ export interface Config {
         providers?: string[];
         authProvider: string;
         oidcTokenProvider?: string;
+        /**
+         * Audience requested from the cluster token broker for this
+         * installation (typically the installation name). Setting it marks the
+         * installation as fully covered by the broker and removes its entry
+         * from the provider settings page.
+         */
+        clusterTokenAudience?: string;
         backendUrl?: string;
         baseDomain?: string;
         region?: string;

--- a/plugins/gs/src/apis/auth/DefaultAuthConnector.test.ts
+++ b/plugins/gs/src/apis/auth/DefaultAuthConnector.test.ts
@@ -1,0 +1,116 @@
+import { ConfigApi, OAuthRequestApi } from '@backstage/core-plugin-api';
+import { DefaultAuthConnector } from './DefaultAuthConnector';
+import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
+
+const configApi = {
+  getOptionalBoolean: jest.fn().mockReturnValue(false),
+} as unknown as ConfigApi;
+
+const oauthRequestApi: OAuthRequestApi = {
+  createAuthRequester: jest.fn(() => jest.fn()),
+  authRequest$: jest.fn(),
+};
+
+const discoveryApi = {
+  getBaseUrl: jest.fn().mockResolvedValue('http://backend/api/auth'),
+} as unknown as DiscoveryApiClient;
+
+function createConnector(
+  clusterTokenProvider?: () => Promise<
+    { token: string; expiresInSeconds?: number } | undefined
+  >,
+) {
+  return new DefaultAuthConnector({
+    configApi,
+    discoveryApi,
+    environment: 'development',
+    provider: { id: 'oidc-golem', title: 'golem', icon: () => null },
+    oauthRequestApi,
+    clusterTokenProvider,
+  });
+}
+
+const legacyRefreshResponse = {
+  providerInfo: {
+    idToken: 'legacy-id-token',
+    accessToken: 'legacy-access-token',
+    scope: 'openid',
+    expiresInSeconds: 1800,
+  },
+};
+
+function mockLegacyRefresh(): jest.SpyInstance {
+  return jest.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(legacyRefreshResponse), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('DefaultAuthConnector', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('refreshSession', () => {
+    it('uses the cluster token broker before the cookie-based refresh', async () => {
+      const fetchSpy = mockLegacyRefresh();
+      const clusterTokenProvider = jest
+        .fn()
+        .mockResolvedValue({ token: 'mc-token', expiresInSeconds: 1740 });
+
+      const session = await createConnector(
+        clusterTokenProvider,
+      ).refreshSession({ scopes: new Set(['openid', 'groups']) });
+
+      expect(clusterTokenProvider).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(session).toEqual({
+        providerInfo: {
+          idToken: 'mc-token',
+          accessToken: 'mc-token',
+          scope: 'openid groups',
+          expiresInSeconds: 1740,
+        },
+      });
+    });
+
+    it('falls back to the cookie-based refresh when the broker path fails', async () => {
+      const fetchSpy = mockLegacyRefresh();
+      const clusterTokenProvider = jest
+        .fn()
+        .mockRejectedValue(new Error('broker unreachable'));
+
+      const session = await createConnector(
+        clusterTokenProvider,
+      ).refreshSession({ scopes: new Set(['openid']) });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(session).toEqual(legacyRefreshResponse);
+    });
+
+    it('falls back to the cookie-based refresh when the broker yields no token', async () => {
+      const fetchSpy = mockLegacyRefresh();
+      const clusterTokenProvider = jest.fn().mockResolvedValue(undefined);
+
+      const session = await createConnector(
+        clusterTokenProvider,
+      ).refreshSession({ scopes: new Set(['openid']) });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(session).toEqual(legacyRefreshResponse);
+    });
+
+    it('uses the cookie-based refresh when no broker is configured', async () => {
+      const fetchSpy = mockLegacyRefresh();
+
+      const session = await createConnector().refreshSession({
+        scopes: new Set(['openid']),
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(session).toEqual(legacyRefreshResponse);
+    });
+  });
+});

--- a/plugins/gs/src/apis/auth/DefaultAuthConnector.ts
+++ b/plugins/gs/src/apis/auth/DefaultAuthConnector.ts
@@ -35,6 +35,14 @@ import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
 
 let warned = false;
 
+/**
+ * Short-lived cluster token minted by the cluster token broker.
+ */
+export type ClusterToken = {
+  token: string;
+  expiresInSeconds?: number;
+};
+
 type Options<AuthSession> = {
   /**
    * DiscoveryApi instance used to locate the auth backend endpoint.
@@ -69,6 +77,13 @@ type Options<AuthSession> = {
    * Options used to configure auth popup
    */
   popupOptions?: PopupOptions;
+  /**
+   * Optional function used to silently mint a cluster token through the
+   * token broker. When provided, refreshSession tries it before the
+   * cookie-based refresh, so broker-covered clusters never trigger a login
+   * popup. Returning undefined or throwing falls back to the legacy flow.
+   */
+  clusterTokenProvider?: () => Promise<ClusterToken | undefined>;
 };
 
 function defaultJoinScopes(scopes: Set<string>) {
@@ -91,6 +106,9 @@ export class DefaultAuthConnector<
   private readonly sessionTransform: (response: any) => Promise<AuthSession>;
   private readonly enableExperimentalRedirectFlow: boolean;
   private readonly popupOptions: PopupOptions | undefined;
+  private readonly clusterTokenProvider?: () => Promise<
+    ClusterToken | undefined
+  >;
   constructor(options: Options<AuthSession>) {
     const {
       configApi,
@@ -101,6 +119,7 @@ export class DefaultAuthConnector<
       oauthRequestApi,
       sessionTransform = id => id,
       popupOptions,
+      clusterTokenProvider,
     } = options;
 
     if (!warned && !configApi) {
@@ -132,6 +151,7 @@ export class DefaultAuthConnector<
     this.joinScopesFunc = joinScopes;
     this.sessionTransform = sessionTransform;
     this.popupOptions = popupOptions;
+    this.clusterTokenProvider = clusterTokenProvider;
   }
 
   async createSession(
@@ -149,6 +169,26 @@ export class DefaultAuthConnector<
   async refreshSession(
     options?: AuthConnectorRefreshSessionOptions,
   ): Promise<any> {
+    if (this.clusterTokenProvider) {
+      try {
+        const clusterToken = await this.clusterTokenProvider();
+        if (clusterToken) {
+          return await this.sessionTransform({
+            providerInfo: {
+              idToken: clusterToken.token,
+              accessToken: clusterToken.token,
+              scope: options ? this.joinScopesFunc(options.scopes) : '',
+              expiresInSeconds: clusterToken.expiresInSeconds,
+            },
+          });
+        }
+      } catch {
+        // The broker is unreachable or the cluster is not migrated yet --
+        // fall back to the legacy cookie-based refresh (and ultimately the
+        // login popup).
+      }
+    }
+
     const res = await fetch(
       await this.buildUrl('/refresh', {
         optional: true,

--- a/plugins/gs/src/apis/auth/GSAuthProviders.ts
+++ b/plugins/gs/src/apis/auth/GSAuthProviders.ts
@@ -8,11 +8,13 @@ import {
   gsAuthProvidersApiRef,
 } from './types';
 import { GiantSwarmIcon } from '../../assets/icons/CustomIcons';
-import { DefaultAuthConnector } from './DefaultAuthConnector';
+import { ClusterToken, DefaultAuthConnector } from './DefaultAuthConnector';
 import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
 
 const OIDC_PROVIDER_NAME_PREFIX = 'oidc-';
 const MCP_PROVIDER_NAME_PREFIX = 'mcp-';
+
+const SUBJECT_TOKEN_HEADER = 'gs-subject-token';
 
 /**
  * A client for authenticating towards Giant Swarm Management APIs.
@@ -85,13 +87,83 @@ export class GSAuthProviders implements GSAuthProvidersApi {
         providerName: oidcTokenProvider,
         providerDisplayName,
         installationName,
+        clusterTokenAudience: installationConfig.getOptionalString(
+          'clusterTokenAudience',
+        ),
       };
     });
   }
 
+  /**
+   * Returns a function that silently mints a per-cluster token through the
+   * cluster token broker (the backend's /api/auth/cluster-token route), or
+   * undefined when the broker path does not apply to this provider. The main
+   * auth provider is excluded: its session is the broker's subject token.
+   */
+  private createClusterTokenProvider(
+    installationName: string,
+    providerName: string,
+  ): (() => Promise<ClusterToken | undefined>) | undefined {
+    if (!this.configApi) {
+      return undefined;
+    }
+    const brokerConfigured = Boolean(
+      this.configApi.getOptionalString('gs.clusterTokenBroker.tokenUrl'),
+    );
+    const mainProviderName =
+      this.configApi.getOptionalString('gs.authProvider');
+    if (
+      !brokerConfigured ||
+      !mainProviderName ||
+      providerName === mainProviderName
+    ) {
+      return undefined;
+    }
+
+    // The cluster token route is served by the main backend, not by
+    // per-installation backend overrides.
+    const backendBaseUrl = this.configApi.getString('backend.baseUrl');
+
+    return async () => {
+      const mainAuthApi = this.getMainAuthApi();
+      const idToken = await mainAuthApi.getIdToken({ optional: true });
+      if (!idToken) {
+        return undefined;
+      }
+      const identity = await mainAuthApi.getBackstageIdentity({
+        optional: true,
+      });
+      if (!identity) {
+        return undefined;
+      }
+
+      const response = await fetch(
+        `${backendBaseUrl}/api/auth/cluster-token/${encodeURIComponent(
+          installationName,
+        )}`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${identity.token}`,
+            [SUBJECT_TOKEN_HEADER]: idToken,
+          },
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Cluster token request failed, ${response.statusText}`);
+      }
+
+      const { token, expiresInSeconds } = await response.json();
+      if (!token) {
+        return undefined;
+      }
+      return { token, expiresInSeconds };
+    };
+  }
+
   private createKubernetesAuthApis() {
     const entries = this.kubernetesAuthProviders.map(
-      ({ providerName, providerDisplayName }) => {
+      ({ providerName, providerDisplayName, installationName }) => {
         const authConnector = new DefaultAuthConnector({
           configApi: this.configApi,
           discoveryApi: this.discoveryApi,
@@ -104,6 +176,10 @@ export class GSAuthProviders implements GSAuthProvidersApi {
             title: providerDisplayName,
             icon: GiantSwarmIcon,
           },
+          clusterTokenProvider: this.createClusterTokenProvider(
+            installationName,
+            providerName,
+          ),
           sessionTransform({ backstageIdentity, ...res }): OAuth2Session {
             const session: OAuth2Session = {
               ...res,
@@ -251,7 +327,26 @@ export class GSAuthProviders implements GSAuthProvidersApi {
   }
 
   getProviders() {
-    return [...this.kubernetesAuthProviders, ...this.mcpAuthProviders];
+    // Installations explicitly marked as covered by the cluster token broker
+    // (clusterTokenAudience set) get their tokens silently through the main
+    // login, so their separate provider entries disappear from the settings
+    // page. The main login itself always stays.
+    const brokerConfigured = Boolean(
+      this.configApi?.getOptionalString('gs.clusterTokenBroker.tokenUrl'),
+    );
+    const mainProviderName =
+      this.configApi?.getOptionalString('gs.authProvider');
+
+    const kubernetesAuthProviders = this.kubernetesAuthProviders.filter(
+      ({ providerName, clusterTokenAudience }) => {
+        if (!brokerConfigured || providerName === mainProviderName) {
+          return true;
+        }
+        return !clusterTokenAudience;
+      },
+    );
+
+    return [...kubernetesAuthProviders, ...this.mcpAuthProviders];
   }
 
   getAuthApi(providerName: string) {

--- a/plugins/gs/src/apis/auth/types.ts
+++ b/plugins/gs/src/apis/auth/types.ts
@@ -29,6 +29,11 @@ export type AuthProvider = {
   providerName: string;
   providerDisplayName: string;
   installationName: string;
+  /**
+   * Audience requested from the cluster token broker for this installation.
+   * When set, the installation is considered fully covered by the broker.
+   */
+  clusterTokenAudience?: string;
 };
 
 export type GSAuthProvidersApi = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10751,10 +10751,12 @@ __metadata:
     "@backstage/plugin-auth-node": "backstage:^"
     "@types/express": "npm:^5.0.0"
     "@types/passport-oauth2": "npm:^1"
+    "@types/supertest": "npm:^2.0.12"
     express: "npm:^5.0.0"
     express-promise-router: "npm:^4.1.1"
     node-fetch: "npm:^3.3.2"
     passport-oauth2: "npm:^1.8.0"
+    supertest: "npm:^6.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Part 2 of #1737 (epic giantswarm/giantswarm#36840): replace the per-management-cluster OAuth popups with silent token minting through the muster token broker, with the legacy popup as fallback.

- **Backend (`auth-backend-module-gs`)**: new authenticated `POST /api/auth/cluster-token/:installation` route. It validates the Backstage user session, takes the user's main Dex ID token from the `gs-subject-token` header (same forwarding pattern the AI chat uses), and performs an RFC 8693 token exchange against the broker's token endpoint as a confidential client (`gs.clusterTokenBroker.tokenUrl`/`clientId`/`clientSecret`, optional `scope`). Minted tokens are cached per (user, installation) with expiry-aware re-exchange (4-minute skew, above the frontend's 3-minute refresh margin) and never persisted.
- **Frontend (`gs`)**: `DefaultAuthConnector.refreshSession()` accepts an optional `clusterTokenProvider` and tries it before the cookie-based refresh. `GSAuthProviders` wires it for every kubernetes auth API except the main provider (whose session is the broker's subject token), forwarding the main Dex ID token and Backstage credentials to the new backend route. Broker failure or an unmigrated cluster falls through to the legacy refresh and ultimately the existing popup, so `KubernetesAuthProviders`/`KubernetesClient` wiring is untouched.
- **ProviderSettings collapse**: installations marked with `gs.installations.<name>.clusterTokenAudience` (the installation→audience mapping; typically the installation name) are treated as fully broker-covered and dropped from `getProviders()`, removing their entries from the user settings page so it collapses to the single main login.
- Config schema additions in `plugins/gs/config.d.ts`: `gs.clusterTokenBroker` (tokenUrl frontend-visible, clientSecret secret) and the per-installation `clusterTokenAudience`.

Activation per deployment is config-only: deploy giantswarm/muster#831, register a confidential Backstage client with the broker, set `gs.clusterTokenBroker`, then migrate clusters by adding them to muster's audience map (popup fallback covers the rest); finally mark installations with `clusterTokenAudience` and drop their `oidc-<mc>` provider entries and `dexAuthCredentials` values.

## Test plan

- [x] Unit tests for the cluster token route: exchange request shape (grant type, subject token, audience override, scope, Basic client auth), per-user caching with expiry-aware re-exchange, 400/404/502 error mapping without leaking broker details
- [x] Unit tests for `DefaultAuthConnector.refreshSession`: broker-first, fallback to cookie refresh on broker error/absence
- [x] `tsc`, ESLint, prettier, jest green for both packages
- [ ] End-to-end validation against a muster deployment with giantswarm/muster#831 (tracked in the epic; popup fallback keeps current behavior until then)

Made with [Cursor](https://cursor.com)