### PR TITLE
fix(muster): iteration-2 truthfulness & coherence fixes

### DIFF
--- a/.changeset/muster-auth-coherence.md
+++ b/.changeset/muster-auth-coherence.md
@@ -8,4 +8,4 @@ Make the muster manager's auth state coherent across every surface: gate create/
 - Auth-failure (HTTP 401 / "authentication failure") errors from the ad-hoc validate/save/delete flows are mapped to a friendly "connect to muster (sign in)" prompt rather than the raw `MCP HTTP Transport Error … (HTTP 401)` transport message.
 - An `Auth Required` server with no tools now reads "requires an authenticated muster session for your user" rather than "the server may be down", matching the dashboard's treatment of `Auth Required` as a session state, not a degraded one.
 
-The MCP-servers-page session probe is extracted to a shared `useMusterSession` hook so the manager and the workflows list resolve session state (and the connect action) the same way.
+The MCP-servers-page session probe is extracted to a shared `useMusterSession` hook so the dashboard, the manager and the workflows list resolve session state (and the connect action) the same way — the dashboard's connect now signs in for the selected installation rather than the default one, and its probe is deduped with the hook's.

--- a/.changeset/muster-auth-coherence.md
+++ b/.changeset/muster-auth-coherence.md
@@ -1,0 +1,11 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Make the muster manager's auth state coherent across every surface: gate create/add affordances on a muster session and stop conflating "auth required" with "down".
+
+- "Add ad-hoc server" (MCP servers) and "Create workflow" (workflows) are now disabled with an explanatory tooltip when there is no authenticated muster session for the selected installation, instead of opening a dialog that fails after the user composes a definition.
+- Auth-failure (HTTP 401 / "authentication failure") errors from the ad-hoc validate/save/delete flows are mapped to a friendly "connect to muster (sign in)" prompt rather than the raw `MCP HTTP Transport Error … (HTTP 401)` transport message.
+- An `Auth Required` server with no tools now reads "requires an authenticated muster session for your user" rather than "the server may be down", matching the dashboard's treatment of `Auth Required` as a session state, not a degraded one.
+
+The MCP-servers-page session probe is extracted to a shared `useMusterSession` hook so the manager and the workflows list resolve session state (and the connect action) the same way.

--- a/.changeset/muster-cold-load-body.md
+++ b/.changeset/muster-cold-load-body.md
@@ -1,0 +1,12 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Render the muster dashboard body immediately on a cold load instead of blanking it behind a full-page spinner.
+
+The dashboard previously gated its whole body on `isLoading` (installations + the single-cluster MCPServer CRD read). On a cold first load that read can be queued behind the Backstage whole-fleet cluster-access warm-up, so the page showed only a spinner for several seconds. The page now:
+
+- gates only on the active installation being resolved, then renders the chrome (identity, endpoint, browse cards, sections) immediately from persisted/last-known data;
+- shows a thin progress bar under the header and `…` / "Loading…" placeholders for the stats, browse counts, and fleet-health matrix while the live CRD read is still in flight, instead of a misleading "0 servers" / "No MCP servers found".
+
+The root-cause serialization fix (foreground proxy reads jumping ahead of the fleet warm-up) ships separately in `@giantswarm/backstage-plugin-gs`.

--- a/.changeset/muster-dashboard-stat-correctness.md
+++ b/.changeset/muster-dashboard-stat-correctness.md
@@ -1,0 +1,8 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Fix the muster dashboard "Servers healthy" stat.
+
+- The stat no longer flips to amber on every remote federated-backend failure. muster federates ~26 management clusters, so at least one backend is almost always degraded; colouring on `healthy != total` made the stat near-permanently amber and useless as a signal. It now warns only when a meaningful fraction (>10%) of aggregated servers is unhealthy, via the shared `serversHealthSummary` helper.
+- The stat now renders whenever the server list has loaded, independent of the muster session. It is computed from the CRD `.status.state` reads (not the auth probe) -- the same data the fleet-health pills below already render unauthenticated -- so hiding only the summary stat when unauthenticated was inconsistent.

--- a/.changeset/muster-health-refresh.md
+++ b/.changeset/muster-health-refresh.md
@@ -1,0 +1,10 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Expose freshness for the muster UI's live health reads.
+
+The kubernetes-read-backed health data (dashboard stat row + fleet health; MCP-servers per-MC pills) was a point-in-time snapshot fetched once on load, with no indication of staleness -- it flapped silently against the live CRD between page loads. It now:
+
+- auto-refreshes in the background via a light `refetchInterval` on the MCPServer/Workflow CRD reads, configured once in `MusterInstanceProvider` so both the dashboard and the MCP-servers manager benefit (without blanking the page);
+- surfaces `dataUpdatedAt` and an `isRefreshing` flag from the provider, rendered as a shared "updated Xs ago" indicator plus a manual refresh control on the dashboard fleet-health section and the MCP-servers standard-servers section.

--- a/.changeset/muster-manager-cleanup.md
+++ b/.changeset/muster-manager-cleanup.md
@@ -1,0 +1,9 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Polish a few copy and edge-state details in the muster manager.
+
+- Core tool-family titles render verbatim again: the `text-transform: capitalize` on the muster-core families panel was turning the curated label "MCP server definitions" into "MCP Server Definitions"; it is dropped, and an explicit "Events" label is added so the un-curated `events` family no longer renders as a bare lowercase segment.
+- The workflows list distinguishes a zero-data installation ("No workflows in this installation.") from a filtered-to-empty result ("No workflows match your filters.") instead of always implying a filter is hiding rows.
+- A stale `/workflows/<name>/run` deep link (the bespoke Run route removed when Run was unified with the tool explorer) now redirects to the workflow detail page, preserving the query string, rather than silently resolving to the full workflows list.

--- a/.changeset/muster-mcp-representative-selection.md
+++ b/.changeset/muster-mcp-representative-selection.md
@@ -1,0 +1,11 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Fix the muster MCP-servers manager so a federated family's "shared" config/auth no longer defaults to an arbitrary peer/customer management cluster.
+
+A phase-1 fix reclassified the `Auth Required` MCPServer state from `warning` to `ok`, which silently flipped `StandardServerDisclosure`'s representative selection (`servers.find(s => severity === 'ok') ?? servers[0]`) from the local installation's own Connected server to the alphabetically-first server in list order — typically a customer MC. That cluster's name, URL and (non-shared) auth/token chain were then presented as the family's canonical face on another installation's screen.
+
+- A shared `selectRepresentative` helper now prefers the active installation's own server (`managementCluster === activeInstallation`), then a `Connected`/`Running` server, then falls back to the first server but flags it unqualified so the family is labelled neutrally rather than by that server's MC.
+- The Configuration caption reflects whether the representative is qualified; when it is not, it states the values are from one cluster and may differ per cluster instead of claiming "shared across the fleet".
+- The Authentication / token-chain block now carries a "shown for `<mc>`; differs per cluster" caveat, since the chain (forward-token vs token-exchange/OBO) legitimately varies per management cluster.

--- a/.changeset/muster-tools-grouping.md
+++ b/.changeset/muster-tools-grouping.md
@@ -1,0 +1,9 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Fix the muster Tool explorer browse tree so shared federated tools are no longer attributed to an arbitrary peer management cluster, the grouping no longer flickers on load, and `?server=` deep links scope correctly.
+
+- Shared/deduplicated federated tools (one `x_<family>` prefix that maps to many management clusters, targeted via the `management_cluster` argument) are now bucketed under a neutral family-level fleet label (`Kubernetes (fleet)` / `Prometheus (fleet)`) instead of the alphabetically-first peer MC, and split by family. Each server bucket's subtitle is derived from the family set it actually holds (and the federated cluster count for fleet groups), not from whichever server created the bucket (ADR muster-ui-iteration-2 D1).
+- The browse grouping waits for the MCPServer CRs to load before rendering, so the sections no longer reshuffle from raw `Server: <segment>` buckets to management-cluster buckets on load.
+- A `?server=` deep link now scopes the browse to that server's tools by tool-name prefix (with a clearable scope banner) instead of seeding a free-text search that also matched every tool whose description mentioned the segment.

