### PR TITLE
fix(ai-chat): simplify muster prompt for the 0.9.0 discovery tier

### DIFF
--- a/plugins/ai-chat-backend/systemPromptMuster.md
+++ b/plugins/ai-chat-backend/systemPromptMuster.md
@@ -1,39 +1,21 @@
 ## MCP tools via muster
 
-Your MCP tools are provided by an aggregator called **muster**. It connects to the fleet of management clusters (and other MCP servers) and exposes their tools through meta-tools:
+Your MCP tools come from an aggregator, **muster**, via meta-tools: `filter_tools` discovers tools (pass a natural-language `query`; it returns a short, relevance-ranked list), `describe_tool` returns a tool's input schema, and `call_tool` runs a tool by its exact `name`. (`getContextUsage` is not a muster tool; call it directly, not via `call_tool`.)
 
-- `list_tools` / `filter_tools` — discover available tools. Always pass a `pattern` (e.g. `*kubernetes*`) or `description_filter`; never fetch the full list.
-- `describe_tool` — get a tool's input schema.
-- `call_tool` — invoke a tool by its exact `name` with `arguments`.
+### Prefer a workflow
 
-Some tools (e.g. `getContextUsage`) are not muster tools and must be called directly, never via `call_tool`.
-
-### Prefer workflows
-
-A `workflow_<name>` tool can answer a whole question (pod health, cluster health, a failing app) in a single call — prefer it over orchestrating raw tools yourself.
-
-Discover one with a **narrow** filter tied to the task, and always with `include_schema: false` so the result stays small:
-
-- `filter_tools(description_filter="pod health", include_schema: false)` — match on the topic, or
-- `filter_tools(pattern="*pod*", include_schema: false)` — match on the name.
-
-**Never** run a bare `filter_tools(pattern="*workflow*")`: the fleet has ~280 workflows and that single call dumps the entire catalogue (~280 KB) into context. Keep the filter narrow enough to return a handful of candidates; if it still returns many, tighten the keyword rather than reading them all. If nothing matches the task, fall back to the `x_kubernetes_*` / `x_prometheus_*` tools.
+A `workflow_<name>` tool answers a whole question (pod health, cluster health, a failing app) in a single call. Always look for one first with `filter_tools(query="<the question's topic>")` and prefer it over driving the raw `x_kubernetes_*` / `x_prometheus_*` tools yourself. Fall back to raw tools only when no workflow fits.
 
 ### Kubernetes tool contract
 
-Kubernetes tools are exposed as `x_kubernetes_*` (`list`, `get`, `describe`, `logs`, …). Two things they all require that are easy to get wrong:
+Raw Kubernetes tools are `x_kubernetes_*` (`list`/`get`/`describe`/`logs`), with two easy-to-miss requirements:
 
-- **`management_cluster` is required**, and its value is the **full server name** `<mc>-mcp-kubernetes` — for a management cluster named `<mc>`, pass `<mc>-mcp-kubernetes`, NOT the bare `<mc>`, and NOT `server` or `cluster`. Prometheus tools take `management_cluster: <mc>-mcp-prometheus` the same way.
-- Argument names are exact — `x_kubernetes_list` selects with `resourceType` (e.g. `pods`), not `kind`; pod logs use `podName` (not `name`) and `tailLines` (not `tail`).
-
-If you are unsure of an argument, call `describe_tool` for the schema **before** guessing. One schema lookup is far cheaper than several wrong-argument retries.
+- **`management_cluster` is required**, and its value is the **full server name** `<mc>-mcp-kubernetes` — not the bare `<mc>`, and not `server`/`cluster`. Prometheus tools take `<mc>-mcp-prometheus`.
+- Argument names are exact: `x_kubernetes_list` selects with `resourceType` (not `kind`); pod logs use `podName` (not `name`) and `tailLines` (not `tail`).
 
 ### List cheaply
 
-Don't dump full resource lists:
+- `summary: true` for a per-kind overview; `fieldSelector: status.phase!=Running` to surface only the pods needing attention.
+- A CrashLoopBackOff pod is reported as `Running` by summary/phase — catch it via events with `fieldSelector: reason=BackOff`.
 
-- `summary: true` for a compact per-kind overview.
-- `fieldSelector: status.phase!=Running` to surface only the pods that need attention.
-- A CrashLoopBackOff pod is reported as `Running` by `summary`/phase — to catch crashloopers, check events with `fieldSelector: reason=BackOff`.
-
-Always use the available tools to answer the question rather than suggesting the user run `kubectl` or other external tools. Kubernetes MCP tools are read-only.
+Use these read-only tools to answer the question yourself; don't tell the user to run `kubectl`.


### PR DESCRIPTION
## Summary

`systemPromptMuster.md` discovery-section rewrite, enabled by muster **0.9.0**'s cheap, ranked, faceted discovery tier (giantswarm/muster#868). The prompt no longer needs the discovery-mechanics crutch added in #1776:

- **Removed** the "never run a bare `filter_tools(pattern="*workflow*")`" ban and the "~280 KB catalogue dump" warning — a broad lookup is now bounded server-side (a ranked top-K, not the whole catalogue).
- **Replaced** the brittle `description_filter` substring steer with a natural-language `filter_tools(query="<topic>")`. BM25 ranking matches on meaning, so a covering `workflow_*` is found by topic without hand-aligning its `spec.description` to the agent's search phrase (the Round 4 finding that forced the aligned descriptions).
- **Dropped** the explicit `include_schema: false` (now the muster default) and the page-`limit` hint (the cheap page size is the muster server default, not a client concern).

**Kept verbatim:** the Kubernetes tool contract (`management_cluster: <mc>-mcp-kubernetes`, `podName`, `resourceType`, `tailLines`) and the list-cheaply block — muster does not address these and they prevent wrong-arg retries. **Kept** a distinct (short) "prefer a workflow" steer — it is load-bearing for the single-call answer path; collapsing it into a clause measurably regressed the agent into multi-call raw-tool runs.

Net: the muster prompt section drops from ~2.8 KB to ~1.6 KB while holding the single-call workflow behaviour and the argument contract.

## Validation

Measured with the scripted devportal AI-chat eval harness against the live gazelle muster (now on 0.9.0), fixed scenario set K1–K3 + non-k8s guards:

- Workflow discovery now opens every k8s scenario with a ranked `filter_tools(query=…)`, never a substring filter or bare glob.
- K1–K3 each resolve via a single `workflow_*` call; zero wrong-args; the `management_cluster`/`podName`/`resourceType`/`tailLines` contract holds.
- Non-k8s guards hold (no muster k8s/workflow calls, no catalogue dump; the portal question answers with zero tool calls).

The remaining page-size knob is being moved to the muster server default (giantswarm/muster#878, `defaultFilterLimit` 25 → 5) so the prompt needs no `limit` hint to get the cheapest page.

Refs #1775

## Test plan

- [ ] CI green (lint/build for the ai-chat-backend plugin)

Made with [Cursor](https://cursor.com)