### PR TITLE
fix(auth-backend-module-gs): distinguish broker invalid_client from subject_invalid

### DIFF
--- a/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
@@ -224,6 +224,43 @@ describe('createClusterTokenRouter', () => {
     });
   });
 
+  it('maps a broker client-auth failure to a broker_client_invalid reason', async () => {
+    mockBrokerResponse(
+      {
+        error: 'invalid_client',
+        error_description: 'client authentication failed',
+      },
+      { status: 401 },
+    );
+
+    const res = await request(buildApp()!)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({
+      error: 'Token exchange failed',
+      reason: 'broker_client_invalid',
+    });
+  });
+
+  it('still maps a non-invalid_client 401 to subject_invalid', async () => {
+    mockBrokerResponse(
+      { error: 'invalid_token', error_description: 'subject token rejected' },
+      { status: 401 },
+    );
+
+    const res = await request(buildApp()!)
+      .post('/cluster-token/golem')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({
+      error: 'Token exchange failed',
+      reason: 'subject_invalid',
+    });
+  });
+
   it('maps an unreachable broker to 502', async () => {
     jest.spyOn(global, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
 

--- a/plugins/auth-backend-module-gs/src/clusterToken/router.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.ts
@@ -35,6 +35,20 @@ type CachedToken = {
   expiresAt: number;
 };
 
+/**
+ * Extracts the OAuth 2.0 `error` code (RFC 6749 section 5.2) from a broker
+ * error response body. Returns undefined for non-JSON bodies (e.g. an HTML
+ * error page from a proxy sitting in front of the broker).
+ */
+function parseOAuthError(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown };
+    return typeof parsed.error === 'string' ? parsed.error : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export interface ClusterTokenRouterOptions {
   config: RootConfigService;
   logger: LoggerService;
@@ -160,13 +174,31 @@ export function createClusterTokenRouter(
           `Cluster token exchange for installation "${installation}" failed with status ${response.status}: ${body}`,
         );
         tokenCache.delete(cacheKey);
-        // A 4xx with an OAuth invalid_grant/invalid_token (or 401) means the
-        // forwarded subject token was rejected -- i.e. the user's main session,
-        // not the cluster, is the problem. Everything else is a broker-side
-        // exchange failure.
+
+        const oauthError = parseOAuthError(body);
+
+        // OAuth `invalid_client` means the broker could not authenticate
+        // ITSELF to muster (e.g. its confidential client record was wiped),
+        // not that the user's subject token was rejected. This is a broker
+        // outage that hits every cluster at once and must not be reported to
+        // users as an expired session.
+        if (oauthError === 'invalid_client') {
+          res.status(502).json({
+            error: 'Token exchange failed',
+            reason: 'broker_client_invalid',
+          });
+          return;
+        }
+
+        // An OAuth invalid_grant/invalid_token/invalid_request (or a bare 401
+        // that is not invalid_client) means the forwarded subject token was
+        // rejected -- i.e. the user's main session, not the cluster, is the
+        // problem. Everything else is a broker-side exchange failure.
         const subjectRejected =
           response.status === 401 ||
-          /invalid_grant|invalid_token|invalid_request/.test(body);
+          oauthError === 'invalid_grant' ||
+          oauthError === 'invalid_token' ||
+          oauthError === 'invalid_request';
         res.status(502).json({
           error: 'Token exchange failed',
           reason: subjectRejected ? 'subject_invalid' : 'exchange_failed',


### PR DESCRIPTION
## Summary

- The cluster-token broker router collapsed every broker `401` into the `subject_invalid` reason, which the frontend renders to users as "sign in again".
- But OAuth `invalid_client` means the **broker** could not authenticate itself to muster (e.g. its confidential client record was wiped from Valkey) -- a broker outage that hits every cluster at once, not an expired user session.
- This change parses the OAuth error code from the broker response and surfaces a distinct `broker_client_invalid` reason for `invalid_client`, while keeping `subject_invalid` for genuine subject-token rejections (`invalid_grant` / `invalid_token` / `invalid_request`, or a bare non-`invalid_client` 401).

The frontend (`GSAuthProviders.ts`) only treats `subject_invalid`/`session-expired` as "sign in again"; an unrecognized 502 reason degrades the cluster instead, so a broker-auth outage is no longer misreported to users as an expired session.

## Test plan

- [x] `auth-backend-module-gs` unit tests pass (12 tests), including new cases:
  - `invalid_client` (401) -> `broker_client_invalid`
  - non-`invalid_client` 401 (`invalid_token`) -> `subject_invalid`
- [x] Package lint clean

Made with [Cursor](https://cursor.com)