### PR TITLE
fix(auth): reclassify cluster token-exchange failures to cut Sentry noise

### DIFF
--- a/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
@@ -77,6 +77,12 @@ function mockBrokerResponse(
 }
 
 describe('createClusterTokenRouter', () => {
+  beforeEach(() => {
+    // Clear accumulated call records (but keep mock implementations) so each
+    // test can assert on logger calls in isolation.
+    jest.clearAllMocks();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -205,6 +211,9 @@ describe('createClusterTokenRouter', () => {
       error: 'Token exchange failed',
       reason: 'exchange_failed',
     });
+    // A broker-side exchange failure is actionable and must reach Sentry.
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.debug).not.toHaveBeenCalled();
   });
 
   it('maps a rejected subject token to a subject_invalid reason', async () => {
@@ -222,6 +231,10 @@ describe('createClusterTokenRouter', () => {
       error: 'Token exchange failed',
       reason: 'subject_invalid',
     });
+    // A rejected subject token is a routine, already-handled outcome; it must
+    // NOT reach Sentry (which the winston bridge forwards at `warn`).
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledTimes(1);
   });
 
   it('maps a broker client-auth failure to a broker_client_invalid reason', async () => {
@@ -242,6 +255,15 @@ describe('createClusterTokenRouter', () => {
       error: 'Token exchange failed',
       reason: 'broker_client_invalid',
     });
+    // A broker self-auth failure is a genuine outage: keep it at `warn`, but
+    // keep the installation out of the message (and in metadata) so a single
+    // outage collapses into one Sentry issue instead of one per installation.
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.not.stringContaining('golem'),
+      expect.objectContaining({ installation: 'golem' }),
+    );
+    expect(logger.debug).not.toHaveBeenCalled();
   });
 
   it('still maps a non-invalid_client 401 to subject_invalid', async () => {
@@ -259,6 +281,8 @@ describe('createClusterTokenRouter', () => {
       error: 'Token exchange failed',
       reason: 'subject_invalid',
     });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledTimes(1);
   });
 
   it('maps an unreachable broker to 502', async () => {

--- a/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.test.ts
@@ -286,7 +286,13 @@ describe('createClusterTokenRouter', () => {
   });
 
   it('maps an unreachable broker to 502', async () => {
-    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    // Mirror an undici fetch rejection: the actionable code lives on
+    // `error.cause`, not the top-level "TypeError: fetch failed" message.
+    jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValue(
+        new TypeError('fetch failed', { cause: new Error('ECONNREFUSED') }),
+      );
 
     const res = await request(buildApp()!)
       .post('/cluster-token/golem')
@@ -297,5 +303,15 @@ describe('createClusterTokenRouter', () => {
       error: 'Token broker is unreachable',
       reason: 'broker_unreachable',
     });
+    // A genuine broker outage must reach Sentry with the underlying cause
+    // preserved, not just the opaque "fetch failed" wrapper.
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.not.stringContaining('golem'),
+      expect.objectContaining({
+        installation: 'golem',
+        cause: expect.stringContaining('ECONNREFUSED'),
+      }),
+    );
   });
 });

