### PR TITLE
docs: document bui (@backstage/ui) adoption and add ui skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -167,8 +167,23 @@ Key backend plugins registered:
 
 Entry point: `packages/app/src/App.tsx`
 
-- React 18 with Material-UI v4 components
+- React 18
 - Backstage frontend plugin system
+
+#### UI component libraries
+
+Three layers, in order of preference for new work. **Prefer bui (`@backstage/ui`)
+for new UI** — it's the new Backstage design system and the direction we're
+migrating toward, and it's already in use across `gs`, `ui-react`, `ai-chat`, and
+`app`. Fall back to the legacy `@backstage/core-components` (classic Backstage
+components) and `@material-ui/core` (MUI v4 + `makeStyles`) only where bui has no
+equivalent yet — e.g. the feature-rich `Table`, `Page`/`Header`/`Content`
+scaffolding. Mixing all three in one file is expected during the migration. The
+bui stylesheet is imported once in `packages/app/src/index.tsx`; no `BUIProvider`
+is needed.
+
+See `docs/ui.md` and the **`ui`** Claude Code skill for details, including how to
+read Backstage Storybook component/story source without cloning the monorepo.
 
 ### Scaffolder Field Extensions
 

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ui
+description: How to build UI in this repo — the bui (@backstage/ui) design system vs legacy @backstage/core-components + MUI v4, which to reach for, and how to read Backstage Storybook component/story source. Use when creating or changing pages, cards, layouts, buttons, or any frontend component.
+---
+
+## The three UI layers in this repo
+
+| Layer | Import from | Status |
+| --- | --- | --- |
+| **bui** — the new Backstage design system | `@backstage/ui` (aka "Backstage UI", "BUI") | **Preferred for new work.** The direction we're migrating toward. |
+| **core-components** — classic Backstage components | `@backstage/core-components` | Legacy but still required where bui has no equivalent (e.g. feature-rich `Table`, `Page`/`Header`/`Content` scaffolding, `Link` with route refs). |
+| **Material UI v4** | `@material-ui/core` | Legacy primitives + `makeStyles`. Used for styling and gaps bui doesn't cover. [MUI v4 docs](https://v4.mui.com/). |
+
+**Rule of thumb: reach for bui first.** Fall back to core-components / MUI v4 only
+when bui lacks the piece you need. Mixing all three in one file is normal and
+expected during the migration — see `ClusterAboutCard.tsx`, which imports `Grid`
+from bui, `Link` from core-components, and `Box`/`Tooltip` from MUI v4 together.
+
+`@backstage/ui` is currently `0.16.0` — a young, fast-moving package. APIs change
+between releases and it is **not** a full replacement for core-components yet.
+When unsure whether a bui component exists or what props it takes, check the
+Storybook source (see below) rather than guessing.
+
+## bui setup (already done)
+
+- The plugin's `package.json` must declare `"@backstage/ui": "backstage:^"`
+  (already present in `gs`, `ui-react`, `ai-chat`, and `app`).
+- The global stylesheet is imported once in `packages/app/src/index.tsx`:
+  `import '@backstage/ui/css/styles.css';`. Don't re-import it per component.
+- We do **not** wrap the app in `BUIProvider` — bui components render against the
+  existing app theme + the global CSS. (Storybook recipes use `BUIProvider`
+  because they render in isolation; the real app doesn't need it.)
+
+## bui components we actually use
+
+Common primitives already in the codebase (import from `@backstage/ui`):
+
+- **Layout**: `Flex`, `Grid`, `Box`, `Container`
+- **Surfaces**: `Card`, `CardHeader`, `CardBody`, `CardFooter`
+- **Typography**: `Text` (e.g. `<Text as="h3" variant="title-x-small" weight="bold">`)
+- **Controls**: `Button`, `ButtonIcon`, `Switch`, `Link`
+- **Overlay/menu**: `Tooltip`, `TooltipTrigger`, `MenuTrigger`, `Menu`, `MenuItem`
+- **Data display**: `Table` + `Cell` / `CellText` / `ColumnConfig`, `List`, `ListRow`, `Avatar`
+- **Page chrome**: `PluginHeader`, `Header` (the two-tier header pattern — plugin-level
+  `PluginHeader` above an entity-level `Header`)
+
+### Cards: use the shared `InfoCard` wrapper
+
+`@giantswarm/backstage-plugin-ui-react` exports an `InfoCard` built on bui's
+`Card`/`CardHeader`/`CardBody`/`CardFooter` with our standard title styling and
+header/footer action slots. Prefer it over hand-rolling a bui `Card` or the
+core-components `InfoCard` for new cards. Source:
+`plugins/ui-react/src/components/InfoCard/InfoCard.tsx`.
+
+### Tables: see the `tables` skill
+
+The bui `Table` (data-driven `columnConfig` + `data`, cells must return
+`Cell`/`CellText`) and the feature-rich core-components `Table` are both
+documented in depth in the **`tables`** skill, including the choice matrix and
+gotchas (loading skeleton needs `data={undefined}`). Read that skill for anything
+table-related; don't duplicate it here.
+
+## Reading Backstage Storybook source
+
+The [Backstage Storybook](https://backstage.io/storybook/) renders components
+from the upstream **`backstage/backstage` monorepo** — stories are `.stories.tsx`
+files colocated with their components. There is **no separate storybook repo**,
+and we do **not** run a local storybook. To learn a pattern (how a page/card is
+composed, what props a bui component takes), read the story + component source
+directly.
+
+### The reliable technique: `index.json` → `importPath` → GitHub raw
+
+Every Storybook deployment publishes a machine-readable index at
+`https://backstage.io/storybook/index.json`. Each entry carries the exact source
+paths:
+
+```json
+{
+  "id": "recipes-pluginheader-and-header--with-tabs",
+  "title": "Recipes/PluginHeader and Header",
+  "importPath": "./packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx",
+  "componentPath": "./packages/ui/src/components/PluginHeader/PluginHeader.tsx"
+}
+```
+
+Then fetch the raw source from GitHub (strip the leading `./`):
+
+```bash
+BASE=https://raw.githubusercontent.com/backstage/backstage/master
+curl -sfL "$BASE/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx"
+curl -sfL "$BASE/packages/ui/src/components/PluginHeader/PluginHeader.tsx"
+```
+
+To find the story ID for a Storybook URL: the `?path=/story/<id>` query param
+**is** the entry `id`. Story IDs can drift between releases (the "Recipes/..."
+example also now exists as "Backstage UI/PluginHeader") — search `index.json` by
+`title` or a keyword rather than trusting an old URL. Quick lookup:
+
+```bash
+curl -sfL https://backstage.io/storybook/index.json \
+  | jq '.entries | to_entries[] | select(.value.title|test("PluginHeader";"i")) | .value | {id,importPath,componentPath}'
+```
+
+### Live inspection with Chrome DevTools
+
+Use the `chrome-devtools` MCP when you want to inspect the *rendered* result
+(DOM, computed styles, a11y tree) or grab `index.json` without CORS friction:
+
+- `new_page` / `navigate_page` to `https://backstage.io/storybook/`
+- `evaluate_script` running `fetch('https://backstage.io/storybook/index.json')`
+  (same-origin, so no CORS block) to pull the index or any raw story text
+- `take_snapshot` for the a11y tree of a rendered story
+
+Note: the chrome-devtools MCP has its own filesystem roots — it can't write into
+the session scratchpad. Fetch text via `evaluate_script` and return it inline, or
+just `curl` the GitHub raw URL from Bash instead.
+
+## Related skills
+
+- **`tables`** — bui `Table` vs core-components `Table`, columns, filtering, faceted sidebars.
+- **`components`** — component directory structure, named exports, barrel files.
+- **`upstream-search`** — searching a *local clone* of `backstage/backstage` (needs `BACKSTAGE_UPSTREAM_DIR` set; the Storybook technique above needs no clone).

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -2,6 +2,31 @@
 
 When working with the Backstage user interface, e. g. in order to create new components, some resources will be helpful.
 
-- Backstage uses [Material UI version 4](https://v4.mui.com/).
+## Component libraries
 
-- The [Backstage Storybook](https://backstage.io/storybook/) allows to explore the existing UI components in a number of different states.
+There are three UI layers in this repo, in order of preference for new work:
+
+- **bui** (`@backstage/ui`, aka "Backstage UI") — the new Backstage design
+  system and the direction we are migrating toward. **Prefer it for new work.**
+  The global stylesheet is imported once in `packages/app/src/index.tsx`.
+
+- **core-components** (`@backstage/core-components`) — the classic Backstage
+  components. Legacy, but still required where bui has no equivalent yet (e.g.
+  the feature-rich `Table`, the `Page`/`Header`/`Content` scaffolding, and
+  `Link` with route refs).
+
+- [Material UI version 4](https://v4.mui.com/) (`@material-ui/core`) — legacy
+  primitives and `makeStyles`, used for styling and gaps the above don't cover.
+
+Mixing all three in one file is normal during the migration. Reach for bui
+first and fall back only when a piece is missing.
+
+## Storybook
+
+The [Backstage Storybook](https://backstage.io/storybook/) allows to explore the
+existing UI components in a number of different states. It renders stories from
+the upstream `backstage/backstage` monorepo; we do not run a local storybook.
+
+To read the source behind a story (to learn a pattern or a component's props),
+use the `index.json` → `importPath` → GitHub raw technique described in the
+`ui` Claude Code skill (`.claude/skills/ui/SKILL.md`).


### PR DESCRIPTION
### What does this PR do?

Documents that **bui (`@backstage/ui`)** is the preferred UI component library for new work and the direction we are migrating toward, and adds a `ui` Claude Code skill.

- **`.claude/CLAUDE.md`** — adds a *UI component libraries* subsection to Frontend Architecture. Previously it mentioned only Material-UI v4, which didn't reflect that bui is already in use (`gs`, `ui-react`, `ai-chat`, `app`) and is the target.
- **`docs/ui.md`** — expands the note to cover all three layers (bui → core-components → MUI v4) in preference order, plus how to read Storybook source.
- **`.claude/skills/ui/SKILL.md`** (new) — bui vs core-components guidance grounded in real files, the shared `InfoCard` wrapper, a hand-off to the existing `tables` skill, and the `index.json` → `importPath` → GitHub raw technique for reading upstream Storybook component/story source without cloning the monorepo.

### What is the effect of this change to users?

No end-user facing change — docs and agent tooling only.

### How does it look like?

N/A (documentation).

### Any background context you can provide?

Prompted by needing to read the source behind Storybook recipes (e.g. the PluginHeader/Header pattern) and realizing the repo guidance didn't capture the bui migration direction.

### Do the docs need to be updated?

Yes — done in this PR.

### Should this change be mentioned in the release notes?

No changeset — no published `@giantswarm/backstage-plugin-*` package source changed.