### PR TITLE
chore(renovate): hold global-agent on v3 (v4 is ESM-only, breaks backend)

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -34,5 +34,15 @@
       groupName: 'date-fns packages',
       matchPackageNames: ['date-fns', 'date-fns-tz'],
     },
+    {
+      // global-agent v4 is ESM-only and removed the CommonJS
+      // `global-agent/bootstrap` entrypoint that packages/backend/src/index.ts
+      // imports. v4 crashes the backend container at startup with
+      // "Cannot find module 'global-agent/bootstrap'" (verified in the
+      // execute-chart-tests smoke test on #1831). Hold on v3 until the backend's
+      // bootstrap import is migrated to the v4 API.
+      matchPackageNames: ['global-agent'],
+      allowedVersions: '<4',
+    },
   ],
 }


### PR DESCRIPTION
## Problem

Renovate keeps proposing `global-agent` v4 (#1831). v4 is **ESM-only** and removed the CommonJS `global-agent/bootstrap` subpath that `packages/backend/src/index.ts` imports (`import 'global-agent/bootstrap';`).

The bump crashes the backend container at startup:

```
Error: Cannot find module 'global-agent/bootstrap'
```

This fails the **required** `execute-chart-tests` smoke test (`test_backstage_deployment_ready` times out because the pod crash-loops). Verified on #1831 (CircleCI build 29383). This is the same class of regression as the earlier global-agent v4 incident (#1599).

## Solution

Pin `global-agent` to `<4` in `renovate-custom.json5` until the backend's `global-agent/bootstrap` import is migrated to the v4 API. v3 works and provides the proxy bootstrap the backend relies on.

## Acceptance criteria

- Renovate no longer opens `global-agent` v4 PRs.
- #1831 closed.

Made with [Cursor](https://cursor.com)