### PR TITLE
chore: migrate grafana.domain config to grafana.hosts

### DIFF
--- a/.changeset/grafana-hosts-config.md
+++ b/.changeset/grafana-hosts-config.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Migrate the example Grafana plugin config from the deprecated `grafana.domain` to the new `grafana.hosts[]` format to silence the deprecation warning.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -254,7 +254,9 @@ catalog:
   #         ociRepository: gsoci.azurecr.io/giantswarm/klaus-plugins
 
 grafana:
-  domain: https://example.com
+  hosts:
+    - id: grafana-net
+      domain: https://example.com
 
 # PagerDuty plugin configuration
 # https://pagerduty.github.io/backstage-plugin-docs/


### PR DESCRIPTION
### What does this PR do?

Updates the example `app-config.yaml` to use the new `grafana.hosts[]` config format instead of the deprecated single-instance `grafana.domain` key.

```yaml
grafana:
  hosts:
    - id: grafana-net
      domain: https://example.com
```

### What is the effect of this change to users?

Removes the console deprecation warning:

> The configuration key 'grafana.domain' of app is deprecated and may be removed soon. Use `grafana.hosts[].domain` in `grafana.hosts` instead.

### Any background context you can provide?

The Grafana plugin was migrated to `@backstage-community/plugin-grafana` (v0.20.0), which deprecates `grafana.domain` in favor of `grafana.hosts[].domain`. The legacy key still works, but emits a deprecation warning. The `proxyPath` default (`/grafana/api`) is unchanged, so it is not set explicitly.

Part of giantswarm/giantswarm#36920. The corresponding GitOps config (giantswarm-management-clusters) is updated in a separate PR.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.