### PR TITLE
ci: salt the node-build dependency-cache key (v1)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -21,13 +21,13 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - node-deps-yarn-{{ checksum "yarn.lock" }}
-        - node-deps-yarn-
+        - node-deps-yarn-v1-{{ checksum "yarn.lock" }}
+        - node-deps-yarn-v1-
     - run:
         name: Install dependencies
         command: yarn install --immutable
     - save_cache:
-        key: node-deps-yarn-{{ checksum "yarn.lock" }}
+        key: node-deps-yarn-v1-{{ checksum "yarn.lock" }}
         paths:
         - .yarn/cache
     - run:


### PR DESCRIPTION
## Summary

- Regenerate `.circleci/workflows.yml` with devctl v8.26.2 (giantswarm/devctl#2056): the Node dependency-cache key gains a `v1` version salt (`node-deps-yarn-v1-{{ checksum "yarn.lock" }}`, restore prefix `node-deps-yarn-v1-`).
- CircleCI cache keys are immutable. The initial node-build adoption (#1835) seeded an empty `.yarn/cache` under the unsalted key, and the real cache could not be stored until the next lockfile bump. Moving to a fresh salted key lets the first run (with `enableGlobalCache: false`) save the real `.yarn/cache`; subsequent runs restore it warm.

## Verified on CircleCI

The salt resolves the empty-seed bug — confirmed end to end:

| Install step | Cold (empty cache, job 30662) | Warm (restored cache, job 30679) |
|---|---|---|
| Resolution | 1.1s | 1.4s |
| **Fetch** | **19.1s** | **4.7s** |
| Link | 2m40s | 2m51s |
| `save_cache` | 8.4s (real archive) | 0.1s (no-op, key hit) |

The cold run stored a real `.yarn/cache` (8.4s save, not the ~16 B empty seed); the warm run restored it (`restore_cache` 6.4s of real content) and the Fetch step dropped 19.1s -> 4.7s.

**Note on the #1829 projection:** the projected ~140-165s/build win does not materialize. The `.yarn/cache` dependency cache only accelerates Yarn's *Fetch* step (~14s saved here). The dominant install cost is the *Link* step (~160-170s: node_modules construction + postinstall builds), which `.yarn/cache` does not cache. Net dependency-cache win on backstage is ~14s/build, not ~140s.

Refs giantswarm/devctl#2056, giantswarm/backstage#1829.