### PR TITLE
ci: adopt generated node-build with Yarn dependency cache

### DIFF
--- a/.circleci/custom.yml
+++ b/.circleci/custom.yml
@@ -3,91 +3,26 @@
 # .circleci/workflows.yml at pipeline runtime (yq `*+`: maps merge, job lists
 # append). devctl never touches this file.
 #
-# Generated job names available to reference in `requires`: build-image (branch),
-# push-to-registries-release, sync-china-registry, build-chart,
+# Generated job names available to reference in `requires`: node-build (the
+# install/verify/build job that persists packages/*/dist/*), push-to-registries
+# (branch), push-to-registries-release, sync-china-registry, build-chart,
 # execute-chart-tests, execute-chart-tests-release, push-chart-release (the
 # operations-platform catalog push).
 #
 # What this file carries beyond the golden pipeline:
-#   - buildjob: the Node build (install/typecheck/lint/prettier/test/build) that
-#     produces packages/*/dist/*. The generated image jobs (build-image and
-#     push-to-registries-release) wait on it via gen.ci.image.preBuildJob:
-#     buildjob and overlay its persisted workspace into the Docker build context
-#     (packages/backend/Dockerfile COPYs packages/backend/dist/*.tar.gz).
 #   - push-to-control-plane-app-catalog: backstage ships the single `backstage`
 #     chart to TWO catalogs. The generated push-chart-release publishes to the
 #     operations-platform catalog (gen.ci.appCatalog); this carries the second
 #     control-plane catalog push.
+#
+# The Node build (install/verify/build -> packages/*/dist/*) is now the
+# generated `node-build` job (gen.ci.node), which the image jobs require for the
+# workspace handoff; the hand-written `buildjob` it replaced lived here before.
 version: 2.1
-
-jobs:
-  buildjob:
-    executor: architect/architect
-    resource_class: large
-    working_directory: ~/backstage
-    docker:
-      - image: cimg/node:24.18.0
-    steps:
-      - checkout
-      - run:
-          name: Print node and yarn version info
-          command: |
-            node --version
-            yarn --version
-      - run:
-          name: Install dependencies
-          command: yarn install --immutable
-      - restore_cache:
-          name: Restore TypeScript incremental build info
-          keys:
-            - v1-tsbuildinfo-{{ .Branch }}-{{ .Revision }}
-            - v1-tsbuildinfo-{{ .Branch }}-
-            - v1-tsbuildinfo-
-      - run:
-          name: Typecheck code using the TypeScript compiler
-          command: NODE_OPTIONS="--max-old-space-size=6144" yarn run tsc --noEmit
-      - save_cache:
-          name: Save TypeScript incremental build info
-          key: v1-tsbuildinfo-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - dist-types/tsconfig.tsbuildinfo
-      - run:
-          name: Lint code using ESlint
-          command: yarn run lint:all
-      - run:
-          name: Validate code style using prettier
-          command: yarn run prettier:check
-      - run:
-          name: Run tests
-          command: yarn run test:all
-      - run:
-          name: Mock secret files
-          command: |
-            touch github-app-credentials.yaml
-      - run:
-          name: Build application
-          command: |
-            yarn run build:backend --config ../../app-config.yaml --config ../../app-config.production.yaml
-            yarn run build:backend-headless-service --config ../../app-config.yaml --config ../../app-config.production.yaml
-          environment:
-            NODE_ENV: production
-      - persist_to_workspace:
-          root: ~/backstage
-          paths:
-            - packages/*/dist/*
 
 workflows:
   build:
     jobs:
-    # Node build feeding the generated image jobs (preBuildJob: buildjob).
-    - buildjob:
-        filters:
-          tags:
-            only: /^v.*/
-          branches:
-            ignore:
-            - main
-
     # Second catalog: the single `backstage` chart also ships to the
     # control-plane catalog. Gated on the same jobs as the generated
     # push-chart-release (operations-platform) so the same tested archive and

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -7,9 +7,51 @@ version: 2.1
 orbs:
   architect: giantswarm/architect@9.5.5
 
+jobs:
+  # Self-contained Node build/test on a cimg/node executor (architect ships no
+  # Node job). Dependencies are restored from a cache keyed on the lockfile
+  # checksum and saved write-once-per-lockfile, the Node analogue of go-build's
+  # GOCACHE persist. The verify/build steps invoke package.json scripts, so a
+  # repo redirects its bespoke toolchain by editing those scripts, not this job.
+  node-build:
+    docker:
+    - image: cimg/node:24.18.0
+    resource_class: large
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - node-deps-yarn-{{ checksum "yarn.lock" }}
+        - node-deps-yarn-
+    - run:
+        name: Install dependencies
+        command: yarn install --immutable
+    - save_cache:
+        key: node-deps-yarn-{{ checksum "yarn.lock" }}
+        paths:
+        - .yarn/cache
+    - run:
+        # The repo composes typecheck/lint/format/test into this one script
+        # (the make-target interface), so CI and local runs share a command.
+        name: Verify
+        command: yarn run ci:verify
+    - run:
+        name: Build
+        command: yarn run ci:build
+    - persist_to_workspace:
+        # Hand the build output to the image jobs, which attach_workspace and
+        # overlay it into the Docker build context (gen.ci.image.preBuildJob).
+        root: .
+        paths:
+        - packages/*/dist/*
+
 workflows:
   build:
     jobs:
+    - node-build:
+        filters:
+          tags:
+            only: /^v.*/
 
     # Branch builds (opt-in): amd64 dev image to gsoci for PR validation,
     # coupled with the branch chart push below. v9's push-to-registries always
