### PR TITLE
docs: changelog entry for ai-chat muster prompt optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ## [Unreleased]
 
+### Changed
+
+- AI chat: optimize the muster system prompt. `systemPromptMuster.md` now front-loads the muster Kubernetes tool contract (`management_cluster: <mc>-mcp-kubernetes`, `podName`, `resourceType`, `tailLines`), steers workflow discovery to a ranked `filter_tools(query="<topic>")` for the muster 0.9.0+ discovery tier, and prefers a matching `workflow_*` over raw `x_kubernetes_*` tools. Cuts tool-call trial-and-error and tokens on common Kubernetes questions (#1776, #1784).
+
 ## [0.137.2] - 2026-06-18
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds the `[Unreleased]` CHANGELOG entry for the AI chat muster system-prompt optimization that merged in #1776 and #1784 (both landed without a changelog note). Pure documentation — no code change.

This precedes cutting the release that ships the optimized prompt to the management clusters (currently pinned to v0.137.2, which predates these commits).

Made with [Cursor](https://cursor.com)