### PR TITLE
refactor(gs): migrate cluster and deployment headers and tabs to bui

### DIFF
--- a/.changeset/bui-cluster-deployment-headers.md
+++ b/.changeset/bui-cluster-deployment-headers.md
@@ -1,0 +1,21 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-react': minor
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Migrate the cluster and deployment pages to a single BUI `PluginHeader`.
+
+- Replace the classic `<Page>`/`<Header>` (blue banner) on the cluster and
+  deployment list and detail pages with the BUI `PluginHeader`, and suppress the
+  app-shell header (`noHeader`) so the two headers no longer stack.
+- Detail-page tabs move from the classic `RoutedTabs` strip to BUI tabs rendered
+  in the plugin header (via a shared `useLayoutTabs` hook), matching the muster
+  and flux sections.
+- Header actions are now BUI buttons: the new `AIChatButtonBui` variant and a
+  BUI-converted "Edit deployment" button. The troubleshoot state uses BUI's
+  `destructive` styling.
+- The dropped header "type" line and the cluster description subtitle now live in
+  the respective "About" cards.
+
+`ai-chat-react` gains a new exported `AIChatButtonBui` component for use in BUI
+contexts; the existing Material UI `AIChatButton` is unchanged.

--- a/plugins/ai-chat-react/package.json
+++ b/plugins/ai-chat-react/package.json
@@ -26,6 +26,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
+    "@backstage/ui": "backstage:^",
     "@material-ui/core": "^4.9.13",
     "classnames": "^2.5.1"
   },

--- a/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
+++ b/plugins/ai-chat-react/src/components/AIChatButton/AIChatButton.tsx
@@ -10,11 +10,12 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import { useApiHolder } from '@backstage/core-plugin-api';
-import { routeResolutionApiRef, useApi } from '@backstage/frontend-plugin-api';
-import { useNavigate } from 'react-router-dom';
 import { AIChatIcon } from '../../assets/icons';
-import { aiChatApiRef, aiChatDrawerApiRef } from '../../api';
-import { rootRouteRef } from '../../routes';
+import { aiChatApiRef } from '../../api';
+import { AIChatButtonItem, AIChatButtonOpenMode } from './types';
+import { useOpenChat } from './useOpenChat';
+
+export type { AIChatButtonItem, AIChatButtonOpenMode } from './types';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -33,13 +34,6 @@ const useStyles = makeStyles(() => ({
     minWidth: 200,
   },
 }));
