### PR TITLE
feat(gs): add Gateways tab with HTTPRoute hostnames and certificates

### DIFF
--- a/.changeset/deployment-gateways-tab.md
+++ b/.changeset/deployment-gateways-tab.md
@@ -1,0 +1,18 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Add a "Gateways" tab to the deployment detail page listing the hostnames
+exposed via Gateway API HTTPRoutes, together with their serving TLS
+certificates.
+
+- New tab shows a table of hostnames (from the
+  `gatewayapi_httproute_hostname_info` metric, scoped to the workload's target
+  namespace), each linking to `https://<hostname>/`.
+- Each row resolves its serving certificate by walking the Gateway API chain
+  (HTTPRoute → parentRef → Gateway listener → cert-manager Certificate, matched
+  by the conventional `gateway-<gateway>-<listener>` name) and shows readiness
+  and expiry, color-coded by severity. Issuer, certificate name/namespace and
+  the matched host pattern are available behind an info tooltip.
+- The deployment "About" card now shows the workload's target namespace when it
+  differs from the HelmRelease/App namespace.

--- a/.claude/skills/tables/SKILL.md
+++ b/.claude/skills/tables/SKILL.md
@@ -1,7 +1,84 @@
 ---
 name: tables
-description: Patterns for implementing tables using '@backstage/core-components' Table, including column definitions, sorting, filtering, and visibility persistence.
+description: Patterns for implementing tables. Covers the bui Table ('@backstage/ui') — preferred for new, simple tables — and the feature-rich '@backstage/core-components' Table with search, filtering, and column-visibility persistence.
 ---
+
+## Choosing a table component
+
+Two table components are in use. **Prefer the bui `Table` (`@backstage/ui`) for
+new tables** — it matches the new Backstage design system and is the direction
+we're moving. But it is not yet a full replacement for the older component.
+
+| Need | Use |
+| --- | --- |
+| Simple listing, no built-in search/filter/column-toggle | **bui `Table`** from `@backstage/ui` |
+| Built-in quick-search, per-column filtering, column-visibility toggle, CSV export | **`Table`** from `@backstage/core-components` (material-table based) |
+
+The `@backstage/core-components` `Table` (documented in the bulk of this skill)
+wraps `@material-table/core` and is still the only option when you need its
+search box, `columnsButton`, `customFilterAndSearch`, or the faceted-sidebar
+pattern. The bui `Table` has **none** of those yet — no search, no filtering, no
+column visibility — so don't reach for it when those are required. Reference for
+bui usage: `plugins/ai-chat/src/components/ConversationHistoryTable/` and
+`plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/`.
+
+## bui Table (`@backstage/ui`)
+
+Data-driven: pass `columnConfig` + `data` (each row must have an `id: string |
+number`). Cells **must** return a cell component (`Cell`, `CellText`, or
+`CellProfile`) at the top level — bare text/fragments break the layout.
+
+```tsx
+import { Cell, CellText, ColumnConfig, Table } from '@backstage/ui';
+
+type Row = { id: string; name: string; status: string };
+
+const columnConfig: ColumnConfig<Row>[] = [
+  { id: 'name', label: 'Name', isRowHeader: true, cell: r => <CellText title={r.name} /> },
+  // CellText renders title (+ optional description) as the standard cell text
+  { id: 'status', label: 'Status', cell: r => <Cell><StatusBadge status={r.status} /></Cell> },
+];
+
+<Table<Row>
+  columnConfig={columnConfig}
+  data={rows}
+  isPending={isLoading}          // built-in loading state (`loading` is deprecated)
+  pagination={{ type: 'none' }}  // or { type: 'page', ... }
+  emptyState={<Text>No results</Text>}
+/>;
+```
+
+Key points:
+- Declare `@backstage/ui` in the plugin's `package.json` (`"backstage:^"`).
+- `ColumnConfig` fields: `id`, `label`, `cell`, plus optional `isRowHeader`,
+  `isSortable`, `isHidden`, `width`/`minWidth`/`maxWidth`, `header`.
+- `Table` handles `isPending` / `emptyState` / `error` internally — you don't
+  need the manual loading/empty branches the core-components Table requires.
+- `CellText` takes `title` (required) + optional `description`, `leadingIcon`,
+  `href`. Use `Cell` to wrap arbitrary custom content.
+- For consumer-managed pagination/sort, pair with the `useTable` hook and spread
+  its `tableProps` (see `ConversationHistoryTable`).
+- `isSortable` sorts in-memory; there is still no built-in search/filter box.
+
+### Gotcha: the loading skeleton needs `data={undefined}`, not `[]`
+
+The animated skeleton (`TableBodySkeleton`) only renders when
+`isPending && data === undefined` (internally `isInitialLoading = pending &&
+!data`). If you pass `data={rows}` where `rows` is `[]` during load, `!data` is
+false, so the skeleton never shows and the `emptyState` flashes instead. Gate
+the data on your loading flag:
+
+```tsx
+<Table
+  columnConfig={columnConfig}
+  data={isLoading ? undefined : rows}  // undefined → skeleton; [] → emptyState
+  isPending={isLoading}
+  emptyState={<Text>No results</Text>}
+/>
+```
+
+Then loading shows the skeleton, and only a settled empty result shows the
+empty state.
 
 ## Table Structure
 

--- a/plugins/gs/src/apis/mimir/metrics.ts
+++ b/plugins/gs/src/apis/mimir/metrics.ts
@@ -214,6 +214,46 @@ export const KubeletRunningPods = {
   source: 'kubelet',
 } as const satisfies PrometheusMetric;
 
