### PR TITLE
fix(telemetry): silence benign PagerDuty legacy-config warning in Sentry

### DIFF
--- a/packages/backend-common/src/rootLogger.ts
+++ b/packages/backend-common/src/rootLogger.ts
@@ -25,6 +25,15 @@ export const rootLogger = createServiceFactory({
             tracesSampleRate: logConfig.getNumber('tracesSampleRate'),
             ignoreErrors: [
               /^Index for techdocs was not created: indexer received 0 documents$/,
+              // Benign warning from @pagerduty/backstage-plugin-backend when we
+              // use the legacy single-token config (`pagerDuty.apiToken`) instead
+              // of the newer `pagerDuty.accounts` format. PagerDuty works fine —
+              // the plugin just logs this and falls back to the legacy path. We
+              // can't migrate to `accounts`: the plugin's single-account branch
+              // never sets its `fallbackEndpointConfig`, so any request without an
+              // explicit `account` (which is what our WhoIsOnCallEntityCard sends)
+              // throws when resolving the API base URL. See giantswarm/giantswarm#37085.
+              /^No PagerDuty accounts configuration found in config file\. Reverting to legacy configuration\.$/,
             ],
           },
           level: 'warn',


### PR DESCRIPTION
### What does this PR do?

Filters the benign `No PagerDuty accounts configuration found in config file. Reverting to legacy configuration.` warning out of the winston→Sentry bridge in `packages/backend-common/src/rootLogger.ts`, matching the existing techdocs `ignoreErrors` precedent.

### What is the effect of this change to users?

No user-facing change. Stops ~300+ recurring Sentry events (`DEVPORTAL-BACKEND-9J`) that the internal dev portal backend emits on every auth-config load. PagerDuty continues to work exactly as before.

### Any background context you can provide?

Resolves giantswarm/giantswarm#37085.

The issue originally proposed migrating our config from the legacy single-token format (`pagerDuty.apiToken`) to the newer `pagerDuty.accounts` format so the plugin stops warning. I verified that path against the installed `@pagerduty/backstage-plugin-backend@0.13.0` and **it breaks PagerDuty**, so this PR takes the issue's documented fallback instead.

Root cause of the breakage: in the single-account branch, `loadPagerDutyEndpointsFromConfig` only sets `EndpointConfig.default` and never sets `fallbackEndpointConfig`. But `getApiBaseUrl(account)` returns `fallbackEndpointConfig.apiBaseUrl` whenever `account` is falsy. Our `WhoIsOnCallEntityCard` calls `getOnCallByPolicyId`/`getServiceByEntity` with no account (our entities carry no `pagerduty.com/account` annotation), so every card render would throw `Cannot read properties of undefined (reading 'apiBaseUrl')`.

Empirical results (harness exercising the real plugin):

| Config | account sent | Result |
|---|---|---|
| legacy (current) | `""` | ✅ `https://api.eu.pagerduty.com/...` |
| single account + EU (proposed) | `""` ← what our frontend sends | ❌ crash |
| single account + EU | `"giantswarm"` | ❌ crash |
| single account + EU | `"default"` | ✅ EU URL |

Since the migration is blocked, this filters the specific message instead — the exact path the issue lists as the fallback.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] N/A — internal `@internal/backend-common` package (not a published `@giantswarm/backstage-plugin-*`); no changeset needed.