### PR TITLE
fix(telemetry): track muster, metrics and ai-chat sub-route page views

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -198,8 +198,13 @@ falls through to the `'Unknown page'` default is reported to Sentry as a
 `Untracked page view: <path>` warning (see `captureEvent`), so forgetting this
 step turns every visit to the new page into recurring Sentry noise across all
 deployments. (Unregistered paths — bot/scanner probes — correctly land on
-"Not Found" and are *not* reported.) Update the test in
-`packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.test.tsx` accordingly.
+"Not Found" and are *not* reported.) Also add a representative path for the new
+route to the `knownTopLevelPaths` list in
+`packages/app/src/utils/telemetry.test.ts` — that enumeration test asserts every
+listed route resolves to a named page, so a missing mapping fails CI instead of
+silently flooding Sentry. Update
+`packages/app/src/apis/analytics/TelemetryDeckAnalyticsApi.test.tsx` too if the
+routing/reporting behaviour changes.
 
 ### Scaffolder Field Extensions
 

--- a/packages/app/src/utils/telemetry.test.ts
+++ b/packages/app/src/utils/telemetry.test.ts
@@ -218,6 +218,67 @@ describe('getTelemetryPageViewPayload', () => {
     });
   });
 
+  it('should return correct payload for AI Chat history sub-route', () => {
+    const result = getTelemetryPageViewPayload('/ai-chat/history');
+    expect(result).toEqual({
+      page: 'AI Chat',
+      view: 'history',
+      path: '/ai-chat/history',
+    });
+  });
+
+  it('should return correct payload for muster index page', () => {
+    const result = getTelemetryPageViewPayload('/muster');
+    expect(result).toEqual({
+      page: 'Muster index',
+      path: '/muster',
+    });
+  });
+
+  it('should return correct payload for muster mcp-servers view', () => {
+    const result = getTelemetryPageViewPayload('/muster/mcp-servers');
+    expect(result).toEqual({
+      page: 'Muster',
+      view: 'mcp-servers',
+      path: '/muster/mcp-servers',
+    });
+  });
+
+  it('should return correct payload for muster workflows view', () => {
+    const result = getTelemetryPageViewPayload('/muster/workflows');
+    expect(result).toEqual({
+      page: 'Muster',
+      view: 'workflows',
+      path: '/muster/workflows',
+    });
+  });
+
+  it('should return correct payload for a muster workflow detail sub-route', () => {
+    const result = getTelemetryPageViewPayload('/muster/workflows/my-workflow');
+    expect(result).toEqual({
+      page: 'Muster',
+      view: 'workflows',
+      path: '/muster/workflows/my-workflow',
+    });
+  });
+
+  it('should return correct payload for muster tools view', () => {
+    const result = getTelemetryPageViewPayload('/muster/tools');
+    expect(result).toEqual({
+      page: 'Muster',
+      view: 'tools',
+      path: '/muster/tools',
+    });
+  });
+
+  it('should return correct payload for metrics page', () => {
+    const result = getTelemetryPageViewPayload('/metrics');
+    expect(result).toEqual({
+      page: 'Metrics',
+      path: '/metrics',
+    });
+  });
+
   it('should return correct payload for search page', () => {
     const result = getTelemetryPageViewPayload('/search');
     expect(result).toEqual({
@@ -231,6 +292,50 @@ describe('getTelemetryPageViewPayload', () => {
     expect(result).toEqual({
       page: 'Unknown page',
       path: '/unknown',
+    });
+  });
+
+  // Guard rail: every registered top-level route must map to a named page.
+  // A registered route that falls through to 'Unknown page' is reported to
+  // Sentry as an "Untracked page view" warning on every visit (see
+  // TelemetryDeckAnalyticsApi.captureEvent). When you add a new page/route,
+  // add a case to getTelemetryPageViewPayload and list a representative path
+  // here so a forgotten mapping fails CI instead of flooding Sentry.
+  describe('all known top-level routes resolve to a named page', () => {
+    const knownTopLevelPaths = [
+      '/',
+      '/catalog',
+      '/catalog/default/component/my-component',
+      '/catalog-graph',
+      '/docs',
+      '/docs/default/component/my-component',
+      '/create',
+      '/create/default/template/my-template',
+      '/settings',
+      '/installations',
+      '/clusters',
+      '/clusters/installation/org-demo/demo-cluster',
+      '/deployments',
+      '/deployments/gorilla/helmrelease/org-demo/my-app',
+      '/flux',
+      '/flux/tree',
+      '/ai-chat',
+      '/ai-chat/history',
+      '/muster',
+      '/muster/dashboard',
+      '/muster/mcp-servers',
+      '/muster/workflows',
+      '/muster/workflows/my-workflow',
+      '/muster/workflows/my-workflow/run',
+      '/muster/tools',
+      '/metrics',
+      '/search',
+    ];
+
+    it.each(knownTopLevelPaths)('%s', pathname => {
+      expect(getTelemetryPageViewPayload(pathname).page).not.toBe(
+        'Unknown page',
+      );
     });
   });
 });

--- a/packages/app/src/utils/telemetry.ts
+++ b/packages/app/src/utils/telemetry.ts
@@ -117,6 +117,32 @@ export function getTelemetryPageViewPayload(pathname: string): {
       payload = { page: 'AI Chat' };
       break;
 
+    case pathname.startsWith('/ai-chat'): {
+      const parts = pathname.split('/');
+      payload = {
+        page: 'AI Chat',
+        view: parts[2],
+      };
+      break;
+    }
+
+    case pathname === '/muster':
+      payload = { page: 'Muster index' };
+      break;
+
+    case pathname.startsWith('/muster'): {
+      const parts = pathname.split('/');
+      payload = {
+        page: 'Muster',
+        view: parts[2],
+      };
+      break;
+    }
+
+    case pathname === '/metrics':
+      payload = { page: 'Metrics' };
+      break;
+
     case pathname === '/search':
       payload = { page: 'Search' };
       break;


### PR DESCRIPTION
### What does this PR do?

Extends the frontend telemetry page-view mapping so registered routes stop falling through to `'Unknown page'`.

Page views are named by `getTelemetryPageViewPayload` (`packages/app/src/utils/telemetry.ts`), a hand-maintained `switch` over path prefixes. When a **registered** route has no matching case it resolves to `'Unknown page'`, and `TelemetryDeckAnalyticsApi.captureEvent` reports it to Sentry as a recurring `Untracked page view: <path>` warning on every visit, across all deployments.

This adds the missing cases:

- **muster route tree** — `/muster` (index) plus a prefix match emitting a `view` attribute for `/muster/dashboard`, `/muster/mcp-servers`, `/muster/workflows` (and its `:name` / `:name/run` sub-routes), `/muster/tools`.
- **`/metrics`**.
- **`/ai-chat` sub-routes** — switched the exact `/ai-chat` match to also handle sub-routes (e.g. `/ai-chat/history`) with a `view` attribute, mirroring the `/flux` pattern.

To keep this robust for future page additions, it adds an enumeration test (`knownTopLevelPaths` in `telemetry.test.ts`) asserting every listed top-level route resolves to a named page — so a newly added page without a mapping fails CI instead of silently emitting Sentry warnings — and updates the `.claude/CLAUDE.md` telemetry guidance to point contributors at that list.

### What is the effect of this change to users?

No user-facing UI change. It stops recurring Sentry noise and starts reporting accurate page-view names for these routes to TelemetryDeck.

### Any background context you can provide?

Closes giantswarm/giantswarm#37084. Observed Sentry signatures: `/muster` (DEVPORTAL-FRONTEND-1F), `/ai-chat/history` (DEVPORTAL-FRONTEND-1C), `/metrics` (BACKSTAGE-ADIDAS-FRONTEND-F).

### Do the docs need to be updated?

No (contributor guidance in `.claude/CLAUDE.md` updated in this PR).

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.

_(No changeset: the change is in `packages/app`, which is released via conventional-commit automation, not the `@giantswarm/backstage-plugin-*` Changesets flow.)_