### PR TITLE
fix(gs): prioritize foreground proxy reads over whole-fleet cluster-access warm-up

### DIFF
--- a/.changeset/gs-foreground-proxy-priority.md
+++ b/.changeset/gs-foreground-proxy-priority.md
@@ -1,0 +1,10 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Stop a single-cluster Kubernetes proxy read from being serialized behind the whole-fleet cluster-access warm-up, which made CRD-backed pages (e.g. the muster dashboard) show a multi-second spinner on a cold first load.
+
+The headless `ClusterAccessConnector` proactively mints a cluster token and probes `/version` for every broker-covered installation on app load. Those probes shared the `KubernetesClient` concurrency lane with the page's own single-cluster read and were enqueued first, so the foreground read waited for the warm-up to drain (~9s on a 23-cluster fleet, with an unreachable cluster holding a slot for the full 10s default timeout).
+
+- `KubernetesClient.proxy` now serves foreground (page) reads ahead of background warm-up probes when a concurrency slot frees, so a single-cluster read is no longer queued behind the whole-fleet warm-up.
+- `KubernetesClient.proxy` accepts a per-request `timeoutMs` override; the cluster-access `/version` probe uses a short (2s) timeout so an unreachable cluster releases its slot quickly instead of dominating the tail.

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
@@ -127,6 +127,69 @@ describe('KubernetesClient.proxy', () => {
     expect(maxObserved).toBe(2);
   });
 
