### PR TITLE
feat(muster): workflow detail page cleanups and shared StackedBarChart

### DIFF
--- a/.changeset/muster-workflow-detail-cleanups.md
+++ b/.changeset/muster-workflow-detail-cleanups.md
@@ -1,0 +1,32 @@
+---
+'@giantswarm/backstage-plugin-ui-react': minor
+'@giantswarm/backstage-plugin-muster': minor
+---
+
+Muster workflow detail page cleanups and a shared chart component.
+
+- Add a theme-aware `StackedBarChart` component (built on recharts) to
+  `@giantswarm/backstage-plugin-ui-react`. Colors, axis text, grid, and tooltip
+  all read from the active MUI theme so it looks native in light and dark mode;
+  recharts stays an implementation detail behind a small `series`-based API.
+- The workflow detail "Runs per day" chart now uses the shared `StackedBarChart`
+  instead of a hand-rolled CSS bar. It spans at least 30 days, fills days with no
+  runs with empty entries, and always ends on today so the right edge reads as
+  "now".
+- Remove the breadcrumb from the workflow detail header.
+- Render the workflow description's Markdown paragraphs with the standard MUI
+  `body1` typography (line height, spacing) so they match other paragraphs.
+- Remove the "Remove via GitOps" button from the GitOps-managed workflow
+  actions, and rename "Edit via GitOps" to a plain "Show manifest" outline
+  button (same manifest dialog).
+- Remove the redundant collapsible "Definition (YAML)" section from the workflow
+  detail page.
+- Align the GitOps "Show manifest" dialog with the "Create workflow" modal: an X
+  icon in the title bar (no footer Close button), a primary "Copy manifest"
+  button, and the manifest rendered read-only in the shared YAML editor with
+  syntax highlighting.
+- `YamlEditorFormField` (ui-react) now accepts a `readOnly` prop, forwarded to
+  the underlying `YamlEditor`.
+- The workflow detail "Executions" panels now size to their content and cap at
+  the viewport (scrolling internally) instead of always reserving a tall fixed
+  height when empty.

--- a/plugins/muster/src/components/WorkflowDetailPage/ExecutionDetailPanel.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/ExecutionDetailPanel.tsx
@@ -12,7 +12,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   panel: {
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius * 2,
-    height: '100%',
+    // Grow with content, but cap at the viewport so long step results scroll
+    // internally instead of stretching the page.
+    maxHeight: 'calc(100vh - 360px)',
     overflow: 'auto',
     padding: theme.spacing(2),
   },

--- a/plugins/muster/src/components/WorkflowDetailPage/ExecutionHistoryPanel.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/ExecutionHistoryPanel.tsx
@@ -18,7 +18,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     borderRadius: theme.shape.borderRadius * 2,
     backgroundColor: theme.palette.background.paper,
     overflow: 'auto',
-    height: '100%',
+    // Grow with content, but cap at the viewport so a long history scrolls
+    // internally instead of stretching the page.
+    maxHeight: 'calc(100vh - 360px)',
   },
   header: {
     padding: theme.spacing(1.5, 2),

--- a/plugins/muster/src/components/WorkflowDetailPage/WorkflowDetailPage.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/WorkflowDetailPage.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import yaml from 'js-yaml';
 import { useApi, useRouteRef } from '@backstage/frontend-plugin-api';
 import {
   Content,
@@ -11,9 +10,6 @@ import {
   ResponseErrorPanel,
 } from '@backstage/core-components';
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
   Box,
   Button,
   Grid,
@@ -28,9 +24,7 @@ import Tune from '@material-ui/icons/Tune';
 import FormatListNumbered from '@material-ui/icons/FormatListNumbered';
 import Share from '@material-ui/icons/Share';
 import History from '@material-ui/icons/History';
-import ChevronRight from '@material-ui/icons/ChevronRight';
 import AccountTree from '@material-ui/icons/AccountTree';
-import ExpandMore from '@material-ui/icons/ExpandMore';
 import { Alert } from '@material-ui/lab';
 import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
 import { useQuery } from '@tanstack/react-query';
@@ -46,12 +40,7 @@ import {
   StateBadge,
   VIOLET,
 } from '../shared';
-import {
-  mcpServersRouteRef,
-  toolExplorerRouteRef,
-  workflowDetailRouteRef,
-  workflowsRouteRef,
-} from '../../routes';
+import { toolExplorerRouteRef, workflowDetailRouteRef } from '../../routes';
 import { WorkflowStepCard } from './WorkflowStepCard';
 import { WorkflowStatsPanel } from './WorkflowStatsPanel';
 import { ExecutionHistoryPanel } from './ExecutionHistoryPanel';
@@ -68,16 +57,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   header: {
     paddingBottom: theme.spacing(3),
     borderBottom: `1px solid ${theme.palette.divider}`,
-  },
-  breadcrumb: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    gap: theme.spacing(0.75),
-    marginBottom: theme.spacing(1.5),
-    color: theme.palette.text.secondary,
-    fontSize: 14,
-    '& svg': { fontSize: 14 },
   },
   titleRow: {
     display: 'flex',
@@ -101,7 +80,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(1.5),
     maxWidth: '80ch',
     color: theme.palette.text.secondary,
-    '& p': { margin: 0 },
+    // MarkdownContent emits bare <p> tags without MUI Typography classes, so
+    // they fall back to the document line-height. Match the body1 variant other
+    // paragraphs use so spacing reads consistently.
+    '& p': {
+      ...theme.typography.body1,
+      margin: 0,
+    },
+    '& p + p': {
+      marginTop: theme.spacing(1),
+    },
   },
   metaRow: {
     marginTop: theme.spacing(2),
@@ -194,26 +182,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontFamily: 'monospace',
     fontSize: 13,
   },
-  yamlAccordion: {
-    borderRadius: theme.shape.borderRadius * 2,
-    '&:before': { display: 'none' },
-  },
-  yamlSummary: {
-    fontWeight: 500,
-  },
-  yamlPre: {
-    margin: 0,
-    width: '100%',
-    overflowX: 'auto',
-    fontFamily: 'monospace',
-    fontSize: 12,
-    lineHeight: 1.6,
-    color: theme.palette.text.secondary,
-  },
-  historyContainer: {
-    height: 'calc(100vh - 360px)',
-    minHeight: 360,
-  },
 }));
 
 /** Append `?installation=` to a route path so deep links keep the instance. */
