### PR TITLE
fix(gs): connect to all clusters on load with bounded concurrency

### DIFF
--- a/.changeset/eager-cluster-access.md
+++ b/.changeset/eager-cluster-access.md
@@ -1,0 +1,6 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+'app': patch
+---
+
+Cluster access is now established for every broker-covered installation on app load, independent of the current route, and the sidebar cluster-access status element is always visible (each installation starts in a new `connecting` state). Proxy requests — including broker token mints — are bounded by a global concurrency limit (`gs.kubernetes.proxyMaxConcurrency`, default 6) so the startup fan-out no longer overwhelms the broker and apiservers with a storm of simultaneous connections that intermittently time out before recovering.

--- a/app-config.example.yaml
+++ b/app-config.example.yaml
@@ -70,9 +70,12 @@ gs:
     clientSecret: ${CLUSTER_TOKEN_BROKER_CLIENT_SECRET}
 
   # Optional: bound each Kubernetes proxy request so one unreachable cluster
-  # cannot freeze the clusters list (default 10000ms).
+  # cannot freeze the clusters list (default 10000ms), and cap how many proxy
+  # requests (including broker token mints) run at once so connecting to every
+  # installation on startup does not storm the broker/apiservers (default 6).
   kubernetes:
     proxyTimeoutMs: 10000
+    proxyMaxConcurrency: 6
 
   installations:
     main:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,11 +56,20 @@ gs:
 
 ### Cluster-access status element
 
-A sidebar status element shows the per-installation access state -- healthy,
-degraded (with a reason such as "Token broker is unreachable" or "API
-unreachable (timeout)"), or session-expired (with a "Sign in again" action that
-triggers the single main login). It is fed by both the broker token flow and
-the clusters list, and requires no configuration.
+A sidebar status element shows the per-installation access state -- connecting
+(the initial state while the first probe is in flight), healthy, degraded (with
+a reason such as "Token broker is unreachable" or "API unreachable (timeout)"),
+or session-expired (with a "Sign in again" action that triggers the single main
+login). It is fed by both the broker token flow and the clusters list, and
+requires no configuration.
+
+Cluster access is established for every broker-covered installation on app load,
+regardless of which page you are on, so the status element is always visible and
+lists every covered installation from the start (instead of only appearing after
+you open the clusters page). The connections are re-checked on a slow interval to
+keep the status live and broker tokens warm. Only broker-covered installations
+(those with `clusterTokenAudience` set) are connected automatically, so this
+never triggers a per-cluster login popup.
 
 When the main Dex session expires, the broker path triggers exactly one main
 login prompt and then resumes -- there are no per-cluster popups.
@@ -76,6 +85,22 @@ status element and retried with capped backoff.
 gs:
   kubernetes:
     proxyTimeoutMs: 10000