+export const GatewayApiHttprouteHostnameInfo = {
+  name: 'gatewayapi_httproute_hostname_info',
+  description:
+    'Info series (value is always 1) with one time series per hostname exposed by a Gateway API HTTPRoute. The `hostname` label holds the exposed host; `name` and `namespace` identify the HTTPRoute. Note: the metric carries no backendRef, so a hostname cannot be linked directly to a specific workload — correlate via `namespace` (and optionally route `name`).',
+  type: 'gauge',
+  source: 'gateway-api-state-metrics',
+} as const satisfies PrometheusMetric;
+
+export const GatewayApiHttprouteParentInfo = {
+  name: 'gatewayapi_httproute_parent_info',
+  description:
+    'Info series (value is always 1) with one time series per parentRef of a Gateway API HTTPRoute. `name`/`namespace` identify the HTTPRoute; `parent_name`/`parent_namespace` identify the Gateway it attaches to; `parent_section_name` is the Gateway listener name.',
+  type: 'gauge',
+  source: 'gateway-api-state-metrics',
+} as const satisfies PrometheusMetric;
+
+export const GatewayApiGatewayListenerInfo = {
+  name: 'gatewayapi_gateway_listener_info',
+  description:
+    'Info series (value is always 1) with one time series per Gateway API Gateway listener. `name`/`namespace` identify the Gateway; `listener_name` is the listener section; `hostname` is the listener hostname pattern (may be a wildcard such as `*.example.com`); `protocol`/`port`/`tls_mode` describe the listener.',
+  type: 'gauge',
+  source: 'gateway-api-state-metrics',
+} as const satisfies PrometheusMetric;
+
+export const CertmanagerCertificateExpirationTimestampSeconds = {
+  name: 'certmanager_certificate_expiration_timestamp_seconds',
+  description:
+    'The unix timestamp (notAfter) after which a cert-manager Certificate expires. `name` is the Certificate resource; `exported_namespace` is its namespace (note: the `namespace` label is the cert-manager controller namespace, not the certificate namespace). `issuer_name`/`issuer_kind`/`issuer_group` identify the issuer.',
+  type: 'gauge',
+  source: 'cert-manager',
+} as const satisfies PrometheusMetric;
+
+export const CertmanagerCertificateReadyStatus = {
+  name: 'certmanager_certificate_ready_status',
+  description:
+    'Readiness of a cert-manager Certificate. Emits one series per `condition` value (True/False/Unknown); the series whose value is 1 is the current state. `name`/`exported_namespace` identify the Certificate.',
+  type: 'gauge',
+  source: 'cert-manager',
+} as const satisfies PrometheusMetric;
+
 /**
  * All registered metrics. Use this to enumerate or inspect the full set
  * of metrics the application relies on.
@@ -245,4 +285,9 @@ export const MetricsRegistry: readonly PrometheusMetric[] = [
   KubeNodeStatusCondition,
   KubeNodeCreated,
   KubeletRunningPods,
+  GatewayApiHttprouteHostnameInfo,
+  GatewayApiHttprouteParentInfo,
+  GatewayApiGatewayListenerInfo,
+  CertmanagerCertificateExpirationTimestampSeconds,
+  CertmanagerCertificateReadyStatus,
 ];

--- a/plugins/gs/src/components/deployments/DeploymentDetailsPage/DeploymentDetailsPage.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentDetailsPage/DeploymentDetailsPage.tsx
@@ -1,6 +1,7 @@
 import { AsyncDeploymentProvider } from './useCurrentDeployment';
 import { DeploymentLayout } from '../DeploymentLayout';
 import { DeploymentOverview } from '../deployment-details/DeploymentOverview';
+import { DeploymentGateway } from '../deployment-details/DeploymentGateway';
 import { QueryClientProvider } from '../../QueryClientProvider';
 import { ErrorsProvider } from '@giantswarm/backstage-plugin-kubernetes-react';
 
@@ -12,6 +13,11 @@ export const DeploymentDetailsPage = () => {
           <DeploymentLayout.Route path="/" title="Overview">
             <ErrorsProvider>
               <DeploymentOverview />
+            </ErrorsProvider>
+          </DeploymentLayout.Route>
+          <DeploymentLayout.Route path="/gateways" title="Gateways">
+            <ErrorsProvider>
+              <DeploymentGateway />
             </ErrorsProvider>
           </DeploymentLayout.Route>
         </DeploymentLayout>

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentGateway.tsx
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentGateway.tsx
@@ -1,0 +1,11 @@
+import { Grid } from '@material-ui/core';
+import { GridItem } from '../../../UI';
+import { DeploymentHttpRoutesCard } from './DeploymentHttpRoutesCard';
+
+export const DeploymentGateway = () => (
+  <Grid container spacing={3} alignItems="stretch">
+    <GridItem xs={12}>
+      <DeploymentHttpRoutesCard />
+    </GridItem>
+  </Grid>
+);

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/CertificateCell/CertificateCell.tsx
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/CertificateCell/CertificateCell.tsx
@@ -1,0 +1,153 @@
+import { ButtonIcon, Cell, Tooltip, TooltipTrigger } from '@backstage/ui';
+import { Typography, makeStyles } from '@material-ui/core';
+import InfoOutlined from '@material-ui/icons/InfoOutlined';
+import { HostnameCertInfo } from '../../../../../hooks/resolveHostnameCert';
+
+type CertSeverity = 'success' | 'warning' | 'error' | 'unknown';
+
+const EXPIRY_WARNING_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+const useStyles = makeStyles(theme => ({
+  certPrimary: {
+    display: 'flex',
+    alignItems: 'center',
+    whiteSpace: 'nowrap',
+  },
+  dot: {
+    display: 'inline-block',
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    marginRight: theme.spacing(1),
+    flexShrink: 0,
+  },
+  dotSuccess: { backgroundColor: theme.palette.success.main },
+  dotWarning: { backgroundColor: theme.palette.warning.main },
+  dotError: { backgroundColor: theme.palette.error.main },
+  dotUnknown: { backgroundColor: theme.palette.text.disabled },
+  infoButton: {
+    marginLeft: theme.spacing(0.5),
+  },
+  tooltip: {
+    maxWidth: 600,
+  },
+  tooltipContent: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr',
+    columnGap: theme.spacing(1),
+    rowGap: theme.spacing(0.5),
+    fontSize: '0.75rem',
+  },
+  tooltipLabel: {
+    opacity: 0.7,
+  },
+  tooltipValue: {
+    wordBreak: 'break-word',
+  },
+}));
+
+function formatExpiry(expirationSeconds?: number): string | undefined {
+  if (expirationSeconds === undefined) return undefined;
+  const days = Math.round((expirationSeconds * 1000 - Date.now()) / MS_PER_DAY);
+  if (days < 0) {
+    return `expired ${-days} ${-days === 1 ? 'day' : 'days'} ago`;
+  }
+  if (days === 0) return 'expires today';
+  return `expires in ${days} ${days === 1 ? 'day' : 'days'}`;
+}
+
+function certSeverity(cert: HostnameCertInfo): CertSeverity {
+  const expiresMs =
+    cert.expirationSeconds !== undefined
+      ? cert.expirationSeconds * 1000
+      : undefined;
+  const expired = expiresMs !== undefined && expiresMs <= Date.now();
+
+  if (cert.ready === 'False' || expired) return 'error';
+  if (
+    expiresMs !== undefined &&
+    (expiresMs - Date.now()) / MS_PER_DAY < EXPIRY_WARNING_DAYS
+  ) {
+    return 'warning';
+  }
+  if (cert.ready === 'True') return 'success';
+  return 'unknown';
+}
+
+function readyLabel(ready?: string): string {
+  if (ready === 'True') return 'Ready';
+  if (ready === 'False') return 'Not ready';
+  return 'Unknown';
+}
+
+/**
+ * Renders the certificate status for a hostname row: a severity-colored dot
+ * with a readiness/expiry summary, and an info tooltip carrying the issuer,
+ * Certificate name/namespace and matched host pattern. Returns a bui `Cell`
+ * so it can be used directly as a `ColumnConfig.cell`.
+ */
+export function CertificateCell({ cert }: { cert?: HostnameCertInfo }) {
+  const classes = useStyles();
+
+  if (!cert) {
+    return (
+      <Cell>
+        <Typography variant="body2" color="textSecondary">
+          —
+        </Typography>
+      </Cell>
+    );
+  }
+
+  const dotClass = {
+    success: classes.dotSuccess,
+    warning: classes.dotWarning,
+    error: classes.dotError,
+    unknown: classes.dotUnknown,
+  }[certSeverity(cert)];
+
+  const expiry = formatExpiry(cert.expirationSeconds);
+  const primary = [readyLabel(cert.ready), expiry].filter(Boolean).join(' · ');
+  const issuer = cert.issuerName;
+
+  return (
+    <Cell>
+      <div className={classes.certPrimary}>
+        <span className={`${classes.dot} ${dotClass}`} />
+        <Typography variant="body2">{primary}</Typography>
+        <TooltipTrigger delay={200}>
+          <ButtonIcon
+            className={classes.infoButton}
+            icon={<InfoOutlined fontSize="inherit" />}
+            aria-label="Certificate details"
+            variant="tertiary"
+            size="small"
+          />
+          <Tooltip className={classes.tooltip}>
+            <div className={classes.tooltipContent}>
+              {issuer && (
+                <>
+                  <span className={classes.tooltipLabel}>Issuer</span>
+                  <span className={classes.tooltipValue}>{issuer}</span>
+                </>
+              )}
+              <span className={classes.tooltipLabel}>Certificate</span>
+              <span className={classes.tooltipValue}>{cert.certName}</span>
+              <span className={classes.tooltipLabel}>Namespace</span>
+              <span className={classes.tooltipValue}>{cert.namespace}</span>
+              {cert.hostnamePattern && (
+                <>
+                  <span className={classes.tooltipLabel}>Host pattern</span>
+                  <span className={classes.tooltipValue}>
+                    {cert.hostnamePattern}
+                  </span>
+                </>
+              )}
+            </div>
+          </Tooltip>
+        </TooltipTrigger>
+      </div>
+    </Cell>
+  );
+}

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/CertificateCell/index.ts
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/CertificateCell/index.ts
@@ -1,0 +1,1 @@
+export { CertificateCell } from './CertificateCell';

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/DeploymentHttpRoutesCard.tsx
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/DeploymentHttpRoutesCard.tsx
@@ -1,0 +1,291 @@
+import { InfoCard } from '@giantswarm/backstage-plugin-ui-react';
+import {
+  ButtonIcon,
+  Cell,
+  CellText,
+  ColumnConfig,
+  Link,
+  Table,
+  Tooltip,
+  TooltipTrigger,
+} from '@backstage/ui';
+import { Typography, makeStyles } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import InfoOutlined from '@material-ui/icons/InfoOutlined';
+import { useCurrentDeployment } from '../../../DeploymentDetailsPage/useCurrentDeployment';
+import { findTargetClusterName } from '../../../utils/findTargetCluster';
+import { getWorkloadNamespace } from '../../../utils/getWorkloadIdentifiers';
+import { useMimirHttpRouteHostnames } from '../../../../hooks/useMimirHttpRouteHostnames';
+import { HostnameCertInfo } from '../../../../hooks/resolveHostnameCert';
+import { HttpRouteHostname } from '../../../../hooks/useMimirHttpRouteHostnames';
+
+type HostnameRow = HttpRouteHostname & { id: string };
+
+const useStyles = makeStyles(theme => ({
+  caption: {
+    marginBottom: theme.spacing(1),
+    maxWidth: 1000,
+  },
+  footnote: {
+    marginTop: theme.spacing(2),
+    maxWidth: 1000,
+  },
+  certPrimary: {
+    display: 'flex',
+    alignItems: 'center',
+    whiteSpace: 'nowrap',
+  },
+  dot: {
+    display: 'inline-block',
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    marginRight: theme.spacing(1),
+    flexShrink: 0,
+  },
+  dotSuccess: { backgroundColor: theme.palette.success.main },
+  dotWarning: { backgroundColor: theme.palette.warning.main },
+  dotError: { backgroundColor: theme.palette.error.main },
+  dotUnknown: { backgroundColor: theme.palette.text.disabled },
+  infoButton: {
+    marginLeft: theme.spacing(0.5),
+  },
+  tooltip: {
+    maxWidth: 600,
+  },
+  tooltipContent: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr',
+    columnGap: theme.spacing(1),
+    rowGap: theme.spacing(0.5),
+    fontSize: '0.75rem',
+  },
+  tooltipLabel: {
+    opacity: 0.7,
+  },
+  tooltipValue: {
+    wordBreak: 'break-word',
+  },
+}));
+
+type CertSeverity = 'success' | 'warning' | 'error' | 'unknown';
+
+const EXPIRY_WARNING_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+function formatExpiry(expirationSeconds?: number): string | undefined {
+  if (expirationSeconds === undefined) return undefined;
+  const days = Math.round((expirationSeconds * 1000 - Date.now()) / MS_PER_DAY);
+  if (days < 0) {
+    return `expired ${-days} ${-days === 1 ? 'day' : 'days'} ago`;
+  }
+  if (days === 0) return 'expires today';
+  return `expires in ${days} ${days === 1 ? 'day' : 'days'}`;
+}
+
+function certSeverity(cert: HostnameCertInfo): CertSeverity {
+  const expiresMs =
+    cert.expirationSeconds !== undefined
+      ? cert.expirationSeconds * 1000
+      : undefined;
+  const expired = expiresMs !== undefined && expiresMs <= Date.now();
+
+  if (cert.ready === 'False' || expired) return 'error';
+  if (
+    expiresMs !== undefined &&
+    (expiresMs - Date.now()) / MS_PER_DAY < EXPIRY_WARNING_DAYS
+  ) {
+    return 'warning';
+  }
+  if (cert.ready === 'True') return 'success';
+  return 'unknown';
+}
+
+function readyLabel(ready?: string): string {
+  if (ready === 'True') return 'Ready';
+  if (ready === 'False') return 'Not ready';
+  return 'Unknown';
+}
+
+function certGroupVersion(labels: Record<string, string>): string {
+  const group = labels.customresource_group;
+  const version = labels.customresource_version;
+  if (group && version) return `${group}/${version}`;
+  return group ?? version ?? '—';
+}
+
+function CertificateCell({ cert }: { cert?: HostnameCertInfo }) {
+  const classes = useStyles();
+
+  if (!cert) {
+    return (
+      <Cell>
+        <Typography variant="body2" color="textSecondary">
+          —
+        </Typography>
+      </Cell>
+    );
+  }
+
+  const dotClass = {
+    success: classes.dotSuccess,
+    warning: classes.dotWarning,
+    error: classes.dotError,
+    unknown: classes.dotUnknown,
+  }[certSeverity(cert)];
+
+  const expiry = formatExpiry(cert.expirationSeconds);
+  const primary = [readyLabel(cert.ready), expiry].filter(Boolean).join(' · ');
+  const issuer = cert.issuerName;
+
+  return (
+    <Cell>
+      <div className={classes.certPrimary}>
+        <span className={`${classes.dot} ${dotClass}`} />
+        <Typography variant="body2">{primary}</Typography>
+        <TooltipTrigger delay={200}>
+          <ButtonIcon
+            className={classes.infoButton}
+            icon={<InfoOutlined fontSize="inherit" />}
+            aria-label="Certificate details"
+            variant="tertiary"
+            size="small"
+          />
+          <Tooltip className={classes.tooltip}>
+            <div className={classes.tooltipContent}>
+              {issuer && (
+                <>
+                  <span className={classes.tooltipLabel}>Issuer</span>
+                  <span className={classes.tooltipValue}>{issuer}</span>
+                </>
+              )}
+              <span className={classes.tooltipLabel}>Certificate</span>
+              <span className={classes.tooltipValue}>{cert.certName}</span>
+              <span className={classes.tooltipLabel}>Namespace</span>
+              <span className={classes.tooltipValue}>{cert.namespace}</span>
+              {cert.hostnamePattern && (
+                <>
+                  <span className={classes.tooltipLabel}>Host pattern</span>
+                  <span className={classes.tooltipValue}>
+                    {cert.hostnamePattern}
+                  </span>
+                </>
+              )}
+            </div>
+          </Tooltip>
+        </TooltipTrigger>
+      </div>
+    </Cell>
+  );
+}
+
+const columnConfig: ColumnConfig<HostnameRow>[] = [
+  {
+    id: 'hostname',
+    label: 'Hostname',
+    isRowHeader: true,
+    cell: row => (
+      <Cell>
+        <Link
+          href={`https://${row.hostname}/`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {row.hostname}
+        </Link>
+      </Cell>
+    ),
+  },
+  {
+    id: 'certificate',
+    label: 'Certificate',
+    cell: row => <CertificateCell cert={row.cert} />,
+  },
+  {
+    id: 'route',
+    label: 'Route',
+    cell: row => <CellText title={row.labels.name ?? '—'} />,
+  },
+  {
+    id: 'crGroupVersion',
+    label: 'Resource group/version',
+    cell: row => <CellText title={certGroupVersion(row.labels)} />,
+  },
+];
+
+export function DeploymentHttpRoutesCard() {
+  const classes = useStyles();
+  const { deployment, installationName } = useCurrentDeployment();
+
+  const clusterName = findTargetClusterName(deployment);
+  const workloadNamespace = getWorkloadNamespace(deployment);
+  const deploymentName = deployment.getName();
+
+  const { hostnames, isLoading, error } = useMimirHttpRouteHostnames({
+    installationName,
+    clusterName,
+    namespace: workloadNamespace,
+    refetchInterval: 30_000,
+  });
+
+  if (!clusterName) {
+    return null;
+  }
+
+  const title = 'Hostnames and certificates';
+
+  if (error) {
+    return (
+      <InfoCard title={title}>
+        <Alert severity="warning">Metrics unavailable</Alert>
+      </InfoCard>
+    );
+  }
+
+  const rows: HostnameRow[] = hostnames.map(entry => ({
+    ...entry,
+    id: entry.hostname,
+  }));
+
+  return (
+    <InfoCard title={title}>
+      <Typography
+        variant="body2"
+        color="textSecondary"
+        component="p"
+        className={classes.caption}
+      >
+        Based on HTTPRoute metrics for namespace{' '}
+        <code>{workloadNamespace || '—'}</code>. The table may contain entries
+        that are not related to <code>{deploymentName}</code>.
+      </Typography>
+      <Table<HostnameRow>
+        columnConfig={columnConfig}
+        data={isLoading ? undefined : rows}
+        isPending={isLoading}
+        pagination={{ type: 'none' }}
+        emptyState={
+          <Typography variant="body2" color="textSecondary">
+            No HTTPRoute hostnames found in namespace{' '}
+            <code>{workloadNamespace || '—'}</code> on cluster{' '}
+            <code>{clusterName}</code>.
+          </Typography>
+        }
+      />
+      <Typography
+        variant="body2"
+        color="textSecondary"
+        component="p"
+        className={classes.footnote}
+      >
+        Certificates are matched to each hostname by following the Gateway API
+        chain: the HTTPRoute's <code>parentRef</code> identifies the Gateway and
+        listener it attaches to, the listener's hostname pattern (e.g.{' '}
+        <code>*.example.com</code>) is matched against the hostname, and the
+        serving certificate is resolved from cert-manager by the listener's
+        conventional Certificate name (
+        <code>gateway-&lt;gateway&gt;-&lt;listener&gt;</code>).
+      </Typography>
+    </InfoCard>
+  );
+}

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/DeploymentHttpRoutesCard.tsx
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/DeploymentHttpRoutesCard.tsx
@@ -1,23 +1,13 @@
 import { InfoCard } from '@giantswarm/backstage-plugin-ui-react';
