### PR TITLE
chore(renovate): hold @material-table/core on v3

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -35,6 +35,17 @@
       matchPackageNames: ['date-fns', 'date-fns-tz'],
     },
     {
+      // @material-table/core v7 is a React 19 / MUI v5-era release: it
+      // peer-requires react >=19.2.0, ships an exports map without a `types`
+      // condition (TS2307 under moduleResolution "bundler"), and
+      // @backstage/core-components still bundles material-table v3 -- the
+      // muster plugin's MTableToolbar override must match that major. Hold on
+      // v3 until the platform moves to React 19 / MUI v5 and core-components
+      // adopts v7 (see #1881).
+      matchPackageNames: ['@material-table/core'],
+      allowedVersions: '<4',
+    },
+    {
       // global-agent v4 is ESM-only and removed the CommonJS
       // `global-agent/bootstrap` entrypoint that packages/backend/src/index.ts
       // imports. v4 crashes the backend container at startup with


### PR DESCRIPTION
## Summary

- Adds an `allowedVersions: '<4'` hold for `@material-table/core` in `renovate-custom.json5`, same pattern as the existing `global-agent` hold.
- The v7 bump (#1881) is structurally unmergeable: v7 peer-requires React >=19.2.0 (repo is React 18 + MUI v4), its exports map lacks a `types` condition (TS2307 under `moduleResolution: "bundler"`), and `@backstage/core-components` bundles material-table v3 -- the muster plugin's `MTableToolbar` toolbar override must match that major.
- Renovate will stop re-proposing v7; the hold is lifted when the platform moves to React 19 / MUI v5 and core-components adopts v7.

## Test plan

- [ ] renovate config validates (json5 syntax)
- [ ] Renovate closes/stops rebasing #1881 on next run

Made with [Cursor](https://cursor.com)