### PR TITLE
chore(renovate): assign reviewers on automerge PRs

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -3,8 +3,10 @@
 // this file. Rules for a whole class of repos belong in
 // giantswarm/renovate-presets instead.
 {
-  reviewers: ['marians'],
   reviewersFromCodeOwners: false,
+  // Assign the reviewer (the generated renovate.json5 default) even on
+  // automerge-enabled PRs at creation time, instead of only when checks fail.
+  assignAutomerge: true,
   prConcurrentLimit: 2,
   schedule: [
     'every weekend',


### PR DESCRIPTION
### What does this PR do?

Two changes to `renovate-custom.json5`:

1. Removes the stray `reviewers: ['marians']` override. With it gone, the
   generated `renovate.json5` default (`reviewers: ['teemow']`) is no longer
   shadowed and becomes the effective Renovate reviewer.
2. Sets `assignAutomerge: true`.

### What is the effect of this change to users?

Renovate now requests the configured reviewer on **every** Renovate PR at
creation time, including automerge-enabled ones. Previously, Renovate's default
`assignAutomerge: false` meant the reviewer was only assigned when a PR failed
status checks — so most clean, auto-merging PRs got no individual reviewer
assigned at all, and the `marians` override (a mistake) only surfaced on stuck
PRs.

The GitHub code-owner gate (`team-bumblebee` review required via branch
protection) is unaffected.

### Any background context you can provide?

`assignAutomerge` default behaviour, [per the Renovate docs](https://docs.renovatebot.com/configuration-options/#assignautomerge):
"By default, Renovate will not assign reviewers and assignees to an
automerge-enabled PR unless it fails status checks. By configuring
assignAutomerge setting to true, Renovate will instead always assign reviewers
and assignees for automerging PRs at time of creation."

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

Not applicable — CI/repo config only, no package changes.