-import {
-  ButtonIcon,
-  Cell,
-  CellText,
-  ColumnConfig,
-  Link,
-  Table,
-  Tooltip,
-  TooltipTrigger,
-} from '@backstage/ui';
+import { Cell, CellText, ColumnConfig, Link, Table } from '@backstage/ui';
 import { Typography, makeStyles } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
-import InfoOutlined from '@material-ui/icons/InfoOutlined';
 import { useCurrentDeployment } from '../../../DeploymentDetailsPage/useCurrentDeployment';
 import { findTargetClusterName } from '../../../utils/findTargetCluster';
 import { getWorkloadNamespace } from '../../../utils/getWorkloadIdentifiers';
 import { useMimirHttpRouteHostnames } from '../../../../hooks/useMimirHttpRouteHostnames';
-import { HostnameCertInfo } from '../../../../hooks/resolveHostnameCert';
 import { HttpRouteHostname } from '../../../../hooks/useMimirHttpRouteHostnames';
+import { CertificateCell } from './CertificateCell';
 
 type HostnameRow = HttpRouteHostname & { id: string };
 
@@ -30,153 +20,13 @@ const useStyles = makeStyles(theme => ({
     marginTop: theme.spacing(2),
     maxWidth: 1000,
   },
-  certPrimary: {
-    display: 'flex',
-    alignItems: 'center',
-    whiteSpace: 'nowrap',
-  },
-  dot: {
-    display: 'inline-block',
-    width: 8,
-    height: 8,
-    borderRadius: '50%',
-    marginRight: theme.spacing(1),
-    flexShrink: 0,
-  },
-  dotSuccess: { backgroundColor: theme.palette.success.main },
-  dotWarning: { backgroundColor: theme.palette.warning.main },
-  dotError: { backgroundColor: theme.palette.error.main },
-  dotUnknown: { backgroundColor: theme.palette.text.disabled },
-  infoButton: {
-    marginLeft: theme.spacing(0.5),
-  },
-  tooltip: {
-    maxWidth: 600,
-  },
-  tooltipContent: {
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr',
-    columnGap: theme.spacing(1),
-    rowGap: theme.spacing(0.5),
-    fontSize: '0.75rem',
-  },
-  tooltipLabel: {
-    opacity: 0.7,
-  },
-  tooltipValue: {
-    wordBreak: 'break-word',
-  },
 }));
