### PR TITLE
ci: reduce node-build duration

### DIFF
--- a/.circleci/custom.yml
+++ b/.circleci/custom.yml
@@ -20,6 +20,15 @@
 # workspace handoff; the hand-written `buildjob` it replaced lived here before.
 version: 2.1
 
+jobs:
+  # Override just the resource_class of the generated `node-build` job. The
+  # dynamic-config deep-merge (yq `*+`) merges this map into the generated
+  # jobs.node-build; scalars from custom.yml win, so `docker`/`steps` stay as
+  # generated and only the executor size changes. Bumped from large (4 vCPU /
+  # 8 GB) to xlarge (8 vCPU / 16 GB) to speed up install/verify/build.
+  node-build:
+    resource_class: xlarge
+
 workflows:
   build:
     jobs:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test --watchAll=false",
     "test:watch": "backstage-cli repo test",
-    "test:all": "backstage-cli repo test --maxWorkers=50% --workerIdleMemoryLimit=1536MB",
+    "test:all": "backstage-cli repo test --coverage --maxWorkers=50% --workerIdleMemoryLimit=1536MB",
     "test:e2e": "playwright test",
     "fix": "backstage-cli repo fix",
     "lint": "backstage-cli repo lint --since origin/main",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "ci:lint": "yarn run lint:all && yarn run prettier:check",
-    "ci:verify": "NODE_OPTIONS=\"--max-old-space-size=6144\" yarn run tsc --noEmit && yarn run ci:lint && yarn run test:all",
+    "ci:verify": "concurrently --names tsc,lint,test -c blue,magenta,green \"NODE_OPTIONS='--max-old-space-size=6144' yarn run tsc --noEmit\" \"yarn run ci:lint\" \"yarn run test:all\"",
     "ci:build": "touch github-app-credentials.yaml && NODE_ENV=production yarn run build:backend --config ../../app-config.yaml --config ../../app-config.production.yaml && NODE_ENV=production yarn run build:backend-headless-service --config ../../app-config.yaml --config ../../app-config.production.yaml",
     "new": "backstage-cli new",
     "postinstall": "yarn patch-package",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test --watchAll=false",
     "test:watch": "backstage-cli repo test",
-    "test:all": "backstage-cli repo test --coverage --maxWorkers=2 --workerIdleMemoryLimit=1536MB",
+    "test:all": "backstage-cli repo test --coverage --maxWorkers=50% --workerIdleMemoryLimit=1536MB",
     "test:e2e": "playwright test",
     "fix": "backstage-cli repo fix",
     "lint": "backstage-cli repo lint --since origin/main",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test --watchAll=false",
     "test:watch": "backstage-cli repo test",
-    "test:all": "backstage-cli repo test --coverage --maxWorkers=50% --workerIdleMemoryLimit=1536MB",
+    "test:all": "backstage-cli repo test --maxWorkers=50% --workerIdleMemoryLimit=1536MB",
     "test:e2e": "playwright test",
     "fix": "backstage-cli repo fix",
     "lint": "backstage-cli repo lint --since origin/main",


### PR DESCRIPTION
### What does this PR do?

Speeds up the CircleCI `node-build` job (~6m40s → ~4m50s, ~28%). Three changes:

1. **`resource_class` `large` → `xlarge`** (4→8 vCPU, 8→16 GB) via `.circleci/custom.yml`. `.circleci/workflows.yml` is generated by `devctl` and marked "DO NOT EDIT"; the setup workflow deep-merges `custom.yml` into it at runtime (`yq '. *+ '` — maps merge, custom.yml scalars win), so this overrides only `resource_class`, leaving the `docker` image and `steps` intact.
2. **`test:all` `--maxWorkers=2` → `--maxWorkers=50%`**. The test phase was the only parallelizable step and was pinned to 2 workers, so a bigger box did nothing on its own — on xlarge 6 of 8 cores sat idle during the longest step. `50%` scales to the runner (4 workers on xlarge, still 2 on `large`) and stays within the 16 GB budget given `--workerIdleMemoryLimit=1536MB`.
3. **Parallelize `ci:verify`** — run `tsc`, `lint`, and `test:all` concurrently via `concurrently` (already a devDep) instead of `&&`-serial, so the single-threaded `tsc` overlaps the now-parallel test phase. `concurrently` exits non-zero if any task fails, preserving CI gating. The `--max-old-space-size=6144` heap override is scoped to the `tsc` command only, so Jest workers don't each grab a 6 GB heap.

### Measured impact (node-build job duration)

| Config | node-build |
|---|---|
| `main` — large + workers=2 | ~6m20s–6m40s |
| xlarge + workers=2 | 6m20s (no change — box unused) |
| xlarge + workers=50% | 5m21s |
| **xlarge + workers=50% + parallel ci:verify** | **4m50s** |

Durations computed from CircleCI's GitHub commit-status timestamps. The `large`→`xlarge` bump alone did nothing because the config forbade the job from using the extra cores; raising worker count and overlapping the serial verify phases is what made the box size pay off. The parallel-verify run completed without memory pressure.

### What is the effect of this change to users?

(No end-user facing change — CI-only.)

### Any background context you can provide?

`yarn install` (I/O/cache-bound) and `ci:build` remain serial and unaffected, and `tsc` is single-threaded — so they set the remaining floor. A coverage-drop was tried and reverted: it showed no measurable gain (5m32s, within noise) and would have removed local coverage reports.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.