-
-export type AIChatButtonItem = {
-  label?: string;
-  message: string;
-};
-
-export type AIChatButtonOpenMode = 'drawer' | 'navigate';
 
 type AIChatButtonProps = {
   items: AIChatButtonItem[];
@@ -68,22 +62,9 @@ const AIChatButtonInner = ({
   variant,
   color,
 }: AIChatButtonInnerProps) => {
-  const routeResolutionApi = useApi(routeResolutionApiRef);
-  const chatPath = routeResolutionApi.resolve(rootRouteRef);
   const classes = useStyles();
-  const navigate = useNavigate();
-  const apiHolder = useApiHolder();
+  const openChat = useOpenChat(openMode);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-  const openChat = (message: string) => {
-    const drawerApi = apiHolder.get(aiChatDrawerApiRef);
-    if (openMode !== 'navigate' && drawerApi) {
-      drawerApi.openDrawer(message);
-    } else if (chatPath) {
-      const params = new URLSearchParams({ message });
-      navigate(`${chatPath()}?${params.toString()}`);
-    }
-  };
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();

--- a/plugins/ai-chat-react/src/components/AIChatButton/types.ts
+++ b/plugins/ai-chat-react/src/components/AIChatButton/types.ts
@@ -1,0 +1,6 @@
+export type AIChatButtonItem = {
+  label?: string;
+  message: string;
+};
+
+export type AIChatButtonOpenMode = 'drawer' | 'navigate';

--- a/plugins/ai-chat-react/src/components/AIChatButton/useOpenChat.ts
+++ b/plugins/ai-chat-react/src/components/AIChatButton/useOpenChat.ts
@@ -1,0 +1,28 @@
+import { useApiHolder } from '@backstage/core-plugin-api';
+import { routeResolutionApiRef, useApi } from '@backstage/frontend-plugin-api';
+import { useNavigate } from 'react-router-dom';
+import { aiChatDrawerApiRef } from '../../api';
+import { rootRouteRef } from '../../routes';
+import { AIChatButtonOpenMode } from './types';
+
+/**
+ * Shared logic for opening the AI chat, used by both the Material UI and the
+ * Backstage UI (bui) variants of the AI chat button. Returns a callback that
+ * opens the chat drawer when available, otherwise navigates to the chat page.
+ */
+export function useOpenChat(openMode?: AIChatButtonOpenMode) {
+  const routeResolutionApi = useApi(routeResolutionApiRef);
+  const chatPath = routeResolutionApi.resolve(rootRouteRef);
+  const navigate = useNavigate();
+  const apiHolder = useApiHolder();
+
+  return (message: string) => {
+    const drawerApi = apiHolder.get(aiChatDrawerApiRef);
+    if (openMode !== 'navigate' && drawerApi) {
+      drawerApi.openDrawer(message);
+    } else if (chatPath) {
+      const params = new URLSearchParams({ message });
+      navigate(`${chatPath()}?${params.toString()}`);
+    }
+  };
+}

--- a/plugins/ai-chat-react/src/components/AIChatButtonBui/AIChatButtonBui.tsx
+++ b/plugins/ai-chat-react/src/components/AIChatButtonBui/AIChatButtonBui.tsx
@@ -1,0 +1,72 @@
+import { useApiHolder } from '@backstage/core-plugin-api';
+import { Button, Menu, MenuItem, MenuTrigger } from '@backstage/ui';
+import { AIChatIcon } from '../../assets/icons';
+import { aiChatApiRef } from '../../api';
+import { AIChatButtonItem, AIChatButtonOpenMode } from '../AIChatButton/types';
+import { useOpenChat } from '../AIChatButton/useOpenChat';
+
+type AIChatButtonBuiProps = {
+  items: AIChatButtonItem[];
+  label?: string;
+  troubleshoot?: boolean;
+  openMode?: AIChatButtonOpenMode;
+  variant?: 'primary' | 'secondary' | 'tertiary';
+};
+
+/**
+ * Backstage UI (bui) variant of the AI chat button, for use in bui contexts
+ * such as the plugin header toolbar. Shares its open-chat behavior with the
+ * Material UI {@link AIChatButton} via {@link useOpenChat}. The troubleshoot
+ * state maps to bui's built-in `destructive` styling.
+ */
+export const AIChatButtonBui = ({
+  items,
+  label,
+  troubleshoot,
+  openMode,
+  variant = 'secondary',
+}: AIChatButtonBuiProps) => {
+  const apiHolder = useApiHolder();
+  const aiChatApi = apiHolder.get(aiChatApiRef);
+  const openChat = useOpenChat(openMode);
+
+  const displayLabel =
+    label ?? (troubleshoot ? 'Troubleshoot with AI' : 'Inspect with AI');
+
+  if (!aiChatApi || items.length === 0) {
+    return null;
+  }
+
+  const icon = <AIChatIcon fontSize="inherit" />;
+
+  if (items.length === 1) {
+    return (
+      <Button
+        variant={variant}
+        destructive={troubleshoot}
+        iconStart={icon}
+        onClick={() => openChat(items[0].message)}
+      >
+        {displayLabel}
+      </Button>
+    );
+  }
+
+  return (
+    <MenuTrigger>
+      <Button variant={variant} destructive={troubleshoot} iconStart={icon}>
+        {displayLabel}
+      </Button>
+      <Menu>
+        {items.map((item, index) => (
+          <MenuItem
+            key={item.label ?? index}
+            onAction={() => openChat(item.message)}
+          >
+            {item.label ?? displayLabel}
+          </MenuItem>
+        ))}
+      </Menu>
+    </MenuTrigger>
+  );
+};

--- a/plugins/ai-chat-react/src/components/AIChatButtonBui/index.ts
+++ b/plugins/ai-chat-react/src/components/AIChatButtonBui/index.ts
@@ -1,0 +1,1 @@
+export { AIChatButtonBui } from './AIChatButtonBui';

--- a/plugins/ai-chat-react/src/components/index.ts
+++ b/plugins/ai-chat-react/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './AIChatButton';
+export * from './AIChatButtonBui';

--- a/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
+++ b/plugins/gs/src/components/clusters/ClusterLayout/ClusterLayout.tsx
@@ -1,33 +1,22 @@
-import {
-  Content,
-  Header,
-  Page,
-  Progress,
-  RoutedTabs,
-} from '@backstage/core-components';
+import { ReactNode } from 'react';
+import { Content, Progress } from '@backstage/core-components';
 import {
   attachComponentData,
   useElementFilter,
 } from '@backstage/core-plugin-api';
 import { useRouteRefParams } from '@backstage/frontend-plugin-api';
-import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/core/styles';
+import { PluginHeader } from '@backstage/ui';
+import StorageIcon from '@material-ui/icons/Storage';
 import { TabProps } from '@material-ui/core/Tab';
 import Alert from '@material-ui/lab/Alert';
 import { useAsyncCluster } from '../ClusterDetailsPage/useCurrentCluster';
 import { clusterDetailsRouteRef } from '../../../routes';
-import { useCurrentUser } from '../../hooks';
+import { useCurrentUser, useLayoutTabs } from '../../hooks';
 import { ClusterAppStatus } from './ClusterAppStatus';
 import { App, Cluster } from '@giantswarm/backstage-plugin-kubernetes-react';
-import { AIChatButton } from '@giantswarm/backstage-plugin-ai-chat-react';
-import { calculateClusterStatus, getClusterDescription } from '../utils';
+import { AIChatButtonBui } from '@giantswarm/backstage-plugin-ai-chat-react';
+import { calculateClusterStatus } from '../utils';
 import { ClusterStatuses } from '../ClusterStatus';
-
-const useStyles = makeStyles(theme => ({
-  headerAction: {
-    color: theme.page.fontColor,
-  },
-}));
 
 export type ClusterLayoutRouteProps = {
   path: string;
@@ -50,20 +39,68 @@ attachComponentData(Route, 'core.gatherMountPoints', true);
 const PageContent = ({
   isLoading,
   error,
-  installationName,
-  cluster,
   clusterApp,
-  isGSUser,
-  children,
+  element,
 }: {
   isLoading: boolean;
   error: Error | null;
-  installationName: string;
-  cluster?: Cluster;
   clusterApp?: App;
-  isGSUser?: boolean;
-  children?: React.ReactNode;
+  element: ReactNode;
 }) => {
+  if (isLoading) {
+    return (
+      <Content>
+        <Progress />
+      </Content>
+    );
+  }
+
+  if (error) {
+    return (
+      <Content>
+        {clusterApp ? (
+          <ClusterAppStatus app={clusterApp} />
+        ) : (
+          <Alert severity="error">{error.toString()}</Alert>
+        )}
+      </Content>
+    );
+  }
+
+  return <Content>{element}</Content>;
+};
+
+function getAIChatMessage(cluster: Cluster, installationName: string): string {
+  const name = cluster.getName();
+  const namespace = cluster.getNamespace();
+  const isTroubleshoot =
+    calculateClusterStatus(cluster) !== ClusterStatuses.Ready;
+
+  return isTroubleshoot
+    ? `Please read the cluster resource named '${name}' in namespace '${namespace}' on management cluster '${installationName}' and help me troubleshoot it.`
+    : `Please read the cluster resource named '${name}' in namespace '${namespace}' on management cluster '${installationName}', and show me basic details, so that I can ask further questions about it.`;
+}
+
+export interface ClusterLayoutProps {
+  children?: React.ReactNode;
+}
+
+export const ClusterLayout = ({ children }: ClusterLayoutProps) => {
+  const { name } = useRouteRefParams(clusterDetailsRouteRef);
+
+  const {
+    cluster,
+    clusterApp,
+    installationName,
+    loading: clusterIsLoading,
+    error: error,
+  } = useAsyncCluster();
+
+  const { isGSUser, isLoading: currentUserIsLoading } =
+    useCurrentUser(installationName);
+
+  const isLoading = clusterIsLoading || currentUserIsLoading;
+
   const routes = useElementFilter(
     children,
     elements =>
@@ -93,82 +130,26 @@ const PageContent = ({
               path: elementProps.path,
               title: elementProps.title,
               children: elementProps.children,
-              tabProps: elementProps.tabProps,
             },
           ];
         }),
     [cluster, isLoading, isGSUser],
   );
 
-  if (isLoading) {
-    return (
-      <Content>
-        <Progress />
-      </Content>
-    );
-  }
-
-  if (error) {
-    return (
-      <Content>
-        {clusterApp ? (
-          <ClusterAppStatus app={clusterApp} />
-        ) : (
-          <Alert severity="error">{error.toString()}</Alert>
-        )}
-      </Content>
-    );
-  }
-
-  return <RoutedTabs routes={routes} />;
-};
-
-function getAIChatMessage(cluster: Cluster, installationName: string): string {
-  const name = cluster.getName();
-  const namespace = cluster.getNamespace();
-  const isTroubleshoot =
-    calculateClusterStatus(cluster) !== ClusterStatuses.Ready;
-
-  return isTroubleshoot
-    ? `Please read the cluster resource named '${name}' in namespace '${namespace}' on management cluster '${installationName}' and help me troubleshoot it.`
-    : `Please read the cluster resource named '${name}' in namespace '${namespace}' on management cluster '${installationName}', and show me basic details, so that I can ask further questions about it.`;
-}
-
-export interface ClusterLayoutProps {
-  children?: React.ReactNode;
-}
-
-export const ClusterLayout = ({ children }: ClusterLayoutProps) => {
-  const classes = useStyles();
-  const { name } = useRouteRefParams(clusterDetailsRouteRef);
-
-  const {
-    cluster,
-    clusterApp,
-    installationName,
-    loading: clusterIsLoading,
-    error: error,
-  } = useAsyncCluster();
-
-  const { isGSUser, isLoading: currentUserIsLoading } =
-    useCurrentUser(installationName);
-
-  const isLoading = clusterIsLoading || currentUserIsLoading;
+  const { tabs, element } = useLayoutTabs(routes);
 
   return (
-    <Page themeId="service">
-      <Header
-        title={name}
-        subtitle={cluster ? getClusterDescription(cluster) : undefined}
-        type="resource - kubernetes cluster"
-      >
-        {cluster && (
-          <Grid item className={classes.headerAction}>
-            <AIChatButton
+    <>
+      <PluginHeader
+        icon={<StorageIcon fontSize="inherit" />}
+        title={`Clusters / ${name}`}
+        tabs={tabs}
+        customActions={
+          cluster ? (
+            <AIChatButtonBui
               troubleshoot={
                 calculateClusterStatus(cluster) !== ClusterStatuses.Ready
               }
-              color="inherit"
               items={[
                 {
                   label: 'AI Chat',
@@ -176,20 +157,16 @@ export const ClusterLayout = ({ children }: ClusterLayoutProps) => {
                 },
               ]}
             />
-          </Grid>
-        )}
-      </Header>
+          ) : undefined
+        }
+      />
       <PageContent
         isLoading={isLoading}
         error={error}
-        installationName={installationName}
-        cluster={cluster}
         clusterApp={clusterApp}
-        isGSUser={isGSUser}
-      >
-        {children}
-      </PageContent>
-    </Page>
+        element={element}
+      />
+    </>
   );
 };
 

--- a/plugins/gs/src/components/clusters/ClustersPage/DefaultClustersPage.tsx
+++ b/plugins/gs/src/components/clusters/ClustersPage/DefaultClustersPage.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 import { Content } from '@backstage/core-components';
+import { PluginHeader } from '@backstage/ui';
+import StorageIcon from '@material-ui/icons/Storage';
 import { FiltersLayout } from '../../FiltersLayout';
 import { ClustersTable } from '../ClustersTable';
 import { ClustersDataProvider } from '../ClustersDataProvider';
@@ -16,16 +18,22 @@ export function BaseClustersPage(props: BaseClustersPageProps) {
   const { filters, content = <ClustersTable /> } = props;
 
   return (
-    <Content>
-      <ErrorsProvider>
-        <ClustersDataProvider>
-          <FiltersLayout>
-            <FiltersLayout.Filters>{filters}</FiltersLayout.Filters>
-            <FiltersLayout.Content>{content}</FiltersLayout.Content>
-          </FiltersLayout>
-        </ClustersDataProvider>
-      </ErrorsProvider>
-    </Content>
+    <>
+      <PluginHeader
+        icon={<StorageIcon fontSize="inherit" />}
+        title="Clusters"
+      />
+      <Content>
+        <ErrorsProvider>
+          <ClustersDataProvider>
+            <FiltersLayout>
+              <FiltersLayout.Filters>{filters}</FiltersLayout.Filters>
+              <FiltersLayout.Content>{content}</FiltersLayout.Content>
+            </FiltersLayout>
+          </ClustersDataProvider>
+        </ErrorsProvider>
+      </Content>
+    </>
   );
 }
 

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterAboutCard/ClusterAboutCard.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterAboutCard/ClusterAboutCard.tsx
@@ -11,6 +11,7 @@ import {
   formatClusterType,
   formatServicePriority,
   getClusterCreationTimestamp,
+  getClusterDescription,
   getClusterOrganization,
   getClusterReleaseVersion,
   getClusterServicePriority,
@@ -145,6 +146,7 @@ export function ClusterAboutCard() {
   useShowErrors(controlPlaneErrors);
 
   const clusterType = calculateClusterType(cluster);
+  const description = getClusterDescription(cluster);
   const releaseVersion = getClusterReleaseVersion(cluster);
   const organization = getClusterOrganization(cluster);
   const servicePriority = getClusterServicePriority(cluster);
@@ -155,6 +157,12 @@ export function ClusterAboutCard() {
   return (
     <InfoCard>
       <Grid.Root columns={{ initial: '1', sm: '2', lg: '3' }} gap="5">
+        <AboutField label="Description">
+          <AboutFieldValue>
+            {description ? description : <NotAvailable />}
+          </AboutFieldValue>
+        </AboutField>
+
         <AboutField label="Type">
           <AboutFieldValue>
             <Box display="inline-flex" alignItems="center">

--- a/plugins/gs/src/components/deployments/DeploymentLayout/DeploymentLayout.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentLayout/DeploymentLayout.tsx
@@ -1,27 +1,22 @@
-import {
-  Content,
-  Header,
-  Page,
-  Progress,
-  RoutedTabs,
-} from '@backstage/core-components';
+import { ReactNode } from 'react';
+import { Content, Progress } from '@backstage/core-components';
 import {
   attachComponentData,
   useElementFilter,
 } from '@backstage/core-plugin-api';
 import { useRouteRefParams } from '@backstage/frontend-plugin-api';
-import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/core/styles';
+import { PluginHeader } from '@backstage/ui';
+import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import { TabProps } from '@material-ui/core/Tab';
 import Alert from '@material-ui/lab/Alert';
 import { useAsyncDeployment } from '../DeploymentDetailsPage/useCurrentDeployment';
 import { deploymentDetailsRouteRef } from '../../../routes';
-import { useCurrentUser } from '../../hooks';
+import { useCurrentUser, useLayoutTabs } from '../../hooks';
 import {
   App,
   HelmRelease,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
-import { AIChatButton } from '@giantswarm/backstage-plugin-ai-chat-react';
+import { AIChatButtonBui } from '@giantswarm/backstage-plugin-ai-chat-react';
 import { getAggregatedStatus } from '../utils/getStatus';
 import {
   useMimirWorkloadStatus,
@@ -33,12 +28,6 @@ import {
   getWorkloadPodPrefix,
 } from '../utils/getWorkloadIdentifiers';
 import { EditDeploymentButton } from './EditDeploymentButton';
-
-const useStyles = makeStyles(theme => ({
-  headerAction: {
-    color: theme.page.fontColor,
-  },
-}));
 
 export type DeploymentLayoutRouteProps = {
   path: string;
@@ -61,54 +50,12 @@ attachComponentData(Route, 'core.gatherMountPoints', true);
 const PageContent = ({
   isLoading,
   error,
-  installationName,
-  deployment,
-  isGSUser,
-  children,
+  element,
 }: {
   isLoading: boolean;
   error: Error | null;
-  installationName: string;
-  deployment?: App | HelmRelease;
-  isGSUser?: boolean;
-  children?: React.ReactNode;
+  element: ReactNode;
 }) => {
-  const routes = useElementFilter(
-    children,
-    elements =>
-      elements
-        .selectByComponentData({
-          key: dataKey,
-          withStrictError:
-            'Child of DeploymentLayout must be a DeploymentLayout.Route',
-        })
-        .getElements<DeploymentLayoutRouteProps>()
-        .flatMap(({ props: elementProps }) => {
-          if (isLoading || !deployment) {
-            return [];
-          } else if (
-            elementProps.if &&
-            !elementProps.if({
-              deployment,
-              installationName,
-              isGSUser: Boolean(isGSUser),
-            })
-          ) {
-            return [];
-          }
-
-          return [
-            {
-              path: elementProps.path,
-              title: elementProps.title,
-              children: elementProps.children,
-              tabProps: elementProps.tabProps,
-            },
-          ];
-        }),
-    [deployment, isLoading, isGSUser],
-  );
-
   if (isLoading) {
     return (
       <Content>
@@ -125,7 +72,7 @@ const PageContent = ({
     );
   }
 
-  return <RoutedTabs routes={routes} />;
+  return <Content>{element}</Content>;
 };
 
 function isWorkloadReady(w: WorkloadReplicaStatus): boolean {
@@ -177,7 +124,6 @@ export interface DeploymentLayoutProps {
 }
 
 export const DeploymentLayout = ({ children }: DeploymentLayoutProps) => {
-  const classes = useStyles();
   const { name } = useRouteRefParams(deploymentDetailsRouteRef);
 
   const {
@@ -206,49 +152,78 @@ export const DeploymentLayout = ({ children }: DeploymentLayoutProps) => {
 
   const isLoading = deploymentIsLoading || currentUserIsLoading;
 
-  const type = `resource - ${deployment && deployment instanceof App ? 'Giant Swarm App' : 'Flux HelmRelease'}`;
-
-  return (
-    <Page themeId="service">
-      <Header title={name} type={type}>
-        {deployment && deployment instanceof HelmRelease && (
-          <Grid item className={classes.headerAction}>
-            <EditDeploymentButton
-              deployment={deployment}
-              installationName={installationName}
-            />
-          </Grid>
-        )}
-        {deployment &&
-          (() => {
-            const { message, isTroubleshoot } = getAIChatMessage(
+  const routes = useElementFilter(
+    children,
+    elements =>
+      elements
+        .selectByComponentData({
+          key: dataKey,
+          withStrictError:
+            'Child of DeploymentLayout must be a DeploymentLayout.Route',
+        })
+        .getElements<DeploymentLayoutRouteProps>()
+        .flatMap(({ props: elementProps }) => {
+          if (isLoading || !deployment) {
+            return [];
+          } else if (
+            elementProps.if &&
+            !elementProps.if({
               deployment,
               installationName,
-              workloads,
-              clusterName,
-              workloadNamespace,
-            );
-            return (
-              <Grid item className={classes.headerAction}>
-                <AIChatButton
-                  troubleshoot={isTroubleshoot}
-                  color="inherit"
-                  items={[{ label: 'AI Chat', message }]}
-                />
-              </Grid>
-            );
-          })()}
-      </Header>
-      <PageContent
-        isLoading={isLoading}
-        error={error}
-        installationName={installationName}
-        deployment={deployment}
-        isGSUser={isGSUser}
-      >
-        {children}
-      </PageContent>
-    </Page>
+              isGSUser: Boolean(isGSUser),
+            })
+          ) {
+            return [];
+          }
+
+          return [
+            {
+              path: elementProps.path,
+              title: elementProps.title,
+              children: elementProps.children,
+            },
+          ];
+        }),
+    [deployment, isLoading, isGSUser],
+  );
+
+  const { tabs, element } = useLayoutTabs(routes);
+
+  return (
+    <>
+      <PluginHeader
+        icon={<CloudUploadIcon fontSize="inherit" />}
+        title={`Deployments / ${name}`}
+        tabs={tabs}
+        customActions={
+          <>
+            {deployment && deployment instanceof HelmRelease && (
+              <EditDeploymentButton
+                deployment={deployment}
+                installationName={installationName}
+              />
+            )}
+            {deployment &&
+              (() => {
+                const { message, isTroubleshoot } = getAIChatMessage(
+                  deployment,
+                  installationName,
+                  workloads,
+                  clusterName,
+                  workloadNamespace,
+                );
+                return (
+                  <AIChatButtonBui
+                    troubleshoot={isTroubleshoot}
+                    items={[{ label: 'AI Chat', message }]}
+                  />
+                );
+              })()}
+          </>
+        }
+      />
+      <PageContent isLoading={isLoading} error={error} element={element} />
+    </>
   );
 };
 

--- a/plugins/gs/src/components/deployments/DeploymentLayout/EditDeploymentButton/EditDeploymentButton.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentLayout/EditDeploymentButton/EditDeploymentButton.tsx
@@ -1,24 +1,15 @@
-import Button from '@material-ui/core/Button';
+import { Button, Tooltip, TooltipTrigger } from '@backstage/ui';
 import EditIcon from '@material-ui/icons/Edit';
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { HelmRelease } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { useEditAppDeploymentTemplate } from '../../../hooks';
 import { useEditDeploymentData } from '../useEditDeploymentData';
 import { useDeploymentEditCompatibility } from './useDeploymentEditCompatibility';
-import { Box, makeStyles, Tooltip } from '@material-ui/core';
 import {
   findTargetClusterName,
   findTargetClusterNamespace,
 } from '../../utils/findTargetCluster';
-
-const useStyles = makeStyles(() => ({
-  button: {
-    textTransform: 'none',
-    paddingLeft: 11,
-    paddingRight: 11,
-  },
-}));
 
 export function EditDeploymentButton({
   deployment,
@@ -27,7 +18,7 @@ export function EditDeploymentButton({
   deployment: HelmRelease;
   installationName: string;
 }) {
-  const classes = useStyles();
+  const navigate = useNavigate();
 
   const { available, getTemplateUrl } = useEditAppDeploymentTemplate();
 
@@ -108,22 +99,20 @@ export function EditDeploymentButton({
   }
 
   return (
-    <Box>
-      <Tooltip title={tooltipTitle}>
-        <span>
-          <Button
-            className={classes.button}
-            color="inherit"
-            size="small"
-            startIcon={<EditIcon />}
-            component={Link}
-            to={editLink ?? ''}
-            disabled={isDisabled}
-          >
-            Edit
-          </Button>
-        </span>
-      </Tooltip>
-    </Box>
+    <TooltipTrigger>
+      <Button
+        variant="secondary"
+        iconStart={<EditIcon fontSize="inherit" />}
+        isDisabled={isDisabled}
+        onClick={() => {
+          if (editLink) {
+            navigate(editLink);
+          }
+        }}
+      >
+        Edit
+      </Button>
+      <Tooltip>{tooltipTitle}</Tooltip>
+    </TooltipTrigger>
   );
 }

--- a/plugins/gs/src/components/deployments/DeploymentsPage/DefaultDeploymentsPage.tsx
+++ b/plugins/gs/src/components/deployments/DeploymentsPage/DefaultDeploymentsPage.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 import { Content } from '@backstage/core-components';
+import { PluginHeader } from '@backstage/ui';
+import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import { DeploymentsTable } from '../DeploymentsTable';
 import { DeploymentsDataProvider } from '../DeploymentsDataProvider';
 import { deploymentsRouteRef } from '../../../routes';
@@ -20,16 +22,22 @@ export function BaseDeploymentsPage(props: BaseDeploymentsPageProps) {
   } = props;
 
   return (
-    <Content>
-      <ErrorsProvider>
-        <DeploymentsDataProvider>
-          <FiltersLayout>
-            <FiltersLayout.Filters>{filters}</FiltersLayout.Filters>
-            <FiltersLayout.Content>{content}</FiltersLayout.Content>
-          </FiltersLayout>
-        </DeploymentsDataProvider>
-      </ErrorsProvider>
-    </Content>
+    <>
+      <PluginHeader
+        icon={<CloudUploadIcon fontSize="inherit" />}
+        title="Deployments"
+      />
+      <Content>
+        <ErrorsProvider>
+          <DeploymentsDataProvider>
+            <FiltersLayout>
+              <FiltersLayout.Filters>{filters}</FiltersLayout.Filters>
+              <FiltersLayout.Content>{content}</FiltersLayout.Content>
+            </FiltersLayout>
+          </DeploymentsDataProvider>
+        </ErrorsProvider>
+      </Content>
+    </>
   );
 }
 

--- a/plugins/gs/src/components/hooks/index.ts
+++ b/plugins/gs/src/components/hooks/index.ts
@@ -19,6 +19,7 @@ export * from './useHelmChartTags';
 export * from './useHelmChartValuesSchema';
 export * from './useHelmChartValuesYaml';
 export * from './useInstallationsInfo';
+export * from './useLayoutTabs';
 export * from './useK8sVersionEOLDate';
 export * from './useNodePoolsForAWSCluster';
 export * from './useNodePoolsForAzureCluster';

--- a/plugins/gs/src/components/hooks/useLayoutTabs.ts
+++ b/plugins/gs/src/components/hooks/useLayoutTabs.ts
@@ -1,0 +1,61 @@
+import { ReactNode } from 'react';
+import { useLocation, useParams, useRoutes } from 'react-router-dom';
+import type { HeaderTab } from '@backstage/ui';
+
+export type LayoutTabRoute = {
+  path: string;
+  title: string;
+  children: JSX.Element;
+};
+
+/**
+ * Turns a layout's sub-routes into bui `PluginHeader` tabs plus the routed
+ * content element for the currently active sub-route.
+ *
+ * The tabs are rendered inside the bui `PluginHeader` (via its `tabs` prop),
+ * matching the muster and flux sections. Each tab links to the absolute path of
+ * its sub-route; `matchStrategy` keeps the tab active for nested paths. This
+ * replaces the classic `RoutedTabs` from `@backstage/core-components`.
+ */
+export function useLayoutTabs(routes: LayoutTabRoute[]): {
+  tabs: HeaderTab[];
+  element: ReactNode;
+} {
+  const { pathname } = useLocation();
+  const params = useParams();
+
+  // Render the element for the active sub-route. Mirrors the route matching in
+  // the classic RoutedTabs: longest path first, falling back to the first tab.
+  const routeObjects = routes.map(({ path, children }) => ({
+    caseSensitive: false,
+    path: `${path}/*`,
+    element: children,
+  }));
+  const sortedRouteObjects = [...routeObjects].sort((a, b) =>
+    b.path.replace(/\/\*$/, '').localeCompare(a.path.replace(/\/\*$/, '')),
+  );
+  const element = useRoutes(sortedRouteObjects) ?? routes[0]?.children;
+
+  // The layout is mounted at a splat route (e.g. `/clusters/:.../*`), so the
+  // base path is the current pathname with the matched remainder removed.
+  const splat = params['*'] ?? '';
+  let basePath =
+    splat && pathname.endsWith(splat)
+      ? pathname.slice(0, pathname.length - splat.length)
+      : pathname;
+  basePath = basePath.replace(/\/+$/, '');
+
+  const tabs: HeaderTab[] = routes.map(({ path, title }) => {
+    const cleanPath = path.replace(/^\//, '').replace(/\/\*$/, '');
+    return {
+      id: path || 'index',
+      label: title,
+      href: cleanPath ? `${basePath}/${cleanPath}` : basePath,
+      // The index tab must match exactly, otherwise it stays active on every
+      // sub-route (its href is a prefix of them all).
+      matchStrategy: cleanPath ? 'prefix' : 'exact',
+    };
+  });
+
+  return { tabs, element };
+}

--- a/plugins/gs/src/plugin.tsx
+++ b/plugins/gs/src/plugin.tsx
@@ -65,6 +65,9 @@ const clustersPage = PageBlueprint.make({
   params: {
     title: 'Clusters',
     icon: <StorageIcon />,
+    // The clusters pages render their own bui PluginHeader (list + detail),
+    // so suppress the app-shell header to avoid stacking two headers.
+    noHeader: true,
     path: '/clusters',
     routeRef: clustersRouteRef,
     loader: async () => {
@@ -80,6 +83,9 @@ const deploymentsPage = PageBlueprint.make({
   params: {
     title: 'Deployments',
     icon: <CloudUploadIcon />,
+    // The deployments pages render their own bui PluginHeader (list + detail),
+    // so suppress the app-shell header to avoid stacking two headers.
+    noHeader: true,
     path: '/deployments',
     routeRef: deploymentsRouteRef,
     loader: async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11372,6 +11372,7 @@ __metadata:
   resolution: "@giantswarm/backstage-plugin-ai-chat-react@workspace:plugins/ai-chat-react"
   dependencies:
     "@backstage/cli": "backstage:^"
+    "@backstage/ui": "backstage:^"
     "@material-ui/core": "npm:^4.9.13"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"


### PR DESCRIPTION
## What

Migrates the **cluster** and **deployment** pages (list + detail) from the classic Backstage `Page`/`Header` to a single BUI `PluginHeader`, and their detail-page tabs from the classic `RoutedTabs` strip to BUI tabs — matching the muster and flux sections.

Previously these pages stacked **two** headers: the NFS app-shell header (white bar) on top of the classic blue `Header` banner. Now there is one BUI `PluginHeader`.

## Changes

- **Single header:** `noHeader: true` on the `clusters` and `deployments` `PageBlueprint`s suppresses the app-shell header; the pages render their own `PluginHeader` (icon + `Section / <name>` title + actions).
- **BUI tabs:** detail-page tabs now render inside the `PluginHeader` via a shared `useLayoutTabs` hook (builds `href`/`matchStrategy` tab items + resolves the active routed content). Replaces `RoutedTabs`. Conditional tabs (e.g. Node Pools / SSH Access) and deep-linking still work.
- **BUI buttons:** new exported `AIChatButtonBui` (shares open-chat logic with the Material UI `AIChatButton` via a new `useOpenChat` hook; troubleshoot → BUI `destructive`); `EditDeploymentButton` converted to a BUI `Button`.
- **Relocated info:** the dropped header "type" line (already shown as the deployment About-card **Type** field) and the cluster description subtitle (now a **Description** field in the cluster About card).

## Why not `SubPageBlueprint`?

That is the muster/flux mechanism for **section-level** tabs at static paths. Cluster/deployment tabs are **per-entity detail** tabs at a dynamic route with conditional visibility, which `SubPageBlueprint` can't express — so the tabs live in the layout and drive content via `useRoutes`, while still rendering through the same BUI `PluginHeader` tabs UI.

## Testing

`yarn tsc`, `yarn lint`, and `yarn prettier:check` pass. Verified in the browser on cluster and deployment list/detail pages: single header, BUI tabs navigate and highlight correctly (including nested paths and conditional tabs), BUI action buttons (incl. troubleshoot/destructive and the Edit disabled+tooltip state).

## Follow-ups

- `PluginHeader` breadcrumbs aren't in the pinned `@backstage/ui@0.16.0`; the `Section / <name>` title is a plain string for now and can become a clickable breadcrumb trail after a `@backstage/ui` bump.
- The entity page header remains classic pending the upstream RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)