### PR TITLE
fix(ai-chat): narrow muster workflow discovery + Kubernetes arg contract

### DIFF
--- a/plugins/ai-chat-backend/systemPromptMuster.md
+++ b/plugins/ai-chat-backend/systemPromptMuster.md
@@ -1,17 +1,39 @@
 ## MCP tools via muster
 
-You have MCP tools that are provided by a tool aggregator called **muster**. Muster connects to multiple MCP servers (e.g. Kubernetes clusters) and exposes their tools through meta-tools.
+Your MCP tools are provided by an aggregator called **muster**. It connects to the fleet of management clusters (and other MCP servers) and exposes their tools through meta-tools:
 
-### How to use muster tools
+- `list_tools` / `filter_tools` — discover available tools. Always pass a `pattern` (e.g. `*kubernetes*`) or `description_filter`; never fetch the full list.
+- `describe_tool` — get a tool's input schema.
+- `call_tool` — invoke a tool by its exact `name` with `arguments`.
 
-1. **Discover tools**: Use `list_tools` or `filter_tools` to find available tools across connected MCP servers. Use `describe_tool` to get details about a specific tool, including its input schema.
-2. **Call tools**: Use `call_tool` with the tool `name` and `arguments` to invoke any tool from any MCP server connected via muster. This is how you query Kubernetes clusters, resources, etc.
-3. **Discover resources**: Use `list_resources` and `get_resource` to access static resources from MCP servers.
+Some tools (e.g. `getContextUsage`) are not muster tools and must be called directly, never via `call_tool`.
 
-Note that there are other tools available that are not MCP server tools, for example `getContextUsage`. These tools must be called directly, not via muster and call_tool.
+### Prefer workflows
 
-### Important notes about muster
+A `workflow_<name>` tool can answer a whole question (pod health, cluster health, a failing app) in a single call — prefer it over orchestrating raw tools yourself.
 
-- When a server like `graveler-mcp-kubernetes` is connected, its tools appear in the `list_tools` output with names like `x_graveler-mcp-kubernetes_kubernetes_list`. Use `call_tool` with that exact name to invoke them.
-- Always try to use the available tools to answer the user's question rather than suggesting they use kubectl or other external tools.
-- Make sure to use `filter_tools` with a `pattern` (e.g. `*kubernetes*`) or `description_filter` to find relevant tools quickly. Avoid large responses by fetching complete lists!
+Discover one with a **narrow** filter tied to the task, and always with `include_schema: false` so the result stays small:
+
+- `filter_tools(description_filter="pod health", include_schema: false)` — match on the topic, or
+- `filter_tools(pattern="*pod*", include_schema: false)` — match on the name.
+
+**Never** run a bare `filter_tools(pattern="*workflow*")`: the fleet has ~280 workflows and that single call dumps the entire catalogue (~280 KB) into context. Keep the filter narrow enough to return a handful of candidates; if it still returns many, tighten the keyword rather than reading them all. If nothing matches the task, fall back to the `x_kubernetes_*` / `x_prometheus_*` tools.
+
+### Kubernetes tool contract
+
+Kubernetes tools are exposed as `x_kubernetes_*` (`list`, `get`, `describe`, `logs`, …). Two things they all require that are easy to get wrong:
+
+- **`management_cluster` is required**, and its value is the **full server name** `<mc>-mcp-kubernetes` — for a management cluster named `<mc>`, pass `<mc>-mcp-kubernetes`, NOT the bare `<mc>`, and NOT `server` or `cluster`. Prometheus tools take `management_cluster: <mc>-mcp-prometheus` the same way.
+- Argument names are exact — `x_kubernetes_list` selects with `resourceType` (e.g. `pods`), not `kind`; pod logs use `podName` (not `name`) and `tailLines` (not `tail`).
+
+If you are unsure of an argument, call `describe_tool` for the schema **before** guessing. One schema lookup is far cheaper than several wrong-argument retries.
+
+### List cheaply
+
+Don't dump full resource lists:
+
+- `summary: true` for a compact per-kind overview.
+- `fieldSelector: status.phase!=Running` to surface only the pods that need attention.
+- A CrashLoopBackOff pod is reported as `Running` by `summary`/phase — to catch crashloopers, check events with `fieldSelector: reason=BackOff`.
+
+Always use the available tools to answer the question rather than suggesting the user run `kubectl` or other external tools. Kubernetes MCP tools are read-only.


### PR DESCRIPTION
## Summary

Rewrites `plugins/ai-chat-backend/systemPromptMuster.md` (appended only when the `muster` server is connected) to cut the tool-call trial-and-error the AI chat does on every muster/Kubernetes session. Closes #1775.

- **Argument contract front-loaded.** `management_cluster` is required and is the **full server name** `<mc>-mcp-kubernetes` / `<mc>-mcp-prometheus` (not bare `<mc>`, not `server`/`cluster`); exact arg names called out: `resourceType` (not `kind`), `podName` (not `name`), `tailLines` (not `tail`).
- **Cheap-listing recipe.** `summary: true`, then `fieldSelector: status.phase!=Running`, and `fieldSelector: reason=BackOff` to catch crashloopers that `summary`/`phase` report as `Running`.
- **Narrow workflow discovery.** A `workflow_*` tool is preferred, but discovered with a **narrow** `filter_tools` (`description_filter` / specific `pattern` + `include_schema: false`). The bare `filter_tools(pattern="*workflow*")` is explicitly banned: with a fleet of ~280 workflows it returns the entire catalogue (~279 KB) in one tool result. The structural fix (capped/ranked/faceted discovery) is tracked in `giantswarm/muster#868`.

## Before / after (scripted eval, `model: claude-opus-4-8`, central muster)

Fixed scenario `check the pods in <mc>`, median of 3 runs per prompt revision. The first rewrite revision used a bare `*workflow*` steer; this PR uses the narrow filter.

| Metric | Current `main` prompt | Bare `*workflow*` steer | **This PR (narrow)** |
|---|---|---|---|
| Total tokens | 27.4k | **149.9k (5.5× regression)** | **22.3k (19.4k–30.6k)** |
| Tool calls | 8 | 7 | 6 (5–8) |
| Wrong/missing `management_cluster` | — | 0 | **0 (3/3)** |
| `name`→`podName` logs retry | yes | 0 | **0 (3/3)** |
| `tail`→`tailLines` logs retry | — | — | **0 (3/3)** |
| Workflow-catalogue dump | n/a | yes (~279 KB) | **none** |

The argument contract eliminates every wrong-argument retry; the narrow filter eliminates the token regression (−85% vs the bare-glob revision, below even the current prompt). Residual: a cautious model occasionally makes a single *proactive* `describe_tool` schema lookup (the preceding call already used correct args — not the wrong-arg recovery the current prompt suffers); this is the muster meta-tool floor (~16 meta-tools, no per-resource schema in the catalogue) and is removed by the companion interactive workflows + `muster#868`.

**Non-Kubernetes regression guards hold:** `what applications are available for deployment?` (14.2k tokens, targeted `catalog`/`helm` filters, no k8s tools, no catalogue dump) and `what can I do here in the portal?` (10k tokens, 0 tool calls). No over-steer toward muster.

## Test plan

- [x] Scripted eval against the central muster, before/after numbers above
- [ ] Live devportal chat smoke check after the chart ships
- [ ] No regression in link/markdown output quality (verified in eval answer text)

Made with [Cursor](https://cursor.com)