@@ -233,8 +201,6 @@ function WorkflowDetailContent() {
 
   const navigate = useNavigate();
   const musterApi = useApi(musterApiRef);
-  const workflowsLink = useRouteRef(workflowsRouteRef);
-  const mcpServersLink = useRouteRef(mcpServersRouteRef);
   const workflowDetailLink = useRouteRef(workflowDetailRouteRef);
   const toolExplorerLink = useRouteRef(toolExplorerRouteRef);
   const { workflows, isLoading, activeInstallation } = useMusterInstance();
@@ -308,13 +274,6 @@ function WorkflowDetailContent() {
   const created = workflow.getCreatedTimestamp();
   const referencingTool = `workflow_${name}`;
 
-  let yamlText: string;
-  try {
-    yamlText = yaml.dump(workflow.jsonData, { lineWidth: 120, noRefs: true });
-  } catch {
-    yamlText = JSON.stringify(workflow.jsonData, null, 2);
-  }
-
   // Running a workflow is just executing its `workflow_<name>` aggregated tool,
   // so "Run" lands on the unified execution surface (the tool explorer) with
   // that tool preselected and its argument form ready.
@@ -346,20 +305,6 @@ function WorkflowDetailContent() {
       <Box className={classes.column}>
         {/* Header */}
         <Box className={classes.header}>
-          <Box className={classes.breadcrumb}>
-            <Link
-              to={withInstallation(mcpServersLink?.() ?? '#', installation)}
-            >
-              MCP Servers
-            </Link>
-            <ChevronRight />
-            <Link to={withInstallation(workflowsLink?.() ?? '#', installation)}>
-              Workflows
-            </Link>
-            <ChevronRight />
-            <span>{name}</span>
-          </Box>
-
           <Box className={classes.titleRow}>
             <Typography variant="h4" className={classes.title}>
               {name}
@@ -528,20 +473,6 @@ function WorkflowDetailContent() {
           </Box>
         )}
 
-        {/* Raw definition */}
-        <Box className={classes.section}>
-          <Accordion variant="outlined" className={classes.yamlAccordion}>
-            <AccordionSummary expandIcon={<ExpandMore />}>
-              <Typography className={classes.yamlSummary}>
-                Definition (YAML)
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <pre className={classes.yamlPre}>{yamlText}</pre>
-            </AccordionDetails>
-          </Accordion>
-        </Box>
-
         {/* Executions — run history + per-execution step results (muster proxy) */}
         <Box className={classes.section}>
           <SectionHeader
@@ -550,7 +481,7 @@ function WorkflowDetailContent() {
             description="Engine- and agent-driven runs of this workflow and their per-step results, as recorded by muster's aggregator. Runs launched from the tool explorer execute the aggregated tool directly and do not appear here."
           />
           <Grid container>
-            <Grid item xs={12} md={4} className={classes.historyContainer}>
+            <Grid item xs={12} md={4}>
               {executionsQuery.error ? (
                 <ResponseErrorPanel
                   title="Failed to load executions"
@@ -564,7 +495,7 @@ function WorkflowDetailContent() {
                 />
               )}
             </Grid>
-            <Grid item xs={12} md={8} className={classes.historyContainer}>
+            <Grid item xs={12} md={8}>
               <ExecutionDetailPanel
                 execution={
                   selectedExecutionId ? executionQuery.data : undefined
@@ -586,9 +517,8 @@ function WorkflowDetailContent() {
  * Standalone (tabless) workflow detail page. CRD-driven: the structure (args,
  * steps, validity, step count) comes from the Workflow CR loaded by the
  * MusterInstanceProvider, while statistics, execution history, and runs use the
- * muster MCP proxy. Ported to the mockup's section rhythm (breadcrumb, header +
- * availability, statistics, arguments, numbered steps, referenced-by,
- * collapsible YAML).
+ * muster MCP proxy. Ported to the mockup's section rhythm (header +
+ * availability, statistics, arguments, numbered steps, referenced-by).
  */
 export function WorkflowDetailPage() {
   // Rendered inside the Workflows tab, which the workflows sub-page already

--- a/plugins/muster/src/components/WorkflowDetailPage/WorkflowStatsPanel.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/WorkflowStatsPanel.tsx
@@ -51,7 +51,14 @@ function padPerDay(perDay: WorkflowStatsPerDay[]): WorkflowStatsPerDay[] {
   }
 
   const byDate = new Map(perDay.map(day => [day.date, day]));
-  const epochs = perDay.map(day => parseDay(day.date));
+  // Drop any unparseable dates so a single malformed key can't turn `end`/`start`
+  // into NaN and collapse the whole chart to an empty range.
+  const epochs = perDay
+    .map(day => parseDay(day.date))
+    .filter(epoch => !Number.isNaN(epoch));
+  if (epochs.length === 0) {
+    return perDay;
+  }
   // Anchor the right edge to today, but never truncate data that (somehow)
   // carries a later date.
   const end = Math.max(...epochs, todayEpoch());

--- a/plugins/muster/src/components/WorkflowDetailPage/WorkflowStatsPanel.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/WorkflowStatsPanel.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Paper,
-  Tooltip,
   Typography,
   makeStyles,
   useTheme,
@@ -10,9 +9,83 @@ import {
 import { Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
+import { StackedBarChart } from '@giantswarm/backstage-plugin-ui-react';
 import { musterApiRef } from '../../apis';
+import type { WorkflowStatsPerDay } from '../../apis';
 import { formatDuration } from '../../lib/formatDuration';
 import { Stat } from '../shared';
+
+/** Minimum number of days the runs-per-day chart always spans. */
+const MIN_CHART_DAYS = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Parse a `YYYY-MM-DD` date to a UTC-midnight epoch (timezone-stable). */
+function parseDay(date: string): number {
+  const [y, m, d] = date.split('-').map(Number);
+  return Date.UTC(y, m - 1, d);
+}
+
+/** Format a UTC-midnight epoch back to `YYYY-MM-DD`. */
+function formatDay(epoch: number): string {
+  return new Date(epoch).toISOString().slice(0, 10);
+}
+
+/** Today's UTC-midnight epoch, matching the backend's `YYYY-MM-DD` days. */
+function todayEpoch(): number {
+  const now = new Date();
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+}
+
+/**
+ * Expand the backend's sparse per-day series into a contiguous range that spans
+ * at least `MIN_CHART_DAYS` days, filling absent days with zero-run entries so
+ * the chart always reads as a full window even when only a single day has data.
+ * Days that already carry data are preserved; the window always ends today so
+ * the chart's right edge reads as "now" even when the most recent run was days
+ * ago.
+ */
+function padPerDay(perDay: WorkflowStatsPerDay[]): WorkflowStatsPerDay[] {
+  if (perDay.length === 0) {
+    return perDay;
+  }
+
+  const byDate = new Map(perDay.map(day => [day.date, day]));
+  const epochs = perDay.map(day => parseDay(day.date));
+  // Anchor the right edge to today, but never truncate data that (somehow)
+  // carries a later date.
+  const end = Math.max(...epochs, todayEpoch());
+  const earliest = Math.min(...epochs);
+  // Reach back far enough to cover MIN_CHART_DAYS, or further if data already
+  // spans a longer window.
+  const start = Math.min(earliest, end - (MIN_CHART_DAYS - 1) * DAY_MS);
+
+  const result: WorkflowStatsPerDay[] = [];
+  for (let epoch = start; epoch <= end; epoch += DAY_MS) {
+    const date = formatDay(epoch);
+    result.push(byDate.get(date) ?? { date, completed: 0, failed: 0 });
+  }
+  return result;
+}
+
+/** Short x-axis tick, e.g. `Jun 30`. Formatted in UTC to match the day keys. */
+function formatAxisDate(date: string): string {
+  return new Date(parseDay(date)).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** Fuller tooltip heading, e.g. `Mon, Jun 30`. */
+function formatTooltipDate(date: string): string {
+  return new Date(parseDay(date)).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
 
 const useStyles = makeStyles((theme: Theme) => ({
   statRow: {
@@ -56,20 +129,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontWeight: 500,
     color: theme.palette.text.secondary,
   },
-  chart: {
-    display: 'flex',
-    alignItems: 'flex-end',
-    gap: 2,
-    height: 160,
-  },
-  barColumn: {
-    flex: '1 1 0',
-    minWidth: 3,
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'flex-end',
-    height: '100%',
-  },
   note: {
     display: 'block',
     marginTop: theme.spacing(1.5),
@@ -86,13 +145,12 @@ export interface WorkflowStatsPanelProps {
  * Run statistics for a workflow, sourced from the muster-backend's derived
  * `/workflows/:name/stats` (computed over a bounded execution sample). Renders
  * the mockup's Statistics block: a Stat row, a completed/failed outcome
- * breakdown, and a dependency-free CSS stacked bar of runs per day.
+ * breakdown, and a recharts stacked bar of runs per day (via the shared
+ * `StackedBarChart` from ui-react).
  *
- * ponytail: the per-day bar is a hand-rolled CSS chart, not a charting library,
- * and the breakdown is two-way (completed/failed) -- muster's execution
+ * ponytail: the breakdown is two-way (completed/failed) -- muster's execution
  * summaries do not carry the mockup's tolerated-step-failure dimension. Upgrade
- * path: a richer summary from the backend plus a chart lib if interaction is
- * needed.
+ * path: a richer summary from the backend to add that third dimension.
  */
 export function WorkflowStatsPanel({
   name,
@@ -139,10 +197,7 @@ export function WorkflowStatsPanel({
   const max =
     data.max_duration_ms !== null ? formatDuration(data.max_duration_ms) : '—';
 
-  const maxPerDay = data.per_day.reduce(
-    (acc, day) => Math.max(acc, day.completed + day.failed),
-    0,
-  );
+  const perDay = padPerDay(data.per_day);
 
   const completedColor = theme.palette.success.main;
   const failedColor = theme.palette.error.main;
@@ -179,49 +234,25 @@ export function WorkflowStatsPanel({
         </span>
       </Box>
 
-      {data.per_day.length > 0 && maxPerDay > 0 && (
+      {perDay.length > 0 && (
         <Paper variant="outlined" className={classes.chartCard}>
           <Typography component="div" className={classes.chartTitle}>
             Runs per day
           </Typography>
-          <Box className={classes.chart}>
-            {data.per_day.map(day => {
-              const total = day.completed + day.failed;
-              const heightPct = (total / maxPerDay) * 100;
-              const completedShare = total > 0 ? day.completed / total : 0;
-              return (
-                <Tooltip
-                  key={day.date}
-                  arrow
-                  title={`${day.date}: ${day.completed} completed, ${day.failed} failed`}
-                >
-                  <div className={classes.barColumn}>
-                    <div
-                      style={{
-                        height: `${heightPct}%`,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        justifyContent: 'flex-end',
-                      }}
-                    >
-                      <div
-                        style={{
-                          height: `${(1 - completedShare) * 100}%`,
-                          backgroundColor: failedColor,
-                        }}
-                      />
-                      <div
-                        style={{
-                          height: `${completedShare * 100}%`,
-                          backgroundColor: completedColor,
-                        }}
-                      />
-                    </div>
-                  </div>
-                </Tooltip>
-              );
-            })}
-          </Box>
+          <StackedBarChart
+            data={perDay}
+            xAxisKey="date"
+            series={[
+              {
+                dataKey: 'completed',
+                name: 'completed',
+                color: completedColor,
+              },
+              { dataKey: 'failed', name: 'failed', color: failedColor },
+            ]}
+            formatXAxisTick={formatAxisDate}
+            formatTooltipLabel={formatTooltipDate}
+          />
         </Paper>
       )}
 

--- a/plugins/muster/src/components/WorkflowsListPage/WorkflowMutationActions.tsx
+++ b/plugins/muster/src/components/WorkflowsListPage/WorkflowMutationActions.tsx
@@ -14,7 +14,6 @@ import {
   makeStyles,
   Theme,
 } from '@material-ui/core';
-import GitHub from '@material-ui/icons/GitHub';
 import Edit from '@material-ui/icons/Edit';
 import DeleteOutline from '@material-ui/icons/DeleteOutline';
 import Add from '@material-ui/icons/Add';
@@ -46,21 +45,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     flex: 1,
     minWidth: 200,
   },
-  manifest: {
-    whiteSpace: 'pre',
-    overflowX: 'auto',
-    fontFamily: 'monospace',
-    fontSize: 12,
-    margin: 0,
-    padding: theme.spacing(1.5),
-    borderRadius: theme.shape.borderRadius,
-    border: `1px solid ${theme.palette.divider}`,
-    backgroundColor: theme.palette.action.hover,
-  },
   titleBar: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+  },
+  // MUI's default DialogActions padding (8px) sits the footer buttons much
+  // closer to the edge than the 24px-padded content above; align the horizontal
+  // padding and give the buttons a bit more breathing room from the edge.
+  dialogActions: {
+    padding: theme.spacing(2, 3),
   },
   closeButton: {
     color: theme.palette.grey[500],
@@ -108,9 +102,18 @@ function GitOpsManifestDialog({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>
-        {intent === 'delete' ? 'Remove via GitOps' : 'Edit via GitOps'} —{' '}
-        {workflow.getName()}
+      <DialogTitle disableTypography className={classes.titleBar}>
+        <Typography variant="h6">
+          {intent === 'delete' ? 'Remove via GitOps' : 'Edit via GitOps'} —{' '}
+          {workflow.getName()}
+        </Typography>
+        <IconButton
+          aria-label="close"
+          className={classes.closeButton}
+          onClick={onClose}
+        >
+          <Close />
+        </IconButton>
       </DialogTitle>
       <DialogContent>
         <DialogContentText component="div">
@@ -128,16 +131,18 @@ function GitOpsManifestDialog({
             : 'To change it, edit its manifest in the management-clusters GitOps repo and open a PR.'}
         </DialogContentText>
         <Box mt={2}>
-          <Typography variant="caption" color="textSecondary">
-            Current manifest
-          </Typography>
-          <pre className={classes.manifest}>{manifest}</pre>
+          <YamlEditorFormField
+            label="Current manifest"
+            value={manifest}
+            readOnly
+            height={360}
+            maxHeight={360}
+          />
         </Box>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={copy}>Copy manifest</Button>
-        <Button onClick={onClose} color="primary">
-          Close
+      <DialogActions className={classes.dialogActions}>
+        <Button onClick={copy} color="primary" variant="contained">
+          Copy manifest
         </Button>
       </DialogActions>
     </Dialog>
@@ -211,7 +216,7 @@ function ConfirmDeleteDialog({
           </Box>
         )}
       </DialogContent>
-      <DialogActions>
+      <DialogActions className={classes.dialogActions}>
         <Button onClick={handleClose}>{done ? 'Close' : 'Cancel'}</Button>
         {!done && (
           <Button
@@ -380,7 +385,7 @@ export function AdHocWorkflowDialog({
           )}
         </Box>
       </DialogContent>
-      <DialogActions>
+      <DialogActions className={classes.dialogActions}>
         <Button onClick={validate} disabled={busy}>
           Validate
         </Button>
@@ -415,9 +420,7 @@ export function WorkflowMutationActions({
   const classes = useStyles();
   const managed = isGitOpsManaged(workflow);
 
-  const [gitopsIntent, setGitopsIntent] = useState<'edit' | 'delete' | null>(
-    null,
-  );
+  const [gitopsEditOpen, setGitopsEditOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -430,23 +433,16 @@ export function WorkflowMutationActions({
         </Typography>
         <Button
           size="small"
-          startIcon={<GitHub />}
-          onClick={() => setGitopsIntent('edit')}
+          variant="outlined"
+          onClick={() => setGitopsEditOpen(true)}
         >
-          Edit via GitOps
-        </Button>
-        <Button
-          size="small"
-          startIcon={<DeleteOutline />}
-          onClick={() => setGitopsIntent('delete')}
-        >
-          Remove via GitOps
+          Show manifest
         </Button>
         <GitOpsManifestDialog
           workflow={workflow}
-          open={gitopsIntent !== null}
-          intent={gitopsIntent ?? 'edit'}
-          onClose={() => setGitopsIntent(null)}
+          open={gitopsEditOpen}
+          intent="edit"
+          onClose={() => setGitopsEditOpen(false)}
         />
       </Box>
     );

--- a/plugins/muster/src/components/WorkflowsListPage/WorkflowMutationActions.tsx
+++ b/plugins/muster/src/components/WorkflowsListPage/WorkflowMutationActions.tsx
@@ -77,19 +77,17 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 /**
  * GitOps "manifest to commit" dialog: GitOps-managed workflows are read-only in
- * the app, so Edit/Remove produce a manifest the operator commits to the
+ * the app, so changes are made by committing the manifest to the
  * management-clusters repo (a PR), never a live mutation. Shows the rendered
  * Workflow manifest and the managing HelmRelease.
  */
 function GitOpsManifestDialog({
   workflow,
   open,
-  intent,
   onClose,
 }: {
   workflow: MusterWorkflow;
   open: boolean;
-  intent: 'edit' | 'delete';
   onClose: () => void;
 }) {
   const classes = useStyles();
@@ -104,8 +102,7 @@ function GitOpsManifestDialog({
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle disableTypography className={classes.titleBar}>
         <Typography variant="h6">
-          {intent === 'delete' ? 'Remove via GitOps' : 'Edit via GitOps'} —{' '}
-          {workflow.getName()}
+          Workflow manifest — {workflow.getName()}
         </Typography>
         <IconButton
           aria-label="close"
@@ -125,10 +122,8 @@ function GitOpsManifestDialog({
             </>
           ) : null}
           . Live changes would be reverted by the reconciler, so they are
-          read-only here.{' '}
-          {intent === 'delete'
-            ? 'To remove it, delete its manifest in the management-clusters GitOps repo and open a PR.'
-            : 'To change it, edit its manifest in the management-clusters GitOps repo and open a PR.'}
+          read-only here. To change it, edit its manifest in the
+          management-clusters GitOps repo and open a PR.
         </DialogContentText>
         <Box mt={2}>
           <YamlEditorFormField
@@ -420,7 +415,7 @@ export function WorkflowMutationActions({
   const classes = useStyles();
   const managed = isGitOpsManaged(workflow);
 
-  const [gitopsEditOpen, setGitopsEditOpen] = useState(false);
+  const [manifestOpen, setManifestOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -434,15 +429,14 @@ export function WorkflowMutationActions({
         <Button
           size="small"
           variant="outlined"
-          onClick={() => setGitopsEditOpen(true)}
+          onClick={() => setManifestOpen(true)}
         >
           Show manifest
         </Button>
         <GitOpsManifestDialog
           workflow={workflow}
-          open={gitopsEditOpen}
-          intent="edit"
-          onClose={() => setGitopsEditOpen(false)}
+          open={manifestOpen}
+          onClose={() => setManifestOpen(false)}
         />
       </Box>
     );

--- a/plugins/ui-react/package.json
+++ b/plugins/ui-react/package.json
@@ -50,6 +50,7 @@
     "qs": "^6.14.0",
     "react-syntax-highlighter": "^15.4.5",
     "react-use": "^17.6.0",
+    "recharts": "^3.9.0",
     "semver": "^7.7.2",
     "use-local-storage-state": "^19.5.0"
   },

--- a/plugins/ui-react/src/components/StackedBarChart/StackedBarChart.tsx
+++ b/plugins/ui-react/src/components/StackedBarChart/StackedBarChart.tsx
@@ -1,0 +1,192 @@
+import { useTheme } from '@material-ui/core/styles';
+import { Box, Paper, Typography } from '@material-ui/core';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+/** One stacked segment: which field it reads, how it's labelled, and its color. */
+export interface StackedBarChartSeries {
+  /** Key in each data row holding this segment's numeric value. */
+  dataKey: string;
+  /** Human-readable label shown in the tooltip. */
+  name: string;
+  /** Bar fill color (typically pulled from the MUI theme by the caller). */
+  color: string;
+}
+
+export interface StackedBarChartProps<T extends object> {
+  /** Rows to plot, one bar per row. */
+  data: T[];
+  /** Key holding the category (x-axis) value for each row. */
+  xAxisKey: keyof T & string;
+  /**
+   * Stacked segments, rendered bottom-to-top in array order (first entry sits
+   * at the base of the stack).
+   */
+  series: StackedBarChartSeries[];
+  /** Chart height in pixels. Width always fills the container. */
+  height?: number;
+  /** Format an x-axis tick label (e.g. shorten an ISO date). */
+  formatXAxisTick?: (value: string) => string;
+  /** Format the category heading shown in the tooltip. */
+  formatTooltipLabel?: (value: string) => string;
+}
+
+interface TooltipEntry {
+  name?: string;
+  value?: number;
+  color?: string;
+  dataKey?: string | number;
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  label?: string;
+  payload?: TooltipEntry[];
+  headingColor: string;
+  paperBackground: string;
+  borderColor: string;
+  secondaryTextColor: string;
+  formatLabel?: (value: string) => string;
+}
+
+/** Themed replacement for recharts' default (unthemed) tooltip. */
+function ChartTooltip({
+  active,
+  label,
+  payload,
+  headingColor,
+  paperBackground,
+  borderColor,
+  secondaryTextColor,
+  formatLabel,
+}: ChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const heading =
+    label !== undefined && formatLabel ? formatLabel(label) : label;
+
+  return (
+    <Paper
+      elevation={2}
+      style={{
+        backgroundColor: paperBackground,
+        border: `1px solid ${borderColor}`,
+        padding: 8,
+      }}
+    >
+      {heading !== undefined && (
+        <Typography
+          variant="caption"
+          component="div"
+          style={{ color: headingColor, fontWeight: 600, marginBottom: 4 }}
+        >
+          {heading}
+        </Typography>
+      )}
+      {/* Bottom-to-top stack reads top-to-bottom in the tooltip. */}
+      {[...payload].reverse().map(entry => (
+        <Box
+          key={String(entry.dataKey)}
+          display="flex"
+          alignItems="center"
+          style={{ gap: 6 }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              backgroundColor: entry.color,
+              flexShrink: 0,
+            }}
+          />
+          <Typography variant="caption" style={{ color: secondaryTextColor }}>
+            {entry.value} {entry.name}
+          </Typography>
+        </Box>
+      ))}
+    </Paper>
+  );
+}
+
+/**
+ * A theme-aware stacked bar chart built on recharts. Colors, axis text, grid,
+ * and tooltip all read from the active MUI theme so charts look native in both
+ * light and dark mode. Consumers pass plain data rows plus a `series` config
+ * describing each stacked segment — recharts stays an implementation detail.
+ */
+export function StackedBarChart<T extends object>({
+  data,
+  xAxisKey,
+  series,
+  height = 160,
+  formatXAxisTick,
+  formatTooltipLabel,
+}: StackedBarChartProps<T>) {
+  const theme = useTheme();
+
+  const axisColor = theme.palette.text.secondary;
+  const gridColor = theme.palette.divider;
+  const tickStyle = { fill: axisColor, fontSize: 11 };
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      {/* recharts infers its DataPointType from `data`; keep that inference
+          permissive (unknown) so string dataKeys type-check regardless of the
+          caller's concrete row type T. */}
+      <BarChart
+        data={data as unknown[]}
+        margin={{ top: 8, right: 8, bottom: 0, left: -16 }}
+      >
+        <CartesianGrid
+          vertical={false}
+          stroke={gridColor}
+          strokeDasharray="3 3"
+        />
+        <XAxis
+          dataKey={xAxisKey as string}
+          tick={tickStyle}
+          tickFormatter={formatXAxisTick}
+          stroke={gridColor}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          allowDecimals={false}
+          tick={tickStyle}
+          stroke={gridColor}
+          width={40}
+        />
+        <Tooltip
+          cursor={{ fill: theme.palette.action.hover }}
+          content={
+            <ChartTooltip
+              headingColor={theme.palette.text.primary}
+              paperBackground={theme.palette.background.paper}
+              borderColor={gridColor}
+              secondaryTextColor={theme.palette.text.secondary}
+              formatLabel={formatTooltipLabel}
+            />
+          }
+        />
+        {series.map(s => (
+          <Bar
+            key={s.dataKey}
+            dataKey={s.dataKey}
+            name={s.name}
+            stackId="stack"
+            fill={s.color}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/plugins/ui-react/src/components/StackedBarChart/index.ts
+++ b/plugins/ui-react/src/components/StackedBarChart/index.ts
@@ -1,0 +1,5 @@
+export { StackedBarChart } from './StackedBarChart';
+export type {
+  StackedBarChartProps,
+  StackedBarChartSeries,
+} from './StackedBarChart';

--- a/plugins/ui-react/src/components/YamlEditorFormField/YamlEditorFormField.tsx
+++ b/plugins/ui-react/src/components/YamlEditorFormField/YamlEditorFormField.tsx
@@ -22,6 +22,7 @@ type YamlEditorFormFieldProps = {
   height?: number;
   maxHeight?: number;
   schema?: JSONSchema7;
+  readOnly?: boolean;
 };
 
 export const YamlEditorFormField = memo(
@@ -36,6 +37,7 @@ export const YamlEditorFormField = memo(
     height,
     maxHeight,
     schema,
+    readOnly,
   }: YamlEditorFormFieldProps) => {
     const theme = useTheme();
     return (
@@ -67,6 +69,7 @@ export const YamlEditorFormField = memo(
             maxHeight={maxHeight !== undefined ? `${maxHeight}px` : undefined}
             theme={theme.palette.type}
             error={error}
+            readOnly={readOnly}
           />
         </Box>
       </FormControl>

--- a/plugins/ui-react/src/components/index.ts
+++ b/plugins/ui-react/src/components/index.ts
@@ -13,6 +13,7 @@ export * from './MultiplePicker';
 export * from './MultipleSelect';
 export * from './NotAvailable';
 export * from './SingleSelect';
+export * from './StackedBarChart';
 export * from './StructuredMetadataList';
 export * from './YamlEditor';
 export * from './YamlEditorFormField';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,6 +11821,7 @@ __metadata:
     react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-syntax-highlighter: "npm:^15.4.5"
     react-use: "npm:^17.6.0"
+    recharts: "npm:^3.9.0"
     semver: "npm:^7.7.2"
     use-local-storage-state: "npm:^19.5.0"
   peerDependencies:
@@ -19656,6 +19657,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@reduxjs/toolkit@npm:^1.9.0 || 2.x.x":
+  version: 2.12.0
+  resolution: "@reduxjs/toolkit@npm:2.12.0"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.0.0"
+    "@standard-schema/utils": "npm:^0.3.0"
+    immer: "npm:^11.0.0"
+    redux: "npm:^5.0.1"
+    redux-thunk: "npm:^3.1.0"
+    reselect: "npm:^5.1.0"
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+    react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: 10c0/2b85e31294a7139994fd78b08eb3ce706ce3b03b5081c13403b93ba4883a152d637171e4d9d969766238851f8915b1daa9f36b5a0a458aff0ff7600ee38795c9
+  languageName: node
+  linkType: hard
+
 "@rehooks/component-size@npm:^1.0.3":
   version: 1.0.3
   resolution: "@rehooks/component-size@npm:1.0.3"
@@ -22247,10 +22270,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.1.0":
+"@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
+  languageName: node
+  linkType: hard
+
+"@standard-schema/utils@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@standard-schema/utils@npm:0.3.0"
+  checksum: 10c0/6eb74cd13e52d5fc74054df51e37d947ef53f3ab9e02c085665dcca3c38c60ece8d735cebbdf18fbb13c775fbcb9becb3f53109b0e092a63f0f7389ce0993fd0
   languageName: node
   linkType: hard
 
@@ -23906,7 +23936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-array@npm:*":
+"@types/d3-array@npm:*, @types/d3-array@npm:^3.0.3":
   version: 3.2.2
   resolution: "@types/d3-array@npm:3.2.2"
   checksum: 10c0/6137cb97302f8a4f18ca22c0560c585cfcb823f276b23d89f2c0c005d72697ec13bca671c08e68b4b0cabd622e3f0e91782ee221580d6774074050be96dd7028
@@ -23985,7 +24015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-ease@npm:*":
+"@types/d3-ease@npm:*, @types/d3-ease@npm:^3.0.0":
   version: 3.0.2
   resolution: "@types/d3-ease@npm:3.0.2"
   checksum: 10c0/aff5a1e572a937ee9bff6465225d7ba27d5e0c976bd9eacdac2e6f10700a7cb0c9ea2597aff6b43a6ed850a3210030870238894a77ec73e309b4a9d0333f099c
@@ -24031,7 +24061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-interpolate@npm:*":
+"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.1":
   version: 3.0.4
   resolution: "@types/d3-interpolate@npm:3.0.4"
   dependencies:
@@ -24075,7 +24105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-scale@npm:*":
+"@types/d3-scale@npm:*, @types/d3-scale@npm:^4.0.2":
   version: 4.0.9
   resolution: "@types/d3-scale@npm:4.0.9"
   dependencies:
@@ -24091,7 +24121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-shape@npm:*":
+"@types/d3-shape@npm:*, @types/d3-shape@npm:^3.1.0":
   version: 3.1.8
   resolution: "@types/d3-shape@npm:3.1.8"
   dependencies:
@@ -24107,14 +24137,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-time@npm:*":
+"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0":
   version: 3.0.4
   resolution: "@types/d3-time@npm:3.0.4"
   checksum: 10c0/6d9e2255d63f7a313a543113920c612e957d70da4fb0890931da6c2459010291b8b1f95e149a538500c1c99e7e6c89ffcce5554dd29a31ff134a38ea94b6d174
   languageName: node
   linkType: hard
 
-"@types/d3-timer@npm:*":
+"@types/d3-timer@npm:*, @types/d3-timer@npm:^3.0.0":
   version: 3.0.2
   resolution: "@types/d3-timer@npm:3.0.2"
   checksum: 10c0/c644dd9571fcc62b1aa12c03bcad40571553020feeb5811f1d8a937ac1e65b8a04b759b4873aef610e28b8714ac71c9885a4d6c127a048d95118f7e5b506d9e1
@@ -29563,7 +29593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.2.0":
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.1.6, d3-array@npm:^3.2.0":
   version: 3.2.4
   resolution: "d3-array@npm:3.2.4"
   dependencies:
@@ -29664,7 +29694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-ease@npm:1 - 3, d3-ease@npm:3":
+"d3-ease@npm:1 - 3, d3-ease@npm:3, d3-ease@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-ease@npm:3.0.1"
   checksum: 10c0/fec8ef826c0cc35cda3092c6841e07672868b1839fcaf556e19266a3a37e6bc7977d8298c0fcb9885e7799bfdcef7db1baaba9cd4dcf4bc5e952cf78574a88b0
@@ -29714,7 +29744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3":
+"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3, d3-interpolate@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-interpolate@npm:3.0.1"
   dependencies:
@@ -29778,7 +29808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-scale@npm:4":
+"d3-scale@npm:4, d3-scale@npm:^4.0.2":
   version: 4.0.2
   resolution: "d3-scale@npm:4.0.2"
   dependencies:
@@ -29798,7 +29828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-shape@npm:3, d3-shape@npm:^3.0.0":
+"d3-shape@npm:3, d3-shape@npm:^3.0.0, d3-shape@npm:^3.1.0":
   version: 3.2.0
   resolution: "d3-shape@npm:3.2.0"
   dependencies:
@@ -29825,7 +29855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3":
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3, d3-time@npm:^3.0.0":
   version: 3.1.0
   resolution: "d3-time@npm:3.1.0"
   dependencies:
@@ -29834,7 +29864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-timer@npm:1 - 3, d3-timer@npm:3":
+"d3-timer@npm:1 - 3, d3-timer@npm:3, d3-timer@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-timer@npm:3.0.1"
   checksum: 10c0/d4c63cb4bb5461d7038aac561b097cd1c5673969b27cbdd0e87fa48d9300a538b9e6f39b4a7f0e3592ef4f963d858c8a9f0e92754db73116770856f2fc04561a
@@ -30118,6 +30148,13 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  languageName: node
+  linkType: hard
+
+"decimal.js-light@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "decimal.js-light@npm:2.5.1"
+  checksum: 10c0/4fd33f535aac9e5bd832796831b65d9ec7914ad129c7437b3ab991b0c2eaaa5a57e654e6174c4a17f1b3895ea366f0c1ab4955cdcdf7cfdcf3ad5a58b456c020
   languageName: node
   linkType: hard
 
@@ -31194,6 +31231,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-toolkit@npm:^1.39.3":
+  version: 1.49.0
+  resolution: "es-toolkit@npm:1.49.0"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+    vitepress-plugin-sandpack@1.1.4:
+      unplugged: true
+  checksum: 10c0/ab0864bb0c5c494ed09043d53a74b58a0ab9df1b89b9b54bce72a63de2869152d7d65e489dc89ab671f0fea243728922c8a8f8c873f1b2a53350a23360b3e2df
+  languageName: node
+  linkType: hard
+
 "es-toolkit@npm:^1.45.1":
   version: 1.47.0
   resolution: "es-toolkit@npm:1.47.0"
@@ -31790,7 +31841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^5.0.4":
+"eventemitter3@npm:^5.0.1, eventemitter3@npm:^5.0.4":
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
@@ -34693,6 +34744,20 @@ __metadata:
   version: 3.0.6
   resolution: "immediate@npm:3.0.6"
   checksum: 10c0/f8ba7ede69bee9260241ad078d2d535848745ff5f6995c7c7cb41cfdc9ccc213f66e10fa5afb881f90298b24a3f7344b637b592beb4f54e582770cdce3f1f039
+  languageName: node
+  linkType: hard
+
+"immer@npm:^10.1.1":
+  version: 10.2.0
+  resolution: "immer@npm:10.2.0"
+  checksum: 10c0/35e66b0585b2aec4e85ae7a993f049405f170799ba89d79205bc3fdae2c5bdaa2b1d35f62803d8beee42b7e85c7f7315a6e93b6a5a510c5a46f03dbe63619e87
+  languageName: node
+  linkType: hard
+
+"immer@npm:^11.0.0":
+  version: 11.1.8
+  resolution: "immer@npm:11.1.8"
+  checksum: 10c0/df971d8a8f6a5312c6dca4a8437e20b3185d6c9cd6830ad526c18ffd50f4037ef8db4f332b0adbcb9f8c5ee2fbe117cf0623e8554e24777105b3cc9faf866d34
   languageName: node
   linkType: hard
 
@@ -43800,6 +43865,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-redux@npm:8.x.x || 9.x.x":
+  version: 9.3.0
+  resolution: "react-redux@npm:9.3.0"
+  dependencies:
+    "@types/use-sync-external-store": "npm:^0.0.6"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.2.25 || ^19
+    react: ^18.0 || ^19
+    redux: ^5.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    redux:
+      optional: true
+  checksum: 10c0/b9f4efcfbfbc90cac9d1709ab3affb1e18a9dc9bd3cceda43bd2e1d9d2394ee0c29df36ec2202d52b566db774888b594c8c5aa86b64f27ef34fca607c687c9e3
+  languageName: node
+  linkType: hard
+
 "react-redux@npm:^7.2.0":
   version: 7.2.9
   resolution: "react-redux@npm:7.2.9"
@@ -44298,6 +44382,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"recharts@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "recharts@npm:3.9.0"
+  dependencies:
+    "@reduxjs/toolkit": "npm:^1.9.0 || 2.x.x"
+    clsx: "npm:^2.1.1"
+    decimal.js-light: "npm:^2.5.1"
+    es-toolkit: "npm:^1.39.3"
+    eventemitter3: "npm:^5.0.1"
+    immer: "npm:^10.1.1"
+    react-redux: "npm:8.x.x || 9.x.x"
+    reselect: "npm:5.2.0"
+    tiny-invariant: "npm:^1.3.3"
+    use-sync-external-store: "npm:^1.2.2"
+    victory-vendor: "npm:^37.0.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/b02e5b6063bae7cc7ee3166551f376bcd25f3bad2839aee759af3acbc7337ade5d82ca214dea7e8b1a72210b3c8da516922d5d31475a85e731814dc57ffad919
+  languageName: node
+  linkType: hard
+
 "rechoir@npm:^0.8.0":
   version: 0.8.0
   resolution: "rechoir@npm:0.8.0"
@@ -44362,6 +44469,15 @@ __metadata:
   peerDependencies:
     immutable: ^3.8.1 || ^4.0.0-rc.1
   checksum: 10c0/c706c9f72a1fbce92d54ab9117ab641b6d7ee69f2860ec6de827dbed5bed918d4677a0895e6564bb59011202bb5e639cf69f4e2d2d14086053b32e5c4e35f512
+  languageName: node
+  linkType: hard
+
+"redux-thunk@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "redux-thunk@npm:3.1.0"
+  peerDependencies:
+    redux: ^5.0.0
+  checksum: 10c0/21557f6a30e1b2e3e470933247e51749be7f1d5a9620069a3125778675ce4d178d84bdee3e2a0903427a5c429e3aeec6d4df57897faf93eb83455bc1ef7b66fd
   languageName: node
   linkType: hard
 
@@ -44758,6 +44874,13 @@ __metadata:
   dependencies:
     lodash: "npm:^4.17.21"
   checksum: 10c0/ad138f987943aeda5f96cd1ccba9752c96352a729a7e3c3e2545568703f7fc9b978d9b46715803408ef178b0d61d36a4b1b506b367b7e78fe6d041fa5bfa5e06
+  languageName: node
+  linkType: hard
+
+"reselect@npm:5.2.0, reselect@npm:^5.1.0":
+  version: 5.2.0
+  resolution: "reselect@npm:5.2.0"
+  checksum: 10c0/d0a8497e404b25a769fe792eacae88b9b576c30870450cd243d76ec9427d91a59c4a2cc00d824d283448b444c4c698a8f961d771c8ae39c759313afb31950e2e
   languageName: node
   linkType: hard
 
@@ -47465,7 +47588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.6":
+"tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.3":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
@@ -49200,6 +49323,28 @@ __metadata:
     "@types/unist": "npm:^3.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: 10c0/e5d9eb4810623f23758cfc2205323e33552fb5972e5c2e6587babe08fe4d24859866277404fb9e2a20afb71013860d96ec806cb257536ae463c87d70022ab9ef
+  languageName: node
+  linkType: hard
+
+"victory-vendor@npm:^37.0.2":
+  version: 37.3.6
+  resolution: "victory-vendor@npm:37.3.6"
+  dependencies:
+    "@types/d3-array": "npm:^3.0.3"
+    "@types/d3-ease": "npm:^3.0.0"
+    "@types/d3-interpolate": "npm:^3.0.1"
+    "@types/d3-scale": "npm:^4.0.2"
+    "@types/d3-shape": "npm:^3.1.0"
+    "@types/d3-time": "npm:^3.0.0"
+    "@types/d3-timer": "npm:^3.0.0"
+    d3-array: "npm:^3.1.6"
+    d3-ease: "npm:^3.0.1"
+    d3-interpolate: "npm:^3.0.1"
+    d3-scale: "npm:^4.0.2"
+    d3-shape: "npm:^3.1.0"
+    d3-time: "npm:^3.0.0"
+    d3-timer: "npm:^3.0.1"
+  checksum: 10c0/0a9628db30b898160409628f26d457ba15adc86472531817d73fbeb847de498d94f91dee5f4caa969195744e91be93e100eeff7a392b591ac5349343a36dec29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

A batch of UI cleanups on the muster **workflow detail** page, plus a new shared chart component in `ui-react`:

- Removes the breadcrumb from the workflow detail header.
- Renders the workflow description's Markdown paragraphs with the standard MUI `body1` typography so their line height/spacing matches other paragraphs.
- Adds a theme-aware, recharts-based **`StackedBarChart`** to `@giantswarm/backstage-plugin-ui-react` and uses it for the "Runs per day" chart. The chart now spans at least **30 days**, always ends on **today**, and fills days with no runs.
- Removes the redundant collapsible "Definition (YAML)" section below the steps.
- Trims the GitOps-managed actions to a single **"Show manifest"** outline button (dropping "Remove via GitOps"), and aligns its dialog with the "Create workflow" modal: X icon in the title bar (no footer Close button), primary "Copy manifest" button, and the manifest shown read-only in the shared YAML editor with syntax highlighting. Adds a `readOnly` passthrough to `YamlEditorFormField`.
- Gives the dialog footers consistent padding (they were cramped against the modal edge).
- Sizes the "Executions" panels to their content with a viewport-based max-height, instead of always reserving a tall fixed height when empty.

### What is the effect of this change to users?

A cleaner, more consistent workflow detail page: no redundant breadcrumb/YAML block, readable description text, a proper 30-day runs chart, GitOps manifest dialog that matches the create-workflow modal, and an Executions section that no longer reserves ~900px when empty.

### Any background context you can provide?

Introduces recharts (v3) as a dependency of `ui-react` only; consuming plugins use the themed `StackedBarChart` wrapper rather than recharts directly.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))


Towards https://github.com/giantswarm/giantswarm/issues/37055