### PR TITLE
fix(gs-backend): map gateway HTML 400 to AuthenticationError in MimirService

### DIFF
--- a/plugins/gs-backend/src/services/MimirService.test.ts
+++ b/plugins/gs-backend/src/services/MimirService.test.ts
@@ -1,4 +1,7 @@
-import { LoggerService, RootConfigService } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
 import {
   AuthenticationError,
   NotFoundError,
@@ -39,7 +42,9 @@ function makeResponse(
   return {
     status,
     ok: status >= 200 && status < 300,
-    headers: { get: (name: string) => (name === 'content-type' ? contentType : null) },
+    headers: {
+      get: (name: string) => (name === 'content-type' ? contentType : null),
+    },
     text: jest.fn().mockResolvedValue(body),
     json: jest.fn().mockResolvedValue(JSON.parse(body)),
   };
@@ -57,7 +62,10 @@ describe('MimirService.query', () => {
   });
 
   it('returns parsed JSON on 200', async () => {
-    const payload = { status: 'success', data: { resultType: 'vector', result: [] } };
+    const payload = {
+      status: 'success',
+      data: { resultType: 'vector', result: [] },
+    };
     mockFetch.mockResolvedValue(makeResponse(200, JSON.stringify(payload)));
 
     const result = await service.query({
@@ -88,7 +96,11 @@ describe('MimirService.query', () => {
     mockFetch.mockResolvedValue(makeResponse(401, 'Unauthorized'));
 
     await expect(
-      service.query({ installationName: 'alba', query: 'up', oidcToken: 'bad' }),
+      service.query({
+        installationName: 'alba',
+        query: 'up',
+        oidcToken: 'bad',
+      }),
     ).rejects.toThrow(AuthenticationError);
   });
 
@@ -96,25 +108,45 @@ describe('MimirService.query', () => {
     mockFetch.mockResolvedValue(makeResponse(403, 'Forbidden'));
 
     await expect(
-      service.query({ installationName: 'alba', query: 'up', oidcToken: 'bad' }),
+      service.query({
+        installationName: 'alba',
+        query: 'up',
+        oidcToken: 'bad',
+      }),
     ).rejects.toThrow(AuthenticationError);
   });
 
   it('throws AuthenticationError on 400 with text/html (gateway rejection)', async () => {
     const htmlBody = '<html><body>Error 400 — token too large</body></html>';
-    mockFetch.mockResolvedValue(makeResponse(400, htmlBody, 'text/html; charset=utf-8'));
+    mockFetch.mockResolvedValue(
+      makeResponse(400, htmlBody, 'text/html; charset=utf-8'),
+    );
 
     await expect(
-      service.query({ installationName: 'alba', query: 'up', oidcToken: 'large-token' }),
+      service.query({
+        installationName: 'alba',
+        query: 'up',
+        oidcToken: 'large-token',
+      }),
     ).rejects.toThrow(AuthenticationError);
   });
 
   it('throws ServiceUnavailableError on 400 with JSON (bad PromQL)', async () => {
-    const jsonBody = JSON.stringify({ status: 'error', errorType: 'bad_data', error: 'invalid query' });
-    mockFetch.mockResolvedValue(makeResponse(400, jsonBody, 'application/json'));
+    const jsonBody = JSON.stringify({
+      status: 'error',
+      errorType: 'bad_data',
+      error: 'invalid query',
+    });
+    mockFetch.mockResolvedValue(
+      makeResponse(400, jsonBody, 'application/json'),
+    );
 
     await expect(
-      service.query({ installationName: 'alba', query: 'invalid{{', oidcToken: 'tok' }),
+      service.query({
+        installationName: 'alba',
+        query: 'invalid{{',
+        oidcToken: 'tok',
+      }),
     ).rejects.toThrow(ServiceUnavailableError);
   });
 
@@ -123,7 +155,11 @@ describe('MimirService.query', () => {
     mockFetch.mockResolvedValue(makeResponse(503, longBody, 'text/plain'));
 
     await expect(
-      service.query({ installationName: 'alba', query: 'up', oidcToken: 'tok' }),
+      service.query({
+        installationName: 'alba',
+        query: 'up',
+        oidcToken: 'tok',
+      }),
     ).rejects.toThrow(/…$/);
   });
 
@@ -132,7 +168,11 @@ describe('MimirService.query', () => {
     mockFetch.mockResolvedValue(makeResponse(503, shortBody, 'text/plain'));
 
     await expect(
-      service.query({ installationName: 'alba', query: 'up', oidcToken: 'tok' }),
+      service.query({
+        installationName: 'alba',
+        query: 'up',
+        oidcToken: 'tok',
+      }),
     ).rejects.toThrow(/service down/);
   });
 
@@ -140,7 +180,11 @@ describe('MimirService.query', () => {
     mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
 
     await expect(
-      service.query({ installationName: 'alba', query: 'up', oidcToken: 'tok' }),
+      service.query({
+        installationName: 'alba',
+        query: 'up',
+        oidcToken: 'tok',
+      }),
     ).rejects.toThrow(ServiceUnavailableError);
   });
 });

--- a/plugins/gs-backend/src/services/MimirService.test.ts
+++ b/plugins/gs-backend/src/services/MimirService.test.ts
@@ -1,0 +1,146 @@
+import { LoggerService, RootConfigService } from '@backstage/backend-plugin-api';
+import {
+  AuthenticationError,
+  NotFoundError,
+  ServiceUnavailableError,
+} from '@backstage/errors';
+import { MimirService } from './MimirService';
+
+jest.mock('node-fetch', () => jest.fn());
+
+import fetch from 'node-fetch';
+
+const mockFetch = fetch as unknown as jest.Mock;
+
+function makeConfig(baseDomain: string): RootConfigService {
+  return {
+    getOptionalString: (key: string) => {
+      if (key === 'gs.installations.alba.baseDomain') return baseDomain;
+      return undefined;
+    },
+  } as unknown as RootConfigService;
+}
+
+function makeLogger(): jest.Mocked<LoggerService> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn().mockReturnThis(),
+  } as unknown as jest.Mocked<LoggerService>;
+}
+
+function makeResponse(
+  status: number,
+  body: string,
+  contentType = 'application/json',
+) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (name: string) => (name === 'content-type' ? contentType : null) },
+    text: jest.fn().mockResolvedValue(body),
+    json: jest.fn().mockResolvedValue(JSON.parse(body)),
+  };
+}
+
+describe('MimirService.query', () => {
+  let service: MimirService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = MimirService.create({
+      config: makeConfig('alba.capi.aws.k8s.3stripes.net'),
+      logger: makeLogger(),
+    });
+  });
+
+  it('returns parsed JSON on 200', async () => {
+    const payload = { status: 'success', data: { resultType: 'vector', result: [] } };
+    mockFetch.mockResolvedValue(makeResponse(200, JSON.stringify(payload)));
+
+    const result = await service.query({
+      installationName: 'alba',
+      query: 'up',
+      oidcToken: 'tok',
+    });
+
+    expect(result.status).toBe('success');
+  });
+
+  it('throws NotFoundError when baseDomain is not configured', async () => {
+    const s = MimirService.create({
+      config: makeConfig(''),
+      logger: makeLogger(),
+    });
+    // Override: return undefined for unknown installation
+    (s as any).config = {
+      getOptionalString: () => undefined,
+    } as unknown as RootConfigService;
+
+    await expect(
+      s.query({ installationName: 'unknown', query: 'up', oidcToken: 'tok' }),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it('throws AuthenticationError on 401', async () => {
+    mockFetch.mockResolvedValue(makeResponse(401, 'Unauthorized'));
+
+    await expect(
+      service.query({ installationName: 'alba', query: 'up', oidcToken: 'bad' }),
+    ).rejects.toThrow(AuthenticationError);
+  });
+
+  it('throws AuthenticationError on 403', async () => {
+    mockFetch.mockResolvedValue(makeResponse(403, 'Forbidden'));
+
+    await expect(
+      service.query({ installationName: 'alba', query: 'up', oidcToken: 'bad' }),
+    ).rejects.toThrow(AuthenticationError);
+  });
+
+  it('throws AuthenticationError on 400 with text/html (gateway rejection)', async () => {
+    const htmlBody = '<html><body>Error 400 — token too large</body></html>';
+    mockFetch.mockResolvedValue(makeResponse(400, htmlBody, 'text/html; charset=utf-8'));
+
+    await expect(
+      service.query({ installationName: 'alba', query: 'up', oidcToken: 'large-token' }),
+    ).rejects.toThrow(AuthenticationError);
+  });
+
+  it('throws ServiceUnavailableError on 400 with JSON (bad PromQL)', async () => {
+    const jsonBody = JSON.stringify({ status: 'error', errorType: 'bad_data', error: 'invalid query' });
+    mockFetch.mockResolvedValue(makeResponse(400, jsonBody, 'application/json'));
+
+    await expect(
+      service.query({ installationName: 'alba', query: 'invalid{{', oidcToken: 'tok' }),
+    ).rejects.toThrow(ServiceUnavailableError);
+  });
+
+  it('truncates long HTML bodies in ServiceUnavailableError', async () => {
+    const longBody = 'x'.repeat(500);
+    mockFetch.mockResolvedValue(makeResponse(503, longBody, 'text/plain'));
+
+    await expect(
+      service.query({ installationName: 'alba', query: 'up', oidcToken: 'tok' }),
+    ).rejects.toThrow(/…$/);
+  });
+
+  it('does not truncate short bodies', async () => {
+    const shortBody = 'service down';
+    mockFetch.mockResolvedValue(makeResponse(503, shortBody, 'text/plain'));
+
+    await expect(
+      service.query({ installationName: 'alba', query: 'up', oidcToken: 'tok' }),
+    ).rejects.toThrow(/service down/);
+  });
+
+  it('throws ServiceUnavailableError on network error', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(
+      service.query({ installationName: 'alba', query: 'up', oidcToken: 'tok' }),
+    ).rejects.toThrow(ServiceUnavailableError);
+  });
+});