+  it('uses the per-request timeout override instead of the default', async () => {
+    const client = createClient(hangingFetch(), 10_000);
+
+    await expect(
+      client.proxy({
+        clusterName: 'golem',
+        path: '/version',
+        timeoutMs: 5,
+      }),
+    ).rejects.toThrow('Request to cluster golem timed out after 5ms');
+  });
+
+  it('serves a foreground read before a queued background warm-up probe', async () => {
+    const started: string[] = [];
+    const release: Array<() => void> = [];
+    const fetch = jest.fn((url: string | URL | Request) => {
+      started.push(String(url));
+      return new Promise<Response>(resolve => {
+        release.push(() => resolve(new Response('{}', { status: 200 })));
+      });
+    });
+
+    // Cap concurrency at 1 so the serving order is observable.
+    const client = createClient(fetch, 10_000, 1);
+
+    // A background probe takes the only slot.
+    const calls = [
+      client.proxy({
+        clusterName: 'golem',
+        path: '/bg-a',
+        background: true,
+      }),
+    ];
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // A second background probe and a foreground read queue behind it.
+    calls.push(
+      client.proxy({
+        clusterName: 'golem',
+        path: '/bg-b',
+        background: true,
+      }),
+      client.proxy({ clusterName: 'golem', path: '/fg' }),
+    );
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(started).toEqual(['http://backend/api/kubernetes/proxy/bg-a']);
+
+    // Freeing the slot serves the foreground read ahead of the queued
+    // background probe, even though the background probe was enqueued first.
+    release.shift()!();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(started[1]).toBe('http://backend/api/kubernetes/proxy/fg');
+
+    // Drain the remaining work.
+    for (let i = 0; i < 5 && release.length > 0; i++) {
+      release.shift()!();
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    await Promise.all(calls);
+    expect(started[2]).toBe('http://backend/api/kubernetes/proxy/bg-b');
+  });
+
   it('returns the response and clears the timeout on success', async () => {
     const response = new Response('{}', { status: 200 });
     const fetch = jest.fn().mockResolvedValue(response);

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
@@ -42,7 +42,10 @@ export class KubernetesClient implements KubernetesApi {
   private readonly proxyTimeoutMs: number;
   private readonly proxyMaxConcurrency: number;
   private activeProxyRequests = 0;
+  // Foreground (page) reads are served before background warm-up probes so a
+  // single-cluster read is never serialized behind the whole-fleet warm-up.
   private readonly proxyQueue: Array<() => void> = [];
+  private readonly proxyBackgroundQueue: Array<() => void> = [];
   private clusters: ClusterConfiguration[] | undefined;
 
   constructor(options: {
@@ -72,22 +75,30 @@ export class KubernetesClient implements KubernetesApi {
 
   /**
    * Bounds simultaneous proxy requests. A released slot is handed directly to
-   * the next waiter (FIFO), so the active count never dips below the number of
+   * the next waiter, so the active count never dips below the number of
    * in-flight requests and the cap holds exactly.
    *
-   * ponytail: a plain counter + a queue of resolvers. Single-tab, in-memory,
-   * no fairness beyond FIFO -- enough to tame the startup fan-out.
+   * Foreground requests (the default) are queued ahead of background warm-up
+   * probes: when a slot frees, a waiting foreground request is always served
+   * before any background one. This is what keeps a single-cluster page read
+   * from being serialized behind the whole-fleet cluster-access warm-up, which
+   * fires first on app load and would otherwise fill the queue.
+   *
+   * ponytail: a plain counter + two FIFO queues of resolvers. Single-tab,
+   * in-memory, no fairness beyond foreground-before-background FIFO -- enough
+   * to tame the startup fan-out without a real scheduler.
    */
-  private async acquireProxySlot(): Promise<void> {
+  private async acquireProxySlot(background: boolean): Promise<void> {
     if (this.activeProxyRequests < this.proxyMaxConcurrency) {
       this.activeProxyRequests++;
       return;
     }
-    await new Promise<void>(resolve => this.proxyQueue.push(resolve));
+    const queue = background ? this.proxyBackgroundQueue : this.proxyQueue;
+    await new Promise<void>(resolve => queue.push(resolve));
   }
 
   private releaseProxySlot(): void {
-    const next = this.proxyQueue.shift();
+    const next = this.proxyQueue.shift() ?? this.proxyBackgroundQueue.shift();
     if (next) {
       next();
     } else {
@@ -160,12 +171,25 @@ export class KubernetesClient implements KubernetesApi {
     clusterName: string;
     path: string;
     init?: RequestInit;
+    /**
+     * Marks the request as a background warm-up (e.g. the fleet cluster-access
+     * `/version` probe). Background requests yield to foreground page reads in
+     * the concurrency queue, so a single-cluster read is never serialized
+     * behind the whole-fleet warm-up. Defaults to false (foreground).
+     */
+    background?: boolean;
+    /**
+     * Per-request timeout override in ms. Defaults to `gs.kubernetes.proxyTimeoutMs`.
+     * Background probes use a short timeout so an unreachable cluster releases
+     * its slot quickly instead of holding it for the full default timeout.
+     */
+    timeoutMs?: number;
   }): Promise<Response> {
     // Wait for a concurrency slot before doing anything (including the broker
     // token mint), so the whole connection is throttled, not just the fetch.
     // Queue time deliberately does not count against the per-request timeout,
     // which starts only once a slot is held.
-    await this.acquireProxySlot();
+    await this.acquireProxySlot(options.background ?? false);
     try {
       const cluster = await this.getCluster(options.clusterName);
       if (!cluster) {
@@ -188,8 +212,9 @@ export class KubernetesClient implements KubernetesApi {
 
       // Bound the request so an unreachable cluster fails fast instead of
       // hanging the whole list. The caller's own signal (if any) still aborts.
+      const timeoutMs = options.timeoutMs ?? this.proxyTimeoutMs;
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), this.proxyTimeoutMs);
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
       const callerSignal = options.init?.signal;
       const onCallerAbort = () => controller.abort();
       if (callerSignal) {
@@ -209,7 +234,7 @@ export class KubernetesClient implements KubernetesApi {
       } catch (error) {
         if (controller.signal.aborted && !callerSignal?.aborted) {
           throw new Error(
-            `Request to cluster ${cluster.name} timed out after ${this.proxyTimeoutMs}ms`,
+            `Request to cluster ${cluster.name} timed out after ${timeoutMs}ms`,
           );
         }
         throw error;

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -4,6 +4,7 @@ import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
 import { ClusterTokenError } from '../../apis/auth/DefaultAuthConnector';
 import { clusterAccessStatusApiRef } from '../../apis/clusterAccessStatus';
+import { KubernetesClient } from '../../apis/kubernetes';
 
 function assertNever(value: never): never {
   throw new Error(`Unhandled probe outcome: ${JSON.stringify(value)}`);
@@ -15,6 +16,15 @@ function assertNever(value: never): never {
  * mint and the apiserver round-trip succeeded.
  */
 const HEALTH_PROBE_PATH = '/version';
+
+/**
+ * Per-probe timeout, deliberately shorter than the default proxy timeout. The
+ * warm-up probes the whole fleet, so an unreachable cluster must release its
+ * concurrency slot quickly instead of holding it for the full default (~10s)
+ * and dominating the tail. A genuinely slow-but-healthy cluster recovers via
+ * the retry/backoff loop and the refresh interval.
+ */
+const PROBE_TIMEOUT_MS = 2000;
 
 /**
  * Re-probe interval. Keeps the sidebar live (a recovered or newly-broken
@@ -154,10 +164,14 @@ export function ClusterAccessConnector() {
           }
           let outcome: ProbeOutcome;
           try {
+            // Background warm-up: yields to foreground page reads and uses a
+            // short timeout so an unreachable cluster does not hold a slot.
             const response = await kubernetesApi.proxy({
               clusterName: installation,
               path: HEALTH_PROBE_PATH,
-            });
+              background: true,
+              timeoutMs: PROBE_TIMEOUT_MS,
+            } as Parameters<KubernetesClient['proxy']>[0]);
             outcome = classifyProbeResponse(response, attempt, MAX_RETRIES);
           } catch (error) {
             outcome = classifyProbeError(error, attempt, MAX_RETRIES);


### PR DESCRIPTION
## Summary

Fixes the root cause of the multi-second spinner on a cold first load of CRD-backed pages (most visibly the muster dashboard): a single-cluster Kubernetes proxy read is serialized behind the headless whole-fleet cluster-access warm-up.

On app load, `ClusterAccessConnector` proactively mints a cluster token + probes `/version` for **every broker-covered installation** (the whole fleet). Those probes share the `KubernetesClient.proxy` concurrency lane (cap 6) with the page's own single-cluster read and are enqueued first, so the foreground read waits for the warm-up to drain. A chrome-devtools cold-load trace showed the single-cluster `mcpservers` read not starting until ~9.2s (then completing in ~55ms), because an unreachable/remote cluster holds a slot for the full 10s default proxy timeout.

## Changes

- `KubernetesClient.proxy` serves **foreground (page) reads ahead of background warm-up probes** when a concurrency slot frees (two-tier FIFO: foreground before background). A single-cluster read is no longer queued behind the whole-fleet warm-up.
- `KubernetesClient.proxy` accepts a per-request `timeoutMs` override. `ClusterAccessConnector`'s `/version` probe uses a short **2s** timeout so an unreachable cluster releases its slot quickly instead of dominating the tail (genuinely slow-but-healthy clusters recover via the existing retry/backoff + refresh interval).
- Bounded concurrency is unchanged (the warm-up still runs in the background).

## Test plan

- [x] `yarn workspace @giantswarm/backstage-plugin-gs test` — added unit tests for the per-request timeout override and for foreground-before-background serving order; existing concurrency/timeout/abort tests still pass.
- [x] `yarn tsc` green.
- [x] `yarn lint` green.
- [ ] Re-run the chrome-devtools cold-load trace on a deployed build (after clearing `REACT_QUERY_OFFLINE_CACHE`) to confirm the body renders in ~2s and the single-cluster CRD read no longer waits behind the fleet warm-up.

Closes #1845 (root-cause portion). The muster-plugin mitigation (render the dashboard body from last-known data instead of gating on `isLoading`) ships separately on the `muster-ui-iteration-2` integration branch.

Made with [Cursor](https://cursor.com)