### PR TITLE
fix(catalog): only add dependsOn for components that exist in the catalog

### DIFF
--- a/.changeset/sbom-filter-dangling-deps.md
+++ b/.changeset/sbom-filter-dangling-deps.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-catalog-backend-module-gs': patch
+---
+
+The SBOM dependency processor now only adds a `dependsOn` entry for components that actually exist in the catalog. Giant Swarm Go packages without a catalog component (e.g. archived libraries like `versionbundle`) are skipped, so they no longer appear as dangling relations ("Entities not found are: ...") on the entity page. If the catalog can't be queried, all dependencies are kept to avoid dropping real dependencies on a transient error.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -236,6 +236,8 @@ The following optional features are available:
 
 For the Giant Swarm devportal, we can enable asynchronous fetching of dependencies between components, based on the GitHub SBOM API. This will start updating dependency info once daily.
 
+Only dependencies whose target component exists in the catalog are added to a component's `dependsOn`. Giant Swarm Go packages that have no catalog component (e.g. archived libraries) are skipped so they don't appear as dangling relations on the entity page.
+
 ```yaml
 catalog:
   processors:

--- a/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/SbomDependencyProcessor.test.ts
+++ b/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/SbomDependencyProcessor.test.ts
@@ -11,6 +11,26 @@ function mockDb(rows: Array<{ dependency_name: string }>) {
   return knex as any;
 }
 
+function mockAuth() {
+  return {
+    getOwnServiceCredentials: jest.fn().mockResolvedValue({}),
+    getPluginRequestToken: jest.fn().mockResolvedValue({ token: 'token' }),
+    authenticate: jest.fn().mockResolvedValue({}),
+  } as any;
+}
+
+// Catalog stub returning the given component names in the default namespace.
+function mockCatalogApi(componentNames: string[]) {
+  return {
+    getEntities: jest.fn().mockResolvedValue({
+      items: componentNames.map(name => ({
+        kind: 'Component',
+        metadata: { name, namespace: 'default' },
+      })),
+    }),
+  } as any;
+}
+
 function makeEntity(overrides: Partial<Entity> = {}): Entity {
   return {
     apiVersion: 'backstage.io/v1alpha1',
@@ -43,13 +63,23 @@ const dummyLogger = {
 
 describe('SbomDependencyProcessor', () => {
   it('returns processor name', () => {
-    const processor = new SbomDependencyProcessor(mockDb([]), dummyLogger);
+    const processor = new SbomDependencyProcessor(
+      mockDb([]),
+      dummyLogger,
+      mockCatalogApi([]),
+      mockAuth(),
+    );
     expect(processor.getProcessorName()).toBe('SbomDependencyProcessor');
   });
 
   it('skips non-Component entities', async () => {
     const entity = makeEntity({ kind: 'API' });
-    const processor = new SbomDependencyProcessor(mockDb([]), dummyLogger);
+    const processor = new SbomDependencyProcessor(
+      mockDb([]),
+      dummyLogger,
+      mockCatalogApi([]),
+      mockAuth(),
+    );
 
     const result = await processor.preProcessEntity(
       entity,
@@ -66,7 +96,12 @@ describe('SbomDependencyProcessor', () => {
     const entity = makeEntity({
       metadata: { name: 'test', annotations: {} },
     });
-    const processor = new SbomDependencyProcessor(mockDb([]), dummyLogger);
+    const processor = new SbomDependencyProcessor(
+      mockDb([]),
+      dummyLogger,
+      mockCatalogApi([]),
+      mockAuth(),
+    );
 
     const result = await processor.preProcessEntity(
       entity,
@@ -81,7 +116,12 @@ describe('SbomDependencyProcessor', () => {
 
   it('returns entity unchanged when no DB rows exist', async () => {
     const entity = makeEntity();
-    const processor = new SbomDependencyProcessor(mockDb([]), dummyLogger);
+    const processor = new SbomDependencyProcessor(
+      mockDb([]),
+      dummyLogger,
+      mockCatalogApi([]),
+      mockAuth(),
+    );
 
     const result = await processor.preProcessEntity(
       entity,
@@ -100,7 +140,12 @@ describe('SbomDependencyProcessor', () => {
       { dependency_name: 'microerror' },
       { dependency_name: 'k8smetadata' },
     ]);
-    const processor = new SbomDependencyProcessor(db, dummyLogger);
+    const processor = new SbomDependencyProcessor(
+      db,
+      dummyLogger,
+      mockCatalogApi(['microerror', 'k8smetadata']),
+      mockAuth(),
+    );
 
     const result = await processor.preProcessEntity(
       entity,
@@ -126,7 +171,12 @@ describe('SbomDependencyProcessor', () => {
       { dependency_name: 'microerror' },
       { dependency_name: 'k8smetadata' },
     ]);
-    const processor = new SbomDependencyProcessor(db, dummyLogger);
+    const processor = new SbomDependencyProcessor(
+      db,
+      dummyLogger,
+      mockCatalogApi(['microerror', 'k8smetadata']),
+      mockAuth(),
+    );
 
     const result = await processor.preProcessEntity(
       entity,
@@ -151,7 +201,12 @@ describe('SbomDependencyProcessor', () => {
       }),
     }) as any;
     const logger = { ...dummyLogger, warn: jest.fn() };
-    const processor = new SbomDependencyProcessor(db, logger);
+    const processor = new SbomDependencyProcessor(
+      db,
+      logger,
+      mockCatalogApi([]),
+      mockAuth(),
+    );
 
     const result = await processor.preProcessEntity(
       entity,
@@ -167,11 +222,76 @@ describe('SbomDependencyProcessor', () => {
     );
   });
 
+  it('filters out dependencies whose component is not in the catalog', async () => {
+    const entity = makeEntity();
+    const db = mockDb([
+      { dependency_name: 'microerror' },
+      { dependency_name: 'versionbundle' },
+    ]);
+    // versionbundle has no catalog component -> should be dropped to avoid a
+    // dangling relation.
+    const processor = new SbomDependencyProcessor(
+      db,
+      dummyLogger,
+      mockCatalogApi(['microerror']),
+      mockAuth(),
+    );
+
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache as any,
+    );
+
+    expect((result.spec as any).dependsOn).toEqual(['component:microerror']);
+  });
+
+  it('keeps all dependencies when the catalog cannot be queried', async () => {
+    const entity = makeEntity();
+    const db = mockDb([
+      { dependency_name: 'microerror' },
+      { dependency_name: 'versionbundle' },
+    ]);
+    const catalogApi = {
+      getEntities: jest.fn().mockRejectedValue(new Error('catalog down')),
+    } as any;
+    const logger = { ...dummyLogger, warn: jest.fn() };
+    const processor = new SbomDependencyProcessor(
+      db,
+      logger,
+      catalogApi,
+      mockAuth(),
+    );
+
+    const result = await processor.preProcessEntity(
+      entity,
+      dummyLocation,
+      dummyEmit,
+      dummyLocation,
+      dummyCache as any,
+    );
+
+    expect((result.spec as any).dependsOn).toEqual([
+      'component:microerror',
+      'component:versionbundle',
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to load existing components'),
+    );
+  });
+
   it('does not emit relations', async () => {
     const entity = makeEntity();
     const db = mockDb([{ dependency_name: 'microerror' }]);
     const emit = jest.fn();
-    const processor = new SbomDependencyProcessor(db, dummyLogger);
+    const processor = new SbomDependencyProcessor(
+      db,
+      dummyLogger,
+      mockCatalogApi(['microerror']),
+      mockAuth(),
+    );
 
     await processor.preProcessEntity(
       entity,

--- a/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/SbomDependencyProcessor.ts
+++ b/plugins/catalog-backend-module-gs/src/SbomDependencyProcessor/SbomDependencyProcessor.ts
@@ -31,10 +31,19 @@ const migrationsDir = resolvePackagePath(
   'migrations',
 );
 
+const EXISTING_COMPONENTS_CACHE_TTL_MS = 5 * 60 * 1000;
+
 export class SbomDependencyProcessor implements CatalogProcessor {
+  private existingComponentsCache?: {
+    names: Set<string>;
+    expiresAt: number;
+  };
+
   constructor(
     private readonly db: Knex,
     private readonly logger: LoggerService,
+    private readonly catalogApi: CatalogService,
+    private readonly auth: AuthService,
   ) {}
 
   static async create(options: {
@@ -78,11 +87,68 @@ export class SbomDependencyProcessor implements CatalogProcessor {
       schedule,
     });
 
-    return new SbomDependencyProcessor(db, logger);
+    return new SbomDependencyProcessor(db, logger, catalogApi, auth);
   }
 
   getProcessorName(): string {
     return 'SbomDependencyProcessor';
+  }
+
+  /**
+   * Returns the names of all Component entities that exist in the `default`
+   * namespace. SBOM dependencies are expressed as the short ref
+   * `component:<name>`, which resolves to `component:default/<name>`, so
+   * filtering against this set drops dependencies whose target component is
+   * not in the catalog (e.g. archived GS Go libs) and would otherwise show up
+   * as dangling relations on the entity page.
+   *
+   * The result is cached briefly to avoid a catalog query per processed
+   * entity. Returns `undefined` if the catalog cannot be queried, in which
+   * case the caller falls back to keeping all dependencies.
+   */
+  private async getExistingComponentNames(): Promise<Set<string> | undefined> {
+    const now = Date.now();
+    if (
+      this.existingComponentsCache &&
+      this.existingComponentsCache.expiresAt > now
+    ) {
+      return this.existingComponentsCache.names;
+    }
+
+    try {
+      const { token } = await this.auth.getPluginRequestToken({
+        onBehalfOf: await this.auth.getOwnServiceCredentials(),
+        targetPluginId: 'catalog',
+      });
+      const credentials = await this.auth.authenticate(token);
+
+      const { items } = await this.catalogApi.getEntities(
+        {
+          filter: { kind: 'Component' },
+          fields: ['metadata.name', 'metadata.namespace'],
+        },
+        { credentials },
+      );
+
+      const names = new Set<string>();
+      for (const item of items) {
+        const namespace = item.metadata.namespace ?? 'default';
+        if (namespace === 'default') {
+          names.add(item.metadata.name);
+        }
+      }
+
+      this.existingComponentsCache = {
+        names,
+        expiresAt: now + EXISTING_COMPONENTS_CACHE_TTL_MS,
+      };
+      return names;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to load existing components for dependency filtering: ${error}`,
+      );
+      return undefined;
+    }
   }
 
   async preProcessEntity(
@@ -117,7 +183,17 @@ export class SbomDependencyProcessor implements CatalogProcessor {
       return entity;
     }
 
-    const sbomDeps = rows.map(row => `component:${row.dependency_name}`);
+    // Only depend on components that actually exist in the catalog. If the
+    // catalog can't be queried, keep all deps rather than silently dropping
+    // real dependencies because of a transient error.
+    const existingComponentNames = await this.getExistingComponentNames();
+    const dependencyNames = existingComponentNames
+      ? rows
+          .map(row => row.dependency_name)
+          .filter(name => existingComponentNames.has(name))
+      : rows.map(row => row.dependency_name);
+
+    const sbomDeps = dependencyNames.map(name => `component:${name}`);
     const existing = ((entity.spec as any)?.dependsOn as string[]) ?? [];
     const merged = [...new Set([...existing, ...sbomDeps])];
 


### PR DESCRIPTION
### What does this PR do?

The SBOM dependency processor (`catalog-backend-module-gs`) mapped every Giant Swarm Go dependency from a repo's GitHub SBOM to a `component:<name>` `dependsOn` ref **without checking that the target component exists** in the catalog. Backstage materializes a relation for each such ref regardless, so packages that have no catalog component (e.g. archived libraries like `versionbundle`) showed up as dangling relations.

The processor now fetches the set of existing `default`-namespace `Component` names (cached for 5 minutes to avoid a catalog query per processed entity) and filters SBOM-derived dependencies to that set before adding them to `spec.dependsOn`. If the catalog can't be queried, all dependencies are kept so a transient error never silently drops real dependencies.

### What is the effect of this change to users?

Entity pages no longer show the warning:

> This entity has relations to other entities, which can't be found in the catalog. Entities not found are: component:default/versionbundle

for Giant Swarm Go packages that aren't represented as catalog components. It's self-correcting: if such a component is later added to the catalog, the dependency reappears automatically.

### How does it look like?

N/A (backend behavior change). Example: `microkit`'s `dependsOn` resolves to `[microerror, micrologger]` instead of `[microerror, micrologger, versionbundle]`.

### Any background context you can provide?

`dependsOn` for components is resolved entirely by this backend processor (the `backstage-catalog-importer` only produces the bare component entity). The dangling-relation warning was the visible symptom of unfiltered SBOM dependencies.

### Do the docs need to be updated?

Yes — done in this PR (`docs/configuration.md`).

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))