--- a/plugins/gs-backend/src/services/MimirService.test.ts
+++ b/plugins/gs-backend/src/services/MimirService.test.ts
@@ -46,7 +46,7 @@ function makeResponse(
       get: (name: string) => (name === 'content-type' ? contentType : null),
     },
     text: jest.fn().mockResolvedValue(body),
-    json: jest.fn().mockResolvedValue(JSON.parse(body)),
+    json: jest.fn().mockImplementation(async () => JSON.parse(body)),
   };
 }
 

--- a/plugins/gs-backend/src/services/MimirService.ts
+++ b/plugins/gs-backend/src/services/MimirService.ts
@@ -104,9 +104,18 @@ export class MimirService {
     }
 
     if (!response.ok) {
+      const contentType = response.headers.get('content-type') ?? '';
       const body = await response.text().catch(() => '');
+      const truncated = body.length > 300 ? `${body.slice(0, 300)}…` : body;
+
+      if (response.status === 400 && contentType.includes('text/html')) {
+        throw new AuthenticationError(
+          `Mimir gateway rejected the request for installation "${installationName}" (HTTP 400)`,
+        );
+      }
+
       throw new ServiceUnavailableError(
-        `Mimir returned HTTP ${response.status} for installation "${installationName}": ${body}`,
+        `Mimir returned HTTP ${response.status} for installation "${installationName}": ${truncated}`,
       );
     }
 


