### PR TITLE
ci: prepare repo for devctl-generated CircleCI config

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -1,1 +1,20 @@
+# app-test-suite config. Consumed by the generated `run-tests-with-ats` CircleCI
+# jobs (execute-chart-tests on branches, execute-chart-tests-release on tags).
+#
+# The smoke test (tests/ats/test_smoke.py) installs the backstage chart on a
+# kind cluster and waits for the `backstage` Deployment to become ready -- the
+# same deployment-readiness check the hand-written execute-smoke-test ran.
+#
+# Image availability: both jobs deploy the freshly-built image. On tags
+# execute-chart-tests-release `requires: push-to-registries-release`; on
+# branches (branchPublish) execute-chart-tests `requires: push-to-registries`
+# (the amd64 dev image). The chart's dev image tag matches the pushed tag, so
+# the smoke validates the chart against the just-built image on every PR.
+#
+# functional and upgrade steps are skipped (no functional tests defined; the
+# hand-written pipeline skipped them too via `--skip-steps upgrade functional`).
+app-tests-deploy-namespace: default
+
 smoke-tests-cluster-type: kind
+
+skip-steps: [functional,upgrade]

--- a/.circleci/custom.yml
+++ b/.circleci/custom.yml
@@ -1,0 +1,109 @@
+# Repo-specific CircleCI jobs. The dynamic-config setup workflow in
+# .circleci/config.yml deep-merges this file into the generated
+# .circleci/workflows.yml at pipeline runtime (yq `*+`: maps merge, job lists
+# append). devctl never touches this file.
+#
+# Generated job names available to reference in `requires`: build-image (branch),
+# push-to-registries-release, sync-china-registry, build-chart,
+# execute-chart-tests, execute-chart-tests-release, push-chart-release (the
+# operations-platform catalog push).
+#
+# What this file carries beyond the golden pipeline:
+#   - buildjob: the Node build (install/typecheck/lint/prettier/test/build) that
+#     produces packages/*/dist/*. The generated image jobs (build-image and
+#     push-to-registries-release) wait on it via gen.ci.image.preBuildJob:
+#     buildjob and overlay its persisted workspace into the Docker build context
+#     (packages/backend/Dockerfile COPYs packages/backend/dist/*.tar.gz).
+#   - push-to-control-plane-app-catalog: backstage ships the single `backstage`
+#     chart to TWO catalogs. The generated push-chart-release publishes to the
+#     operations-platform catalog (gen.ci.appCatalog); this carries the second
+#     control-plane catalog push.
+version: 2.1
+
+jobs:
+  buildjob:
+    executor: architect/architect
+    resource_class: large
+    working_directory: ~/backstage
+    docker:
+      - image: cimg/node:24.16.0
+    steps:
+      - checkout
+      - run:
+          name: Print node and yarn version info
+          command: |
+            node --version
+            yarn --version
+      - run:
+          name: Install dependencies
+          command: yarn install --immutable
+      - restore_cache:
+          name: Restore TypeScript incremental build info
+          keys:
+            - v1-tsbuildinfo-{{ .Branch }}-{{ .Revision }}
+            - v1-tsbuildinfo-{{ .Branch }}-
+            - v1-tsbuildinfo-
+      - run:
+          name: Typecheck code using the TypeScript compiler
+          command: NODE_OPTIONS="--max-old-space-size=6144" yarn run tsc --noEmit
+      - save_cache:
+          name: Save TypeScript incremental build info
+          key: v1-tsbuildinfo-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - dist-types/tsconfig.tsbuildinfo
+      - run:
+          name: Lint code using ESlint
+          command: yarn run lint:all
+      - run:
+          name: Validate code style using prettier
+          command: yarn run prettier:check
+      - run:
+          name: Run tests
+          command: yarn run test:all
+      - run:
+          name: Mock secret files
+          command: |
+            touch github-app-credentials.yaml
+      - run:
+          name: Build application
+          command: |
+            yarn run build:backend --config ../../app-config.yaml --config ../../app-config.production.yaml
+            yarn run build:backend-headless-service --config ../../app-config.yaml --config ../../app-config.production.yaml
+          environment:
+            NODE_ENV: production
+      - persist_to_workspace:
+          root: ~/backstage
+          paths:
+            - packages/*/dist/*
+
+workflows:
+  build:
+    jobs:
+    # Node build feeding the generated image jobs (preBuildJob: buildjob).
+    - buildjob:
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    # Second catalog: the single `backstage` chart also ships to the
+    # control-plane catalog. Gated on the same jobs as the generated
+    # push-chart-release (operations-platform) so the same tested archive and
+    # released image are published to both.
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-to-control-plane-app-catalog
+        app_catalog: control-plane-catalog
+        app_catalog_test: control-plane-test-catalog
+        chart: backstage
+        requires:
+        - execute-chart-tests-release
+        - push-to-registries-release
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,11 @@ helm/backstage/README.md
 helm/backstage/values.schema.json
 .vscode
 .github
+# CI config: .circleci/{config,workflows}.yml are devctl-generated (DO NOT EDIT)
+# and custom.yml/.ats are hand-maintained CI infra -- not prettier-governed,
+# same as the generated .github workflows above.
+.circleci
+.ats
 .yarn
 .pre-commit-config.yaml
 .claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
+### Changed
+
+- CI: prepare for the devctl-generated CircleCI config. The repo-specific jobs (the Node `buildjob` that feeds the image build, and the second `control-plane-catalog` chart push) move to `.circleci/custom.yml`; the `.ats/main.yaml` smoke-test config and a `renovate-custom.json5` (preserving the repo's Renovate reviewers, package groups, and schedule) are added so the upcoming generated `config.yml`/`workflows.yml` and regenerated `renovate.json5` keep the existing behavior.
+
 ## [0.137.0] - 2026-06-17
 
 ### Changed

--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -1,0 +1,36 @@
+// Repo-specific Renovate rules, layered on top of the generated renovate.json5
+// (which extends this file last, so these rules win). devctl never touches
+// this file. Rules for a whole class of repos belong in
+// giantswarm/renovate-presets instead.
+{
+  reviewers: ['marians'],
+  reviewersFromCodeOwners: false,
+  prConcurrentLimit: 2,
+  schedule: [
+    'every weekend',
+    'every weekday after 5pm',
+    'every weekday before 8am',
+  ],
+  packageRules: [
+    {
+      groupName: 'ai-sdk packages',
+      matchPackageNames: ['@ai-sdk{/,}**'],
+    },
+    {
+      groupName: 'assistant-ui packages',
+      matchPackageNames: ['@assistant-ui{/,}**'],
+    },
+    {
+      groupName: 'backstage packages',
+      matchPackageNames: ['@backstage{/,}**'],
+    },
+    {
+      groupName: 'testing-library packages',
+      matchPackageNames: ['@testing-library{/,}**'],
+    },
+    {
+      groupName: 'date-fns packages',
+      matchPackageNames: ['date-fns', 'date-fns-tz'],
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Prep step before the `align-files` generation lands the devctl-generated CircleCI config. The current hand-written `config.yml` keeps running unchanged on this PR (the new `custom.yml` is inert until a dynamic-config `config.yml` exists), so nothing breaks here.

- `.circleci/custom.yml` — the repo-specific jobs the generator can't produce:
  - the Node `buildjob` (install/typecheck/lint/prettier/test/build) that persists `packages/*/dist/*` and feeds the image build (referenced from `team-bumblebee.yaml` as `gen.ci.image.preBuildJob: buildjob`)
  - `push-to-control-plane-app-catalog` — the single `backstage` chart also ships to the control-plane catalog (the generated push handles the operations-platform catalog)
- `.ats/main.yaml` — smoke-test config (kind cluster, `default` namespace, skip functional/upgrade), consumed by the generated `run-tests-with-ats` jobs
- `renovate-custom.json5` — preserves the repo's Renovate reviewers, package groups, and schedule across the upcoming `renovate.json5` regeneration

Once merged, the `align-files` dispatch (giantswarm/github already carries the `backstage` opt-in + devctl v8.20.0) generates `config.yml`/`workflows.yml` and regenerates `renovate.json5`.

## Test plan

- [ ] existing hand-written pipeline stays green on this PR

Made with [Cursor](https://cursor.com)