### PR TITLE
ci: enable changesets npm publishing for backstage plugins

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.github/workflows/release-plugins.yaml
+++ b/.github/workflows/release-plugins.yaml
@@ -1,0 +1,63 @@
+# Plugin release axis (changesets -> npm).
+#
+# Independent of the app axis (git-cliff `auto_release.yaml`, which tags
+# `vX.Y.Z` and drives the CircleCI image/chart pipeline). This workflow only
+# touches the `@giantswarm/backstage-plugin-*` npm packages.
+#
+# On every push to main, changesets/action either:
+#   - opens/updates a "Version Packages" PR consuming any pending
+#     `.changeset/*.md` files (PR title `chore(release): version plugins` --
+#     a non-bumping conventional type, so merging it does NOT make git-cliff
+#     cut a spurious app `vX.Y.Z` release), or
+#   - if the merged push already carried the version bump, builds the plugins
+#     and runs `changeset publish` to publish the bumped packages to npm and
+#     push their `@pkg@ver` tags (architect's `/^v.*/` filter ignores these).
+name: release-plugins
+
+on:
+  push:
+    branches:
+      - main
+
+# Avoid two publish runs racing on overlapping pushes to main.
+concurrency:
+  group: release-plugins-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write        # create the Version Packages PR branch + plugin tags
+  pull-requests: write   # open/update the Version Packages PR
+
+jobs:
+  release:
+    name: Release plugins
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Create Version Packages PR or publish to npm
+        uses: changesets/action@v1
+        with:
+          version: yarn changeset version
+          publish: yarn release:plugins
+          commit: 'chore(release): version plugins'
+          title: 'chore(release): version plugins'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,11 @@
 checksumBehavior: update
 
+# Auth token for publishing @giantswarm/backstage-plugin-* to npm. Populated
+# from the NPM_TOKEN env var (set as a GitHub Actions secret) only in the
+# release-plugins workflow; expands to empty everywhere else so installs and
+# local development are unaffected.
+npmAuthToken: '${NPM_TOKEN:-}'
+
 # Yarn 4.14 changed the default of enableScripts to false, which prevents
 # native modules (e.g. better-sqlite3) from building their bindings.
 # Restore the pre-4.14 behavior for this existing project.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "new": "backstage-cli new",
+    "release:plugins": "yarn build:all && changeset publish",
     "postinstall": "yarn patch-package",
     "prepare": "husky"
   },

--- a/plugins/ai-chat-backend/package.json
+++ b/plugins/ai-chat-backend/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-ai-chat-backend",
   "version": "0.17.3",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/ai-chat-react/package.json
+++ b/plugins/ai-chat-react/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-ai-chat-react",
   "version": "0.5.0",
   "license": "Apache-2.0",
-  "private": true,
   "description": "Web library for the ai-chat plugin",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/ai-chat/package.json
+++ b/plugins/ai-chat/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-ai-chat",
   "version": "0.14.0",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/auth-backend-module-gs/package.json
+++ b/plugins/auth-backend-module-gs/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/catalog-backend-module-gs/package.json
+++ b/plugins/catalog-backend-module-gs/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/error-reporter-react/package.json
+++ b/plugins/error-reporter-react/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-error-reporter-react",
   "version": "0.3.0",
   "license": "Apache-2.0",
-  "private": true,
   "description": "Web library for error reporting",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/flux-react/package.json
+++ b/plugins/flux-react/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-flux-react",
   "version": "0.14.2",
   "license": "Apache-2.0",
-  "private": true,
   "description": "Web library for the Flux plugin",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/flux/package.json
+++ b/plugins/flux/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-flux",
   "version": "0.9.2",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/gs-backend/package.json
+++ b/plugins/gs-backend/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-gs-backend",
   "version": "0.10.2",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/gs-common/package.json
+++ b/plugins/gs-common/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/gs-node/package.json
+++ b/plugins/gs-node/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/gs/package.json
+++ b/plugins/gs/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",

--- a/plugins/kubernetes-react/package.json
+++ b/plugins/kubernetes-react/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-kubernetes-react",
   "version": "0.16.0",
   "license": "Apache-2.0",
-  "private": true,
   "description": "Web library for the GS Kubernetes plugin",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/plugins/muster-backend/package.json
+++ b/plugins/muster-backend/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-muster-backend",
   "version": "0.2.3",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/muster/package.json
+++ b/plugins/muster/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-muster",
   "version": "0.3.0",
   "license": "Apache-2.0",
-  "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/plugins/scaffolder-backend-module-gs/package.json
+++ b/plugins/scaffolder-backend-module-gs/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/techdocs-backend-module-gs/package.json
+++ b/plugins/techdocs-backend-module-gs/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/ui-react/package.json
+++ b/plugins/ui-react/package.json
@@ -2,7 +2,6 @@
   "name": "@giantswarm/backstage-plugin-ui-react",
   "version": "0.8.5",
   "license": "Apache-2.0",
-  "private": true,
   "description": "Web library for the ui plugin",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary

Implements the plugin release axis (Axis 2) of the accepted two-axis release model — `giantswarm/backstage#1772` step 4. The app axis (git-cliff `auto_release.yaml`) is already live; this PR makes the 18 `@giantswarm/backstage-plugin-*` packages independently publishable to npm via changesets, on their own version/tag namespace.

- Drop `"private": true` from the 18 `plugins/*` packages (the `packages/*` app packages stay private).
- Set `.changeset/config.json` `access: public`.
- Add `release:plugins` root script (`yarn build:all && changeset publish`).
- Add `.github/workflows/release-plugins.yaml` using `changesets/action`: on push to `main` it opens/updates a **Version Packages** PR titled `chore(release): version plugins`, and publishes the bumped plugins to npm. Auth via `NPM_TOKEN` (wired through `.yarnrc.yml` `npmAuthToken`, empty elsewhere).

The two axes never collide: architect's `/^v.*/` tag filter fires only on the app `vX.Y.Z` tag, never on `@pkg@ver` plugin tags. The `chore(release):` Version-Packages title is a non-bumping conventional type, so merging it does **not** make git-cliff cut a spurious app release (`cliff.toml` bumps only on `feat`/`fix`/breaking — verified).

## ⚠️ Do not merge until NPM_TOKEN is provisioned

`changesets/action` runs the `publish` command on any push to `main` where **no changeset files are present** (the normal post-Version-PR state). Because none of the 18 plugins are on npm yet, the **first** merge of this PR will trigger an inaugural `changeset publish` of **all 18** `@giantswarm/backstage-plugin-*` packages at their current versions.

Prerequisites before merge (org-admin):
1. The npm `@giantswarm` org must exist with publish rights (it currently has zero published packages).
2. An `NPM_TOKEN` repo secret (publish rights, 2FA-on-publish disabled) must be set on this repo.

Without the token the `release-plugins` workflow run fails on the publish step. Keep this PR open until the token is in place; merging is then a deliberate, supervised initial publish.

## Test plan

- [x] All 18 plugins valid JSON, prettier-clean; `yarn install --immutable` reports no lockfile drift.
- [x] `cliff.toml` confirmed: `chore(release):` does not bump → no spurious app release.
- [x] Local dry-run: a changeset for one plugin bumps only that plugin (root `package.json` stays `0.138.0`).
- [ ] After `NPM_TOKEN` is provisioned: merge, confirm the inaugural publish lands the plugins on npm with no app `vX.Y.Z` tag cut.