### PR DESCRIPTION
## What

Two changes to `plugins/gs-backend/src/services/MimirService.ts`:

1. **Map gateway HTML 400 → `AuthenticationError`**: when the observability gateway returns HTTP 400 with `Content-Type: text/html`, the request was rejected at the nginx layer (oversized `Authorization` header) before reaching Mimir. Surfacing this as `AuthenticationError` gives the caller actionable signal — prompting re-authentication or token refresh — instead of the misleading `ServiceUnavailableError`.

2. **Truncate response bodies in error messages**: all non-2xx error paths now cap the body at 300 chars (`…`-terminated). The gateway's branded HTML error page is several KB and was being dumped verbatim into Sentry events.

A `MimirService.test.ts` is added alongside the service; previously there was no test file.

## Why the 400 happens (for context)

The gs-backend forwards the user's dex OIDC token as `Authorization: Bearer <token>`. Adidas Azure-AD dex tokens carry many group claims and can exceed nginx's default `large_client_header_buffers 4 8k`. When the token is too large, mimir-gateway nginx responds with HTTP 400 + an HTML error page. The Envoy gateway's `BackendTrafficPolicy` then replaces the body with the GS branded HTML page, leaving the 400 status intact.

The platform-side fix (raising `large_client_header_buffers` to `4 32k` in shared-configs) is in giantswarm/shared-configs#676. This PR hardens the client against the error in case it occurs on other installations or for other reasons.

Fixes giantswarm/giantswarm#36913