### PR TITLE
fix(flux): make tree view fill the viewport and tighten spacing

### DIFF
--- a/.changeset/shaggy-dots-tan.md
+++ b/.changeset/shaggy-dots-tan.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-flux-react': patch
+'@giantswarm/backstage-plugin-flux': patch
+---
+
+Flux tree view now fills the available viewport height with its own internal scrolling, instead of collapsing to the height of the filter column. The tree also sits flush against the right and bottom page edges, and the gap above it is reduced.

--- a/plugins/flux-react/src/components/FluxOverview/ContentContainer/ContentContainer.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ContentContainer/ContentContainer.tsx
@@ -1,4 +1,4 @@
-import { useContainerDimensions } from '@giantswarm/backstage-plugin-ui-react';
+import { ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => {
@@ -8,7 +8,15 @@ const useStyles = makeStyles(theme => {
   return {
     root: {
       position: 'relative',
-      flex: 1,
+      // Cancel the Backstage Content (<article>) right and bottom padding so
+      // the tree's scrollbar sits flush against the page edge and the tree
+      // reaches the viewport bottom. Matches Content's paddingRight (spacing(2)
+      // on xs, spacing(3) on sm+) and paddingBottom (spacing(3)).
+      marginRight: theme.spacing(-2),
+      marginBottom: theme.spacing(-3),
+      [theme.breakpoints.up('sm')]: {
+        marginRight: theme.spacing(-3),
+      },
 
       '&::before': {
         content: '\"\"',
@@ -39,18 +47,56 @@ const useStyles = makeStyles(theme => {
 });
 
 type ContentContainerProps = {
-  renderContent: (containerHeight: number) => React.ReactNode;
+  renderContent: (containerHeight: number) => ReactNode;
 };
 
+/**
+ * Sizes the (virtualized) tree to fill the available vertical space.
+ *
+ * The app shell does not provide a flowed full-height container to inherit
+ * from: the sidebar is `position: fixed` (sized against the viewport), while
+ * the page content column is `position: static` and content-sized, so a
+ * `height: 100%` / `flexGrow` chain collapses to the content height. We instead
+ * anchor directly to the viewport: available height = viewport height minus the
+ * container's top offset (everything rendered above it), re-measured on resize
+ * and whenever content above reflows.
+ */
 export const ContentContainer = ({ renderContent }: ContentContainerProps) => {
   const classes = useStyles();
-  const [containerRef, dimensions] = useContainerDimensions();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    const node = rootRef.current;
+    if (!node) {
+      return undefined;
+    }
+
+    const measure = () => {
+      const { top } = node.getBoundingClientRect();
+      const next = Math.max(0, window.innerHeight - top);
+      // Ignore sub-pixel jitter; this also keeps the body ResizeObserver below
+      // from looping, since growing the tree never shifts its own top offset.
+      setHeight(prev => (Math.abs(prev - next) > 1 ? next : prev));
+    };
+
+    measure();
+
+    window.addEventListener('resize', measure);
+    // Content above the tree (page header, filters, error banners) can reflow
+    // and shift our top offset; re-measure when the document body resizes.
+    const resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(document.body);
+
+    return () => {
+      window.removeEventListener('resize', measure);
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   return (
-    <div className={classes.root}>
-      <div className={classes.inner} ref={containerRef}>
-        {renderContent(dimensions.height)}
-      </div>
+    <div className={classes.root} ref={rootRef} style={{ height }}>
+      <div className={classes.inner}>{renderContent(height)}</div>
     </div>
   );
 };

--- a/plugins/flux/src/components/FluxResourcesTreePage/FluxResourcesTreePage.tsx
+++ b/plugins/flux/src/components/FluxResourcesTreePage/FluxResourcesTreePage.tsx
@@ -1,12 +1,28 @@
 import { type ReactNode } from 'react';
 import { Content } from '@backstage/core-components';
+import { makeStyles } from '@material-ui/core';
 import { FluxResourcesTreeView } from '@giantswarm/backstage-plugin-flux-react';
 import { QueryClientProvider } from '../QueryClientProvider';
 
+const useStyles = makeStyles({
+  // The tree view manages its own height and reaches the viewport edges, so
+  // drop Content's top padding. Otherwise it stacks with the plugin header's
+  // bottom margin into an oversized gap above the content. `&&` doubles the
+  // selector specificity so it wins over BackstageContent-root regardless of
+  // stylesheet injection order.
+  content: {
+    '&&': {
+      paddingTop: 0,
+    },
+  },
+});
+
 export function FluxResourcesTreePage({ filters }: { filters: ReactNode }) {
+  const classes = useStyles();
+
   return (
     <QueryClientProvider>
-      <Content>
+      <Content className={classes.content}>
         <FluxResourcesTreeView filters={filters} />
       </Content>
     </QueryClientProvider>


### PR DESCRIPTION
### What does this PR do?

Fixes the Flux **tree view** (`/flux/tree`) layout so the tree uses the full available height instead of collapsing to the height of the left-hand filter column.

Root cause: the app shell provides no flowed full-height container for page content to inherit from — the sidebar is full-height only because it is `position: fixed`, while the content column is `position: static` and content-sized. So the existing `height: 100%` / `flexGrow` chain (and `FiltersLayout fullHeight`) had nothing to resolve against and collapsed.

Changes (scoped to the tree view only — `ContentContainer` is used solely by `FluxOverview`, which is used solely by the tree):

- **`flux-react` `ContentContainer`**: anchor the virtualized tree's height directly to the viewport (`window.innerHeight − container.top`), re-measured on window resize and body reflow via `ResizeObserver`. Cancel the Backstage `Content` right/bottom padding with matching negative margins so the scrollbar and the bottom edge sit flush with the page.
- **`flux` `FluxResourcesTreePage`**: drop the `Content` top padding (via a `&&` specificity-bumped class) so it no longer stacks with the plugin header's bottom margin into an oversized gap.

### What is the effect of this change to users?

The Flux tree view fills the available vertical space and scrolls internally, instead of being squeezed into a short box the height of the filters. Spacing around the tree is tightened (flush right/bottom edges, smaller top gap).

### How does it look like?

Before: the tree was clipped to ~350px (the filter column height) with the rest of the viewport empty.
After: the tree fills from just below the tabs to the bottom of the viewport and scrolls internally.

Verified end-to-end in the running app via Chrome DevTools (measured against the live DOM): tree scroll area fills the viewport height, `scrollHeight` far exceeds the visible area (internal scroll), and the scroll container's right/bottom edges align exactly with the viewport with no document overflow.

### Any background context you can provide?

The fix is deliberately targeted rather than changing the global app-shell layout: the tree is the one page here that genuinely needs a viewport-bounded, internally-scrolling area (it renders a virtualized list that requires an explicit pixel height), while the rest of the app is fine flowing at document height.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.