+```
+
+### `gs.kubernetes.proxyMaxConcurrency`
+
+Caps how many Kubernetes proxy requests run at once across the whole app,
+including broker token mints (default `6`). Establishing access to every
+installation on startup would otherwise fan out into a storm of simultaneous
+connections that overwhelms the broker and the management-cluster apiservers,
+causing some requests to hit the proxy timeout before recovering on retry.
+Bounding concurrency smooths that storm; `6` matches the browser's own per-host
+connection limit, beyond which extra parallelism stops helping.
+
+```yaml
+gs:
+  kubernetes:
+    proxyMaxConcurrency: 6
 ```
 
 ## Cluster details page resources

--- a/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/app/src/modules/nav/Sidebar.tsx
@@ -25,7 +25,10 @@ import {
   aiChatDrawerApiRef,
   rootRouteRef as aiChatRouteRef,
 } from '@giantswarm/backstage-plugin-ai-chat-react';
-import { ClusterAccessStatusSidebarItem } from '@giantswarm/backstage-plugin-gs';
+import {
+  ClusterAccessConnector,
+  ClusterAccessStatusSidebarItem,
+} from '@giantswarm/backstage-plugin-gs';
 
 function AiChatSidebarItem() {
   const apiHolder = useApiHolder();
@@ -121,6 +124,7 @@ export const SidebarContent = NavContentBlueprint.make({
           </SidebarGroup>
           <SidebarSpace />
           <SidebarDivider />
+          <ClusterAccessConnector />
           <ClusterAccessStatusSidebarItem />
           <SidebarDivider />
           <SidebarGroup

--- a/plugins/gs/config.d.ts
+++ b/plugins/gs/config.d.ts
@@ -122,6 +122,14 @@ export interface Config {
        * cluster cannot freeze the whole clusters list. Defaults to 10000.
        */
       proxyTimeoutMs?: number;
+      /**
+       * Maximum number of simultaneous in-flight Kubernetes proxy requests
+       * across the whole app (including broker token mints). Bounds the
+       * startup fan-out when every configured installation connects at once,
+       * which otherwise overwhelms the broker and apiservers and produces
+       * spurious timeouts that only resolve on retry. Defaults to 6.
+       */
+      proxyMaxConcurrency?: number;
     };
   };
 }

--- a/plugins/gs/src/apis/auth/GSAuthProviders.ts
+++ b/plugins/gs/src/apis/auth/GSAuthProviders.ts
@@ -439,6 +439,24 @@ export class GSAuthProviders implements GSAuthProvidersApi {
     return [...kubernetesAuthProviders, ...this.mcpAuthProviders];
   }
 
+  getBrokerCoveredInstallations(): string[] {
+    const brokerConfigured = Boolean(
+      this.configApi?.getOptionalString('gs.clusterTokenBroker.tokenUrl'),
+    );
+    if (!brokerConfigured) {
+      return [];
+    }
+    const mainProviderName =
+      this.configApi?.getOptionalString('gs.authProvider');
+
+    return this.kubernetesAuthProviders
+      .filter(
+        ({ providerName, clusterTokenAudience }) =>
+          providerName !== mainProviderName && Boolean(clusterTokenAudience),
+      )
+      .map(({ installationName }) => installationName);
+  }
+
   getAuthApi(providerName: string) {
     return (
       this.kubernetesAuthApis[providerName] || this.mcpAuthApis[providerName]

--- a/plugins/gs/src/apis/auth/types.ts
+++ b/plugins/gs/src/apis/auth/types.ts
@@ -43,6 +43,14 @@ export type GSAuthProvidersApi = {
   getKubernetesAuthApis: () => { [providerName: string]: AuthApi };
   getMCPAuthApis: () => { [providerName: string]: AuthApi };
   getProviders: () => AuthProvider[];
+  /**
+   * Names of installations whose cluster access is fully covered by the token
+   * broker (broker configured, `clusterTokenAudience` set, not the main
+   * provider). These can be connected to silently -- without a per-cluster
+   * login popup -- so they are the set the global cluster-access connector
+   * probes on startup.
+   */
+  getBrokerCoveredInstallations: () => string[];
 };
 
 export type GSAuthProvidersApiCreateOptions = {

--- a/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.test.ts
+++ b/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.test.ts
@@ -22,6 +22,23 @@ describe('ClusterAccessStatusStore', () => {
     ]);
   });
 
+  it('seeds installations as connecting and lets later states replace it', () => {
+    const store = ClusterAccessStatusStore.create();
+
+    store.recordConnecting('golem');
+    store.recordConnecting('alpha');
+    expect(store.getSnapshot()).toEqual([
+      expect.objectContaining({ installation: 'alpha', state: 'connecting' }),
+      expect.objectContaining({ installation: 'golem', state: 'connecting' }),
+    ]);
+
+    store.recordHealthy('golem');
+    expect(store.getSnapshot()).toEqual([
+      expect.objectContaining({ installation: 'alpha', state: 'connecting' }),
+      expect.objectContaining({ installation: 'golem', state: 'healthy' }),
+    ]);
+  });
+
   it('replays the latest snapshot to new subscribers', async () => {
     const store = ClusterAccessStatusStore.create();
     store.recordHealthy('golem');

--- a/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.ts
+++ b/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.ts
@@ -23,6 +23,10 @@ export class ClusterAccessStatusStore implements ClusterAccessStatusApi {
     return new ClusterAccessStatusStore();
   }
 
+  recordConnecting(installation: string): void {
+    this.record(installation, 'connecting', undefined);
+  }
+
   recordHealthy(installation: string): void {
     this.record(installation, 'healthy', undefined);
   }

--- a/plugins/gs/src/apis/clusterAccessStatus/types.ts
+++ b/plugins/gs/src/apis/clusterAccessStatus/types.ts
@@ -4,9 +4,15 @@ import { createApiRef } from '@backstage/core-plugin-api';
 /**
  * Coarse health of per-cluster access, surfaced in the sidebar status element.
  * `session-expired` is distinct from `degraded` because it is fixed by a single
- * main SSO re-login, not by the cluster recovering.
+ * main SSO re-login, not by the cluster recovering. `connecting` is the initial
+ * state while the first access probe is still in flight -- it lets the sidebar
+ * list every covered installation immediately instead of waiting for a result.
  */
-export type ClusterAccessState = 'healthy' | 'degraded' | 'session-expired';
+export type ClusterAccessState =
+  | 'connecting'
+  | 'healthy'
+  | 'degraded'
+  | 'session-expired';
 
 export type ClusterAccessStatusEntry = {
   installation: string;
@@ -23,6 +29,11 @@ export type ClusterAccessStatusEntry = {
  * by the sidebar cluster-access status element.
  */
 export interface ClusterAccessStatusApi {
+  /**
+   * Marks an installation as connecting -- used to seed the sidebar with every
+   * broker-covered installation before its first access probe settles.
+   */
+  recordConnecting(installation: string): void;
   recordHealthy(installation: string): void;
   recordDegraded(installation: string, reason?: string): void;
   recordSessionExpired(installation: string, reason?: string): void;

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
@@ -27,9 +27,17 @@ function hangingFetch(): jest.Mock {
   );
 }
 
-function createClient(fetch: FetchApi['fetch'], proxyTimeoutMs?: number) {
+function createClient(
+  fetch: FetchApi['fetch'],
+  proxyTimeoutMs?: number,
+  proxyMaxConcurrency?: number,
+) {
   const configApi = {
-    getOptionalNumber: jest.fn().mockReturnValue(proxyTimeoutMs),
+    getOptionalNumber: jest.fn((key: string) =>
+      key === 'gs.kubernetes.proxyMaxConcurrency'
+        ? proxyMaxConcurrency
+        : proxyTimeoutMs,
+    ),
   } as unknown as ConfigApi;
   const discoveryApi = {
     getBaseUrl: jest.fn().mockResolvedValue('http://backend/api/kubernetes'),
@@ -74,6 +82,49 @@ describe('KubernetesClient.proxy', () => {
         init: { signal: controller.signal },
       }),
     ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('bounds the number of simultaneous in-flight proxy requests', async () => {
+    let activeFetches = 0;
+    let maxObserved = 0;
+    const release: Array<() => void> = [];
+    const fetch = jest.fn(() => {
+      activeFetches++;
+      maxObserved = Math.max(maxObserved, activeFetches);
+      return new Promise<Response>(resolve => {
+        release.push(() => {
+          activeFetches--;
+          resolve(new Response('{}', { status: 200 }));
+        });
+      });
+    });
+
+    // Cap concurrency at 2; fire four requests at once.
+    const client = createClient(fetch, 10_000, 2);
+    const calls = [0, 1, 2, 3].map(() =>
+      client.proxy({ clusterName: 'golem', path: '/version' }),
+    );
+
+    // Let the first batch start.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // Drain: each release frees a slot for the next queued request. Loop with
+    // macrotask ticks so queued requests have time to acquire and fetch.
+    for (
+      let i = 0;
+      i < 20 && (fetch.mock.calls.length < 4 || release.length > 0);
+      i++
+    ) {
+      if (release.length > 0) {
+        release.shift()!();
+      }
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    await Promise.all(calls);
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(maxObserved).toBe(2);
   });
 
   it('returns the response and clears the timeout on success', async () => {

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
@@ -22,6 +22,17 @@ import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
  */
 const DEFAULT_PROXY_TIMEOUT_MS = 10000;
 
+/**
+ * Default cap on simultaneous in-flight proxy requests across the whole app.
+ * With every configured installation kicking off discovery + list (and a
+ * broker token mint) at once, an unbounded fan-out hammers the broker and the
+ * management-cluster apiservers, so some requests hit the proxy timeout before
+ * recovering on retry. Bounding concurrency smooths that storm. The browser's
+ * own per-host connection limit is ~6, so this matches the level at which
+ * extra parallelism stops helping. Override with `gs.kubernetes.proxyMaxConcurrency`.
+ */
+const DEFAULT_PROXY_MAX_CONCURRENCY = 6;
+
 export class KubernetesClient implements KubernetesApi {
   private readonly backendClient: KubernetesBackendClient;
   private readonly configApi: ConfigApi;
@@ -29,6 +40,9 @@ export class KubernetesClient implements KubernetesApi {
   private readonly fetchApi: FetchApi;
   private readonly kubernetesAuthProvidersApi: KubernetesAuthProvidersApi;
   private readonly proxyTimeoutMs: number;
+  private readonly proxyMaxConcurrency: number;
+  private activeProxyRequests = 0;
+  private readonly proxyQueue: Array<() => void> = [];
   private clusters: ClusterConfiguration[] | undefined;
 
   constructor(options: {
@@ -50,6 +64,35 @@ export class KubernetesClient implements KubernetesApi {
     this.proxyTimeoutMs =
       options.configApi.getOptionalNumber('gs.kubernetes.proxyTimeoutMs') ??
       DEFAULT_PROXY_TIMEOUT_MS;
+    this.proxyMaxConcurrency =
+      options.configApi.getOptionalNumber(
+        'gs.kubernetes.proxyMaxConcurrency',
+      ) ?? DEFAULT_PROXY_MAX_CONCURRENCY;
+  }
+
+  /**
+   * Bounds simultaneous proxy requests. A released slot is handed directly to
+   * the next waiter (FIFO), so the active count never dips below the number of
+   * in-flight requests and the cap holds exactly.
+   *
+   * ponytail: a plain counter + a queue of resolvers. Single-tab, in-memory,
+   * no fairness beyond FIFO -- enough to tame the startup fan-out.
+   */
+  private async acquireProxySlot(): Promise<void> {
+    if (this.activeProxyRequests < this.proxyMaxConcurrency) {
+      this.activeProxyRequests++;
+      return;
+    }
+    await new Promise<void>(resolve => this.proxyQueue.push(resolve));
+  }
+
+  private releaseProxySlot(): void {
+    const next = this.proxyQueue.shift();
+    if (next) {
+      next();
+    } else {
+      this.activeProxyRequests--;
+    }
   }
 
   getObjectsByEntity(
@@ -118,57 +161,66 @@ export class KubernetesClient implements KubernetesApi {
     path: string;
     init?: RequestInit;
   }): Promise<Response> {
-    const cluster = await this.getCluster(options.clusterName);
-    if (!cluster) {
-      throw new Error(`Cluster ${options.clusterName} not found`);
-    }
-    const { authProvider, oidcTokenProvider } = cluster;
-    const kubernetesCredentials = await this.getCredentials(
-      authProvider,
-      oidcTokenProvider,
-    );
-    const url = `${await this.discoveryApi.getBaseUrl('kubernetes', cluster.name)}/proxy${
-      options.path
-    }`;
-    const headers = KubernetesClient.getKubernetesHeaders(
-      options,
-      kubernetesCredentials?.token,
-      authProvider,
-      oidcTokenProvider,
-    );
-
-    // Bound the request so an unreachable cluster fails fast instead of
-    // hanging the whole list. The caller's own signal (if any) still aborts.
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.proxyTimeoutMs);
-    const callerSignal = options.init?.signal;
-    const onCallerAbort = () => controller.abort();
-    if (callerSignal) {
-      if (callerSignal.aborted) {
-        controller.abort();
-      } else {
-        callerSignal.addEventListener('abort', onCallerAbort);
-      }
-    }
-
+    // Wait for a concurrency slot before doing anything (including the broker
+    // token mint), so the whole connection is throttled, not just the fetch.
+    // Queue time deliberately does not count against the per-request timeout,
+    // which starts only once a slot is held.
+    await this.acquireProxySlot();
     try {
-      return await this.fetchApi.fetch(url, {
-        ...options.init,
-        headers,
-        signal: controller.signal,
-      });
-    } catch (error) {
-      if (controller.signal.aborted && !callerSignal?.aborted) {
-        throw new Error(
-          `Request to cluster ${cluster.name} timed out after ${this.proxyTimeoutMs}ms`,
-        );
+      const cluster = await this.getCluster(options.clusterName);
+      if (!cluster) {
+        throw new Error(`Cluster ${options.clusterName} not found`);
       }
-      throw error;
-    } finally {
-      clearTimeout(timeout);
+      const { authProvider, oidcTokenProvider } = cluster;
+      const kubernetesCredentials = await this.getCredentials(
+        authProvider,
+        oidcTokenProvider,
+      );
+      const url = `${await this.discoveryApi.getBaseUrl('kubernetes', cluster.name)}/proxy${
+        options.path
+      }`;
+      const headers = KubernetesClient.getKubernetesHeaders(
+        options,
+        kubernetesCredentials?.token,
+        authProvider,
+        oidcTokenProvider,
+      );
+
+      // Bound the request so an unreachable cluster fails fast instead of
+      // hanging the whole list. The caller's own signal (if any) still aborts.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.proxyTimeoutMs);
+      const callerSignal = options.init?.signal;
+      const onCallerAbort = () => controller.abort();
       if (callerSignal) {
-        callerSignal.removeEventListener('abort', onCallerAbort);
+        if (callerSignal.aborted) {
+          controller.abort();
+        } else {
+          callerSignal.addEventListener('abort', onCallerAbort);
+        }
       }
+
+      try {
+        return await this.fetchApi.fetch(url, {
+          ...options.init,
+          headers,
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (controller.signal.aborted && !callerSignal?.aborted) {
+          throw new Error(
+            `Request to cluster ${cluster.name} timed out after ${this.proxyTimeoutMs}ms`,
+          );
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+        if (callerSignal) {
+          callerSignal.removeEventListener('abort', onCallerAbort);
+        }
+      }
+    } finally {
+      this.releaseProxySlot();
     }
   }
 

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.test.ts
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.test.ts
@@ -1,0 +1,62 @@
+import {
+  classifyProbeError,
+  classifyProbeResponse,
+} from './ClusterAccessConnector';
+import { ClusterTokenError } from '../../apis/auth/DefaultAuthConnector';
+
+const MAX_RETRIES = 2;
+
+describe('classifyProbeResponse', () => {
+  it('treats a 2xx as healthy', () => {
+    expect(
+      classifyProbeResponse({ ok: true, status: 200 }, 0, MAX_RETRIES),
+    ).toEqual({ kind: 'healthy' });
+  });
+
+  it('maps 401/403/404 to a degraded reason and does not retry', () => {
+    expect(
+      classifyProbeResponse({ ok: false, status: 403 }, 0, MAX_RETRIES),
+    ).toEqual({ kind: 'degraded', reason: 'Access forbidden' });
+    expect(
+      classifyProbeResponse({ ok: false, status: 404 }, 0, MAX_RETRIES),
+    ).toEqual({ kind: 'degraded', reason: 'API not found' });
+  });
+
+  it('retries a 5xx while attempts remain, then degrades', () => {
+    expect(
+      classifyProbeResponse({ ok: false, status: 503 }, 0, MAX_RETRIES),
+    ).toEqual({ kind: 'retry' });
+    expect(
+      classifyProbeResponse(
+        { ok: false, status: 503 },
+        MAX_RETRIES,
+        MAX_RETRIES,
+      ),
+    ).toEqual({ kind: 'degraded', reason: 'API request failed (503)' });
+  });
+});
+
+describe('classifyProbeError', () => {
+  it('skips a broker token error so the recorded state is not overwritten', () => {
+    const error = new ClusterTokenError('golem', 'session-expired');
+    expect(classifyProbeError(error, MAX_RETRIES, MAX_RETRIES)).toEqual({
+      kind: 'skip',
+    });
+  });
+
+  it('retries a transient error while attempts remain', () => {
+    expect(classifyProbeError(new Error('boom'), 0, MAX_RETRIES)).toEqual({
+      kind: 'retry',
+    });
+  });
+
+  it('degrades a timeout once retries are exhausted', () => {
+    expect(
+      classifyProbeError(
+        new Error('Request to cluster golem timed out after 10000ms'),
+        MAX_RETRIES,
+        MAX_RETRIES,
+      ),
+    ).toEqual({ kind: 'degraded', reason: 'API unreachable (timeout)' });
+  });
+});

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -1,0 +1,181 @@
+import { useEffect } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
+import { gsAuthProvidersApiRef } from '../../apis/auth';
+import { clusterAccessStatusApiRef } from '../../apis/clusterAccessStatus';
+
+/**
+ * Cheap, broadly-authorized apiserver endpoint used as a liveness probe. It is
+ * served to any authenticated request, so a 2xx means both the broker token
+ * mint and the apiserver round-trip succeeded.
+ */
+const HEALTH_PROBE_PATH = '/version';
+
+/**
+ * Re-probe interval. Keeps the sidebar live (a recovered or newly-broken
+ * cluster updates without visiting the clusters page) and keeps broker tokens
+ * warm. Cheap because the proxy bounds concurrency.
+ */
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+const MAX_RETRIES = 2;
+const RETRY_BASE_DELAY_MS = 1000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function describeProbeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/timed out/i.test(message)) {
+    return 'API unreachable (timeout)';
+  }
+  return message || 'Cluster access failed';
+}
+
+function describeHttpError(status: number): string {
+  if (status === 401 || status === 403) {
+    return 'Access forbidden';
+  }
+  if (status === 404) {
+    return 'API not found';
+  }
+  return `API request failed (${status})`;
+}
+
+/**
+ * What to do with a single probe result. `skip` means another layer (the
+ * cluster token provider) already recorded the precise state and we must not
+ * overwrite it.
+ */
+export type ProbeOutcome =
+  | { kind: 'healthy' }
+  | { kind: 'degraded'; reason: string }
+  | { kind: 'retry' }
+  | { kind: 'skip' };
+
+/** Maps a probe HTTP response to an outcome. 5xx is retried while attempts remain. */
+export function classifyProbeResponse(
+  response: Pick<Response, 'ok' | 'status'>,
+  attempt: number,
+  maxRetries: number,
+): ProbeOutcome {
+  if (response.ok) {
+    return { kind: 'healthy' };
+  }
+  if (response.status >= 500 && attempt < maxRetries) {
+    return { kind: 'retry' };
+  }
+  return { kind: 'degraded', reason: describeHttpError(response.status) };
+}
+
+/**
+ * Maps a thrown probe error to an outcome. A broker token mint failure
+ * (`ClusterTokenError`) was already recorded with its precise state, so it is
+ * skipped; transient apiserver/network errors are retried while attempts remain.
+ */
+export function classifyProbeError(
+  error: unknown,
+  attempt: number,
+  maxRetries: number,
+): ProbeOutcome {
+  if ((error as { name?: string })?.name === 'ClusterTokenError') {
+    return { kind: 'skip' };
+  }
+  if (attempt < maxRetries) {
+    return { kind: 'retry' };
+  }
+  return { kind: 'degraded', reason: describeProbeError(error) };
+}
+
+/**
+ * Headless component that proactively establishes cluster access for every
+ * broker-covered installation, regardless of which page the user is on. It
+ * runs once on app load (and on a slow refresh interval), seeding the sidebar
+ * cluster-access status with every installation so the status element is
+ * visible immediately, then probing each cluster's apiserver to surface real
+ * health. Only broker-covered installations are probed, so this never triggers
+ * a per-cluster login popup. Renders nothing.
+ */
+export function ClusterAccessConnector() {
+  const kubernetesApi = useApi(kubernetesApiRef);
+  const authProvidersApi = useApi(gsAuthProvidersApiRef);
+  const statusApi = useApi(clusterAccessStatusApiRef);
+
+  useEffect(() => {
+    const installations = authProvidersApi.getBrokerCoveredInstallations();
+    if (installations.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    // Seed once so the sidebar lists every covered installation immediately,
+    // before any probe settles. Re-probes (interval) intentionally do not
+    // reset entries to "connecting", to avoid flicker.
+    for (const installation of installations) {
+      statusApi.recordConnecting(installation);
+    }
+
+    const apply = (installation: string, outcome: ProbeOutcome): boolean => {
+      switch (outcome.kind) {
+        case 'healthy':
+          statusApi.recordHealthy(installation);
+          return true;
+        case 'degraded':
+          statusApi.recordDegraded(installation, outcome.reason);
+          return true;
+        case 'skip':
+          return true;
+        case 'retry':
+          return false;
+        default:
+          return true;
+      }
+    };
+
+    const probe = async (installation: string) => {
+      for (let attempt = 0; ; attempt++) {
+        if (cancelled) {
+          return;
+        }
+        let outcome: ProbeOutcome;
+        try {
+          const response = await kubernetesApi.proxy({
+            clusterName: installation,
+            path: HEALTH_PROBE_PATH,
+          });
+          outcome = classifyProbeResponse(response, attempt, MAX_RETRIES);
+        } catch (error) {
+          outcome = classifyProbeError(error, attempt, MAX_RETRIES);
+        }
+        if (cancelled) {
+          return;
+        }
+        // A retry with capped backoff is what lets an initial-storm timeout
+        // resolve on its own instead of sticking as degraded.
+        if (!apply(installation, outcome)) {
+          await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
+          continue;
+        }
+        return;
+      }
+    };
+
+    const connectAll = () => {
+      installations.forEach(installation => {
+        probe(installation);
+      });
+    };
+
+    connectAll();
+    const interval = setInterval(connectAll, REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [kubernetesApi, authProvidersApi, statusApi]);
+
+  return null;
+}

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -2,7 +2,12 @@ import { useEffect } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
+import { ClusterTokenError } from '../../apis/auth/DefaultAuthConnector';
 import { clusterAccessStatusApiRef } from '../../apis/clusterAccessStatus';
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled probe outcome: ${JSON.stringify(value)}`);
+}
 
 /**
  * Cheap, broadly-authorized apiserver endpoint used as a liveness probe. It is
@@ -79,7 +84,7 @@ export function classifyProbeError(
   attempt: number,
   maxRetries: number,
 ): ProbeOutcome {
-  if ((error as { name?: string })?.name === 'ClusterTokenError') {
+  if (error instanceof ClusterTokenError) {
     return { kind: 'skip' };
   }
   if (attempt < maxRetries) {
@@ -109,6 +114,9 @@ export function ClusterAccessConnector() {
     }
 
     let cancelled = false;
+    // Installations with a probe loop (including its retry backoff) still
+    // running, so a refresh tick never stacks a second loop on the same one.
+    const inFlight = new Set<string>();
 
     // Seed once so the sidebar lists every covered installation immediately,
     // before any probe settles. Re-probes (interval) intentionally do not
@@ -130,35 +138,43 @@ export function ClusterAccessConnector() {
         case 'retry':
           return false;
         default:
-          return true;
+          return assertNever(outcome);
       }
     };
 
     const probe = async (installation: string) => {
-      for (let attempt = 0; ; attempt++) {
-        if (cancelled) {
-          return;
-        }
-        let outcome: ProbeOutcome;
-        try {
-          const response = await kubernetesApi.proxy({
-            clusterName: installation,
-            path: HEALTH_PROBE_PATH,
-          });
-          outcome = classifyProbeResponse(response, attempt, MAX_RETRIES);
-        } catch (error) {
-          outcome = classifyProbeError(error, attempt, MAX_RETRIES);
-        }
-        if (cancelled) {
-          return;
-        }
-        // A retry with capped backoff is what lets an initial-storm timeout
-        // resolve on its own instead of sticking as degraded.
-        if (!apply(installation, outcome)) {
-          await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
-          continue;
-        }
+      if (inFlight.has(installation)) {
         return;
+      }
+      inFlight.add(installation);
+      try {
+        for (let attempt = 0; ; attempt++) {
+          if (cancelled) {
+            return;
+          }
+          let outcome: ProbeOutcome;
+          try {
+            const response = await kubernetesApi.proxy({
+              clusterName: installation,
+              path: HEALTH_PROBE_PATH,
+            });
+            outcome = classifyProbeResponse(response, attempt, MAX_RETRIES);
+          } catch (error) {
+            outcome = classifyProbeError(error, attempt, MAX_RETRIES);
+          }
+          if (cancelled) {
+            return;
+          }
+          // A retry with capped backoff is what lets an initial-storm timeout
+          // resolve on its own instead of sticking as degraded.
+          if (!apply(installation, outcome)) {
+            await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
+            continue;
+          }
+          return;
+        }
+      } finally {
+        inFlight.delete(installation);
       }
     };
 

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
@@ -23,12 +23,14 @@ import {
 import { gsAuthApiRef } from '../../apis/auth/types';
 
 const STATE_COLORS: Record<ClusterAccessState, string> = {
+  connecting: '#9e9e9e',
   healthy: '#2e7d32',
   degraded: '#f9a825',
   'session-expired': '#c62828',
 };
 
 const STATE_LABELS: Record<ClusterAccessState, string> = {
+  connecting: 'Connecting…',
   healthy: 'Healthy',
   degraded: 'Degraded',
   'session-expired': 'Session expired',
@@ -55,8 +57,10 @@ const useStyles = makeStyles(theme => ({
 
 /**
  * Computes the worst (most actionable) state across all tracked clusters.
- * session-expired wins over degraded wins over healthy, because an expired
- * main session is the one thing the user can immediately fix.
+ * session-expired wins over degraded, because an expired main session is the
+ * one thing the user can immediately fix. `connecting` ranks above plain
+ * healthy so the badge reflects in-flight probes on startup, but below any
+ * real problem.
  */
 function overallState(entries: ClusterAccessStatusEntry[]): ClusterAccessState {
   if (entries.some(e => e.state === 'session-expired')) {
@@ -64,6 +68,9 @@ function overallState(entries: ClusterAccessStatusEntry[]): ClusterAccessState {
   }
   if (entries.some(e => e.state === 'degraded')) {
     return 'degraded';
+  }
+  if (entries.some(e => e.state === 'connecting')) {
+    return 'connecting';
   }
   return 'healthy';
 }

--- a/plugins/gs/src/components/ClusterAccessStatus/index.ts
+++ b/plugins/gs/src/components/ClusterAccessStatus/index.ts
@@ -1,1 +1,2 @@
 export { ClusterAccessStatusSidebarItem } from './ClusterAccessStatusSidebarItem';
+export { ClusterAccessConnector } from './ClusterAccessConnector';

--- a/plugins/gs/src/index.ts
+++ b/plugins/gs/src/index.ts
@@ -15,7 +15,10 @@ export {
   type ClusterAccessStatusEntry,
   type ClusterAccessState,
 } from './apis/clusterAccessStatus';
-export { ClusterAccessStatusSidebarItem } from './components/ClusterAccessStatus';
+export {
+  ClusterAccessStatusSidebarItem,
+  ClusterAccessConnector,
+} from './components/ClusterAccessStatus';
 export { KubernetesClient } from './apis/kubernetes/KubernetesClient';
 export { createCustomEntityPresentationRenderer as createGSEntityPresentationRenderer } from './apis/entityPresentation';
 export { CustomCatalogPage as GSCustomCatalogPage } from './components/catalog/CustomCatalogPage';


### PR DESCRIPTION
## Summary

Immediate fix for three cluster-access issues in the devportal (most visible on gazelle with many installations):

- **Sidebar status element is now always visible.** It previously only appeared after visiting the clusters page, because the status store was only populated by `ClustersDataProvider`. A new headless `ClusterAccessConnector` seeds every broker-covered installation into the store on app load, so the element renders from the start. A new `connecting` state (grey "Connecting…") shows installations whose first probe is still in flight.
- **Connections to all installations are established regardless of page.** `ClusterAccessConnector` is mounted once in the app `Sidebar` (always present) and probes each broker-covered installation's apiserver (`GET /version`) on load and on a slow refresh interval — so access is warm and health is surfaced no matter which page you're on. Only broker-covered installations (`clusterTokenAudience` set) are probed, so this never triggers a per-cluster login popup.
- **The connection storm / intermittent timeouts are smoothed.** All Kubernetes proxy requests (including broker token mints) now go through a global concurrency semaphore in `KubernetesClient.proxy`, capped at `gs.kubernetes.proxyMaxConcurrency` (default 6, matching the browser's per-host limit). The per-request 10s timeout starts only **after** a slot is acquired, so queue time isn't counted as a timeout. The connector also retries transient timeouts/5xx with capped backoff, so a cluster that times out under initial load resolves on its own instead of sticking.

## Changes

- `plugins/gs`: new `ClusterAccessConnector` (+ pure-logic unit test); `connecting` state and `recordConnecting` in the cluster-access status store/types; `GSAuthProviders.getBrokerCoveredInstallations()`; concurrency semaphore + config knob in `KubernetesClient` (+ test); sidebar `connecting` visuals; exports.
- `packages/app`: mount `ClusterAccessConnector` in the nav `Sidebar`.
- Docs/config: `app-config.example.yaml`, `docs/configuration.md`, changeset.

## Notes for reviewers

- **Health probe path** is `/version` (cheap, broadly authorized for any authenticated request). If cluster RBAC restricts it, the discovery `/api` endpoint (already used by the clusters page) is an alternative.
- **Concurrency default of 6** is a starting point and is now a config knob (`gs.kubernetes.proxyMaxConcurrency`) for per-deployment tuning.

## Review follow-ups

Refinements from code review (no behavior change, tests + lint green):

- `ClusterAccessConnector` now detects broker-token failures via `instanceof ClusterTokenError` instead of a string `name` check (type-safe, drops the `as` cast).
- The probe-outcome `switch` uses an `assertNever` exhaustiveness guard instead of an unreachable `default`, so a future `ProbeOutcome` variant fails at compile time.
- Each installation's probe loop is guarded by an in-flight set, so a refresh tick can't stack a second loop on a still-running (e.g. backing-off) probe.
- Deliberately left as-is: the `/timed out/i` message match. The same match in `ClustersDataProvider` is intentional resilience against errors being wrapped/reconstructed across Backstage's data-fetching layers; a typed-error swap there would risk a regression, so the (cheap) string contract stays.
- Confirmed no re-entrancy deadlock in the semaphore: broker token mints run inside `getCredentials` **after** a slot is acquired and use a direct `fetch` (not a nested `proxy()` call), so they are bounded by the semaphore without re-acquiring a slot.

## Test plan

- [x] `tsc` typecheck clean (gs plugin; pre-existing unrelated errors elsewhere)
- [x] eslint + prettier clean on changed files
- [x] Unit tests: cluster-access status store (`connecting` seeding), `KubernetesClient` proxy concurrency cap, probe-outcome classifiers (14 tests across 3 suites pass)
- [ ] Manual: load the portal on a page other than `/clusters` and confirm the sidebar status element is visible and lists all installations
- [ ] Manual: on a deployment with many installations (e.g. gazelle), confirm no storm of simultaneous timeouts on startup; degraded clusters recover without a full reload

Made with [Cursor](https://cursor.com)