--- a/.changeset/muster-tools-polish.md
+++ b/.changeset/muster-tools-polish.md
@@ -1,0 +1,9 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Polish the muster tool explorer: pre-select enum defaults, keep result-table headers readable, and collapse the large browse groups.
+
+- Enum/select argument fields now pre-select the schema `default` (e.g. `x_kubernetes_list`'s `output` shows `slim`) so the form reflects the value the tool will actually use instead of rendering a blank select.
+- Result-table column headers no longer squeeze to one letter per line: header cells get `white-space: nowrap` and the horizontal scroll handles the width.
+- The browse tree now expands only the Core group by default, so the 282-row Workflows group is collapsed on load (consistent with the MCP-servers collapse-by-default direction); the long tail is reached via search.

--- a/.changeset/muster-workflow-search.md
+++ b/.changeset/muster-workflow-search.md
@@ -1,0 +1,7 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Make the workflow-list search token-aware and relevance-ranked instead of a naive substring filter.
+
+The previous filter matched the query against any substring of a workflow's name or description, so searching "dex" returned `loki-request-errors` and `memcached-low-hit-ratio` purely because their descriptions mention "in**dex**". Search now matches on word/token boundaries (a query token must be a prefix of a name/description token), requires every query token to match, and orders results by relevance (name matches and exact tokens rank above description-only and prefix matches). "dex" now returns the dex workflows, not "index"-only matches.

--- a/.changeset/muster-workflow-truthfulness.md
+++ b/.changeset/muster-workflow-truthfulness.md
@@ -1,0 +1,10 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Decouple the muster workflow availability badge from the validator's `status.valid`, and clarify the workflow Executions/Statistics panels.
+
+A workflow whose aggregated `workflow_<name>` tool executes was reading "Unavailable" purely because muster's validator flagged its definition (e.g. the false-positive that demands a top-level `tool` on `parallel`/`forEach` container steps). The UI then contradicted itself: an "Unavailable" badge next to a working Run button.
+
+- `MusterWorkflow.isRunnable()` now backs the availability badge (every loaded Workflow CR is runnable because muster exposes its `workflow_<name>` tool). The validator verdict surfaces separately as a non-blocking "Validation warning" badge plus a reworded detail-page callout, instead of an "Unavailable" availability state (ADR D2). The workflows-list filter is repurposed from Available/Unavailable to Valid/Validation-warnings to stay coherent.
+- The Executions and Statistics panels now state that they reflect engine- and agent-driven runs recorded by muster's aggregator, and that a run launched from the tool explorer executes the aggregated tool directly and is not recorded there (its result is shown inline in the explorer).

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test --watchAll=false",
     "test:watch": "backstage-cli repo test",
-    "test:all": "backstage-cli repo test --coverage",
+    "test:all": "backstage-cli repo test --coverage --maxWorkers=2 --workerIdleMemoryLimit=1536MB",
     "test:e2e": "playwright test",
     "fix": "backstage-cli repo fix",
     "lint": "backstage-cli repo lint --since origin/main",

--- a/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
+++ b/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
@@ -23,7 +23,7 @@ import { useMusterInstance } from '../MusterInstanceProvider';
 import { InstallationPicker } from '../InstallationPicker';
 import { FleetHealthMatrix } from './FleetHealthMatrix';
 import { SectionHeader, Stat, StateBadge } from '../shared';
-import { mcpServerStateSeverity } from '../../lib/k8s';
+import { serversHealthSummary } from '../../lib/k8s';
 import { musterApiRef } from '../../apis';
 import { mcpServersRouteRef, workflowsRouteRef } from '../../routes';
 
@@ -318,12 +318,13 @@ export function DashboardPage() {
   // ponytail: aggregator "servers healthy" is derived from the CRD
   // `.status.state` severity (always readable, no muster session), not a
   // dedicated core_service_list call. `Auth Required` counts as healthy (the
-  // browsing user has a session); only genuinely degraded states subtract.
+  // browsing user has a session); only genuinely degraded states subtract. The
+  // tone warns only when a meaningful fraction is unhealthy, so a single remote
+  // federated backend being down does not paint the stat permanently amber.
   // Upgrade path is a backend /overview route surfacing the aggregator
   // service's live servers_connected + tools.
-  const serversHealthy = mcpServers.filter(
-    s => mcpServerStateSeverity(s.getState()) === 'ok',
-  ).length;
+  const { healthy: serversHealthy, tone: serversHealthyTone } =
+    serversHealthSummary(mcpServers);
 
   // On a cold load the single-cluster CRD read can be queued behind the
   // whole-fleet auth warm-up. Rather than blank the whole body behind a
@@ -439,17 +440,16 @@ export function DashboardPage() {
                 label="Workflows"
                 value={workflowsPending ? '…' : workflows.length}
               />
-              {authenticated && (
-                <Stat
-                  label="Servers healthy"
-                  value={
-                    serversPending
-                      ? '…'
-                      : `${serversHealthy}/${mcpServers.length}`
-                  }
-                  tone={serversHealthy === mcpServers.length ? 'ok' : 'warning'}
-                />
-              )}
+              {/* Computed from the CRD reads, not the muster session, so it
+                  renders whenever the server list has loaded -- the same data
+                  the fleet-health pills below show unauthenticated. */}
+              <Stat
+                label="Servers healthy"
+                value={
+                  serversPending ? '…' : `${serversHealthy}/${mcpServers.length}`
+                }
+                tone={serversPending ? undefined : serversHealthyTone}
+              />
             </Box>
           </Paper>
 

--- a/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
+++ b/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import {
   Box,
   Button,
@@ -19,7 +19,7 @@ import { Content, Link, Progress } from '@backstage/core-components';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
-import { useMusterInstance } from '../MusterInstanceProvider';
+import { useMusterInstance, useMusterSession } from '../MusterInstanceProvider';
 import { InstallationPicker } from '../InstallationPicker';
 import { FleetHealthMatrix } from './FleetHealthMatrix';
 import { FreshnessIndicator, SectionHeader, Stat, StateBadge } from '../shared';
@@ -272,8 +272,6 @@ export function DashboardPage() {
   const mcpServersLink = useRouteRef(mcpServersRouteRef);
   const workflowsLink = useRouteRef(workflowsRouteRef);
 
-  const requiresAuth = activeInstallationInfo?.requiresAuth ?? false;
-
   // The logged-in Backstage identity, shown in the "Authenticated as" badge.
   const { data: profile } = useQuery({
     queryKey: ['muster', 'identity'],
@@ -281,34 +279,26 @@ export function DashboardPage() {
   });
   const userLabel = profile?.displayName ?? profile?.email ?? 'you';
 
-  // Live aggregator probe: the tool count (the only stat that needs the muster
-  // session) and, by succeeding at all, that the session is authenticated. One
-  // round-trip; failing with an auth error flips the card to "Not authenticated".
+  // Session state (authenticated + connect) comes from the shared hook so the
+  // dashboard, the MCP-servers manager and the workflows page agree (ADR D3).
+  // The hook's probe and the count query below share the
+  // `['muster', 'overview', <installation>]` key, so react-query dedupes them to
+  // one round-trip and a connect refetch updates both.
   const {
-    data: overview,
-    isError: overviewFailed,
-    isLoading: overviewLoading,
-    refetch: refetchOverview,
-  } = useQuery({
+    authenticated,
+    connecting,
+    connect: handleConnect,
+  } = useMusterSession();
+
+  // The tool count is the only stat that needs the muster session; read it from
+  // the (deduped) overview query rather than the session hook, which only
+  // exposes auth state.
+  const { data: overview, isLoading: overviewLoading } = useQuery({
     queryKey: ['muster', 'overview', activeInstallation],
     queryFn: () =>
       musterApi.filterTools({ installation: activeInstallation, limit: 1 }),
     enabled: Boolean(activeInstallation),
   });
-
-  const [connecting, setConnecting] = useState(false);
-  const handleConnect = async () => {
-    setConnecting(true);
-    try {
-      await musterApi.signIn();
-      await refetchOverview();
-    } finally {
-      setConnecting(false);
-    }
-  };
-
-  // Authenticated when no auth is required, or the live probe succeeded.
-  const authenticated = !requiresAuth || (!overviewFailed && Boolean(overview));
   const toolCount = overview?.total;
 
   // Tools stat: '—' when unauthenticated, '…' while the probe is in flight,

--- a/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
+++ b/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  LinearProgress,
   Paper,
   Typography,
   makeStyles,
@@ -44,6 +45,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   // Reading-capped column (mockup `max-w-5xl`).
   column: {
     maxWidth: 1024,
+  },
+  // Thin progress bar shown under the header while the live CRD read is in
+  // flight, so a cold fleet warm-up does not blank the whole body.
+  bodyProgress: {
+    marginBottom: theme.spacing(2),
+    borderRadius: theme.shape.borderRadius,
   },
   intro: {
     maxWidth: '70ch',
@@ -318,14 +325,29 @@ export function DashboardPage() {
     s => mcpServerStateSeverity(s.getState()) === 'ok',
   ).length;
 
+  // On a cold load the single-cluster CRD read can be queued behind the
+  // whole-fleet auth warm-up. Rather than blank the whole body behind a
+  // full-page spinner, render the page chrome immediately from whatever
+  // persisted/last-known data react-query restored, and show placeholders +
+  // a thin progress bar only for the stats/health that have not arrived yet.
+  // (The root-cause serialization fix ships separately in plugins/gs.)
+  const serversPending = isLoading && mcpServers.length === 0;
+  const workflowsPending = isLoading && workflows.length === 0;
+
   return (
     <Content>
       <InstallationPicker />
 
-      {isLoading || !activeInstallation ? (
+      {!activeInstallation ? (
         <Progress />
       ) : (
         <Box className={classes.column}>
+          {isLoading && (
+            <LinearProgress
+              className={classes.bodyProgress}
+              aria-label="Loading live muster data"
+            />
+          )}
           <Typography variant="body2" className={classes.intro}>
             The live inventory of everything the platform&apos;s agents can
             reach right now — the MCP servers, their tools, and the reusable
@@ -408,13 +430,23 @@ export function DashboardPage() {
             </Box>
 
             <Box className={classes.statRow}>
-              <Stat label="Aggregated servers" value={mcpServers.length} />
+              <Stat
+                label="Aggregated servers"
+                value={serversPending ? '…' : mcpServers.length}
+              />
               <Stat label="Tools" value={toolStat} />
-              <Stat label="Workflows" value={workflows.length} />
+              <Stat
+                label="Workflows"
+                value={workflowsPending ? '…' : workflows.length}
+              />
               {authenticated && (
                 <Stat
                   label="Servers healthy"
-                  value={`${serversHealthy}/${mcpServers.length}`}
+                  value={
+                    serversPending
+                      ? '…'
+                      : `${serversHealthy}/${mcpServers.length}`
+                  }
                   tone={serversHealthy === mcpServers.length ? 'ok' : 'warning'}
                 />
               )}
@@ -435,7 +467,7 @@ export function DashboardPage() {
                 icon={<Dns />}
                 title="MCP servers"
                 description="The MCP servers muster aggregates and the tools they expose, with per-cluster health."
-                count={`${mcpServers.length} servers`}
+                count={serversPending ? 'Loading…' : `${mcpServers.length} servers`}
               />
               <BrowseCard
                 to={withInstallation(
@@ -445,7 +477,9 @@ export function DashboardPage() {
                 icon={<AccountTree />}
                 title="Workflows"
                 description="Reusable, named compositions of tool calls — searchable and filterable by availability."
-                count={`${workflows.length} workflows`}
+                count={
+                  workflowsPending ? 'Loading…' : `${workflows.length} workflows`
+                }
               />
             </Box>
           </Box>
@@ -457,7 +491,13 @@ export function DashboardPage() {
               title="Fleet health"
               description="MCPServer state grouped by server, mirroring the MCP-servers manager: each standard family and integration server carries a health pill per management cluster it is federated across (the worst state in that family × cluster cell)."
             />
-            <FleetHealthMatrix servers={mcpServers} />
+            {serversPending ? (
+              <Typography variant="body2" color="textSecondary">
+                Loading fleet health…
+              </Typography>
+            ) : (
+              <FleetHealthMatrix servers={mcpServers} />
+            )}
           </Box>
         </Box>
       )}

--- a/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
+++ b/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
@@ -439,7 +439,9 @@ export function DashboardPage() {
               <Stat
                 label="Servers healthy"
                 value={
-                  serversPending ? '…' : `${serversHealthy}/${mcpServers.length}`
+                  serversPending
+                    ? '…'
+                    : `${serversHealthy}/${mcpServers.length}`
                 }
                 tone={serversPending ? undefined : serversHealthyTone}
               />
@@ -460,7 +462,9 @@ export function DashboardPage() {
                 icon={<Dns />}
                 title="MCP servers"
                 description="The MCP servers muster aggregates and the tools they expose, with per-cluster health."
-                count={serversPending ? 'Loading…' : `${mcpServers.length} servers`}
+                count={
+                  serversPending ? 'Loading…' : `${mcpServers.length} servers`
+                }
               />
               <BrowseCard
                 to={withInstallation(
@@ -471,7 +475,9 @@ export function DashboardPage() {
                 title="Workflows"
                 description="Reusable, named compositions of tool calls — searchable and filterable by availability."
                 count={
-                  workflowsPending ? 'Loading…' : `${workflows.length} workflows`
+                  workflowsPending
+                    ? 'Loading…'
+                    : `${workflows.length} workflows`
                 }
               />
             </Box>

--- a/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
+++ b/plugins/muster/src/components/DashboardPage/DashboardPage.tsx
@@ -22,7 +22,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useMusterInstance } from '../MusterInstanceProvider';
 import { InstallationPicker } from '../InstallationPicker';
 import { FleetHealthMatrix } from './FleetHealthMatrix';
-import { SectionHeader, Stat, StateBadge } from '../shared';
+import { FreshnessIndicator, SectionHeader, Stat, StateBadge } from '../shared';
 import { serversHealthSummary } from '../../lib/k8s';
 import { musterApiRef } from '../../apis';
 import { mcpServersRouteRef, workflowsRouteRef } from '../../routes';
@@ -263,6 +263,9 @@ export function DashboardPage() {
     mcpServers,
     workflows,
     isLoading,
+    dataUpdatedAt,
+    isRefreshing,
+    retry,
   } = useMusterInstance();
   const musterApi = useApi(musterApiRef);
   const identityApi = useApi(identityApiRef);
@@ -490,6 +493,13 @@ export function DashboardPage() {
               icon={<Dns />}
               title="Fleet health"
               description="MCPServer state grouped by server, mirroring the MCP-servers manager: each standard family and integration server carries a health pill per management cluster it is federated across (the worst state in that family × cluster cell)."
+              action={
+                <FreshnessIndicator
+                  updatedAt={dataUpdatedAt}
+                  isRefreshing={isRefreshing}
+                  onRefresh={retry}
+                />
+              }
             />
             {serversPending ? (
               <Typography variant="body2" color="textSecondary">

--- a/plugins/muster/src/components/McpServersPage/CoreFamiliesPanel.tsx
+++ b/plugins/muster/src/components/McpServersPage/CoreFamiliesPanel.tsx
@@ -18,7 +18,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   familyTitle: {
     fontWeight: 600,
-    textTransform: 'capitalize',
   },
   count: {
     fontSize: 12,
@@ -37,6 +36,7 @@ const FAMILY_LABELS: Record<string, string> = {
   config: 'Configuration',
   mcpserver: 'MCP server definitions',
   auth: 'Authentication',
+  events: 'Events',
 };
 
 type Family = { key: string; label: string; tools: ToolSummary[] };

--- a/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
+++ b/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
@@ -84,8 +84,11 @@ export function McpServersPage() {
 
   // Session state (and the connect action) are resolved once via the shared
   // hook so the manager, the dashboard and the workflows page agree (ADR D3).
-  const { authenticated, connecting, connect: handleConnect } =
-    useMusterSession();
+  const {
+    authenticated,
+    connecting,
+    connect: handleConnect,
+  } = useMusterSession();
 
   const { standard, integration } = useMemo(
     () => partitionServers(mcpServers),

--- a/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
+++ b/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
@@ -191,6 +191,7 @@ export function McpServersPage() {
                     key={group.family}
                     family={group.family}
                     servers={group.servers}
+                    activeInstallation={activeInstallation}
                     authenticated={authenticated}
                     defaultExpanded={false}
                   />

--- a/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
+++ b/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
@@ -14,7 +14,12 @@ import Lock from '@material-ui/icons/Lock';
 import { Content, EmptyState, Progress } from '@backstage/core-components';
 import { InstallationPicker } from '../InstallationPicker';
 import { useMusterInstance, useMusterSession } from '../MusterInstanceProvider';
-import { SectionHeader, Gate, DisclosureAccordion } from '../shared';
+import {
+  SectionHeader,
+  Gate,
+  DisclosureAccordion,
+  FreshnessIndicator,
+} from '../shared';
 import { partitionServers } from '../../lib/serverGrouping';
 import { StandardServerDisclosure } from './StandardServerDisclosure';
 import { IntegrationServerDisclosure } from './IntegrationServerDisclosure';
@@ -65,8 +70,15 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export function McpServersPage() {
   const classes = useStyles();
-  const { mcpServers, activeInstallation, activeInstallationInfo, isLoading } =
-    useMusterInstance();
+  const {
+    mcpServers,
+    activeInstallation,
+    activeInstallationInfo,
+    isLoading,
+    dataUpdatedAt,
+    isRefreshing,
+    retry,
+  } = useMusterInstance();
 
   const requiresAuth = activeInstallationInfo?.requiresAuth ?? false;
 
@@ -146,6 +158,13 @@ export function McpServersPage() {
             icon={<Dns />}
             title="Standard servers"
             description="muster federates the same backend MCP servers across the management clusters in this installation. Each family's tool surface is identical, so it is shown once; connection health is tracked per management cluster."
+            action={
+              <FreshnessIndicator
+                updatedAt={dataUpdatedAt}
+                isRefreshing={isRefreshing}
+                onRefresh={retry}
+              />
+            }
           />
           {standard.length === 0 ? (
             <Typography variant="body2" color="textSecondary">

--- a/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
+++ b/plugins/muster/src/components/McpServersPage/McpServersPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   Box,
   Button,
@@ -12,13 +12,10 @@ import Power from '@material-ui/icons/Power';
 import Build from '@material-ui/icons/Build';
 import Lock from '@material-ui/icons/Lock';
 import { Content, EmptyState, Progress } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
-import { useQuery } from '@tanstack/react-query';
 import { InstallationPicker } from '../InstallationPicker';
-import { useMusterInstance } from '../MusterInstanceProvider';
+import { useMusterInstance, useMusterSession } from '../MusterInstanceProvider';
 import { SectionHeader, Gate, DisclosureAccordion } from '../shared';
 import { partitionServers } from '../../lib/serverGrouping';
-import { musterApiRef } from '../../apis';
 import { StandardServerDisclosure } from './StandardServerDisclosure';
 import { IntegrationServerDisclosure } from './IntegrationServerDisclosure';
 import { CoreFamiliesPanel } from './CoreFamiliesPanel';
@@ -70,35 +67,13 @@ export function McpServersPage() {
   const classes = useStyles();
   const { mcpServers, activeInstallation, activeInstallationInfo, isLoading } =
     useMusterInstance();
-  const musterApi = useApi(musterApiRef);
 
   const requiresAuth = activeInstallationInfo?.requiresAuth ?? false;
 
-  // Live probe: one round-trip that doubles as the auth check (a 401/403 flips
-  // the page to the not-authenticated state). Same pattern as the dashboard.
-  const {
-    data: probe,
-    isError: probeFailed,
-    refetch,
-  } = useQuery({
-    queryKey: ['muster', 'overview', activeInstallation],
-    queryFn: () =>
-      musterApi.filterTools({ installation: activeInstallation, limit: 1 }),
-    enabled: Boolean(activeInstallation),
-  });
-
-  const authenticated = !requiresAuth || (!probeFailed && Boolean(probe));
-
-  const [connecting, setConnecting] = useState(false);
-  const handleConnect = async () => {
-    setConnecting(true);
-    try {
-      await musterApi.signIn();
-      await refetch();
-    } finally {
-      setConnecting(false);
-    }
-  };
+  // Session state (and the connect action) are resolved once via the shared
+  // hook so the manager, the dashboard and the workflows page agree (ADR D3).
+  const { authenticated, connecting, connect: handleConnect } =
+    useMusterSession();
 
   const { standard, integration } = useMemo(
     () => partitionServers(mcpServers),
@@ -207,7 +182,12 @@ export function McpServersPage() {
             icon={<Power />}
             title="Integration servers"
             description="Singular MCP servers muster fronts outside the management-cluster structure — customer integrations and shared services. Each carries its own endpoint, auth chain, and tool surface."
-            action={<AddAdHocServerButton installation={activeInstallation} />}
+            action={
+              <AddAdHocServerButton
+                installation={activeInstallation}
+                authenticated={authenticated}
+              />
+            }
           />
           {integration.length === 0 ? (
             <Typography variant="body2" color="textSecondary">

--- a/plugins/muster/src/components/McpServersPage/ServerMutationActions.tsx
+++ b/plugins/muster/src/components/McpServersPage/ServerMutationActions.tsx
@@ -19,6 +19,7 @@ import DeleteOutline from '@material-ui/icons/DeleteOutline';
 import PlayArrow from '@material-ui/icons/PlayArrow';
 import Stop from '@material-ui/icons/Stop';
 import Replay from '@material-ui/icons/Replay';
+import Tooltip from '@material-ui/core/Tooltip';
 import { useApi } from '@backstage/core-plugin-api';
 import { musterApiRef } from '../../apis';
 import { MCPServer } from '../../lib/k8s';
@@ -29,6 +30,7 @@ import {
   toManifestYaml,
   toMcpServerDefinition,
 } from '../../lib/gitops';
+import { mutationErrorMessage } from '../../lib/authError';
 import { StateBadge } from '../shared';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -185,7 +187,7 @@ function ConfirmActionDialog({
       await musterApi.callTool(action.tool, action.args, server.cluster);
       setDone(true);
     } catch (e) {
-      setError((e as Error).message);
+      setError(mutationErrorMessage(e));
     } finally {
       setBusy(false);
     }
@@ -313,7 +315,7 @@ export function AdHocServerDialog({
       await musterApi.callTool('core_mcpserver_validate', def, target);
       setMessage('Definition is valid.');
     } catch (e) {
-      setError((e as Error).message);
+      setError(mutationErrorMessage(e));
     } finally {
       setBusy(false);
     }
@@ -334,7 +336,7 @@ export function AdHocServerDialog({
       );
       setMessage('Saved. The CRD list will refresh shortly.');
     } catch (e) {
-      setError((e as Error).message);
+      setError(mutationErrorMessage(e));
     } finally {
       setBusy(false);
     }
@@ -537,20 +539,39 @@ export function ServerMutationActions({ server }: ServerMutationActionsProps) {
  */
 export function AddAdHocServerButton({
   installation,
+  authenticated = true,
 }: {
   installation?: string;
+  /**
+   * Whether there is an authenticated muster session for this installation.
+   * Adding an ad-hoc server runs `core_mcpserver_*` live through muster, which
+   * needs a session -- so it is disabled (with an explanatory tooltip) when
+   * there is none, rather than failing after the user composes a definition.
+   */
+  authenticated?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const button = (
+    <Button
+      size="small"
+      startIcon={<Edit />}
+      onClick={() => setOpen(true)}
+      disabled={!authenticated}
+      title="Create a live ad-hoc MCP server"
+    >
+      Add ad-hoc server
+    </Button>
+  );
   return (
     <>
-      <Button
-        size="small"
-        startIcon={<Edit />}
-        onClick={() => setOpen(true)}
-        title="Create a live ad-hoc MCP server"
-      >
-        Add ad-hoc server
-      </Button>
+      {authenticated ? (
+        button
+      ) : (
+        <Tooltip title="Connect to muster (sign in) to add an ad-hoc server.">
+          {/* span wrapper so the tooltip still fires over the disabled button */}
+          <span>{button}</span>
+        </Tooltip>
+      )}
       <AdHocServerDialog
         installation={installation}
         open={open}

--- a/plugins/muster/src/components/McpServersPage/StandardServerDisclosure.tsx
+++ b/plugins/muster/src/components/McpServersPage/StandardServerDisclosure.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography, makeStyles, Theme } from '@material-ui/core';
-import { MCPServer, mcpServerStateSeverity } from '../../lib/k8s';
+import { MCPServer } from '../../lib/k8s';
 import { DisclosureAccordion, Gate, InstallationHealthPill } from '../shared';
-import { presenceByMc } from '../../lib/serverGrouping';
+import { presenceByMc, selectRepresentative } from '../../lib/serverGrouping';
 import {
   AuthChain,
   DetailBlock,
@@ -65,6 +65,11 @@ export interface StandardServerDisclosureProps {
   family: string;
   /** All MCPServer CRs of that family across the active instance's target MCs. */
   servers: MCPServer[];
+  /**
+   * The active muster installation. Used to prefer this installation's own
+   * server as the family's representative rather than an arbitrary peer MC.
+   */
+  activeInstallation?: string;
   authenticated: boolean;
   defaultExpanded?: boolean;
 }
@@ -80,16 +85,21 @@ export interface StandardServerDisclosureProps {
 export function StandardServerDisclosure({
   family,
   servers,
+  activeInstallation,
   authenticated,
   defaultExpanded,
 }: StandardServerDisclosureProps) {
   const classes = useStyles();
   const presence = presenceByMc(servers);
 
-  // Representative instance for shared config/auth/tools: prefer a healthy one.
-  const representative =
-    servers.find(s => mcpServerStateSeverity(s.getState()) === 'ok') ??
-    servers[0];
+  // Representative instance for shared config/auth/tools: prefer the active
+  // installation's own server, then a connected one (never an arbitrary peer MC
+  // by list order -- see selectRepresentative / ADR D1).
+  const rep = selectRepresentative(servers, activeInstallation);
+  const representative = rep?.server ?? servers[0];
+  const repMc =
+    representative.getManagementCluster() ?? representative.getName();
+  const qualified = rep?.qualified ?? false;
   const toolPrefix = `x_${family}`;
   const managed = isGitOpsManaged(representative);
   const releaseId = provenanceReleaseId(readProvenance(representative));
@@ -127,13 +137,18 @@ export function StandardServerDisclosure({
       <DetailBlock title="Configuration">
         <ServerConfig server={representative} />
         <Typography variant="caption" color="textSecondary">
-          Shared across the fleet; shown for{' '}
-          {representative.getManagementCluster() ?? representative.getName()}.
+          {qualified
+            ? `Shared across the fleet; shown for ${repMc}.`
+            : `Federated across the fleet; no connected representative on this installation — values shown are from ${repMc} and may differ per cluster.`}
         </Typography>
       </DetailBlock>
 
       <DetailBlock title="Authentication / token chain">
         <AuthChain server={representative} />
+        <Typography variant="caption" color="textSecondary">
+          Shown for {repMc}; the auth/token chain differs per cluster (e.g.
+          forward-token vs token-exchange/OBO).
+        </Typography>
       </DetailBlock>
 
       <DetailBlock title="GitOps provenance">

--- a/plugins/muster/src/components/McpServersPage/serverDetail.tsx
+++ b/plugins/muster/src/components/McpServersPage/serverDetail.tsx
@@ -370,9 +370,15 @@ export function ServerTools({
 
   const tools = data?.tools ?? [];
   if (tools.length === 0) {
+    // `Auth Required` is a session state, not a degraded one (ADR D3): the
+    // server exposes no tools because this user's session lacks the audience,
+    // not because it "may be down".
+    const authGated = server.getState() === 'Auth Required';
     return (
       <Typography variant="body2" className={classes.note}>
-        No tools exposed (server may be down or require authentication).
+        {authGated
+          ? 'No tools exposed — this server requires an authenticated muster session for your user.'
+          : 'No tools exposed (the server may be down or unreachable).'}
       </Typography>
     );
   }

--- a/plugins/muster/src/components/MusterInstanceProvider/MusterInstanceProvider.tsx
+++ b/plugins/muster/src/components/MusterInstanceProvider/MusterInstanceProvider.tsx
@@ -20,6 +20,14 @@ import { MusterInstallationInfo } from '../../apis/types';
 
 const STORAGE_KEY = 'muster-installation';
 
+// A light background refetch so the live health reads (per-MC pills, the
+// "Servers healthy" stat, fleet health) don't drift silently from the CRD
+// between page loads. Configured once here so both the dashboard and the
+// MCP-servers manager inherit it (ADR D4). The reads are trivially cheap once
+// the cluster auth is warm; the manual refresh control covers the gap between
+// intervals.
+const HEALTH_REFETCH_INTERVAL_MS = 30_000;
+
 export type MusterInstance = {
   /**
    * The muster installations the picker may offer. Sourced from the backend's
@@ -38,6 +46,11 @@ export type MusterInstance = {
   /** Workflow CRs of the active instance. */
   workflows: MusterWorkflow[];
   isLoading: boolean;
+  /** Epoch-ms of the most recent successful CRD read, or undefined while cold. */
+  dataUpdatedAt: number | undefined;
+  /** Whether a (background or manual) health refetch is currently in flight. */
+  isRefreshing: boolean;
+  /** Re-fetch the live CRD reads on demand (manual refresh / error retry). */
   retry: () => void;
 };
 
@@ -186,13 +199,38 @@ export const MusterInstanceProvider = ({
     errors: mcpServerErrors,
     isLoading: isLoadingServers,
     retry: retryServers,
-  } = useResources(clusters, MCPServer);
+    queries: mcpServerQueries,
+  } = useResources(clusters, MCPServer, {}, {
+    refetchInterval: HEALTH_REFETCH_INTERVAL_MS,
+  });
 
   const {
     resources: workflows,
     errors: workflowErrors,
     retry: retryWorkflows,
-  } = useResources(clusters, MusterWorkflow);
+    queries: workflowQueries,
+  } = useResources(clusters, MusterWorkflow, {}, {
+    refetchInterval: HEALTH_REFETCH_INTERVAL_MS,
+  });
+
+  // Freshness surfaced from the underlying react-query state: the newest
+  // successful read across both CRD fan-outs, and whether any read is in
+  // flight. The FreshnessIndicator turns these into "updated Xs ago" + a
+  // spinner on the manual refresh control (ADR D4).
+  const dataUpdatedAt = useMemo(() => {
+    const times = [...mcpServerQueries, ...workflowQueries]
+      .map(({ query }) => query.dataUpdatedAt)
+      .filter(t => t > 0);
+    return times.length > 0 ? Math.max(...times) : undefined;
+  }, [mcpServerQueries, workflowQueries]);
+
+  const isRefreshing = useMemo(
+    () =>
+      [...mcpServerQueries, ...workflowQueries].some(
+        ({ query }) => query.isFetching,
+      ),
+    [mcpServerQueries, workflowQueries],
+  );
 
   const errors = useMemo(
     () => [...mcpServerErrors, ...workflowErrors],
@@ -228,6 +266,8 @@ export const MusterInstanceProvider = ({
         (Boolean(activeInstallation) &&
           isLoadingServers &&
           mcpServers.length === 0),
+      dataUpdatedAt,
+      isRefreshing,
       retry: () => {
         retryServers();
         retryWorkflows();
@@ -242,6 +282,8 @@ export const MusterInstanceProvider = ({
       mcpServers,
       workflows,
       isLoadingServers,
+      dataUpdatedAt,
+      isRefreshing,
       retryServers,
       retryWorkflows,
     ],

--- a/plugins/muster/src/components/MusterInstanceProvider/MusterInstanceProvider.tsx
+++ b/plugins/muster/src/components/MusterInstanceProvider/MusterInstanceProvider.tsx
@@ -200,18 +200,28 @@ export const MusterInstanceProvider = ({
     isLoading: isLoadingServers,
     retry: retryServers,
     queries: mcpServerQueries,
-  } = useResources(clusters, MCPServer, {}, {
-    refetchInterval: HEALTH_REFETCH_INTERVAL_MS,
-  });
+  } = useResources(
+    clusters,
+    MCPServer,
+    {},
+    {
+      refetchInterval: HEALTH_REFETCH_INTERVAL_MS,
+    },
+  );
 
   const {
     resources: workflows,
     errors: workflowErrors,
     retry: retryWorkflows,
     queries: workflowQueries,
-  } = useResources(clusters, MusterWorkflow, {}, {
-    refetchInterval: HEALTH_REFETCH_INTERVAL_MS,
-  });
+  } = useResources(
+    clusters,
+    MusterWorkflow,
+    {},
+    {
+      refetchInterval: HEALTH_REFETCH_INTERVAL_MS,
+    },
+  );
 
   // Freshness surfaced from the underlying react-query state: the newest
   // successful read across both CRD fan-outs, and whether any read is in

--- a/plugins/muster/src/components/MusterInstanceProvider/index.ts
+++ b/plugins/muster/src/components/MusterInstanceProvider/index.ts
@@ -3,3 +3,5 @@ export {
   useMusterInstance,
 } from './MusterInstanceProvider';
 export type { MusterInstance } from './MusterInstanceProvider';
+export { useMusterSession } from './useMusterSession';
+export type { MusterSession } from './useMusterSession';

--- a/plugins/muster/src/components/MusterInstanceProvider/useMusterSession.ts
+++ b/plugins/muster/src/components/MusterInstanceProvider/useMusterSession.ts
@@ -1,0 +1,54 @@
+import { useCallback, useState } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { useQuery } from '@tanstack/react-query';
+import { musterApiRef } from '../../apis';
+import { useMusterInstance } from './MusterInstanceProvider';
+
+export type MusterSession = {
+  /** True once muster doesn't require auth, or a probe call succeeds. */
+  authenticated: boolean;
+  /** Whether a connect (sign-in) round-trip is in flight. */
+  connecting: boolean;
+  /** Trigger the OAuth popup for the active installation, then re-probe. */
+  connect: () => Promise<void>;
+};
+
+/**
+ * Resolves whether the browsing user has an authenticated muster session for
+ * the active installation, and exposes a connect action. A single lightweight
+ * `filter_tools(limit=1)` probe doubles as the auth check (a 401/403 flips
+ * `authenticated` to false). Shared by every surface that gates muster
+ * mutations/tools so they agree on session state (ADR D3) -- the probe is keyed
+ * per installation so react-query dedupes it across pages.
+ */
+export function useMusterSession(): MusterSession {
+  const { activeInstallation, activeInstallationInfo } = useMusterInstance();
+  const musterApi = useApi(musterApiRef);
+  const requiresAuth = activeInstallationInfo?.requiresAuth ?? false;
+
+  const {
+    data: probe,
+    isError: probeFailed,
+    refetch,
+  } = useQuery({
+    queryKey: ['muster', 'overview', activeInstallation],
+    queryFn: () =>
+      musterApi.filterTools({ installation: activeInstallation, limit: 1 }),
+    enabled: Boolean(activeInstallation),
+  });
+
+  const authenticated = !requiresAuth || (!probeFailed && Boolean(probe));
+
+  const [connecting, setConnecting] = useState(false);
+  const connect = useCallback(async () => {
+    setConnecting(true);
+    try {
+      await musterApi.signIn(activeInstallation);
+      await refetch();
+    } finally {
+      setConnecting(false);
+    }
+  }, [musterApi, activeInstallation, refetch]);
+
+  return { authenticated, connecting, connect };
+}

--- a/plugins/muster/src/components/Router.tsx
+++ b/plugins/muster/src/components/Router.tsx
@@ -1,4 +1,10 @@
-import { Navigate, Routes, Route, useLocation, useParams } from 'react-router-dom';
+import {
+  Navigate,
+  Routes,
+  Route,
+  useLocation,
+  useParams,
+} from 'react-router-dom';
 import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { workflowDetailRouteRef } from '../routes';
 import { QueryClientProvider } from './QueryClientProvider';

--- a/plugins/muster/src/components/Router.tsx
+++ b/plugins/muster/src/components/Router.tsx
@@ -1,8 +1,23 @@
-import { Routes, Route } from 'react-router-dom';
+import { Navigate, Routes, Route, useLocation, useParams } from 'react-router-dom';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { workflowDetailRouteRef } from '../routes';
 import { QueryClientProvider } from './QueryClientProvider';
 import { MusterPage } from './MusterPage';
 import { WorkflowDetailPage } from './WorkflowDetailPage';
+
+/**
+ * The bespoke `/workflows/:name/run` route was removed when Run was unified with
+ * the tool explorer; a lingering deep link used to silently resolve to the full
+ * workflows list. Redirect it to the workflow detail (preserving the query
+ * string, e.g. `?installation=`) so the named workflow is not dropped.
+ */
+const LegacyRunRedirect = () => {
+  const { name = '' } = useParams();
+  const { search } = useLocation();
+  const detailLink = useRouteRef(workflowDetailRouteRef);
+  const to = detailLink ? detailLink({ name }) : '..';
+  return <Navigate to={`${to}${search}`} replace />;
+};
 
 export const Router = () => {
   return (
@@ -14,6 +29,7 @@ export const Router = () => {
           path={workflowDetailRouteRef.path}
           element={<WorkflowDetailPage />}
         />
+        <Route path="/workflows/:name/run" element={<LegacyRunRedirect />} />
         <Route path="/*" element={<MusterPage />} />
       </Routes>
     </QueryClientProvider>

--- a/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
@@ -440,11 +440,11 @@ function BrowseGroups({
   }
   return (
     <>
-      {groups.map((group, index) => (
+      {groups.map(group => (
         <Accordion
           key={group.key}
           className={classes.group}
-          defaultExpanded={group.kind === 'core' || index < 2}
+          defaultExpanded={group.kind === 'core'}
           TransitionProps={{ unmountOnExit: true }}
         >
           <AccordionSummary

--- a/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
@@ -4,6 +4,7 @@ import {
   AccordionDetails,
   AccordionSummary,
   Box,
+  Button,
   Chip,
   IconButton,
   InputAdornment,
@@ -27,6 +28,7 @@ import {
   groupTools,
   ServerPrefixInfo,
   ToolGroup,
+  toolsForServer,
 } from '../../lib/toolGrouping';
 import { ExplorerError } from './ExplorerError';
 import { BrowserSkeleton } from './states';
@@ -82,6 +84,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '0.7rem',
     color: theme.palette.text.secondary,
     margin: theme.spacing(1, 0, 0.5),
+  },
+  scopeBanner: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(1),
   },
   kbd: {
     fontFamily: 'monospace',
@@ -151,8 +159,17 @@ export interface ToolBrowserProps {
   /** MCPServer-derived prefixes, used to group server tools by management cluster. */
   servers: ServerPrefixInfo[];
   prefs: ToolPrefs;
-  /** Initial search query, e.g. seeded from a `?server=` deep link. */
-  initialQuery?: string;
+  /**
+   * Server CR name from a `?server=` deep link: scopes the browse to that
+   * server's tools (prefix filter) instead of seeding a free-text search.
+   */
+  serverScope?: string;
+  /**
+   * Whether the MCPServer CRs are still loading. The browse grouping depends on
+   * them, so hold the skeleton until they resolve to avoid reshuffling sections
+   * from raw `Server: <segment>` buckets to MC/fleet buckets on load (F2).
+   */
+  serversLoading?: boolean;
 }
 
 /**
@@ -167,12 +184,15 @@ export function ToolBrowser({
   onSelect,
   servers,
   prefs,
-  initialQuery = '',
+  serverScope,
+  serversLoading = false,
 }: ToolBrowserProps) {
   const classes = useStyles();
   const musterApi = useApi(musterApiRef);
-  const [query, setQuery] = useState(initialQuery);
+  const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(-1);
+  // A `?server=` deep link scopes the browse until the user clears it.
+  const [scopeCleared, setScopeCleared] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
   const trimmed = query.trim();
 
@@ -214,9 +234,19 @@ export function ToolBrowser({
     return map;
   }, [allTools]);
 
+  // Scope to a `?server=` deep link's tools (by prefix) when set, the search box
+  // is empty, and the user hasn't cleared the scope.
+  const scoped = useMemo(
+    () =>
+      serverScope && !scopeCleared && trimmed === ''
+        ? toolsForServer(allTools, serverScope, servers)
+        : undefined,
+    [serverScope, scopeCleared, trimmed, allTools, servers],
+  );
+
   const groups = useMemo(
-    () => groupTools(allTools, servers),
-    [allTools, servers],
+    () => groupTools(scoped ? scoped.tools : allTools, servers),
+    [scoped, allTools, servers],
   );
 
   const searchTools = search.data?.tools ?? [];
@@ -285,17 +315,35 @@ export function ToolBrowser({
         />
       ) : (
         <>
-          {(favouriteTools.length > 0 || recentTools.length > 0) && (
-            <QuickAccess
-              favourites={favouriteTools}
-              recents={recentTools}
-              selected={selected}
-              prefs={prefs}
-              onSelect={onSelect}
-            />
+          {scoped ? (
+            <Box className={classes.scopeBanner}>
+              <Chip
+                size="small"
+                color="primary"
+                label={`Server: ${serverScope}`}
+              />
+              <Typography variant="caption" color="textSecondary">
+                {scoped.tools.length} tool
+                {scoped.tools.length === 1 ? '' : 's'}
+              </Typography>
+              <Box flexGrow={1} />
+              <Button size="small" onClick={() => setScopeCleared(true)}>
+                Show all tools
+              </Button>
+            </Box>
+          ) : (
+            (favouriteTools.length > 0 || recentTools.length > 0) && (
+              <QuickAccess
+                favourites={favouriteTools}
+                recents={recentTools}
+                selected={selected}
+                prefs={prefs}
+                onSelect={onSelect}
+              />
+            )
           )}
           <BrowseGroups
-            isLoading={browse.isLoading}
+            isLoading={browse.isLoading || serversLoading}
             error={browse.error}
             installation={installation}
             groups={groups}

--- a/plugins/muster/src/components/ToolExplorerPage/ToolDetailPanel.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolDetailPanel.tsx
@@ -16,6 +16,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { musterApiRef } from '../../apis';
 import {
   buildArgs,
+  enumDefaults,
   fieldKind,
   FormValue,
   schemaFields,
@@ -120,6 +121,27 @@ export function ToolDetailPanel({
   });
 
   const fields = useMemo(() => schemaFields(data?.inputSchema), [data]);
+
+  // Once the schema resolves, pre-select enum defaults for fields the user (or
+  // a remembered session) hasn't set yet, so the form shows the effective value
+  // rather than a blank select.
+  useEffect(() => {
+    const defaults = enumDefaults(fields);
+    if (Object.keys(defaults).length === 0) {
+      return;
+    }
+    setValues(prev => {
+      let changed = false;
+      const next = { ...prev };
+      for (const [key, value] of Object.entries(defaults)) {
+        if (next[key] === undefined) {
+          next[key] = value;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [fields]);
 
   const mutation = useMutation({
     mutationFn: async (args: Record<string, unknown>) => {

--- a/plugins/muster/src/components/ToolExplorerPage/ToolExplorerPage.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolExplorerPage.tsx
@@ -80,7 +80,7 @@ function AuthAffordance({ installation }: { installation: string }) {
 
 function ExplorerBody({ installation }: { installation: string }) {
   const classes = useStyles();
-  const { mcpServers } = useMusterInstance();
+  const { mcpServers, isLoading } = useMusterInstance();
   const [searchParams] = useSearchParams();
   // Deep-link entry points (e.g. a workflow's "Run" button or a server's
   // "open in tool explorer" link) preselect a tool via `?tool=` and/or scope
@@ -103,9 +103,10 @@ function ExplorerBody({ installation }: { installation: string }) {
     [mcpServers],
   );
 
-  // When deep-linked to a server without a specific tool, seed the browser
-  // search with the server name so its tools surface immediately.
-  const initialQuery = toolParam ? '' : (serverParam ?? '');
+  // A `?server=` deep link (without a specific tool) scopes the browse to that
+  // server's tools by prefix -- not a free-text search, which would also match
+  // every tool whose description mentions the segment (tools F4).
+  const serverScope = toolParam ? undefined : serverParam;
 
   const handleSelect = (name: string) => {
     setSelected(name);
@@ -124,7 +125,8 @@ function ExplorerBody({ installation }: { installation: string }) {
               onSelect={handleSelect}
               servers={servers}
               prefs={prefs}
-              initialQuery={initialQuery}
+              serverScope={serverScope}
+              serversLoading={isLoading}
             />
           </Paper>
         </Grid>

--- a/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.tsx
@@ -57,6 +57,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
+  headerCell: {
+    whiteSpace: 'nowrap',
+  },
   tableWrap: {
     maxHeight: 480,
     overflow: 'auto',
@@ -205,7 +208,9 @@ export function ToolResultViewer({
             <TableHead>
               <TableRow>
                 {table.columns.map(col => (
-                  <TableCell key={col}>{col}</TableCell>
+                  <TableCell key={col} className={classes.headerCell}>
+                    {col}
+                  </TableCell>
                 ))}
               </TableRow>
             </TableHead>

--- a/plugins/muster/src/components/WorkflowDetailPage/ExecutionHistoryPanel.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/ExecutionHistoryPanel.tsx
@@ -76,7 +76,7 @@ export function ExecutionHistoryPanel({
         ))}
         {executions.length === 0 && (
           <ListItem>
-            <ListItemText secondary="No executions recorded for this workflow." />
+            <ListItemText secondary="No engine- or agent-driven executions recorded. Runs launched from the tool explorer are not recorded here." />
           </ListItem>
         )}
       </List>

--- a/plugins/muster/src/components/WorkflowDetailPage/WorkflowDetailPage.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/WorkflowDetailPage.tsx
@@ -370,7 +370,10 @@ function WorkflowDetailContent() {
             <Typography variant="h4" className={classes.title}>
               {name}
             </Typography>
-            <AvailabilityBadge available={workflow.isValid()} />
+            <AvailabilityBadge available={workflow.isRunnable()} />
+            {workflow.hasValidationWarning() && (
+              <StateBadge tone="warning" label="Validation warning" />
+            )}
             {isGitOpsManaged(workflow) ? (
               <StateBadge tone="info" label="GitOps" />
             ) : (
@@ -411,9 +414,10 @@ function WorkflowDetailContent() {
           </Box>
         </Box>
 
-        {!workflow.isValid() && (
+        {workflow.hasValidationWarning() && (
           <Alert severity="warning" style={{ marginTop: theme.spacing(2) }}>
-            This workflow is marked invalid by muster.
+            muster's validator flagged this workflow's definition. It can still
+            be run — this is a non-blocking warning, not an availability state.
             {validationErrors.length > 0 && (
               <ul style={{ margin: '4px 0 0', paddingLeft: 20 }}>
                 {validationErrors.map(err => (
@@ -429,7 +433,7 @@ function WorkflowDetailContent() {
           <SectionHeader
             icon={<BarChart />}
             title="Statistics"
-            description="How often this workflow runs and how reliably, over a recent sample of executions."
+            description="How often this workflow runs and how reliably, over a recent sample of executions recorded by muster's workflow engine (engine- and agent-driven runs). A run launched from the tool explorer is not recorded here; its result is shown inline there."
           />
           <WorkflowStatsPanel name={name} installation={installation} />
         </Box>
@@ -549,7 +553,7 @@ function WorkflowDetailContent() {
           <SectionHeader
             icon={<History />}
             title="Executions"
-            description="Past runs of this workflow and their per-step results, from the muster aggregator."
+            description="Engine- and agent-driven runs of this workflow and their per-step results, as recorded by muster's aggregator. Runs launched from the tool explorer execute the aggregated tool directly and do not appear here."
           />
           <Grid container>
             <Grid item xs={12} md={4} className={classes.historyContainer}>

--- a/plugins/muster/src/components/WorkflowDetailPage/WorkflowStatsPanel.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/WorkflowStatsPanel.tsx
@@ -121,7 +121,8 @@ export function WorkflowStatsPanel({
   if (!data || data.runs === 0) {
     return (
       <Typography variant="body2" color="textSecondary">
-        No executions recorded for this workflow yet.
+        No engine- or agent-driven executions recorded for this workflow yet.
+        Runs launched from the tool explorer are not recorded here.
       </Typography>
     );
   }

--- a/plugins/muster/src/components/WorkflowsListPage/WorkflowMutationActions.tsx
+++ b/plugins/muster/src/components/WorkflowsListPage/WorkflowMutationActions.tsx
@@ -17,6 +17,7 @@ import GitHub from '@material-ui/icons/GitHub';
 import Edit from '@material-ui/icons/Edit';
 import DeleteOutline from '@material-ui/icons/DeleteOutline';
 import Add from '@material-ui/icons/Add';
+import Tooltip from '@material-ui/core/Tooltip';
 import { useApi } from '@backstage/core-plugin-api';
 import { musterApiRef } from '../../apis';
 import { MusterWorkflow } from '../../lib/k8s';
@@ -27,6 +28,7 @@ import {
   toManifestYaml,
   toWorkflowDefinition,
 } from '../../lib/gitops';
+import { mutationErrorMessage } from '../../lib/authError';
 import { StateBadge } from '../shared';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -168,7 +170,7 @@ function ConfirmDeleteDialog({
       );
       setDone(true);
     } catch (e) {
-      setError((e as Error).message);
+      setError(mutationErrorMessage(e));
     } finally {
       setBusy(false);
     }
@@ -284,7 +286,7 @@ export function AdHocWorkflowDialog({
       await musterApi.callTool('core_workflow_validate', def, target);
       setMessage('Definition is valid.');
     } catch (e) {
-      setError((e as Error).message);
+      setError(mutationErrorMessage(e));
     } finally {
       setBusy(false);
     }
@@ -305,7 +307,7 @@ export function AdHocWorkflowDialog({
       );
       setMessage('Saved. The CRD list will refresh shortly.');
     } catch (e) {
-      setError((e as Error).message);
+      setError(mutationErrorMessage(e));
     } finally {
       setBusy(false);
     }
@@ -463,21 +465,41 @@ export function WorkflowMutationActions({
  */
 export function CreateWorkflowButton({
   installation,
+  authenticated = true,
 }: {
   installation?: string;
+  /**
+   * Whether there is an authenticated muster session for this installation.
+   * Creating a workflow runs `core_workflow_*` live through muster, which needs
+   * a session -- so it is disabled (with an explanatory tooltip) when there is
+   * none, rather than failing with a raw 401 after the user composes a
+   * definition.
+   */
+  authenticated?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const button = (
+    <Button
+      size="small"
+      variant="outlined"
+      startIcon={<Add />}
+      onClick={() => setOpen(true)}
+      disabled={!authenticated}
+      title="Create a live ad-hoc workflow"
+    >
+      Create workflow
+    </Button>
+  );
   return (
     <>
-      <Button
-        size="small"
-        variant="outlined"
-        startIcon={<Add />}
-        onClick={() => setOpen(true)}
-        title="Create a live ad-hoc workflow"
-      >
-        Create workflow
-      </Button>
+      {authenticated ? (
+        button
+      ) : (
+        <Tooltip title="Connect to muster (sign in) to create a workflow.">
+          {/* span wrapper so the tooltip still fires over the disabled button */}
+          <span>{button}</span>
+        </Tooltip>
+      )}
       <AdHocWorkflowDialog
         installation={installation}
         open={open}

--- a/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
+++ b/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
@@ -30,7 +30,7 @@ import {
 import Search from '@material-ui/icons/Search';
 import MoreHoriz from '@material-ui/icons/MoreHoriz';
 import { InstallationPicker } from '../InstallationPicker';
-import { useMusterInstance } from '../MusterInstanceProvider';
+import { useMusterInstance, useMusterSession } from '../MusterInstanceProvider';
 import { AvailabilityBadge, StateBadge } from '../shared';
 import { MusterWorkflow } from '../../lib/k8s';
 import { isGitOpsManaged } from '../../lib/gitops';
@@ -163,6 +163,7 @@ function RowActions({ name, detailHref, runHref }: RowActionsProps) {
 export function WorkflowsListPage() {
   const classes = useStyles();
   const { workflows, activeInstallation, isLoading } = useMusterInstance();
+  const { authenticated } = useMusterSession();
   const workflowDetailLink = useRouteRef(workflowDetailRouteRef);
   const toolExplorerLink = useRouteRef(toolExplorerRouteRef);
 
@@ -259,7 +260,10 @@ export function WorkflowsListPage() {
         <Typography variant="caption" className={classes.showing}>
           Showing {filtered.length} of {workflows.length}
         </Typography>
-        <CreateWorkflowButton installation={activeInstallation} />
+        <CreateWorkflowButton
+          installation={activeInstallation}
+          authenticated={authenticated}
+        />
       </Box>
 
       <TableContainer className={classes.tableRegion}>

--- a/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
+++ b/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
@@ -34,6 +34,7 @@ import { useMusterInstance, useMusterSession } from '../MusterInstanceProvider';
 import { AvailabilityBadge, StateBadge } from '../shared';
 import { MusterWorkflow } from '../../lib/k8s';
 import { isGitOpsManaged } from '../../lib/gitops';
+import { searchByRelevance } from '../../lib/workflowSearch';
 import { toolExplorerRouteRef, workflowDetailRouteRef } from '../../routes';
 import { CreateWorkflowButton } from './WorkflowMutationActions';
 
@@ -190,17 +191,17 @@ export function WorkflowsListPage() {
   };
 
   const filtered = useMemo(() => {
-    const needle = query.trim().toLowerCase();
-    return workflows.filter(w => {
+    const byStatus = workflows.filter(w => {
       const valid = w.isValid();
       if (statusFilter === 'valid' && !valid) return false;
       if (statusFilter === 'warnings' && valid) return false;
-      if (!needle) return true;
-      return (
-        w.getName().toLowerCase().includes(needle) ||
-        (w.getDescription() ?? '').toLowerCase().includes(needle)
-      );
+      return true;
     });
+    // Token-boundary scored search (F3): "dex" must not match "index".
+    return searchByRelevance(byStatus, query, w => ({
+      name: w.getName(),
+      description: w.getDescription() ?? '',
+    }));
   }, [workflows, query, statusFilter]);
 
   if (isLoading) {

--- a/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
+++ b/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
@@ -37,7 +37,7 @@ import { isGitOpsManaged } from '../../lib/gitops';
 import { toolExplorerRouteRef, workflowDetailRouteRef } from '../../routes';
 import { CreateWorkflowButton } from './WorkflowMutationActions';
 
-type AvailFilter = 'all' | 'available' | 'unavailable';
+type StatusFilter = 'all' | 'valid' | 'warnings';
 
 const useStyles = makeStyles((theme: Theme) => ({
   // Fixed filter bar above the scrolling table (mockup's `border-b py-3`).
@@ -167,7 +167,7 @@ export function WorkflowsListPage() {
   const toolExplorerLink = useRouteRef(toolExplorerRouteRef);
 
   const [query, setQuery] = useState('');
-  const [avail, setAvail] = useState<AvailFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
 
   const detailHref = (workflow: MusterWorkflow) => {
     const base = workflowDetailLink?.({ name: workflow.getName() }) ?? '#';
@@ -191,16 +191,16 @@ export function WorkflowsListPage() {
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase();
     return workflows.filter(w => {
-      const available = w.isValid();
-      if (avail === 'available' && !available) return false;
-      if (avail === 'unavailable' && available) return false;
+      const valid = w.isValid();
+      if (statusFilter === 'valid' && !valid) return false;
+      if (statusFilter === 'warnings' && valid) return false;
       if (!needle) return true;
       return (
         w.getName().toLowerCase().includes(needle) ||
         (w.getDescription() ?? '').toLowerCase().includes(needle)
       );
     });
-  }, [workflows, query, avail]);
+  }, [workflows, query, statusFilter]);
 
   if (isLoading) {
     return (
@@ -249,12 +249,12 @@ export function WorkflowsListPage() {
           className={classes.availSelect}
           variant="outlined"
           margin="dense"
-          value={avail}
-          onChange={e => setAvail(e.target.value as AvailFilter)}
+          value={statusFilter}
+          onChange={e => setStatusFilter(e.target.value as StatusFilter)}
         >
           <MenuItem value="all">All workflows</MenuItem>
-          <MenuItem value="available">Available only</MenuItem>
-          <MenuItem value="unavailable">Unavailable only</MenuItem>
+          <MenuItem value="valid">Valid only</MenuItem>
+          <MenuItem value="warnings">Validation warnings</MenuItem>
         </Select>
         <Typography variant="caption" className={classes.showing}>
           Showing {filtered.length} of {workflows.length}
@@ -308,7 +308,12 @@ export function WorkflowsListPage() {
                     {w.getStepCount()}
                   </TableCell>
                   <TableCell>
-                    <AvailabilityBadge available={w.isValid()} />
+                    <Box display="flex" flexWrap="wrap" gridGap={4}>
+                      <AvailabilityBadge available={w.isRunnable()} />
+                      {w.hasValidationWarning() && (
+                        <StateBadge tone="warning" label="Validation warning" />
+                      )}
+                    </Box>
                   </TableCell>
                   <TableCell>
                     {isGitOpsManaged(w) ? (

--- a/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
+++ b/plugins/muster/src/components/WorkflowsListPage/WorkflowsListPage.tsx
@@ -340,7 +340,9 @@ export function WorkflowsListPage() {
             {filtered.length === 0 && (
               <TableRow>
                 <TableCell colSpan={7} className={classes.emptyRow}>
-                  No workflows match your filters.
+                  {workflows.length === 0
+                    ? 'No workflows in this installation.'
+                    : 'No workflows match your filters.'}
                 </TableCell>
               </TableRow>
             )}

--- a/plugins/muster/src/components/shared/AvailabilityBadge.tsx
+++ b/plugins/muster/src/components/shared/AvailabilityBadge.tsx
@@ -30,8 +30,10 @@ export interface AvailabilityBadgeProps {
  * Availability as muster reports it for the current caller, ported from the
  * mockups' `availability-badge.tsx`: an emerald "Available" (check) or a muted
  * "Unavailable" (minus) outlined pill. Shared by the Workflows table and the
- * workflow detail header so the two never drift. In the CRD-driven port,
- * availability maps onto `.status.valid` (a valid workflow is runnable).
+ * workflow detail header so the two never drift. Availability is runnability
+ * (`MusterWorkflow.isRunnable()`), decoupled from the validator's
+ * `.status.valid` per ADR D2: a validator complaint surfaces separately as a
+ * non-blocking "Validation warning", not as an "Unavailable" state.
  */
 export function AvailabilityBadge({ available }: AvailabilityBadgeProps) {
   const classes = useStyles();

--- a/plugins/muster/src/components/shared/FreshnessIndicator.tsx
+++ b/plugins/muster/src/components/shared/FreshnessIndicator.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import Refresh from '@material-ui/icons/Refresh';
+import { formatUpdatedAgo } from '../../lib/freshness';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+  },
+  label: {
+    fontVariantNumeric: 'tabular-nums',
+    whiteSpace: 'nowrap',
+  },
+}));
+
+export interface FreshnessIndicatorProps {
+  /** Epoch-ms of the most recent successful health read, or undefined while cold. */
+  updatedAt?: number;
+  /** Whether a (background or manual) refetch is currently in flight. */
+  isRefreshing: boolean;
+  /** Re-fetch the live health reads. */
+  onRefresh: () => void;
+}
+
+/**
+ * Shows how fresh the kubernetes-read-backed health data is ("updated Xs ago")
+ * and offers a manual refresh, so a snapshot no longer flaps silently against
+ * the live CRD (ADR D4). The relative label ticks on its own clock so it stays
+ * honest between the provider's background refetches. Renders nothing until the
+ * first successful read produces a timestamp.
+ */
+export function FreshnessIndicator({
+  updatedAt,
+  isRefreshing,
+  onRefresh,
+}: FreshnessIndicatorProps) {
+  const classes = useStyles();
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 10_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!updatedAt) {
+    return null;
+  }
+
+  return (
+    <Box className={classes.root}>
+      <Typography variant="caption" className={classes.label}>
+        {formatUpdatedAgo(updatedAt, now)}
+      </Typography>
+      <Tooltip title="Refresh health data">
+        <span>
+          <IconButton
+            size="small"
+            aria-label="Refresh health data"
+            disabled={isRefreshing}
+            onClick={onRefresh}
+          >
+            {isRefreshing ? (
+              <CircularProgress size={16} color="inherit" />
+            ) : (
+              <Refresh fontSize="small" />
+            )}
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/plugins/muster/src/components/shared/index.ts
+++ b/plugins/muster/src/components/shared/index.ts
@@ -12,6 +12,8 @@ export { ToolList } from './ToolList';
 export type { ToolListItem, ToolListProps } from './ToolList';
 export { Gate } from './Gate';
 export type { GateProps } from './Gate';
+export { FreshnessIndicator } from './FreshnessIndicator';
+export type { FreshnessIndicatorProps } from './FreshnessIndicator';
 export { InstallationHealthPill } from './InstallationHealthPill';
 export type { InstallationHealthPillProps } from './InstallationHealthPill';
 export { toneColors, severityTone, VIOLET } from './tones';

--- a/plugins/muster/src/lib/authError.test.ts
+++ b/plugins/muster/src/lib/authError.test.ts
@@ -1,0 +1,50 @@
+import {
+  isMusterAuthError,
+  mutationErrorMessage,
+  MUSTER_AUTH_PROMPT,
+} from './authError';
+
+describe('isMusterAuthError', () => {
+  it('detects the backstage-backend 401 tag', () => {
+    const e = new Error('Muster request failed with status 401');
+    e.name = 'UnauthorizedError';
+    expect(isMusterAuthError(e)).toBe(true);
+  });
+
+  it('detects an MCP transport 401 surfaced in the message', () => {
+    const e = new Error(
+      'MCP HTTP Transport Error: POSTing to endpoint (HTTP 401): authentication failure: token uses the unknown key "abc"',
+    );
+    expect(isMusterAuthError(e)).toBe(true);
+  });
+
+  it('detects a bare "authentication failure" message', () => {
+    expect(isMusterAuthError(new Error('authentication failure'))).toBe(true);
+  });
+
+  it('does not flag non-auth errors', () => {
+    expect(isMusterAuthError(new Error('step "probe": tool is required'))).toBe(
+      false,
+    );
+    expect(isMusterAuthError(new Error('Invalid JSON: Unexpected token'))).toBe(
+      false,
+    );
+    expect(isMusterAuthError(undefined)).toBe(false);
+    expect(isMusterAuthError(null)).toBe(false);
+  });
+});
+
+describe('mutationErrorMessage', () => {
+  it('maps an auth failure to the connect prompt', () => {
+    const e = new Error('… (HTTP 401): authentication failure');
+    expect(mutationErrorMessage(e)).toBe(MUSTER_AUTH_PROMPT);
+  });
+
+  it('passes through a non-auth error message verbatim', () => {
+    expect(mutationErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('falls back when there is no message', () => {
+    expect(mutationErrorMessage({})).toBe('The request failed.');
+  });
+});

--- a/plugins/muster/src/lib/authError.ts
+++ b/plugins/muster/src/lib/authError.ts
@@ -1,0 +1,34 @@
+/**
+ * Whether an error raised by a muster call is an authentication failure (the
+ * user has no usable muster session for the target installation). Covers both
+ * the backstage-backend signal (`MusterApiClient` tags a 401 response as
+ * `UnauthorizedError`) and the case where muster's MCP transport surfaces the
+ * 401 inside an otherwise-2xx `/call` body, e.g.
+ * `MCP HTTP Transport Error: POSTing to endpoint (HTTP 401): authentication failure: …`.
+ */
+export function isMusterAuthError(error: unknown): boolean {
+  const e = error as { name?: string; message?: string } | null | undefined;
+  if (!e) {
+    return false;
+  }
+  if (e.name === 'UnauthorizedError') {
+    return true;
+  }
+  return /\bHTTP 401\b|\b401\b|authentication failure/i.test(e.message ?? '');
+}
+
+/** User-facing prompt shown in place of a raw transport error on a 401. */
+export const MUSTER_AUTH_PROMPT =
+  'This action requires an authenticated muster session for this installation. Connect to muster (sign in) and try again.';
+
+/**
+ * Maps an error from a muster mutation (validate/save/run) to a message fit for
+ * the UI: a friendly connect prompt for auth failures, the raw message
+ * otherwise.
+ */
+export function mutationErrorMessage(error: unknown): string {
+  if (isMusterAuthError(error)) {
+    return MUSTER_AUTH_PROMPT;
+  }
+  return (error as Error)?.message ?? 'The request failed.';
+}

--- a/plugins/muster/src/lib/authError.ts
+++ b/plugins/muster/src/lib/authError.ts
@@ -14,7 +14,7 @@ export function isMusterAuthError(error: unknown): boolean {
   if (e.name === 'UnauthorizedError') {
     return true;
   }
-  return /\bHTTP 401\b|\b401\b|authentication failure/i.test(e.message ?? '');
+  return /\bHTTP 401\b|authentication failure/i.test(e.message ?? '');
 }
 
 /** User-facing prompt shown in place of a raw transport error on a 401. */

--- a/plugins/muster/src/lib/freshness.test.ts
+++ b/plugins/muster/src/lib/freshness.test.ts
@@ -1,0 +1,33 @@
+import { formatUpdatedAgo } from './freshness';
+
+describe('formatUpdatedAgo', () => {
+  const now = 1_000_000_000_000;
+
+  it('returns empty string when there is no timestamp yet', () => {
+    expect(formatUpdatedAgo(undefined, now)).toBe('');
+    expect(formatUpdatedAgo(0, now)).toBe('');
+  });
+
+  it('reports "just now" within the first few seconds', () => {
+    expect(formatUpdatedAgo(now, now)).toBe('updated just now');
+    expect(formatUpdatedAgo(now - 4_000, now)).toBe('updated just now');
+  });
+
+  it('reports seconds under a minute', () => {
+    expect(formatUpdatedAgo(now - 12_000, now)).toBe('updated 12s ago');
+    expect(formatUpdatedAgo(now - 59_000, now)).toBe('updated 59s ago');
+  });
+
+  it('reports minutes under an hour', () => {
+    expect(formatUpdatedAgo(now - 60_000, now)).toBe('updated 1m ago');
+    expect(formatUpdatedAgo(now - 59 * 60_000, now)).toBe('updated 59m ago');
+  });
+
+  it('reports hours beyond an hour', () => {
+    expect(formatUpdatedAgo(now - 3 * 60 * 60_000, now)).toBe('updated 3h ago');
+  });
+
+  it('never reports a negative duration for a future timestamp', () => {
+    expect(formatUpdatedAgo(now + 5_000, now)).toBe('updated just now');
+  });
+});

--- a/plugins/muster/src/lib/freshness.ts
+++ b/plugins/muster/src/lib/freshness.ts
@@ -1,0 +1,29 @@
+/**
+ * Formats how long ago the live health reads were last updated, for the
+ * dashboard / MCP-servers freshness indicator (ADR D4). Pure so it can be unit
+ * tested without rendering; the component supplies `now` from a ticking clock.
+ *
+ * Returns an empty string when there is no successful read yet (no timestamp),
+ * so the caller can render nothing during the cold first load.
+ */
+export function formatUpdatedAgo(
+  updatedAt: number | undefined,
+  now: number,
+): string {
+  if (!updatedAt || updatedAt <= 0) {
+    return '';
+  }
+  const secs = Math.max(0, Math.round((now - updatedAt) / 1000));
+  if (secs < 5) {
+    return 'updated just now';
+  }
+  if (secs < 60) {
+    return `updated ${secs}s ago`;
+  }
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) {
+    return `updated ${mins}m ago`;
+  }
+  const hrs = Math.floor(mins / 60);
+  return `updated ${hrs}h ago`;
+}

--- a/plugins/muster/src/lib/k8s/MCPServer.test.ts
+++ b/plugins/muster/src/lib/k8s/MCPServer.test.ts
@@ -1,4 +1,9 @@
-import { MCPServer, mcpServerStateSeverity } from './MCPServer';
+import {
+  MCPServer,
+  MCPServerState,
+  mcpServerStateSeverity,
+  serversHealthSummary,
+} from './MCPServer';
 
 function makeServer(spec: Record<string, unknown>, name = 'srv'): MCPServer {
   return new MCPServer(
@@ -7,6 +12,19 @@ function makeServer(spec: Record<string, unknown>, name = 'srv'): MCPServer {
       kind: 'MCPServer',
       metadata: { name },
       spec,
+    } as never,
+    'gazelle',
+  );
+}
+
+function makeStateServer(state: MCPServerState, name = 'srv'): MCPServer {
+  return new MCPServer(
+    {
+      apiVersion: 'muster.giantswarm.io/v1alpha1',
+      kind: 'MCPServer',
+      metadata: { name },
+      spec: { type: 'streamable-http' },
+      status: { state },
     } as never,
     'gazelle',
   );
@@ -49,5 +67,43 @@ describe('mcpServerStateSeverity', () => {
 
   it('treats Auth Required as healthy, not a warning', () => {
     expect(mcpServerStateSeverity('Auth Required')).toBe('ok');
+  });
+});
+
+describe('serversHealthSummary', () => {
+  function fleet(healthy: number, unhealthy: number): MCPServer[] {
+    return [
+      ...Array.from({ length: healthy }, (_, i) =>
+        makeStateServer('Auth Required', `ok-${i}`),
+      ),
+      ...Array.from({ length: unhealthy }, (_, i) =>
+        makeStateServer('Failed', `bad-${i}`),
+      ),
+    ];
+  }
+
+  it('counts ok-severity servers (Auth Required is healthy)', () => {
+    const { healthy, total } = serversHealthSummary([
+      makeStateServer('Connected'),
+      makeStateServer('Auth Required'),
+      makeStateServer('Failed'),
+    ]);
+    expect(healthy).toBe(2);
+    expect(total).toBe(3);
+  });
+
+  it('stays ok when only a few remote backends are down (5/55)', () => {
+    // The gazelle steady state: 5 federated backends Failed out of 55 must not
+    // paint the stat amber.
+    expect(serversHealthSummary(fleet(50, 5)).tone).toBe('ok');
+  });
+
+  it('warns once a meaningful fraction is unhealthy', () => {
+    expect(serversHealthSummary(fleet(49, 6)).tone).toBe('warning');
+  });
+
+  it('is ok for an all-healthy or empty fleet', () => {
+    expect(serversHealthSummary(fleet(12, 0)).tone).toBe('ok');
+    expect(serversHealthSummary([]).tone).toBe('ok');
   });
 });

--- a/plugins/muster/src/lib/k8s/MCPServer.ts
+++ b/plugins/muster/src/lib/k8s/MCPServer.ts
@@ -190,3 +190,47 @@ export function worstSeverity(
 ): MCPServerSeverity {
   return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
 }
+
+/**
+ * Fraction of aggregated servers that must be unhealthy before the dashboard
+ * "Servers healthy" stat flips to amber.
+ *
+ * muster federates ~26 management clusters, so at least one remote backend is
+ * almost always degraded (goose/violet/garm DNS failures across trials).
+ * Colouring the stat amber on `healthy != total` made it near-permanently amber
+ * and therefore useless as a signal (dashboard review F1). Warn only when a
+ * meaningful fraction is unhealthy so the colour means "act on this".
+ *
+ * ponytail: fixed 10% threshold (5/55 stays green, 6/55 warns). The orthogonal
+ * scope question -- count the selected installation's own servers vs the full
+ * federated fan-out -- is a deferred PM decision (iteration-2 ADR open
+ * question #4), so the count still covers every aggregated server.
+ */
+export const SERVERS_HEALTH_WARNING_FRACTION = 0.1;
+
+export interface ServersHealthSummary {
+  healthy: number;
+  total: number;
+  tone: 'ok' | 'warning';
+}
+
+/**
+ * Counts how many aggregated servers are healthy (severity `ok`, which includes
+ * `Auth Required`) and decides the dashboard stat tone via
+ * {@link SERVERS_HEALTH_WARNING_FRACTION}.
+ */
+export function serversHealthSummary(
+  servers: Pick<MCPServer, 'getState'>[],
+): ServersHealthSummary {
+  const total = servers.length;
+  const healthy = servers.filter(
+    s => mcpServerStateSeverity(s.getState()) === 'ok',
+  ).length;
+  const unhealthyFraction = total === 0 ? 0 : (total - healthy) / total;
+  return {
+    healthy,
+    total,
+    tone:
+      unhealthyFraction > SERVERS_HEALTH_WARNING_FRACTION ? 'warning' : 'ok',
+  };
+}

--- a/plugins/muster/src/lib/k8s/MusterWorkflow.test.ts
+++ b/plugins/muster/src/lib/k8s/MusterWorkflow.test.ts
@@ -1,0 +1,46 @@
+import { MusterWorkflow } from './MusterWorkflow';
+
+function makeWorkflow(
+  status: Record<string, unknown> | undefined,
+  name = 'wf',
+): MusterWorkflow {
+  return new MusterWorkflow(
+    {
+      apiVersion: 'muster.giantswarm.io/v1alpha1',
+      kind: 'Workflow',
+      metadata: { name },
+      spec: { steps: [{ id: 'probe', parallel: [{ id: 'a', tool: 't' }] }] },
+      ...(status ? { status } : {}),
+    } as never,
+    'gazelle',
+  );
+}
+
+describe('MusterWorkflow runnable vs valid (D2 decoupling)', () => {
+  it('a validator-invalid workflow is still runnable and reads a warning', () => {
+    const wf = makeWorkflow({
+      valid: false,
+      validationErrors: ["step 'probe': tool is required"],
+    });
+    expect(wf.isValid()).toBe(false);
+    expect(wf.isRunnable()).toBe(true);
+    expect(wf.hasValidationWarning()).toBe(true);
+    expect(wf.getValidationErrors()).toEqual([
+      "step 'probe': tool is required",
+    ]);
+  });
+
+  it('a valid workflow is runnable with no validation warning', () => {
+    const wf = makeWorkflow({ valid: true });
+    expect(wf.isValid()).toBe(true);
+    expect(wf.isRunnable()).toBe(true);
+    expect(wf.hasValidationWarning()).toBe(false);
+  });
+
+  it('treats a missing status as runnable but warns (valid defaults false)', () => {
+    const wf = makeWorkflow(undefined);
+    expect(wf.isValid()).toBe(false);
+    expect(wf.isRunnable()).toBe(true);
+    expect(wf.hasValidationWarning()).toBe(true);
+  });
+});

--- a/plugins/muster/src/lib/k8s/MusterWorkflow.ts
+++ b/plugins/muster/src/lib/k8s/MusterWorkflow.ts
@@ -101,12 +101,40 @@ export class MusterWorkflow extends KubeObject<MusterWorkflowInterface> {
     return this.jsonData.status?.stepCount ?? this.getSteps().length;
   }
 
+  /**
+   * Whether muster considers the workflow definition valid (`status.valid`).
+   * This is a *quality* signal, not a runnability one: muster's validator has
+   * false-positives (e.g. it demands a top-level `tool` on `parallel`/`forEach`
+   * container steps), so an invalid workflow can still run. Surface validation
+   * complaints via `getValidationErrors()` as a non-blocking warning rather than
+   * gating runnability on this — see `isRunnable()`.
+   */
   isValid() {
     return this.jsonData.status?.valid ?? false;
   }
 
+  /**
+   * Whether the workflow can be run. muster exposes an aggregated
+   * `workflow_<name>` tool for every Workflow CR regardless of the validator's
+   * `status.valid` verdict, so any loaded workflow is runnable. Decoupling this
+   * from `isValid()` is decision D2 of the muster-UI iteration-2 ADR: a workflow
+   * that executes must never present as "Unavailable".
+   *
+   * ponytail: the CRD carries no per-workflow runnable signal, so any loaded
+   * workflow is treated as runnable. Upgrade path: if muster surfaces a
+   * tool-existence/health flag for the aggregated tool, gate on it here.
+   */
+  isRunnable() {
+    return true;
+  }
+
   getValidationErrors() {
     return this.jsonData.status?.validationErrors ?? [];
+  }
+
+  /** True when muster flagged the definition but it remains runnable. */
+  hasValidationWarning() {
+    return !this.isValid();
   }
 
   getReferencedTools() {

--- a/plugins/muster/src/lib/k8s/index.ts
+++ b/plugins/muster/src/lib/k8s/index.ts
@@ -3,6 +3,8 @@ export {
   MANAGEMENT_CLUSTER_LABEL,
   mcpServerStateSeverity,
   worstSeverity,
+  serversHealthSummary,
+  SERVERS_HEALTH_WARNING_FRACTION,
 } from './MCPServer';
 export type {
   MCPServerState,
@@ -10,6 +12,7 @@ export type {
   MCPServerFamily,
   MCPServerAuth,
   MCPServerTokenExchange,
+  ServersHealthSummary,
 } from './MCPServer';
 export { MusterWorkflow, WORKFLOW_CATEGORY_LABEL } from './MusterWorkflow';
 export type {

--- a/plugins/muster/src/lib/schemaForm.test.ts
+++ b/plugins/muster/src/lib/schemaForm.test.ts
@@ -1,4 +1,9 @@
-import { buildArgs, fieldKind, schemaFields } from './schemaForm';
+import {
+  buildArgs,
+  enumDefaults,
+  fieldKind,
+  schemaFields,
+} from './schemaForm';
 
 describe('schemaFields', () => {
   it('flattens an object schema and marks required fields', () => {
@@ -28,6 +33,31 @@ describe('schemaFields', () => {
   it('returns no fields for a schema without properties', () => {
     expect(schemaFields(undefined)).toEqual([]);
     expect(schemaFields({ type: 'object' })).toEqual([]);
+  });
+});
+
+describe('enumDefaults', () => {
+  it('seeds only enum fields that declare a default, as strings', () => {
+    const fields = schemaFields({
+      type: 'object',
+      properties: {
+        output: { type: 'string', enum: ['slim', 'full'], default: 'slim' },
+        priority: { type: 'integer', enum: [1, 2, 3], default: 2 },
+        format: { type: 'string', enum: ['json', 'yaml'] },
+        replicas: { type: 'integer', default: 1 },
+        name: { type: 'string' },
+      },
+    });
+
+    expect(enumDefaults(fields)).toEqual({ output: 'slim', priority: '2' });
+  });
+
+  it('returns nothing when no enum field has a default', () => {
+    const fields = schemaFields({
+      type: 'object',
+      properties: { name: { type: 'string', default: 'x' } },
+    });
+    expect(enumDefaults(fields)).toEqual({});
   });
 });
 

--- a/plugins/muster/src/lib/schemaForm.test.ts
+++ b/plugins/muster/src/lib/schemaForm.test.ts
@@ -1,9 +1,4 @@
-import {
-  buildArgs,
-  enumDefaults,
-  fieldKind,
-  schemaFields,
-} from './schemaForm';
+import { buildArgs, enumDefaults, fieldKind, schemaFields } from './schemaForm';
 
 describe('schemaFields', () => {
   it('flattens an object schema and marks required fields', () => {

--- a/plugins/muster/src/lib/schemaForm.ts
+++ b/plugins/muster/src/lib/schemaForm.ts
@@ -76,6 +76,23 @@ export function fieldKind(field: SchemaField): FieldKind {
   }
 }
 
+/**
+ * Seed initial form values from each enum/select field's schema `default`, so
+ * the widget shows the value the tool will actually use instead of rendering
+ * blank. Only enum fields are seeded: scalar defaults are surfaced as helper
+ * text and a blank optional field is still omitted (the tool applies its own
+ * default), so seeding them would only add redundant payload.
+ */
+export function enumDefaults(fields: SchemaField[]): Record<string, FormValue> {
+  const out: Record<string, FormValue> = {};
+  for (const field of fields) {
+    if (fieldKind(field) === 'enum' && field.default !== undefined) {
+      out[field.name] = String(field.default);
+    }
+  }
+  return out;
+}
+
 /** Flatten an object input schema into an ordered list of editable fields. */
 export function schemaFields(schema?: JsonSchema): SchemaField[] {
   const properties = schema?.properties;

--- a/plugins/muster/src/lib/serverGrouping.test.ts
+++ b/plugins/muster/src/lib/serverGrouping.test.ts
@@ -1,5 +1,9 @@
 import { MCPServer, MANAGEMENT_CLUSTER_LABEL } from './k8s';
-import { partitionServers, presenceByMc } from './serverGrouping';
+import {
+  partitionServers,
+  presenceByMc,
+  selectRepresentative,
+} from './serverGrouping';
 
 function makeServer(opts: {
   name: string;
@@ -56,5 +60,54 @@ describe('presenceByMc', () => {
       makeServer({ name: 'k8s', mc: 'alpha', state: 'Auth Required' }),
     ]);
     expect(presence[0].severity).toBe('ok');
+  });
+});
+
+describe('selectRepresentative', () => {
+  // Federated families are listed in MC-alphabetical order, so the first server
+  // is a peer/customer MC; selection must not default to it (ADR D1).
+  const fleet = () => [
+    makeServer({ name: 'k8s-agama', mc: 'agama', state: 'Auth Required' }),
+    makeServer({ name: 'k8s-gazelle', mc: 'gazelle', state: 'Connected' }),
+    makeServer({ name: 'k8s-zebra', mc: 'zebra', state: 'Auth Required' }),
+  ];
+
+  it('prefers the active installation own server over list order', () => {
+    const rep = selectRepresentative(fleet(), 'gazelle');
+    expect(rep?.server.getManagementCluster()).toBe('gazelle');
+    expect(rep?.qualified).toBe(true);
+  });
+
+  it('prefers a connected server when the active installation has none of its own', () => {
+    const rep = selectRepresentative(fleet(), 'not-in-fleet');
+    expect(rep?.server.getManagementCluster()).toBe('gazelle');
+    expect(rep?.qualified).toBe(true);
+  });
+
+  it('does not default to the first (Auth Required) server by list order', () => {
+    const rep = selectRepresentative(
+      [
+        makeServer({ name: 'k8s-agama', mc: 'agama', state: 'Auth Required' }),
+        makeServer({ name: 'k8s-beta', mc: 'beta', state: 'Connected' }),
+      ],
+      undefined,
+    );
+    expect(rep?.server.getManagementCluster()).toBe('beta');
+  });
+
+  it('falls back to the first server but flags it unqualified when none own/connected', () => {
+    const rep = selectRepresentative(
+      [
+        makeServer({ name: 'k8s-agama', mc: 'agama', state: 'Auth Required' }),
+        makeServer({ name: 'k8s-zebra', mc: 'zebra', state: 'Failed' }),
+      ],
+      'gazelle',
+    );
+    expect(rep?.server.getManagementCluster()).toBe('agama');
+    expect(rep?.qualified).toBe(false);
+  });
+
+  it('returns undefined for an empty fleet', () => {
+    expect(selectRepresentative([], 'gazelle')).toBeUndefined();
   });
 });

--- a/plugins/muster/src/lib/serverGrouping.ts
+++ b/plugins/muster/src/lib/serverGrouping.ts
@@ -47,6 +47,57 @@ export function partitionServers(servers: MCPServer[]): {
   return { standard, integration };
 }
 
+export type Representative = {
+  /** The server whose shared config/auth/tools are shown for the family. */
+  server: MCPServer;
+  /**
+   * Whether `server` legitimately stands in for the family on this screen: it is
+   * the active installation's own server, or at least a connected one. When
+   * false, no single MC should head the family (label it neutrally, e.g.
+   * "kubernetes (fleet)") because the representative is an arbitrary fallback.
+   */
+  qualified: boolean;
+};
+
+/**
+ * Choose the server that represents a federated family's shared config/auth/tools.
+ *
+ * A federated family is replicated across many management clusters whose auth
+ * chains legitimately differ, so "which one do we show?" matters: showing an
+ * arbitrary peer/customer MC misrepresents the family on another installation's
+ * screen. The order (ADR muster-ui-iteration-2, D1) is:
+ *
+ * 1. the active installation's own server (`managementCluster === active`), else
+ * 2. a connected server (`Connected`/`Running`), else
+ * 3. the first server as a fallback, flagged `qualified: false` so the caller
+ *    labels the family neutrally rather than by that server's MC.
+ *
+ * Note: severity `ok` is NOT a sufficient signal since `Auth Required` is now
+ * `ok` -- list order would then surface an arbitrary (alphabetically-first) MC.
+ */
+export function selectRepresentative(
+  servers: MCPServer[],
+  activeInstallation?: string,
+): Representative | undefined {
+  if (servers.length === 0) {
+    return undefined;
+  }
+  const own =
+    activeInstallation !== undefined
+      ? servers.find(s => s.getManagementCluster() === activeInstallation)
+      : undefined;
+  if (own) {
+    return { server: own, qualified: true };
+  }
+  const connected = servers.find(
+    s => s.getState() === 'Connected' || s.getState() === 'Running',
+  );
+  if (connected) {
+    return { server: connected, qualified: true };
+  }
+  return { server: servers[0], qualified: false };
+}
+
 export type McPresence = {
   mc: string;
   severity: MCPServerSeverity;

--- a/plugins/muster/src/lib/toolGrouping.test.ts
+++ b/plugins/muster/src/lib/toolGrouping.test.ts
@@ -1,4 +1,4 @@
-import { groupTools, ServerPrefixInfo } from './toolGrouping';
+import { groupTools, ServerPrefixInfo, toolsForServer } from './toolGrouping';
 
 const servers: ServerPrefixInfo[] = [
   {
@@ -60,5 +60,129 @@ describe('groupTools', () => {
   it('falls back to a per-segment section when the prefix is unknown', () => {
     const groups = groupTools([tool('x_mystery_do_thing')], []);
     expect(groups[0].key).toBe('Server: mystery');
+  });
+
+  it('derives a server bucket subtitle from the family set, not the first server', () => {
+    const groups = groupTools(
+      [
+        tool('x_kubernetes-gazelle_get_pods'),
+        tool('x_prometheus-gazelle_query'),
+      ],
+      servers,
+    );
+    const gazelle = groups.find(g => g.key === 'gazelle');
+    expect(gazelle?.subtitle).toBe('kubernetes, prometheus');
+  });
+
+  // A federated family dedupes the same tool across many management clusters
+  // into one tool (same prefix). It must not be attributed to an arbitrary peer
+  // MC by list order (ADR D1) -- it goes under a neutral fleet label.
+  describe('shared/federated tools (one prefix, many management clusters)', () => {
+    const fleet: ServerPrefixInfo[] = [
+      {
+        prefix: 'x_kubernetes',
+        serverName: 'agama-mcp-kubernetes',
+        managementCluster: 'agama',
+        family: 'kubernetes',
+      },
+      {
+        prefix: 'x_kubernetes',
+        serverName: 'gazelle-mcp-kubernetes',
+        managementCluster: 'gazelle',
+        family: 'kubernetes',
+      },
+      {
+        prefix: 'x_prometheus',
+        serverName: 'agama-mcp-prometheus',
+        managementCluster: 'agama',
+        family: 'prometheus',
+      },
+      {
+        prefix: 'x_prometheus',
+        serverName: 'gazelle-mcp-prometheus',
+        managementCluster: 'gazelle',
+        family: 'prometheus',
+      },
+      {
+        prefix: 'x_pd',
+        serverName: 'pd',
+        managementCluster: 'gazelle',
+      },
+    ];
+
+    it('buckets shared tools under a neutral family fleet label, never a peer MC', () => {
+      const groups = groupTools(
+        [
+          tool('x_kubernetes_list'),
+          tool('x_kubernetes_get'),
+          tool('x_prometheus_query'),
+        ],
+        fleet,
+      );
+      const keys = groups.map(g => g.key);
+      expect(keys).toContain('Kubernetes (fleet)');
+      expect(keys).toContain('Prometheus (fleet)');
+      // The alphabetically-first peer cluster must not head the core toolset.
+      expect(keys).not.toContain('agama');
+    });
+
+    it('splits the families so a fleet group is never mislabelled by one family', () => {
+      const groups = groupTools(
+        [tool('x_kubernetes_list'), tool('x_prometheus_query')],
+        fleet,
+      );
+      const k8s = groups.find(g => g.key === 'Kubernetes (fleet)');
+      const prom = groups.find(g => g.key === 'Prometheus (fleet)');
+      expect(k8s?.tools).toHaveLength(1);
+      expect(prom?.tools).toHaveLength(1);
+      expect(k8s?.subtitle).toBe('2 clusters');
+    });
+
+    it('keeps a single-MC integration server under its own MC bucket', () => {
+      const groups = groupTools(
+        [tool('x_pd_list_services'), tool('x_kubernetes_list')],
+        fleet,
+      );
+      const gazelle = groups.find(g => g.key === 'gazelle');
+      expect(gazelle?.tools.map(t => t.name)).toEqual(['x_pd_list_services']);
+      expect(
+        groups.find(g => g.key === 'Kubernetes (fleet)')?.tools,
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('toolsForServer', () => {
+    const fleet: ServerPrefixInfo[] = [
+      {
+        prefix: 'x_runbooks',
+        serverName: 'runbooks',
+        managementCluster: 'gazelle',
+      },
+      {
+        prefix: 'x_kubernetes',
+        serverName: 'gazelle-mcp-kubernetes',
+        managementCluster: 'gazelle',
+        family: 'kubernetes',
+      },
+    ];
+    const tools = [
+      tool('x_runbooks_search'),
+      tool('x_runbooks_get'),
+      tool('x_kubernetes_list'),
+      tool('workflow_runbook-driven'),
+    ];
+
+    it('scopes to a server by prefix, not by description substring', () => {
+      const scoped = toolsForServer(tools, 'runbooks', fleet);
+      expect(scoped?.prefix).toBe('x_runbooks');
+      expect(scoped?.tools.map(t => t.name)).toEqual([
+        'x_runbooks_search',
+        'x_runbooks_get',
+      ]);
+    });
+
+    it('returns undefined for an unknown server so the caller can fall back', () => {
+      expect(toolsForServer(tools, 'nope', fleet)).toBeUndefined();
+    });
   });
 });

--- a/plugins/muster/src/lib/toolGrouping.ts
+++ b/plugins/muster/src/lib/toolGrouping.ts
@@ -2,8 +2,8 @@ import { ToolSummary } from '../apis';
 
 /**
  * What the tool browser needs to know about one aggregated MCP server to place
- * its tools under the right management-cluster section. Derived from the
- * MCPServer CRs the active installation exposes (see MCPServer.getToolNamePrefix).
+ * its tools under the right section. Derived from the MCPServer CRs the active
+ * installation exposes (see MCPServer.getToolNamePrefix).
  */
 export interface ServerPrefixInfo {
   /** The `x_<segment>` prefix muster gives this server's tools. */
@@ -24,53 +24,88 @@ export interface ToolGroup {
   tools: ToolSummary[];
 }
 
+/** Capitalise a family segment for a section label ("kubernetes" -> "Kubernetes"). */
+function titleCase(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+/** The bare `<segment>` of an `x_<segment>_...` tool name. */
+function segmentOf(name: string): string {
+  return name.slice(2).split('_')[0] || 'unknown';
+}
+
 /**
- * Resolve the server a tool belongs to by longest-matching tool-name prefix.
- * Prefixes can share a leading segment, so the longest match wins (e.g.
- * `x_kubernetes_gazelle_*` beats `x_kubernetes_*`).
+ * Resolve every server whose tool-name prefix matches `name`, keeping only the
+ * longest-matching prefixes. Prefixes can share a leading segment (e.g.
+ * `x_kubernetes_gazelle_*` beats `x_kubernetes_*`), so the longest match wins.
+ * A federated family dedupes many same-prefix servers (one per management
+ * cluster) into a single tool, so several servers can legitimately tie at the
+ * longest match -- the caller treats that as a shared family.
  */
-function matchServer(
+function matchServers(
   name: string,
   servers: ServerPrefixInfo[],
-): ServerPrefixInfo | undefined {
-  let best: ServerPrefixInfo | undefined;
+): ServerPrefixInfo[] {
+  let bestLen = -1;
+  let matches: ServerPrefixInfo[] = [];
   for (const server of servers) {
-    if (
-      (name === server.prefix || name.startsWith(`${server.prefix}_`)) &&
-      (!best || server.prefix.length > best.prefix.length)
-    ) {
-      best = server;
+    if (name === server.prefix || name.startsWith(`${server.prefix}_`)) {
+      if (server.prefix.length > bestLen) {
+        bestLen = server.prefix.length;
+        matches = [server];
+      } else if (server.prefix.length === bestLen) {
+        matches.push(server);
+      }
     }
   }
-  return best;
+  return matches;
+}
+
+interface GroupAcc {
+  group: ToolGroup;
+  /** Families seen in this bucket, so the subtitle reflects the set, not the first. */
+  families: Set<string>;
+  /** Management clusters a fleet bucket federates over. */
+  clusters: Set<string>;
+  fleet: boolean;
 }
 
 /**
  * Group a tool catalogue into the explorer's sections: Core, Workflows, and one
- * section per management cluster (resolved from the MCPServer CRs). Tools whose
- * `x_<segment>` prefix can't be resolved to a CR fall back to a per-segment
- * "Server: <segment>" section so nothing is hidden.
+ * section per server scope. Federated families (`kubernetes`, `prometheus`)
+ * deduplicate the same tool across many management clusters into a single tool
+ * targeted via a `management_cluster` argument; those shared tools are bucketed
+ * under a neutral family-level "fleet" label rather than attributed to an
+ * arbitrary peer/customer MC (ADR muster-ui-iteration-2, D1). A tool whose
+ * prefix resolves to exactly one MC is bucketed under that MC; one that can't be
+ * resolved to a CR falls back to a per-segment "Server: <segment>" section so
+ * nothing is hidden.
  *
- * ponytail: management-cluster resolution depends on the CR tool-name prefixes
- * being unique; when CRDs aren't readable the server sections degrade to the
- * raw name segment. Upgrade path: aggregator-provided server metadata per tool.
+ * ponytail: management-cluster resolution depends on the CR tool-name prefixes;
+ * when CRDs aren't readable the server sections degrade to the raw name segment.
+ * Upgrade path: aggregator-provided server metadata per tool.
  */
 export function groupTools(
   tools: ToolSummary[],
   servers: ServerPrefixInfo[],
 ): ToolGroup[] {
-  const groups = new Map<string, ToolGroup>();
+  const groups = new Map<string, GroupAcc>();
 
   const bucket = (
     key: string,
     kind: ToolGroupKind,
-    subtitle?: string,
-  ): ToolGroup => {
+    fleet = false,
+  ): GroupAcc => {
     const existing = groups.get(key);
     if (existing) {
       return existing;
     }
-    const created: ToolGroup = { key, kind, subtitle, tools: [] };
+    const created: GroupAcc = {
+      group: { key, kind, tools: [] },
+      families: new Set(),
+      clusters: new Set(),
+      fleet,
+    };
     groups.set(key, created);
     return created;
   };
@@ -78,26 +113,68 @@ export function groupTools(
   for (const tool of tools) {
     const name = tool.name;
     if (name.startsWith('core_')) {
-      bucket('Core', 'core').tools.push(tool);
+      bucket('Core', 'core').group.tools.push(tool);
       continue;
     }
     if (name.startsWith('workflow_')) {
-      bucket('Workflows', 'workflow').tools.push(tool);
+      bucket('Workflows', 'workflow').group.tools.push(tool);
       continue;
     }
     if (name.startsWith('x_')) {
-      const server = matchServer(name, servers);
-      if (server?.managementCluster) {
-        bucket(server.managementCluster, 'server', server.family).tools.push(
-          tool,
-        );
+      const matches = matchServers(name, servers);
+      const clusters = new Set(
+        matches
+          .map(s => s.managementCluster)
+          .filter((mc): mc is string => Boolean(mc)),
+      );
+      const family = matches.find(s => s.family)?.family;
+
+      // Shared/deduplicated federated tool: one prefix maps to several
+      // management clusters. Don't head it with an arbitrary peer MC (D1) --
+      // bucket it under a neutral family-level fleet label.
+      if (clusters.size > 1) {
+        const key = `${titleCase(family ?? segmentOf(name))} (fleet)`;
+        const entry = bucket(key, 'server', true);
+        entry.group.tools.push(tool);
+        if (family) {
+          entry.families.add(family);
+        }
+        for (const mc of clusters) {
+          entry.clusters.add(mc);
+        }
         continue;
       }
-      const segment = server?.family ?? name.slice(2).split('_')[0];
-      bucket(`Server: ${segment || 'unknown'}`, 'server').tools.push(tool);
+
+      const mc = matches[0]?.managementCluster;
+      if (mc) {
+        const entry = bucket(mc, 'server');
+        entry.group.tools.push(tool);
+        if (family) {
+          entry.families.add(family);
+        }
+        continue;
+      }
+
+      const segment = family ?? segmentOf(name);
+      bucket(`Server: ${segment}`, 'server').group.tools.push(tool);
       continue;
     }
-    bucket('Other', 'other').tools.push(tool);
+    bucket('Other', 'other').group.tools.push(tool);
+  }
+
+  // Derive each server bucket's subtitle from what it actually holds (the family
+  // set / federated cluster count) rather than from the first server that
+  // created it -- a multi-family MC must not be mislabelled by one family.
+  for (const entry of groups.values()) {
+    if (entry.group.kind !== 'server') {
+      continue;
+    }
+    if (entry.fleet) {
+      entry.group.subtitle =
+        entry.clusters.size > 0 ? `${entry.clusters.size} clusters` : 'fleet';
+    } else if (entry.families.size > 0) {
+      entry.group.subtitle = [...entry.families].sort().join(', ');
+    }
   }
 
   const rank = (group: ToolGroup) => {
@@ -107,8 +184,34 @@ export function groupTools(
     return 2;
   };
 
-  return [...groups.values()].sort((a, b) => {
-    const r = rank(a) - rank(b);
-    return r !== 0 ? r : a.key.localeCompare(b.key);
-  });
+  return [...groups.values()]
+    .map(entry => entry.group)
+    .sort((a, b) => {
+      const r = rank(a) - rank(b);
+      return r !== 0 ? r : a.key.localeCompare(b.key);
+    });
+}
+
+/**
+ * Resolve the tools belonging to one server, identified by its `x_<segment>`
+ * prefix. Used to scope the browse panel to a `?server=` deep link (prefix
+ * filter) instead of seeding a free-text search that also matches description
+ * text -- see tools F4. Returns `undefined` when the server name can't be
+ * resolved to a known prefix, so the caller can fall back to the full browse.
+ */
+export function toolsForServer(
+  tools: ToolSummary[],
+  serverName: string,
+  servers: ServerPrefixInfo[],
+): { prefix: string; tools: ToolSummary[] } | undefined {
+  const prefix = servers.find(s => s.serverName === serverName)?.prefix;
+  if (!prefix) {
+    return undefined;
+  }
+  return {
+    prefix,
+    tools: tools.filter(
+      t => t.name === prefix || t.name.startsWith(`${prefix}_`),
+    ),
+  };
 }

--- a/plugins/muster/src/lib/workflowSearch.test.ts
+++ b/plugins/muster/src/lib/workflowSearch.test.ts
@@ -23,8 +23,12 @@ describe('searchScore', () => {
 
   it('matches a query token as a prefix of a name token, not mid-token', () => {
     // The F3 bug: "dex" must NOT match "index".
-    expect(searchScore('dex-error-rate-high', '', tokens('dex'))).toBeGreaterThan(0);
-    expect(searchScore('loki-request-errors', 'index_stats', tokens('dex'))).toBe(0);
+    expect(
+      searchScore('dex-error-rate-high', '', tokens('dex')),
+    ).toBeGreaterThan(0);
+    expect(
+      searchScore('loki-request-errors', 'index_stats', tokens('dex')),
+    ).toBe(0);
     expect(
       searchScore('memcached-low-hit-ratio', 'index-cache hit', tokens('dex')),
     ).toBe(0);
@@ -32,7 +36,11 @@ describe('searchScore', () => {
 
   it('ranks a name match above a description-only match', () => {
     const nameHit = searchScore('dex-error-rate', 'unrelated', tokens('dex'));
-    const descHit = searchScore('something-else', 'dex session errors', tokens('dex'));
+    const descHit = searchScore(
+      'something-else',
+      'dex session errors',
+      tokens('dex'),
+    );
     expect(nameHit).toBeGreaterThan(descHit);
     expect(descHit).toBeGreaterThan(0);
   });
@@ -44,7 +52,9 @@ describe('searchScore', () => {
   });
 
   it('requires every query token to match (AND semantics)', () => {
-    expect(searchScore('dex-error-rate', '', tokens('dex error'))).toBeGreaterThan(0);
+    expect(
+      searchScore('dex-error-rate', '', tokens('dex error')),
+    ).toBeGreaterThan(0);
     expect(searchScore('dex-error-rate', '', tokens('dex missing'))).toBe(0);
   });
 });
@@ -52,10 +62,19 @@ describe('searchScore', () => {
 describe('searchByRelevance', () => {
   const fields = (i: { name: string; description: string }) => i;
   const workflows = [
-    { name: 'dex-error-rate-high', description: 'Dex authentication error rate' },
+    {
+      name: 'dex-error-rate-high',
+      description: 'Dex authentication error rate',
+    },
     { name: 'dex-token-issuance', description: 'Dex token issuance latency' },
-    { name: 'loki-request-errors', description: 'Loki request errors, index_stats' },
-    { name: 'memcached-low-hit-ratio', description: 'memcached index-cache hit ratio' },
+    {
+      name: 'loki-request-errors',
+      description: 'Loki request errors, index_stats',
+    },
+    {
+      name: 'memcached-low-hit-ratio',
+      description: 'memcached index-cache hit ratio',
+    },
   ];
 
   it('returns only boundary matches for "dex", excluding index-only rows', () => {

--- a/plugins/muster/src/lib/workflowSearch.test.ts
+++ b/plugins/muster/src/lib/workflowSearch.test.ts
@@ -1,0 +1,82 @@
+import { searchByRelevance, searchScore, tokenize } from './workflowSearch';
+
+describe('tokenize', () => {
+  it('splits on non-alphanumeric boundaries and lowercases', () => {
+    expect(tokenize('dex-error-rate-high')).toEqual([
+      'dex',
+      'error',
+      'rate',
+      'high',
+    ]);
+    expect(tokenize('index_stats, index-cache')).toEqual([
+      'index',
+      'stats',
+      'index',
+      'cache',
+    ]);
+    expect(tokenize('   ')).toEqual([]);
+  });
+});
+
+describe('searchScore', () => {
+  const tokens = (q: string) => tokenize(q);
+
+  it('matches a query token as a prefix of a name token, not mid-token', () => {
+    // The F3 bug: "dex" must NOT match "index".
+    expect(searchScore('dex-error-rate-high', '', tokens('dex'))).toBeGreaterThan(0);
+    expect(searchScore('loki-request-errors', 'index_stats', tokens('dex'))).toBe(0);
+    expect(
+      searchScore('memcached-low-hit-ratio', 'index-cache hit', tokens('dex')),
+    ).toBe(0);
+  });
+
+  it('ranks a name match above a description-only match', () => {
+    const nameHit = searchScore('dex-error-rate', 'unrelated', tokens('dex'));
+    const descHit = searchScore('something-else', 'dex session errors', tokens('dex'));
+    expect(nameHit).toBeGreaterThan(descHit);
+    expect(descHit).toBeGreaterThan(0);
+  });
+
+  it('ranks an exact token above a prefix token', () => {
+    const exact = searchScore('dex', '', tokens('dex'));
+    const prefix = searchScore('dexterity', '', tokens('dex'));
+    expect(exact).toBeGreaterThan(prefix);
+  });
+
+  it('requires every query token to match (AND semantics)', () => {
+    expect(searchScore('dex-error-rate', '', tokens('dex error'))).toBeGreaterThan(0);
+    expect(searchScore('dex-error-rate', '', tokens('dex missing'))).toBe(0);
+  });
+});
+
+describe('searchByRelevance', () => {
+  const fields = (i: { name: string; description: string }) => i;
+  const workflows = [
+    { name: 'dex-error-rate-high', description: 'Dex authentication error rate' },
+    { name: 'dex-token-issuance', description: 'Dex token issuance latency' },
+    { name: 'loki-request-errors', description: 'Loki request errors, index_stats' },
+    { name: 'memcached-low-hit-ratio', description: 'memcached index-cache hit ratio' },
+  ];
+
+  it('returns only boundary matches for "dex", excluding index-only rows', () => {
+    const names = searchByRelevance(workflows, 'dex', fields).map(w => w.name);
+    expect(names).toEqual(
+      expect.arrayContaining(['dex-error-rate-high', 'dex-token-issuance']),
+    );
+    expect(names).not.toContain('loki-request-errors');
+    expect(names).not.toContain('memcached-low-hit-ratio');
+  });
+
+  it('orders name matches ahead of description-only matches', () => {
+    const items = [
+      { name: 'other', description: 'mentions dex once' },
+      { name: 'dex-workflow', description: 'no relevant words' },
+    ];
+    const names = searchByRelevance(items, 'dex', fields).map(w => w.name);
+    expect(names[0]).toBe('dex-workflow');
+  });
+
+  it('returns the input unchanged for an empty query', () => {
+    expect(searchByRelevance(workflows, '   ', fields)).toBe(workflows);
+  });
+});

--- a/plugins/muster/src/lib/workflowSearch.ts
+++ b/plugins/muster/src/lib/workflowSearch.ts
@@ -1,0 +1,92 @@
+/**
+ * Token-aware scored search for the workflow list. Replaces the previous naive
+ * `name/description.includes(needle)` substring filter, which matched the query
+ * "dex" against "in**dex**" so `loki-request-errors` / `memcached-low-hit-ratio`
+ * (whose descriptions mention "index") polluted the results (workflows.md F3).
+ *
+ * Matching is on word/token boundaries: a query token matches a text token only
+ * when it is a prefix of that token, so "dex" matches "dex-error-rate-high" but
+ * not "index_stats". Every query token must match somewhere (name or
+ * description) for the item to be kept (AND semantics). Name matches outrank
+ * description matches and exact token matches outrank prefixes, yielding a
+ * relevance order.
+ */
+
+const NAME_WEIGHT = 2;
+const EXACT_SCORE = 3;
+const PREFIX_SCORE = 2;
+
+/** Lowercase and split on any run of non-alphanumeric characters. */
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/** Best boundary-aware score of one query token against a set of text tokens. */
+function tokenScore(queryToken: string, textTokens: string[]): number {
+  let best = 0;
+  for (const t of textTokens) {
+    if (t === queryToken) {
+      return EXACT_SCORE;
+    }
+    if (t.startsWith(queryToken)) {
+      best = PREFIX_SCORE;
+    }
+  }
+  return best;
+}
+
+/**
+ * Relevance score of a name/description pair against the (already tokenized)
+ * query. Returns 0 when any query token fails to match either field, so a 0
+ * score means "filtered out".
+ */
+export function searchScore(
+  name: string,
+  description: string,
+  queryTokens: string[],
+): number {
+  const nameTokens = tokenize(name);
+  const descTokens = tokenize(description);
+  let total = 0;
+  for (const q of queryTokens) {
+    const nameScore = tokenScore(q, nameTokens);
+    const best = nameScore > 0 ? nameScore * NAME_WEIGHT : tokenScore(q, descTokens);
+    if (best === 0) {
+      return 0;
+    }
+    total += best;
+  }
+  return total;
+}
+
+export interface SearchFields {
+  name: string;
+  description: string;
+}
+
+/**
+ * Filter `items` to those matching `query` on token boundaries, ordered by
+ * relevance (highest score first). An empty query returns the items unchanged
+ * (original order preserved).
+ */
+export function searchByRelevance<T>(
+  items: T[],
+  query: string,
+  getFields: (item: T) => SearchFields,
+): T[] {
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) {
+    return items;
+  }
+  return items
+    .map(item => {
+      const { name, description } = getFields(item);
+      return { item, score: searchScore(name, description, queryTokens) };
+    })
+    .filter(scored => scored.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map(scored => scored.item);
+}

--- a/plugins/muster/src/lib/workflowSearch.ts
+++ b/plugins/muster/src/lib/workflowSearch.ts
@@ -53,7 +53,8 @@ export function searchScore(
   let total = 0;
   for (const q of queryTokens) {
     const nameScore = tokenScore(q, nameTokens);
-    const best = nameScore > 0 ? nameScore * NAME_WEIGHT : tokenScore(q, descTokens);
+    const best =
+      nameScore > 0 ? nameScore * NAME_WEIGHT : tokenScore(q, descTokens);
     if (best === 0) {
       return 0;
     }


### PR DESCRIPTION
## Summary

Iteration-2 polish for the muster Backstage plugin, driven by the deployed-gazelle e2e review (`reviews/2026-06-28-muster-ui-review`) and ADR `muster-ui-iteration-2`. The theme is **truthfulness**: stop the UI from misrepresenting federated state, auth state, and workflow availability, and stop it from blanking on a cold load.

### Federated representation (D1)
- **MCP-servers manager**: a federated family's "shared" config/auth no longer defaults to an arbitrary alphabetically-first peer/customer MC. A shared `selectRepresentative` helper prefers the active installation's own server, then a Connected/Running one, else falls back but flags itself `unqualified` so the family is labelled neutrally and the Configuration/Auth captions caveat per-cluster differences.
- **Tool explorer browse tree**: shared/deduplicated federated tools are bucketed under a neutral family-level fleet label (`Kubernetes (fleet)` / `Prometheus (fleet)`) instead of a peer MC, split by family, with subtitles derived from the family/cluster set the bucket actually holds. Grouping waits for the MCPServer CRs so sections no longer reshuffle on load.

### Auth coherence (D3)
- Session state is resolved once via a shared `useMusterSession` hook, used by the dashboard, the MCP-servers manager and the workflows list so every surface agrees (and signs in for the selected installation).
- "Add ad-hoc server" / "Create workflow" are disabled with an explanatory tooltip when there is no session, instead of failing after the user composes a definition.
- Auth-failure (HTTP 401 / "authentication failure") errors from validate/save/delete map to a friendly connect prompt instead of the raw MCP transport message.
- An `Auth Required` server with no tools reads as a session state, not "may be down".

### Workflow truthfulness (D2)
- Availability is decoupled from the validator's `status.valid`: `MusterWorkflow.isRunnable()` backs the badge (every loaded Workflow CR exposes a `workflow_<name>` tool), and a validator complaint surfaces as a non-blocking "Validation warning" badge instead of "Unavailable". The list filter becomes Valid / Validation-warnings.
- Executions/Statistics panels clarify they reflect engine- and agent-driven runs recorded by the aggregator; tool-explorer runs are shown inline, not recorded there.

### Freshness & cold load (D4)
- Live health reads auto-refresh in the background (light `refetchInterval` configured once in the provider); a shared `FreshnessIndicator` shows "updated Xs ago" + a manual refresh on the dashboard and MCP-servers sections.
- The dashboard renders its chrome immediately on a cold load with placeholders + a thin progress bar, instead of a full-page spinner behind the fleet warm-up.
- The "Servers healthy" stat warns only when a meaningful fraction (>10%) is unhealthy, so one degraded remote backend doesn't paint it permanently amber.

### Polish
- Workflow-list search is token/boundary-aware and relevance-ranked (so "dex" no longer matches "in**dex**").
- Tool explorer: enum fields pre-select their schema default; result-table headers `nowrap`; only the Core browse group expands by default.
- Core tool-family titles render verbatim (no forced capitalize); empty-state copy distinguishes zero-data from filtered-empty; the legacy `/workflows/:name/run` deep link redirects to the detail page preserving the query string.

### Review follow-ups (last commit)
- DashboardPage adopts `useMusterSession` rather than hand-rolling its own probe/connect (deduped by query key); fixes its connect signing in for the default installation instead of the active one.
- `isMusterAuthError` drops the over-broad bare `401` match, keeping the precise `HTTP 401` / `authentication failure` signals.

## Test plan
- [x] `yarn backstage-cli repo test plugins/muster/src` — 77 frontend tests pass (new pure-function suites: `authError`, `freshness`, `workflowSearch`, `serversHealthSummary`, `selectRepresentative`, `toolsForServer`, `enumDefaults`, runnable-vs-valid).
- [x] `yarn tsc` — clean.
- [x] Lint clean on changed files.
- [ ] e2e re-validation against deployed gazelle (follow the iteration-1 trial steps).

Changesets included per change.

Made with [Cursor](https://cursor.com)