### PR TITLE
docs: document cluster-token broker setup in example config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,17 @@ AUTH_DEX_GOLEM_CLIENT_SECRET=''
 AUTH_DEX_SNAIL_CLIENT_ID=''
 AUTH_DEX_SNAIL_CLIENT_SECRET=''
 
+# Muster cluster-token broker. Enables the silent per-cluster token path and,
+# with it, the "Cluster access" sidebar item (see gs.clusterTokenBroker in
+# app-config.example.yaml). URL is the broker's OAuth token endpoint, e.g.
+# https://muster.gazelle.awsprod.gigantic.io/oauth/token. The client id/secret
+# are the confidential muster broker client -- same values the devportal
+# deployment uses (gazelle Secret backstage-dex-auth-credentials-secret, keys
+# AUTH_DEX_MUSTER_BROKER_CLIENT_ID / _SECRET), also in 1Password.
+CLUSTER_TOKEN_BROKER_URL=''
+AUTH_DEX_MUSTER_BROKER_CLIENT_ID=''
+AUTH_DEX_MUSTER_BROKER_CLIENT_SECRET=''
+
 AWS_ACCESS_KEY_ID=''
 AWS_SECRET_ACCESS_KEY=''
 

--- a/app-config.example.yaml
+++ b/app-config.example.yaml
@@ -63,7 +63,10 @@ gs:
   # Muster cluster-token broker. Setting `tokenUrl` enables the silent
   # per-cluster token path; without it Backstage falls back to per-cluster
   # OIDC popups. `clientId`/`clientSecret` are the confidential client
-  # registered with the broker (backend-only / secret).
+  # registered with the broker (backend-only / secret). This block is also
+  # what makes the "Cluster access" sidebar item appear: it shows the live
+  # health of every broker-covered installation (those with
+  # `clusterTokenAudience` set below). Env var values: see .env.example.
   clusterTokenBroker:
     tokenUrl: ${CLUSTER_TOKEN_BROKER_URL} # e.g. https://muster.example.gigantic.io/oauth/token
     clientId: ${CLUSTER_TOKEN_BROKER_CLIENT_ID}
@@ -89,7 +92,10 @@ gs:
       oidcTokenProvider: oidc-example
       # Marks this installation as fully broker-covered: its token is minted
       # silently from the main session, and it gets no entry on the provider
-      # settings page.
+      # settings page. NOTE: this has no effect on the main installation --
+      # the one whose `oidcTokenProvider` equals `gs.authProvider` above (here
+      # `main`) is always excluded from broker coverage, so do not bother
+      # setting `clusterTokenAudience` on it.
       clusterTokenAudience: example
       pipeline: stable
       providers:


### PR DESCRIPTION
### What does this PR do?

Fills the gaps that made enabling the **"Cluster access"** sidebar item (the muster cluster-token broker) hard to figure out from the example config alone. The broker *mechanism* was well documented, but the end-to-end setup was not self-serve.

- **`.env.example`**: adds the three broker variables — `CLUSTER_TOKEN_BROKER_URL`, `AUTH_DEX_MUSTER_BROKER_CLIENT_ID`, `AUTH_DEX_MUSTER_BROKER_CLIENT_SECRET` — grouped with the other `AUTH_DEX_*` vars, with a comment on the OAuth endpoint format and where the values live (the gazelle `backstage-dex-auth-credentials-secret` / 1Password). Previously these were missing entirely, so following the config example led to silently unset vars.
- **`app-config.example.yaml`**: notes that the `clusterTokenBroker` block is what makes the "Cluster access" sidebar item appear, and documents that `clusterTokenAudience` has **no effect** on the main installation (the one whose `oidcTokenProvider` equals `gs.authProvider`) — it is always excluded from broker coverage.

### What is the effect of this change to users?

No runtime change — documentation/example-config only. Makes it possible for the next developer to enable cluster access locally without reverse-engineering the code or inspecting the live devportal deployment.

### Any background context you can provide?

Discovered while enabling the "Cluster access" widget in a local setup: the item is data-driven (it renders only when `getBrokerCoveredInstallations()` is non-empty), which requires both `gs.clusterTokenBroker.tokenUrl` and per-installation `clusterTokenAudience`. The example config covered the config keys but not the env vars, the link to the visible feature, or the main-provider exclusion.

### Do the docs need to be updated?

No — this PR is the doc update (example config files).

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. (Not applicable — no published `@giantswarm/backstage-plugin-*` package changed; example config only.)