### PR TITLE
fix(ci): cap release image build to linux/amd64

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -37,6 +37,13 @@ workflows:
         name: push-to-registries-release
         dockerfile: packages/backend/Dockerfile
         split-china-push: true
+        # amd64-only: the backstage backend image bundles native modules
+        # (isolated-vm, better-sqlite3, keytar) whose arm64 cross-build runs
+        # under QEMU emulation and silently exceeds the orb's 20m no-output
+        # timeout. Every prior release was single-arch amd64 and the management
+        # clusters are amd64, so arm64 is unused. Kept in sync with the
+        # ImagePlatforms knob in giantswarm/github (team-bumblebee.yaml).
+        platforms: linux/amd64
         requires:
         # Repo-owned pre-build job (defined in .circleci/custom.yml). The
         # generated job cannot be injected with this dependency via the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
+### Fixed
+
+- CI: cap the release image build to `linux/amd64`. The devctl-generated config built a multi-arch (amd64+arm64) image, but the arm64 cross-build of the backend's native modules (`isolated-vm`, `better-sqlite3`, `keytar`) runs under QEMU emulation and silently exceeds the orb's 20m no-output timeout, which blocked the tag pipeline (and therefore the chart catalog push) on `v0.137.1`. Every prior release was single-arch amd64 and the management clusters are amd64, so arm64 is unused.
+
 ## [0.137.1] - 2026-06-18
 
 ### Changed


### PR DESCRIPTION
## Problem

The `v0.137.1` tag pipeline's `push-to-registries-release` job **times out** and fails, leaving `push-chart-release` / `push-to-control-plane-app-catalog` as `not_run` — so the **chart never publishes to the catalog**.

Root cause: the new devctl-generated `.circleci/workflows.yml` builds a **multi-arch (amd64 + arm64)** release image (no `platforms` pin). The arm64 cross-build of the backend's native modules (`isolated-vm`, `better-sqlite3`, `keytar`) runs under **QEMU emulation** and is silent for >20 min, tripping the architect orb's 20m no-output timeout. Reproduced on two consecutive runs.

This is a regression from the CI migration: `v0.136.0` and `v0.137.0` release images are **single-arch amd64** (verified in the registry). The management clusters are amd64, so arm64 is unused.

## Fix

Pin `platforms: linux/amd64` on `push-to-registries-release`, mirroring the existing amd64 branch build. This restores the prior single-arch behavior and unblocks the chart publish.

`workflows.yml` is devctl-generated; the matching `ImagePlatforms: linux/amd64` knob is added to the source of truth in `giantswarm/github` (`repositories/team-bumblebee.yaml`) in a sibling PR, so the next align run regenerates the same pin (no drift).

## Test plan

- [ ] Re-cut the release after merge; confirm `push-to-registries-release` completes (amd64-only) and the chart publishes to the operations-platform catalog.

Made with [Cursor](https://cursor.com)