### PR TITLE
ci: cache the node-build output (node_modules) to skip native rebuilds

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -23,6 +23,15 @@ jobs:
         keys:
         - node-deps-yarn-v1-{{ checksum "yarn.lock" }}
         - node-deps-yarn-v1-
+    # Build-output cache: restore the materialized node_modules (with its
+    # compiled native addons) so the install reconciles incrementally instead
+    # of recompiling better-sqlite3/isolated-vm/etc. from source via node-gyp
+    # every run. Keyed on the node image version -- a node bump must not restore
+    # stale-ABI binaries. The Node analogue of go-build's $GOCACHE persist.
+    - restore_cache:
+        keys:
+        - node-build-yarn-v1-24.18.0-{{ checksum "yarn.lock" }}
+        - node-build-yarn-v1-24.18.0-
     - run:
         name: Install dependencies
         command: yarn install --immutable
@@ -30,6 +39,11 @@ jobs:
         key: node-deps-yarn-v1-{{ checksum "yarn.lock" }}
         paths:
         - .yarn/cache
+    - save_cache:
+        key: node-build-yarn-v1-24.18.0-{{ checksum "yarn.lock" }}
+        paths:
+        - node_modules
+        - .yarn/install-state.gz
     - run:
         # The repo composes typecheck/lint/format/test into this one script
         # (the make-target interface), so CI and local runs share a command.


### PR DESCRIPTION
## Summary

- Regenerated `.circleci/workflows.yml` with devctl v8.29.0 (giantswarm/devctl#2063/#2064): the node-build job now caches the **build output** (`node_modules` + `.yarn/install-state.gz`), keyed on the node image version + lockfile (`node-build-yarn-v1-24.18.0-{{ checksum "yarn.lock" }}`), in addition to the `.yarn/cache` tarball cache.
- **Why:** the tarball cache only saved ~14s (fetch 19s->4.7s); the warm install was still ~179s because the Link step recompiles native addons (better-sqlite3, isolated-vm, tree-sitter, …) from source via node-gyp every run. Those `.node` binaries live in `node_modules`, which the tarball cache doesn't hold. Restoring `node_modules` lets the install reconcile instead of recompiling — the Node analogue of go-build's `$GOCACHE`.

Records the warm-install number projected in #1829. Closes the perf gap that devctl#2056 alone could not.

## Test plan

- [ ] cold node-build saves node_modules under the build-cache key
- [ ] warm node-build restores it and skips the node-gyp rebuild (Link step drops sharply)

Made with [Cursor](https://cursor.com)