-
-type CertSeverity = 'success' | 'warning' | 'error' | 'unknown';
-
-const EXPIRY_WARNING_DAYS = 14;
-const MS_PER_DAY = 86_400_000;
-
-function formatExpiry(expirationSeconds?: number): string | undefined {
-  if (expirationSeconds === undefined) return undefined;
-  const days = Math.round((expirationSeconds * 1000 - Date.now()) / MS_PER_DAY);
-  if (days < 0) {
-    return `expired ${-days} ${-days === 1 ? 'day' : 'days'} ago`;
-  }
-  if (days === 0) return 'expires today';
-  return `expires in ${days} ${days === 1 ? 'day' : 'days'}`;
-}
-
-function certSeverity(cert: HostnameCertInfo): CertSeverity {
-  const expiresMs =
-    cert.expirationSeconds !== undefined
-      ? cert.expirationSeconds * 1000
-      : undefined;
-  const expired = expiresMs !== undefined && expiresMs <= Date.now();
-
-  if (cert.ready === 'False' || expired) return 'error';
-  if (
-    expiresMs !== undefined &&
-    (expiresMs - Date.now()) / MS_PER_DAY < EXPIRY_WARNING_DAYS
-  ) {
-    return 'warning';
-  }
-  if (cert.ready === 'True') return 'success';
-  return 'unknown';
-}
-
-function readyLabel(ready?: string): string {
-  if (ready === 'True') return 'Ready';
-  if (ready === 'False') return 'Not ready';
-  return 'Unknown';
-}
 
 function certGroupVersion(labels: Record<string, string>): string {
   const group = labels.customresource_group;
   const version = labels.customresource_version;
   if (group && version) return `${group}/${version}`;
   return group ?? version ?? '—';
-}
-
-function CertificateCell({ cert }: { cert?: HostnameCertInfo }) {
-  const classes = useStyles();
-
-  if (!cert) {
-    return (
-      <Cell>
-        <Typography variant="body2" color="textSecondary">
-          —
-        </Typography>
-      </Cell>
-    );
-  }
-
-  const dotClass = {
-    success: classes.dotSuccess,
-    warning: classes.dotWarning,
-    error: classes.dotError,
-    unknown: classes.dotUnknown,
-  }[certSeverity(cert)];
-
-  const expiry = formatExpiry(cert.expirationSeconds);
-  const primary = [readyLabel(cert.ready), expiry].filter(Boolean).join(' · ');
-  const issuer = cert.issuerName;
-
-  return (
-    <Cell>
-      <div className={classes.certPrimary}>
-        <span className={`${classes.dot} ${dotClass}`} />
-        <Typography variant="body2">{primary}</Typography>
-        <TooltipTrigger delay={200}>
-          <ButtonIcon
-            className={classes.infoButton}
-            icon={<InfoOutlined fontSize="inherit" />}
-            aria-label="Certificate details"
-            variant="tertiary"
-            size="small"
-          />
-          <Tooltip className={classes.tooltip}>
-            <div className={classes.tooltipContent}>
-              {issuer && (
-                <>
-                  <span className={classes.tooltipLabel}>Issuer</span>
-                  <span className={classes.tooltipValue}>{issuer}</span>
-                </>
-              )}
-              <span className={classes.tooltipLabel}>Certificate</span>
-              <span className={classes.tooltipValue}>{cert.certName}</span>
-              <span className={classes.tooltipLabel}>Namespace</span>
-              <span className={classes.tooltipValue}>{cert.namespace}</span>
-              {cert.hostnamePattern && (
-                <>
-                  <span className={classes.tooltipLabel}>Host pattern</span>
-                  <span className={classes.tooltipValue}>
-                    {cert.hostnamePattern}
-                  </span>
-                </>
-              )}
-            </div>
-          </Tooltip>
-        </TooltipTrigger>
-      </div>
-    </Cell>
-  );
 }
 
 const columnConfig: ColumnConfig<HostnameRow>[] = [

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/index.ts
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/index.ts
@@ -1,0 +1,1 @@
+export { DeploymentHttpRoutesCard } from './DeploymentHttpRoutesCard';

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/index.ts
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/index.ts
@@ -1,0 +1,1 @@
+export { DeploymentGateway } from './DeploymentGateway';

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentOverview/DeploymentAboutCard/DeploymentAboutCard.tsx
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentOverview/DeploymentAboutCard/DeploymentAboutCard.tsx
@@ -32,6 +32,7 @@ import {
   findTargetClusterNamespace,
   findTargetClusterType,
 } from '../../../utils/findTargetCluster';
+import { getWorkloadNamespace } from '../../../utils/getWorkloadIdentifiers';
 import { getSourceKind, getSourceName } from '../../../utils/getSource';
 import { getUpdatedTimestamp } from '../../../utils/getUpdatedTimestamp';
 import {
@@ -53,6 +54,7 @@ export function DeploymentAboutCard() {
 
   const name = deployment.getName();
   const namespace = deployment.getNamespace();
+  const targetNamespace = getWorkloadNamespace(deployment);
 
   const clusterName = findTargetClusterName(deployment);
 
@@ -145,6 +147,11 @@ export function DeploymentAboutCard() {
         <AboutField label="Cluster" value={clusterName}>
           <AboutFieldValue>{clusterEl}</AboutFieldValue>
         </AboutField>
+
+        {targetNamespace && targetNamespace !== namespace && (
+          <AboutField label="Target namespace" value={targetNamespace} />
+        )}
+
         <AboutField label="App">
           <AboutFieldValue>
             <AsyncValue

--- a/plugins/gs/src/components/hooks/resolveHostnameCert.test.ts
+++ b/plugins/gs/src/components/hooks/resolveHostnameCert.test.ts
@@ -1,0 +1,210 @@
+import { MimirMetricSample } from '../../apis/mimir/types';
+import {
+  hostnameMatchesListener,
+  resolveHostnameCert,
+  ResolveInputs,
+} from './resolveHostnameCert';
+
+function sample(
+  metric: Record<string, string>,
+  value = '1',
+): MimirMetricSample {
+  return { metric, value: [0, value] };
+}
+
+describe('hostnameMatchesListener', () => {
+  it('matches an exact pattern', () => {
+    expect(hostnameMatchesListener('foo.example.com', 'foo.example.com')).toBe(
+      true,
+    );
+  });
+
+  it('matches a single extra label against a wildcard', () => {
+    expect(hostnameMatchesListener('foo.example.com', '*.example.com')).toBe(
+      true,
+    );
+  });
+
+  it('does not match multiple labels against a wildcard', () => {
+    expect(hostnameMatchesListener('a.b.example.com', '*.example.com')).toBe(
+      false,
+    );
+  });
+
+  it('does not match the bare suffix against a wildcard', () => {
+    expect(hostnameMatchesListener('example.com', '*.example.com')).toBe(false);
+  });
+
+  it('never matches an empty pattern', () => {
+    expect(hostnameMatchesListener('foo.example.com', undefined)).toBe(false);
+    expect(hostnameMatchesListener('foo.example.com', '')).toBe(false);
+  });
+});
+
+describe('resolveHostnameCert', () => {
+  it('resolves a route with no sectionName by matching the listener hostname', () => {
+    // Mirrors the `backstage` route: parentRef has no section, so
+    // `parent_section_name` is empty and the listener must be found by
+    // hostname match against the Gateway's listeners.
+    const inputs: ResolveInputs = {
+      hostnameSamples: [
+        sample({
+          hostname: 'devportal.giantswarm.io',
+          namespace: 'backstage',
+          name: 'backstage',
+        }),
+      ],
+      parentSamples: [
+        sample({
+          namespace: 'backstage',
+          name: 'backstage',
+          parent_name: 'giantswarm-default',
+          parent_namespace: 'envoy-gateway-system',
+          parent_section_name: '',
+        }),
+      ],
+      listenerSamples: [
+        sample({
+          name: 'giantswarm-default',
+          namespace: 'envoy-gateway-system',
+          listener_name: 'giantswarmio-https',
+          hostname: '*.giantswarm.io',
+        }),
+        sample({
+          name: 'giantswarm-default',
+          namespace: 'envoy-gateway-system',
+          listener_name: 'https',
+          hostname: '*.gazelle.awsprod.gigantic.io',
+        }),
+        sample({
+          name: 'giantswarm-default',
+          namespace: 'envoy-gateway-system',
+          listener_name: 'http',
+        }),
+      ],
+      expirationSamples: [
+        sample(
+          {
+            name: 'gateway-giantswarm-default-giantswarmio-https',
+            exported_namespace: 'envoy-gateway-system',
+            issuer_name: 'letsencrypt-giantswarm-gateway',
+            issuer_kind: 'Issuer',
+          },
+          '1789466925',
+        ),
+      ],
+      readySamples: [
+        sample(
+          {
+            name: 'gateway-giantswarm-default-giantswarmio-https',
+            exported_namespace: 'envoy-gateway-system',
+            condition: 'True',
+          },
+          '1',
+        ),
+      ],
+    };
+
+    const result = resolveHostnameCert('devportal.giantswarm.io', inputs);
+
+    expect(result).toEqual({
+      certName: 'gateway-giantswarm-default-giantswarmio-https',
+      namespace: 'envoy-gateway-system',
+      hostnamePattern: '*.giantswarm.io',
+      ready: 'True',
+      expirationSeconds: 1789466925,
+      issuerName: 'letsencrypt-giantswarm-gateway',
+      issuerKind: 'Issuer',
+    });
+  });
+
+  it('honors an explicit sectionName and skips non-matching listeners', () => {
+    // Mirrors the `schema-server` route: it pins two sections; only the one
+    // whose listener hostname matches the queried hostname should resolve.
+    const inputs: ResolveInputs = {
+      hostnameSamples: [
+        sample({
+          hostname: 'schema.giantswarm.io',
+          namespace: 'schema-server',
+          name: 'schema-server',
+        }),
+      ],
+      parentSamples: [
+        sample({
+          namespace: 'schema-server',
+          name: 'schema-server',
+          parent_name: 'giantswarm-default',
+          parent_namespace: 'envoy-gateway-system',
+          parent_section_name: 'giantswarmio-https',
+        }),
+        sample({
+          namespace: 'schema-server',
+          name: 'schema-server',
+          parent_name: 'giantswarm-default',
+          parent_namespace: 'envoy-gateway-system',
+          parent_section_name: 'https',
+        }),
+      ],
+      listenerSamples: [
+        sample({
+          name: 'giantswarm-default',
+          namespace: 'envoy-gateway-system',
+          listener_name: 'giantswarmio-https',
+          hostname: '*.giantswarm.io',
+        }),
+        sample({
+          name: 'giantswarm-default',
+          namespace: 'envoy-gateway-system',
+          listener_name: 'https',
+          hostname: '*.operations.awsprod.gigantic.io',
+        }),
+      ],
+      expirationSamples: [
+        sample(
+          {
+            name: 'gateway-giantswarm-default-giantswarmio-https',
+            exported_namespace: 'envoy-gateway-system',
+          },
+          '1789137370',
+        ),
+      ],
+      readySamples: [],
+    };
+
+    const result = resolveHostnameCert('schema.giantswarm.io', inputs);
+
+    expect(result?.certName).toBe(
+      'gateway-giantswarm-default-giantswarmio-https',
+    );
+    expect(result?.hostnamePattern).toBe('*.giantswarm.io');
+  });
+
+  it('returns undefined when no listener certificate is found', () => {
+    const inputs: ResolveInputs = {
+      hostnameSamples: [
+        sample({ hostname: 'foo.example.com', namespace: 'ns', name: 'r' }),
+      ],
+      parentSamples: [
+        sample({
+          namespace: 'ns',
+          name: 'r',
+          parent_name: 'gw',
+          parent_namespace: 'gw-ns',
+          parent_section_name: '',
+        }),
+      ],
+      listenerSamples: [
+        sample({
+          name: 'gw',
+          namespace: 'gw-ns',
+          listener_name: 'https',
+          hostname: '*.example.com',
+        }),
+      ],
+      expirationSamples: [],
+      readySamples: [],
+    };
+
+    expect(resolveHostnameCert('foo.example.com', inputs)).toBeUndefined();
+  });
+});

--- a/plugins/gs/src/components/hooks/resolveHostnameCert.ts
+++ b/plugins/gs/src/components/hooks/resolveHostnameCert.ts
@@ -1,0 +1,161 @@
+import { MimirMetricSample } from '../../apis/mimir/types';
+
+export interface HostnameCertInfo {
+  /** The resolved cert-manager Certificate resource name. */
+  certName: string;
+  /** The Certificate's namespace (from the `exported_namespace` label). */
+  namespace: string;
+  /** The Gateway listener hostname pattern that matched (e.g. `*.example.com`). */
+  hostnamePattern?: string;
+  /** Current readiness, if a ready-status series was found. */
+  ready?: 'True' | 'False' | 'Unknown';
+  /** Unix timestamp (seconds) after which the certificate expires. */
+  expirationSeconds?: number;
+  /** Issuer identity, when available. */
+  issuerName?: string;
+  issuerKind?: string;
+}
+
+/**
+ * Gateway API wildcard hostname match. A listener hostname of `*.example.com`
+ * matches exactly one extra DNS label (`foo.example.com` but not
+ * `a.b.example.com`), per the Gateway API spec. An exact pattern matches only
+ * itself. An empty pattern (e.g. an HTTP listener) never matches.
+ */
+export function hostnameMatchesListener(
+  hostname: string,
+  pattern: string | undefined,
+): boolean {
+  if (!pattern) return false;
+  if (pattern === hostname) return true;
+  if (pattern.startsWith('*.')) {
+    const suffix = pattern.slice(1); // ".example.com"
+    if (!hostname.endsWith(suffix)) return false;
+    const prefix = hostname.slice(0, hostname.length - suffix.length);
+    return prefix.length > 0 && !prefix.includes('.');
+  }
+  return false;
+}
+
+/** cert-manager's gateway-shim auto-generated Certificate name for a listener. */
+function gatewayListenerCertName(
+  gatewayName: string,
+  listenerName: string,
+): string {
+  return `gateway-${gatewayName}-${listenerName}`;
+}
+
+export interface ResolveInputs {
+  /** `gatewayapi_httproute_hostname_info` series (workload namespace). */
+  hostnameSamples: MimirMetricSample[];
+  /** `gatewayapi_httproute_parent_info` series (workload namespace). */
+  parentSamples: MimirMetricSample[];
+  /** `gatewayapi_gateway_listener_info` series (cluster-wide). */
+  listenerSamples: MimirMetricSample[];
+  /** `certmanager_certificate_expiration_timestamp_seconds` series (cluster-wide). */
+  expirationSamples: MimirMetricSample[];
+  /** `certmanager_certificate_ready_status` series (cluster-wide). */
+  readySamples: MimirMetricSample[];
+}
+
+/**
+ * Resolves the serving TLS certificate for a hostname by walking the chain:
+ *
+ *   HTTPRoute (hostname) → parentRef (Gateway + listener section)
+ *     → Gateway listener (hostname pattern) → cert-manager Certificate
+ *
+ * The route→listener and hostname→listener hops are exact label / wildcard
+ * matches. The final listener→certificate hop relies on cert-manager's
+ * gateway-shim naming convention (`gateway-<gateway>-<listener>`), so it is
+ * best-effort: when no matching Certificate series exists, `undefined` is
+ * returned and the caller should render the cert as unknown rather than wrong.
+ */
+export function resolveHostnameCert(
+  hostname: string,
+  inputs: ResolveInputs,
+): HostnameCertInfo | undefined {
+  const {
+    hostnameSamples,
+    parentSamples,
+    listenerSamples,
+    expirationSamples,
+    readySamples,
+  } = inputs;
+
+  // Routes (namespace/name) that expose this hostname.
+  const routeKeys = new Set(
+    hostnameSamples
+      .filter(s => s.metric.hostname === hostname)
+      .map(s => `${s.metric.namespace}/${s.metric.name}`),
+  );
+  if (routeKeys.size === 0) return undefined;
+
+  // parentRefs of those routes → candidate (gateway, listener) sections.
+  const candidateListeners = parentSamples
+    .filter(s => routeKeys.has(`${s.metric.namespace}/${s.metric.name}`))
+    .map(s => ({
+      gatewayName: s.metric.parent_name,
+      gatewayNamespace: s.metric.parent_namespace,
+      listenerName: s.metric.parent_section_name,
+    }))
+    .filter(l => l.gatewayName && l.listenerName);
+
+  // Pick the listener whose hostname pattern actually matches this hostname.
+  for (const candidate of candidateListeners) {
+    const listener = listenerSamples.find(
+      s =>
+        s.metric.name === candidate.gatewayName &&
+        s.metric.namespace === candidate.gatewayNamespace &&
+        s.metric.listener_name === candidate.listenerName,
+    );
+    if (!listener) continue;
+    if (!hostnameMatchesListener(hostname, listener.metric.hostname)) continue;
+
+    // Listener → Certificate (naming convention).
+    const certName = gatewayListenerCertName(
+      candidate.gatewayName,
+      candidate.listenerName,
+    );
+    const certNamespace = candidate.gatewayNamespace;
+
+    const expiration = expirationSamples.find(
+      s =>
+        s.metric.name === certName &&
+        s.metric.exported_namespace === certNamespace,
+    );
+
+    const readySeries = readySamples.filter(
+      s =>
+        s.metric.name === certName &&
+        s.metric.exported_namespace === certNamespace,
+    );
+    const activeReady = readySeries.find(s => s.value?.[1] === '1');
+    const readyCondition = activeReady?.metric.condition as
+      | 'True'
+      | 'False'
+      | 'Unknown'
+      | undefined;
+
+    // Require at least one cert signal, otherwise treat as unresolved.
+    if (!expiration && readySeries.length === 0) return undefined;
+
+    const expirationSeconds = expiration?.value?.[1]
+      ? Number(expiration.value[1])
+      : undefined;
+
+    return {
+      certName,
+      namespace: certNamespace,
+      hostnamePattern: listener.metric.hostname,
+      ready: readyCondition,
+      expirationSeconds:
+        expirationSeconds !== undefined && !isNaN(expirationSeconds)
+          ? expirationSeconds
+          : undefined,
+      issuerName: expiration?.metric.issuer_name,
+      issuerKind: expiration?.metric.issuer_kind,
+    };
+  }
+
+  return undefined;
+}

--- a/plugins/gs/src/components/hooks/resolveHostnameCert.ts
+++ b/plugins/gs/src/components/hooks/resolveHostnameCert.ts
@@ -61,11 +61,14 @@ export interface ResolveInputs {
 /**
  * Resolves the serving TLS certificate for a hostname by walking the chain:
  *
- *   HTTPRoute (hostname) → parentRef (Gateway + listener section)
+ *   HTTPRoute (hostname) → parentRef (Gateway, optional listener section)
  *     → Gateway listener (hostname pattern) → cert-manager Certificate
  *
- * The route→listener and hostname→listener hops are exact label / wildcard
- * matches. The final listener→certificate hop relies on cert-manager's
+ * The listener is identified by matching the hostname against each of the
+ * Gateway's listener hostname patterns; a parentRef `sectionName`, when set,
+ * further constrains which listener is considered. (A route without a
+ * sectionName attaches to every matching listener.) The final
+ * listener→certificate hop relies on cert-manager's
  * gateway-shim naming convention (`gateway-<gateway>-<listener>`), so it is
  * best-effort: when no matching Certificate series exists, `undefined` is
  * returned and the caller should render the cert as unknown rather than wrong.
@@ -90,71 +93,81 @@ export function resolveHostnameCert(
   );
   if (routeKeys.size === 0) return undefined;
 
-  // parentRefs of those routes → candidate (gateway, listener) sections.
-  const candidateListeners = parentSamples
+  // parentRefs of those routes → candidate Gateways. `parent_section_name` is
+  // the listener the route pins to, but it is optional: a route without a
+  // sectionName attaches to *every* listener of the Gateway whose hostname
+  // matches. So we keep the section only as an extra constraint when present,
+  // and otherwise resolve the listener purely by hostname match.
+  const candidateParents = parentSamples
     .filter(s => routeKeys.has(`${s.metric.namespace}/${s.metric.name}`))
     .map(s => ({
       gatewayName: s.metric.parent_name,
       gatewayNamespace: s.metric.parent_namespace,
-      listenerName: s.metric.parent_section_name,
+      section: s.metric.parent_section_name || undefined,
     }))
-    .filter(l => l.gatewayName && l.listenerName);
+    .filter(p => p.gatewayName && p.gatewayNamespace);
 
-  // Pick the listener whose hostname pattern actually matches this hostname.
-  for (const candidate of candidateListeners) {
-    const listener = listenerSamples.find(
+  for (const parent of candidateParents) {
+    // Listeners of this Gateway whose hostname pattern matches the hostname,
+    // restricted to the pinned section when the parentRef named one.
+    const matchingListeners = listenerSamples.filter(
       s =>
-        s.metric.name === candidate.gatewayName &&
-        s.metric.namespace === candidate.gatewayNamespace &&
-        s.metric.listener_name === candidate.listenerName,
-    );
-    if (!listener) continue;
-    if (!hostnameMatchesListener(hostname, listener.metric.hostname)) continue;
-
-    // Listener → Certificate (naming convention).
-    const certName = gatewayListenerCertName(
-      candidate.gatewayName,
-      candidate.listenerName,
-    );
-    const certNamespace = candidate.gatewayNamespace;
-
-    const expiration = expirationSamples.find(
-      s =>
-        s.metric.name === certName &&
-        s.metric.exported_namespace === certNamespace,
+        s.metric.name === parent.gatewayName &&
+        s.metric.namespace === parent.gatewayNamespace &&
+        (parent.section ? s.metric.listener_name === parent.section : true) &&
+        hostnameMatchesListener(hostname, s.metric.hostname),
     );
 
-    const readySeries = readySamples.filter(
-      s =>
-        s.metric.name === certName &&
-        s.metric.exported_namespace === certNamespace,
-    );
-    const activeReady = readySeries.find(s => s.value?.[1] === '1');
-    const readyCondition = activeReady?.metric.condition as
-      | 'True'
-      | 'False'
-      | 'Unknown'
-      | undefined;
+    for (const listener of matchingListeners) {
+      const listenerName = listener.metric.listener_name;
 
-    // Require at least one cert signal, otherwise treat as unresolved.
-    if (!expiration && readySeries.length === 0) return undefined;
+      // Listener → Certificate (cert-manager gateway-shim naming convention).
+      const certName = gatewayListenerCertName(
+        parent.gatewayName,
+        listenerName,
+      );
+      const certNamespace = parent.gatewayNamespace;
 
-    const expirationSeconds = expiration?.value?.[1]
-      ? Number(expiration.value[1])
-      : undefined;
+      const expiration = expirationSamples.find(
+        s =>
+          s.metric.name === certName &&
+          s.metric.exported_namespace === certNamespace,
+      );
 
-    return {
-      certName,
-      namespace: certNamespace,
-      hostnamePattern: listener.metric.hostname,
-      ready: readyCondition,
-      expirationSeconds:
-        expirationSeconds !== undefined && !isNaN(expirationSeconds)
-          ? expirationSeconds
-          : undefined,
-      issuerName: expiration?.metric.issuer_name,
-      issuerKind: expiration?.metric.issuer_kind,
-    };
+      const readySeries = readySamples.filter(
+        s =>
+          s.metric.name === certName &&
+          s.metric.exported_namespace === certNamespace,
+      );
+
+      // No cert signal for this listener — keep trying the route's other
+      // matching listeners/parents rather than giving up.
+      if (!expiration && readySeries.length === 0) continue;
+
+      const activeReady = readySeries.find(s => s.value?.[1] === '1');
+      const readyCondition = activeReady?.metric.condition as
+        | 'True'
+        | 'False'
+        | 'Unknown'
+        | undefined;
+
+      const expirationSeconds = expiration?.value?.[1]
+        ? Number(expiration.value[1])
+        : undefined;
+
+      return {
+        certName,
+        namespace: certNamespace,
+        hostnamePattern: listener.metric.hostname,
+        ready: readyCondition,
+        expirationSeconds:
+          expirationSeconds !== undefined && !isNaN(expirationSeconds)
+            ? expirationSeconds
+            : undefined,
+        issuerName: expiration?.metric.issuer_name,
+        issuerKind: expiration?.metric.issuer_kind,
+      };
+    }
   }
 
   return undefined;

--- a/plugins/gs/src/components/hooks/useMimirHttpRouteHostnames.ts
+++ b/plugins/gs/src/components/hooks/useMimirHttpRouteHostnames.ts
@@ -1,0 +1,152 @@
+import { useMemo } from 'react';
+import { useMimirQuery } from './useMimirQuery';
+import { MimirMetricSample, MimirQueryResponse } from '../../apis/mimir/types';
+import {
+  CertmanagerCertificateExpirationTimestampSeconds,
+  CertmanagerCertificateReadyStatus,
+  GatewayApiGatewayListenerInfo,
+  GatewayApiHttprouteHostnameInfo,
+  GatewayApiHttprouteParentInfo,
+} from '../../apis/mimir/metrics';
+import { HostnameCertInfo, resolveHostnameCert } from './resolveHostnameCert';
+
+export interface HttpRouteHostname {
+  /** The hostname exposed by the HTTPRoute (the `hostname` label). */
+  hostname: string;
+  /** All labels of the series, exposed verbatim for debugging/filtering. */
+  labels: Record<string, string>;
+  /** The serving TLS certificate, resolved via the Gateway listener. */
+  cert?: HostnameCertInfo;
+}
+
+function samplesOf(
+  response: MimirQueryResponse | undefined,
+): MimirMetricSample[] {
+  return response?.data?.result ?? [];
+}
+
+/**
+ * Groups the raw series by `hostname` and merges their labels. The same
+ * hostname can be exposed by several HTTPRoutes (e.g. a route and its
+ * companion HTTP→HTTPS redirect route), producing one series each. For each
+ * label, values that agree collapse to a single value; values that differ
+ * across the merged series are joined (e.g. `name` becomes a comma-separated
+ * list of route names), so no debugging detail is lost.
+ */
+function extractHostnames(samples: MimirMetricSample[]): HttpRouteHostname[] {
+  const byHostname = new Map<string, Record<string, Set<string>>>();
+  for (const sample of samples) {
+    const hostname = sample.metric.hostname ?? '';
+    let labelSets = byHostname.get(hostname);
+    if (!labelSets) {
+      labelSets = {};
+      byHostname.set(hostname, labelSets);
+    }
+    for (const [key, value] of Object.entries(sample.metric)) {
+      (labelSets[key] ??= new Set()).add(value);
+    }
+  }
+
+  return Array.from(byHostname.entries())
+    .map(([hostname, labelSets]) => {
+      const labels: Record<string, string> = {};
+      for (const [key, values] of Object.entries(labelSets)) {
+        labels[key] = Array.from(values).sort().join(', ');
+      }
+      return { hostname, labels };
+    })
+    .sort((a, b) => a.hostname.localeCompare(b.hostname));
+}
+
+/**
+ * Fetches the hostnames exposed by Gateway API HTTPRoutes in the workload's
+ * target namespace, and enriches each with its serving TLS certificate.
+ *
+ * The metric carries no backendRef, so hostnames are narrowed to the workload
+ * via `cluster_id` + `namespace`. Certificates are resolved by walking
+ * HTTPRoute → Gateway listener → cert-manager Certificate (see
+ * `resolveHostnameCert`). The full label set is surfaced per series so the
+ * filtering can be verified.
+ */
+export function useMimirHttpRouteHostnames(options: {
+  installationName: string;
+  clusterName: string | undefined;
+  namespace: string | undefined;
+  refetchInterval?: number | false;
+}) {
+  const { installationName, clusterName, namespace, refetchInterval } = options;
+
+  const isEnabled = Boolean(clusterName && namespace);
+  const nsSelector = `cluster_id="${clusterName}",namespace="${namespace}"`;
+  const clusterSelector = `cluster_id="${clusterName}"`;
+
+  const hostnamesQuery = `${GatewayApiHttprouteHostnameInfo.name}{${nsSelector}}`;
+  const parentsQuery = `${GatewayApiHttprouteParentInfo.name}{${nsSelector}}`;
+  const listenersQuery = `${GatewayApiGatewayListenerInfo.name}{${clusterSelector}}`;
+  const expirationQuery = `${CertmanagerCertificateExpirationTimestampSeconds.name}{${clusterSelector}}`;
+  const readyQuery = `${CertmanagerCertificateReadyStatus.name}{${clusterSelector}}`;
+
+  const {
+    data: hostnamesData,
+    isLoading,
+    error,
+  } = useMimirQuery({
+    installationName,
+    query: hostnamesQuery,
+    enabled: isEnabled,
+    refetchInterval,
+  });
+
+  // Certificate-resolution queries. These only enrich the result — failures or
+  // slowness here must not block rendering the hostnames themselves.
+  const { data: parentsData } = useMimirQuery({
+    installationName,
+    query: parentsQuery,
+    enabled: isEnabled,
+    refetchInterval,
+  });
+  const { data: listenersData } = useMimirQuery({
+    installationName,
+    query: listenersQuery,
+    enabled: isEnabled,
+    refetchInterval,
+  });
+  const { data: expirationData } = useMimirQuery({
+    installationName,
+    query: expirationQuery,
+    enabled: isEnabled,
+    refetchInterval,
+  });
+  const { data: readyData } = useMimirQuery({
+    installationName,
+    query: readyQuery,
+    enabled: isEnabled,
+    refetchInterval,
+  });
+
+  return useMemo(() => {
+    const hostnameSamples = samplesOf(hostnamesData);
+    const inputs = {
+      hostnameSamples,
+      parentSamples: samplesOf(parentsData),
+      listenerSamples: samplesOf(listenersData),
+      expirationSamples: samplesOf(expirationData),
+      readySamples: samplesOf(readyData),
+    };
+
+    const hostnames = extractHostnames(hostnameSamples).map(entry => ({
+      ...entry,
+      cert: resolveHostnameCert(entry.hostname, inputs),
+    }));
+
+    return { hostnames, isLoading, error };
+  }, [
+    hostnamesData,
+    parentsData,
+    listenersData,
+    expirationData,
+    readyData,
+    isLoading,
+    error,
+  ]);
+}


### PR DESCRIPTION
### What does this PR do?

Adds a **Gateways** tab to the deployment detail page (`/deployments/{installation}/helmrelease/{namespace}/{name}/gateways`) that lists the hostnames exposed via Gateway API HTTPRoutes for the workload, alongside their serving TLS certificates.

- **Hostnames table** (bui `Table`): built from the `gatewayapi_httproute_hostname_info` metric, scoped by `cluster_id` + the workload's target namespace. Duplicate series (a route and its HTTP→HTTPS redirect route sharing a hostname) are de-duplicated. Each hostname links to `https://<hostname>/`.
- **Certificate column**: each row resolves its serving certificate by walking the Gateway API chain — HTTPRoute `parentRef` → Gateway listener (wildcard-matched against the hostname) → cert-manager Certificate via the conventional `gateway-<gateway>-<listener>` name. Shows readiness + expiry, color-coded by severity (red if not-ready/expired, amber if <14 days, green if ready). Issuer, certificate name/namespace, and the matched host pattern are behind an info (ⓘ) tooltip.
- **About card**: now shows the workload's **Target namespace** when it differs from the HelmRelease/App CR namespace.
- Registers the new metrics in the central Mimir metrics registry, and documents the bui `Table` (plus its loading-skeleton gotcha) in the `tables` skill.

### What is the effect of this change to users?

Users can see, per deployment, which hostnames it exposes through Envoy Gateway HTTPRoutes and whether the TLS certificates serving those hostnames are healthy and when they expire — without leaving Backstage.

### How does it look like?

<img width="1469" height="369" alt="image" src="https://github.com/user-attachments/assets/d80bed29-47c9-4ff9-9027-65421858c7a7" />


<img width="1241" height="427" alt="image" src="https://github.com/user-attachments/assets/a57d7a09-6ff1-4c18-ad40-da24ad7f02bd" />



### Any background context you can provide?

The certificate join is metrics-only. The final listener→certificate hop relies on cert-manager's gateway-shim naming convention (`gateway-<gateway>-<listener>`); when no matching certificate series is found, the certificate is shown as unresolved rather than guessed. The metric carries no backendRef, so hostnames are correlated to the workload by namespace — the tab copy notes the table may include entries unrelated to the specific release.

### Do the docs need to be updated?

Yes

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))