@@ -20,10 +62,7 @@ workflows:
         dockerfile: packages/backend/Dockerfile
         platforms: linux/amd64
         requires:
-        # Repo-owned pre-build job (defined in .circleci/custom.yml). The
-        # branch image build needs the same workspace handoff as the release
-        # job, so the generator carries the dependency.
-        - buildjob
+        - node-build
         filters:
           branches:
             ignore:
@@ -39,10 +78,7 @@ workflows:
         split-china-push: true
         platforms: linux/amd64
         requires:
-        # Repo-owned pre-build job (defined in .circleci/custom.yml). The
-        # generated job cannot be injected with this dependency via the
-        # append-only custom.yml merge, so the generator carries it.
-        - buildjob
+        - node-build
         filters:
           tags:
             only: /^v.*/
@@ -76,6 +112,8 @@ workflows:
         push_to_appcatalog: false
         push_to_oci_registry: false
         persist_chart_archive: true
+        requires:
+        - node-build
         filters:
           tags:
             only: /^v.*/

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,6 +5,12 @@ checksumBehavior: update
 # Restore the pre-4.14 behavior for this existing project.
 enableScripts: true
 
+# Keep the dependency cache project-local (.yarn/cache) instead of the Yarn 4
+# default global folder. The generated CircleCI node-build job caches and
+# restores .yarn/cache keyed on yarn.lock; with the global cache the project dir
+# is empty and the cache is a no-op. .yarn/cache is gitignored (no zero-install).
+enableGlobalCache: false
+
 nodeLinker: node-modules
 
 plugins:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
+    "ci:verify": "NODE_OPTIONS=\"--max-old-space-size=6144\" yarn run tsc --noEmit && yarn run lint:all && yarn run prettier:check && yarn run test:all",
+    "ci:build": "touch github-app-credentials.yaml && NODE_ENV=production yarn run build:backend --config ../../app-config.yaml --config ../../app-config.production.yaml && NODE_ENV=production yarn run build:backend-headless-service --config ../../app-config.yaml --config ../../app-config.production.yaml",
     "new": "backstage-cli new",
     "postinstall": "yarn patch-package",
     "prepare": "husky"


### PR DESCRIPTION
## Summary

Replaces the hand-written `.circleci/custom.yml` `buildjob` with the generated `node-build` job (the Node analogue of `go-build`), which adds the lockfile-keyed Yarn dependency cache the old job lacked.

- `node-build` restores/saves `.yarn/cache` keyed on `yarn.lock` (write-once-per-lockfile). The old `buildjob` cached only `dist-types/tsconfig.tsbuildinfo` and ran `yarn install --immutable` **cold on every run**.
- Adds composed `package.json` scripts so the generated job invokes one command per phase (the make-target interface):
  - `ci:verify` -> `tsc --noEmit` (6 GB heap) + `lint:all` + `prettier:check` + `test:all`
  - `ci:build` -> mock secret + `build:backend` + `build:backend-headless-service` (NODE_ENV=production, same `--config` flags as before)
- `node-build` persists `packages/*/dist/*`; the image (`push-to-registries[-release]`), chart (`build-chart`) jobs require it via the language-derived wiring, so `image.preBuildJob` is no longer needed.
- The second control-plane catalog push (`push-to-control-plane-app-catalog`) stays in `custom.yml`.

The source-of-truth change (flip `language: node`, add the `gen.ci.node` block, wire the action knobs) is giantswarm/github#5556. After it lands, align-files regenerates this `.circleci/workflows.yml` identically (no-op). This PR applies the regenerated config now so CI is green on merge.

## Context

Part of the Node/TypeScript CI workstream (giantswarm/giantswarm#37023, epic #36729). The PoC flagship of the wave -- the largest Node codebase, caching nothing today.

Resolves #1829.

## Perf (cache win)

- **Before** (`buildjob`, cold install every run, last 30 days, 208 runs): median **~339s**, mean 331s, p95 407s.
- **After**: to be recorded from this PR's CI -- first run cold (populates `.yarn/cache`), second run warm (install becomes a near no-op).

## Test plan

- [ ] First PR build green: `node-build` runs `ci:verify` + `ci:build`, persists `packages/*/dist/*`, populates the cache.
- [ ] Second build (rerun / push): warm cache, `yarn install --immutable` near-instant; record wall-clock delta.
- [ ] Image + chart jobs attach the workspace and build from `packages/*/dist/*`.

Made with [Cursor](https://cursor.com)