### PR TITLE
feat(gs): compact cluster access widget and cover non-broker installations

### DIFF
--- a/.changeset/cluster-access-widget-compact.md
+++ b/.changeset/cluster-access-widget-compact.md
@@ -1,0 +1,18 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Make the "Cluster access" sidebar widget cleaner and cover non-broker installations.
+
+- Compacted the popover: the header now shows a problem-first count summary
+  ("1 degraded · 4 healthy", or "All N healthy" when nothing needs attention)
+  instead of a single worst-state word, and each installation is a single-line
+  row. Healthy/connecting rows drop the redundant status label, while degraded
+  and session-expired rows show the reason left-aligned next to the name so the
+  list is easy to scan.
+- Surfaced non-broker installations (per-cluster OIDC popup logins), which were
+  previously invisible because only broker-covered installations are probed.
+  They can't be probed proactively without triggering a login popup, so the
+  connector now mirrors their auth session state: an installation appears while
+  the user is signed in and drops off on sign-out. Adds a `remove` method to the
+  cluster-access status store to support this.

--- a/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.test.ts
+++ b/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.test.ts
@@ -39,6 +39,29 @@ describe('ClusterAccessStatusStore', () => {
     ]);
   });
 
+  it('removes an installation and notifies, but ignores an unknown one', async () => {
+    const store = ClusterAccessStatusStore.create();
+    store.recordHealthy('golem');
+    store.recordHealthy('alpha');
+
+    const snapshots: ClusterAccessStatusEntry[][] = [];
+    const subscription = store.status$().subscribe(s => snapshots.push(s));
+    await flush();
+    const baseline = snapshots.length;
+
+    store.remove('golem');
+    expect(store.getSnapshot()).toEqual([
+      expect.objectContaining({ installation: 'alpha', state: 'healthy' }),
+    ]);
+    expect(snapshots.length).toBe(baseline + 1);
+
+    // Not tracked -- no change, no churn.
+    store.remove('unknown');
+    expect(snapshots.length).toBe(baseline + 1);
+
+    subscription.unsubscribe();
+  });
+
   it('replays the latest snapshot to new subscribers', async () => {
     const store = ClusterAccessStatusStore.create();
     store.recordHealthy('golem');

--- a/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.ts
+++ b/plugins/gs/src/apis/clusterAccessStatus/ClusterAccessStatusStore.ts
@@ -39,6 +39,15 @@ export class ClusterAccessStatusStore implements ClusterAccessStatusApi {
     this.record(installation, 'session-expired', reason);
   }
 
+  remove(installation: string): void {
+    if (!this.entries.delete(installation)) {
+      // Not tracked -- nothing changed, don't churn subscribers.
+      return;
+    }
+    const snapshot = this.getSnapshot();
+    this.subscribers.forEach(notify => notify(snapshot));
+  }
+
   getSnapshot(): ClusterAccessStatusEntry[] {
     return [...this.entries.values()].sort((a, b) =>
       a.installation.localeCompare(b.installation),

--- a/plugins/gs/src/apis/clusterAccessStatus/types.ts
+++ b/plugins/gs/src/apis/clusterAccessStatus/types.ts
@@ -37,6 +37,13 @@ export interface ClusterAccessStatusApi {
   recordHealthy(installation: string): void;
   recordDegraded(installation: string, reason?: string): void;
   recordSessionExpired(installation: string, reason?: string): void;
+  /**
+   * Drops an installation from the status set. Used for non-broker
+   * installations, which are tracked by auth session state rather than probed:
+   * when the user signs out of one it is no longer accessed and should leave
+   * the widget entirely.
+   */
+  remove(installation: string): void;
   getSnapshot(): ClusterAccessStatusEntry[];
   /**
    * Replays the latest snapshot to a new subscriber (on the next tick) and

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, SessionState } from '@backstage/core-plugin-api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
 import { ClusterTokenError } from '../../apis/auth/DefaultAuthConnector';
@@ -110,7 +110,12 @@ export function classifyProbeError(
  * cluster-access status with every installation so the status element is
  * visible immediately, then probing each cluster's apiserver to surface real
  * health. Only broker-covered installations are probed, so this never triggers
- * a per-cluster login popup. Renders nothing.
+ * a per-cluster login popup.
+ *
+ * Non-broker installations (per-cluster OIDC popup logins) can't be probed for
+ * the same reason, so they are instead surfaced by mirroring their auth session
+ * state: they appear while the user is signed in and drop off on sign-out.
+ * Renders nothing.
  */
 export function ClusterAccessConnector() {
   const kubernetesApi = useApi(kubernetesApiRef);
@@ -206,6 +211,46 @@ export function ClusterAccessConnector() {
       clearInterval(interval);
     };
   }, [kubernetesApi, authProvidersApi, statusApi]);
+
+  // Non-broker installations can't be probed proactively: a proxy call on one
+  // without a live session would pop up a per-cluster login. So instead of
+  // probing apiserver health, we mirror their auth session state -- an
+  // installation the user is signed in to shows up as accessible and drops off
+  // the widget when signed out. This is the "different logic" from the broker
+  // path above, which probes real apiserver health.
+  useEffect(() => {
+    const kubernetesAuthApis = authProvidersApi.getKubernetesAuthApis();
+    const brokerCovered = new Set(
+      authProvidersApi.getBrokerCoveredInstallations(),
+    );
+    // getProviders() already excludes broker-covered installations; the
+    // kubernetesAuthApis check drops MCP providers, and the brokerCovered guard
+    // is belt-and-suspenders so the two paths never both own an installation.
+    const nonBrokerProviders = authProvidersApi
+      .getProviders()
+      .filter(
+        provider =>
+          Boolean(kubernetesAuthApis[provider.providerName]) &&
+          !brokerCovered.has(provider.installationName),
+      );
+
+    const subscriptions = nonBrokerProviders.map(provider =>
+      kubernetesAuthApis[provider.providerName]
+        .sessionState$()
+        .subscribe(sessionState => {
+          if (sessionState === SessionState.SignedIn) {
+            statusApi.recordHealthy(provider.installationName);
+          } else {
+            // SignedOut -- no live session, so it is no longer accessed.
+            statusApi.remove(provider.installationName);
+          }
+        }),
+    );
+
+    return () => {
+      subscriptions.forEach(subscription => subscription.unsubscribe());
+    };
+  }, [authProvidersApi, statusApi]);
 
   return null;
 }

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.test.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.test.tsx
@@ -1,0 +1,45 @@
+import { ClusterAccessStatusEntry } from '../../apis/clusterAccessStatus';
+import { summarize } from './ClusterAccessStatusSidebarItem';
+
+function entry(
+  installation: string,
+  state: ClusterAccessStatusEntry['state'],
+  reason?: string,
+): ClusterAccessStatusEntry {
+  return { installation, state, reason, lastChecked: 0 };
+}
+
+describe('summarize', () => {
+  it('collapses to a single muted part when everything is healthy', () => {
+    const parts = summarize([
+      entry('a', 'healthy'),
+      entry('b', 'healthy'),
+      entry('c', 'healthy'),
+    ]);
+
+    expect(parts).toEqual([
+      { key: 'healthy', label: 'All 3 healthy', muted: true },
+    ]);
+  });
+
+  it('lists non-empty states worst-first with healthy muted', () => {
+    const parts = summarize([
+      entry('a', 'healthy'),
+      entry('b', 'degraded', 'Access forbidden'),
+      entry('c', 'healthy'),
+      entry('d', 'session-expired'),
+    ]);
+
+    expect(parts).toEqual([
+      { key: 'session-expired', label: '1 session expired', muted: false },
+      { key: 'degraded', label: '1 degraded', muted: false },
+      { key: 'healthy', label: '2 healthy', muted: true },
+    ]);
+  });
+
+  it('omits states with a zero count', () => {
+    const parts = summarize([entry('a', 'connecting'), entry('b', 'degraded')]);
+
+    expect(parts.map(p => p.key)).toEqual(['degraded', 'connecting']);
+  });
+});

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
@@ -94,23 +94,16 @@ const useStyles = makeStyles(theme => ({
 }));
 
 /**
- * Computes the worst (most actionable) state across all tracked clusters.
- * session-expired wins over degraded, because an expired main session is the
- * one thing the user can immediately fix. `connecting` ranks above plain
- * healthy so the badge reflects in-flight probes on startup, but below any
- * real problem.
+ * Computes the worst (most actionable) state across all tracked clusters, using
+ * the shared {@link STATE_ORDER} severity ranking: session-expired wins over
+ * degraded, because an expired main session is the one thing the user can
+ * immediately fix; `connecting` ranks above plain healthy so the badge reflects
+ * in-flight probes on startup, but below any real problem. No entries → healthy.
  */
 function overallState(entries: ClusterAccessStatusEntry[]): ClusterAccessState {
-  if (entries.some(e => e.state === 'session-expired')) {
-    return 'session-expired';
-  }
-  if (entries.some(e => e.state === 'degraded')) {
-    return 'degraded';
-  }
-  if (entries.some(e => e.state === 'connecting')) {
-    return 'connecting';
-  }
-  return 'healthy';
+  return (
+    STATE_ORDER.find(state => entries.some(e => e.state === state)) ?? 'healthy'
+  );
 }
 
 type SummaryPart = { key: ClusterAccessState; label: string; muted: boolean };

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
@@ -5,10 +5,6 @@ import {
   Box,
   Button,
   Divider,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   Popover,
   Typography,
   makeStyles,
@@ -36,19 +32,61 @@ const STATE_LABELS: Record<ClusterAccessState, string> = {
   'session-expired': 'Session expired',
 };
 
+// Lowercase wording used in the header count summary ("1 degraded · 4 healthy").
+const SUMMARY_LABELS: Record<ClusterAccessState, string> = {
+  connecting: 'connecting',
+  healthy: 'healthy',
+  degraded: 'degraded',
+  'session-expired': 'session expired',
+};
+
+// Severity order shared by the summary and the row list -- worst first.
+const STATE_ORDER: ClusterAccessState[] = [
+  'session-expired',
+  'degraded',
+  'connecting',
+  'healthy',
+];
+
 const useStyles = makeStyles(theme => ({
   popover: {
     width: 340,
     maxWidth: '90vw',
   },
   header: {
-    padding: theme.spacing(2, 2, 1, 2),
+    padding: theme.spacing(1.5, 2, 1, 2),
+  },
+  summary: {
+    marginTop: theme.spacing(0.25),
   },
   badge: {
     position: 'absolute',
     right: -3,
     bottom: -3,
     fontSize: 11,
+  },
+  list: {
+    padding: theme.spacing(0.5, 0),
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.5, 2),
+  },
+  name: {
+    flexShrink: 0,
+  },
+  reason: {
+    flex: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    // The caption is a smaller font than the name; nudge it down so its
+    // baseline lines up with the installation name instead of sitting high.
+    position: 'relative',
+    top: 2,
   },
   actions: {
     padding: theme.spacing(1, 2, 2, 2),
@@ -73,6 +111,36 @@ function overallState(entries: ClusterAccessStatusEntry[]): ClusterAccessState {
     return 'connecting';
   }
   return 'healthy';
+}
+
+type SummaryPart = { key: ClusterAccessState; label: string; muted: boolean };
+
+/**
+ * Compact, problem-first count of states for the header. Collapses to a single
+ * "All N healthy" part when nothing needs attention; otherwise lists each
+ * non-empty state worst-first ("1 degraded · 4 healthy").
+ */
+export function summarize(entries: ClusterAccessStatusEntry[]): SummaryPart[] {
+  const counts: Record<ClusterAccessState, number> = {
+    'session-expired': 0,
+    degraded: 0,
+    connecting: 0,
+    healthy: 0,
+  };
+  for (const entry of entries) {
+    counts[entry.state]++;
+  }
+
+  const total = entries.length;
+  if (counts.healthy === total) {
+    return [{ key: 'healthy', label: `All ${total} healthy`, muted: true }];
+  }
+
+  return STATE_ORDER.filter(state => counts[state] > 0).map(state => ({
+    key: state,
+    label: `${counts[state]} ${SUMMARY_LABELS[state]}`,
+    muted: state === 'healthy',
+  }));
 }
 
 function StatusDot({ color }: { color: string }) {
@@ -104,6 +172,7 @@ export function ClusterAccessStatusSidebarItem() {
   }, [statusApi]);
 
   const state = useMemo(() => overallState(entries), [entries]);
+  const summary = useMemo(() => summarize(entries), [entries]);
   const sessionExpired = state === 'session-expired';
   const color = STATE_COLORS[state];
 
@@ -138,24 +207,52 @@ export function ClusterAccessStatusSidebarItem() {
       >
         <div className={classes.header}>
           <Typography variant="subtitle1">Cluster access</Typography>
-          <Typography variant="body2" color="textSecondary">
-            {STATE_LABELS[state]}
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            className={classes.summary}
+          >
+            {summary.map((part, index) => (
+              <span key={part.key}>
+                {index > 0 && ' · '}
+                <span
+                  style={
+                    part.muted ? undefined : { color: STATE_COLORS[part.key] }
+                  }
+                >
+                  {part.label}
+                </span>
+              </span>
+            ))}
           </Typography>
         </div>
         <Divider />
-        <List dense>
-          {entries.map(entry => (
-            <ListItem key={entry.installation}>
-              <ListItemIcon style={{ minWidth: 32 }}>
+        <div className={classes.list}>
+          {entries.map(entry => {
+            const reason =
+              entry.state === 'degraded' || entry.state === 'session-expired'
+                ? (entry.reason ?? STATE_LABELS[entry.state])
+                : undefined;
+            return (
+              <div key={entry.installation} className={classes.row}>
                 <StatusDot color={STATE_COLORS[entry.state]} />
-              </ListItemIcon>
-              <ListItemText
-                primary={entry.installation}
-                secondary={entry.reason ?? STATE_LABELS[entry.state]}
-              />
-            </ListItem>
-          ))}
-        </List>
+                <Typography variant="body2" noWrap className={classes.name}>
+                  {entry.installation}
+                </Typography>
+                {reason && (
+                  <Typography
+                    variant="caption"
+                    color="textSecondary"
+                    className={classes.reason}
+                    title={reason}
+                  >
+                    {reason}
+                  </Typography>
+                )}
+              </div>
+            );
+          })}
+        </div>
         {sessionExpired && (
           <>
             <Divider />


### PR DESCRIPTION
### What does this PR do?

Two improvements to the "Cluster access" sidebar popover widget:

1. **Cleaner, more compact layout.** The header now shows a problem-first count summary (`1 degraded · 4 healthy`, or `All N healthy` when nothing needs attention) with problem counts colored, instead of a single worst-state word. Each installation is a single-line row: healthy/connecting rows drop the redundant status label, and degraded/session-expired rows show the reason left-aligned right next to the name so the list is easy to scan across many rows.

2. **Non-broker installations are now visible.** Previously the widget only listed broker-covered installations, because those are the only ones the connector probes. Installations connected via a per-cluster OIDC popup never appeared. They can't be probed proactively (a proxy call without a live session would trigger a login popup), so the connector now mirrors their auth session state instead: an installation shows up while the user is signed in and drops off on sign-out. This adds a `remove` method to the cluster-access status store.

### What is the effect of this change to users?

- The Cluster access overlay is denser and quicker to read, especially with many installations.
- Installations you're signed in to via a per-cluster login now appear in the widget alongside broker-covered ones.

### How does it look like?

Each row now reads e.g. `● grouse  API unreachable (timeout)` — status dot, name, then the reason immediately after the name (left-aligned). Healthy clusters are just `● name`. Header example: `Cluster access` / `1 degraded · 4 healthy`.

<img width="581" height="351" alt="image" src="https://github.com/user-attachments/assets/fe9de6e3-242f-445f-bfa7-dfdcafab7c48" />


### Any background context you can provide?

Non-broker installations are surfaced via `authApi.sessionState$()` (`SignedIn` → record healthy, `SignedOut` → remove), which never triggers a popup — the same signal the provider settings page already uses.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))