--- a/plugins/auth-backend-module-gs/src/clusterToken/router.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.ts
@@ -157,10 +157,13 @@ export function createClusterTokenRouter(
           body: params.toString(),
         });
       } catch (error) {
-        logger.warn(
-          `Cluster token exchange for installation "${installation}" failed: broker unreachable`,
-          error as Error,
-        );
+        // A broker fault, not a user problem. Keep the installation out of the
+        // message so the winston->Sentry bridge groups every installation's
+        // outage into a single issue instead of one per installation.
+        logger.warn('Cluster token exchange failed: token broker unreachable', {
+          installation,
+          error: String(error),
+        });
         res.status(502).json({
           error: 'Token broker is unreachable',
           reason: 'broker_unreachable',
@@ -170,19 +173,32 @@ export function createClusterTokenRouter(
 
       if (!response.ok) {
         const body = await response.text().catch(() => '');
-        logger.warn(
-          `Cluster token exchange for installation "${installation}" failed with status ${response.status}: ${body}`,
-        );
         tokenCache.delete(cacheKey);
 
         const oauthError = parseOAuthError(body);
+
+        // The high-cardinality installation and raw body go into structured
+        // metadata, never the log message. The Sentry transport fingerprints
+        // `warn`/`error` on the message text, so a constant message per root
+        // cause collapses a broker fault into one Sentry issue rather than one
+        // per installation.
+        const meta = {
+          installation,
+          status: response.status,
+          oauthError: oauthError ?? null,
+          body,
+        };
 
         // OAuth `invalid_client` means the broker could not authenticate
         // ITSELF to muster (e.g. its confidential client record was wiped),
         // not that the user's subject token was rejected. This is a broker
         // outage that hits every cluster at once and must not be reported to
-        // users as an expired session.
+        // users as an expired session. Genuinely actionable -> stays at `warn`.
         if (oauthError === 'invalid_client') {
+          logger.warn(
+            'Cluster token exchange failed: broker could not authenticate to muster (invalid_client)',
+            meta,
+          );
           res.status(502).json({
             error: 'Token exchange failed',
             reason: 'broker_client_invalid',
@@ -193,15 +209,35 @@ export function createClusterTokenRouter(
         // An OAuth invalid_grant/invalid_token/invalid_request (or a bare 401
         // that is not invalid_client) means the forwarded subject token was
         // rejected -- i.e. the user's main session, not the cluster, is the
-        // problem. Everything else is a broker-side exchange failure.
+        // problem. This is routine (expired sessions) and already handled with
+        // 0 user impact, so it logs at `debug` and stays out of Sentry.
         const subjectRejected =
           response.status === 401 ||
           oauthError === 'invalid_grant' ||
           oauthError === 'invalid_token' ||
           oauthError === 'invalid_request';
+        if (subjectRejected) {
+          logger.debug(
+            'Cluster token exchange rejected: subject token invalid or expired',
+            meta,
+          );
+          res.status(502).json({
+            error: 'Token exchange failed',
+            reason: 'subject_invalid',
+          });
+          return;
+        }
+
+        // Everything else is a broker-side exchange failure -- e.g.
+        // `invalid_target`, where the audience/installation is not served by
+        // the broker (a registration/config gap). Actionable -> stays at `warn`.
+        logger.warn(
+          'Cluster token exchange failed: broker rejected the exchange',
+          meta,
+        );
         res.status(502).json({
           error: 'Token exchange failed',
-          reason: subjectRejected ? 'subject_invalid' : 'exchange_failed',
+          reason: 'exchange_failed',
         });
         return;
       }
@@ -212,7 +248,8 @@ export function createClusterTokenRouter(
       };
       if (!tokenResponse.access_token) {
         logger.warn(
-          `Cluster token exchange for installation "${installation}" returned no access_token`,
+          'Cluster token exchange failed: broker returned no access_token',
+          { installation },
         );
         res
           .status(502)

--- a/plugins/auth-backend-module-gs/src/clusterToken/router.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.ts
@@ -163,6 +163,13 @@ export function createClusterTokenRouter(
         logger.warn('Cluster token exchange failed: token broker unreachable', {
           installation,
           error: String(error),
+          // undici puts the actionable code (ECONNREFUSED/ENOTFOUND) on
+          // error.cause; String(error) alone collapses to "TypeError: fetch
+          // failed", which would make every outage cause look identical.
+          cause:
+            error instanceof Error && error.cause !== undefined
+              ? String(error.cause)
+              : null,
         });
         res.status(502).json({
           error: 'Token broker is unreachable',


### PR DESCRIPTION
### What does this PR do?

The cluster token-exchange router in `plugins/auth-backend-module-gs/src/clusterToken/router.ts` logged a `warn` for **every** non-OK broker response, embedding the installation name and raw response body in the message. The winston→Sentry bridge forwards `warn`/`error` logs, and Sentry fingerprints on the message text, so a handful of root causes exploded into dozens of Sentry issues and ~1000+ events — even though all of these are already handled gracefully (the handler returns a structured `502`/`reason` to the frontend, 0 user impact).

Two changes:

1. **Reclassify by cause.** Routine subject-token rejections (`invalid_grant` / `invalid_token` / `invalid_request`, and bare 401s that are not `invalid_client`) — the `subject_invalid` cases — now log at `debug`. They're expected and already handled, so they no longer reach Sentry. Genuine broker faults stay at `warn`: `invalid_client` (broker self-auth failure → `broker_client_invalid`), `invalid_target` / other broker-side failures (`exchange_failed`), an unreachable broker, and a missing `access_token`.
2. **Stop per-installation Sentry sprawl.** The installation name and raw body move out of the log *message* and into structured metadata, and each root cause uses a constant message. Since the Sentry transport groups on message text, one broker outage now collapses into a single Sentry issue instead of ~24 (one per installation).

> Note: the `winston-sentry-log` transport computes a `fingerprint` but never applies it to the scope, so grouping is driven purely by message text — hence the constant-message approach rather than an explicit fingerprint.

This path is only active where `gs.clusterTokenBroker` is configured (today, the internal dev portal instance).

### What is the effect of this change to users?

No user-facing change. Handler responses (`502` + `reason`) are unchanged; this is observability hygiene only.

### How does it look like?

Log level and message change only. Example: a rejected/expired subject token now logs at `debug` (`Cluster token exchange rejected: subject token invalid or expired`) with `{ installation, status, oauthError, body }` in metadata, instead of a per-installation `warn`.

### Any background context you can provide?

Closes giantswarm/giantswarm#37086.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

  The affected package (`@giantswarm/backstage-plugin-auth-backend-module-gs`) is `private`, so no changeset is required.