### PR TITLE
fix(plans): surface GitHub comment errors and highlight comment threads

### DIFF
--- a/.changeset/plans-comment-errors-and-thread-highlight.md
+++ b/.changeset/plans-comment-errors-and-thread-highlight.md
@@ -1,0 +1,16 @@
+---
+'@giantswarm/backstage-plugin-plans-backend': patch
+'@giantswarm/backstage-plugin-plans': patch
+---
+
+Surface GitHub errors on plan comment writes and make comment threads stand out.
+
+- The backend proxy no longer collapses every non-2xx GitHub response into an
+  opaque 500. A GitHub 403 (typically the GitHub App missing `Pull requests` /
+  `Issues` write permission) is now mapped to a `NotAllowedError` (HTTP 403) and
+  GitHub's own message (e.g. "Resource not accessible by integration") is
+  included, so the reply form shows an actionable error instead of a generic
+  failure. As a 4xx it also stops being reported to Sentry as a server fault.
+- Review threads and the PR discussion now render inside a single primary-colored
+  box (with a left accent) instead of blending into the page, so each
+  conversation reads as one unit.

--- a/plugins/plans-backend/src/router.test.ts
+++ b/plugins/plans-backend/src/router.test.ts
@@ -14,6 +14,7 @@ function jsonResponse(body: unknown, status = 200) {
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,
+    text: async () => JSON.stringify(body),
   } as Response;
 }
 
@@ -175,6 +176,23 @@ describe('createRouter', () => {
       const response = await request(app).get('/pulls');
 
       expect(response.status).toBe(500);
+    });
+
+    it('maps a GitHub 403 to NotAllowedError and surfaces its message', async () => {
+      fetchFn.mockResolvedValue(
+        jsonResponse(
+          { message: 'Resource not accessible by integration' },
+          403,
+        ),
+      );
+
+      const response = await request(app).get('/pulls');
+
+      expect(response.status).toBe(403);
+      expect(response.body.error.name).toBe('NotAllowedError');
+      expect(response.body.error.message).toContain(
+        'Resource not accessible by integration',
+      );
     });
   });
 

--- a/plugins/plans-backend/src/router.ts
+++ b/plugins/plans-backend/src/router.ts
@@ -6,6 +6,7 @@ import {
 import { Config } from '@backstage/config';
 import {
   InputError,
+  NotAllowedError,
   NotFoundError,
   ServiceUnavailableError,
 } from '@backstage/errors';
@@ -160,7 +161,21 @@ export async function createRouter(
       throw new NotFoundError(`GitHub responded with 404 for ${path}`);
     }
     if (!response.ok) {
-      throw new Error(`GitHub responded with ${response.status} for ${path}`);
+      // Surface GitHub's own explanation (e.g. "Resource not accessible by
+      // integration", which is what a missing GitHub App write permission
+      // looks like) instead of an opaque status code.
+      const detail = await response.text().catch(() => '');
+      const message = `GitHub responded with ${response.status} for ${path}${
+        detail ? `: ${detail}` : ''
+      }`;
+      // A 403 is an authorization failure -- almost always the GitHub App
+      // lacking a permission (Pull requests / Issues: write) -- not a fault on
+      // our side. Map it to a real 403 so the client sees an actionable error
+      // rather than a 500, and so it does not page us through Sentry.
+      if (response.status === 403) {
+        throw new NotAllowedError(message);
+      }
+      throw new Error(message);
     }
     return response.json();
   };

--- a/plugins/plans/src/components/AnnotatedMarkdown/AnnotatedMarkdown.tsx
+++ b/plugins/plans/src/components/AnnotatedMarkdown/AnnotatedMarkdown.tsx
@@ -109,11 +109,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     margin: theme.spacing(1, 0, 2),
   },
   thread: {
-    border: `1px solid ${theme.palette.divider}`,
+    border: `1px solid ${theme.palette.primary.main}`,
+    borderLeft: `4px solid ${theme.palette.primary.main}`,
     borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(1, 2),
     marginBottom: theme.spacing(1),
-    backgroundColor: theme.palette.background.paper,
+    backgroundColor: theme.palette.action.hover,
   },
 }));
 

--- a/plugins/plans/src/components/ProposedTab/DiffView.tsx
+++ b/plugins/plans/src/components/ProposedTab/DiffView.tsx
@@ -69,7 +69,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   thread: {
     maxWidth: 720,
-    padding: theme.spacing(1, 0),
+    padding: theme.spacing(1, 2),
+    marginBottom: theme.spacing(1),
+    border: `1px solid ${theme.palette.primary.main}`,
+    borderLeft: `4px solid ${theme.palette.primary.main}`,
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.action.hover,
   },
 }));
 

--- a/plugins/plans/src/components/PullReviewPage/PullReviewPage.tsx
+++ b/plugins/plans/src/components/PullReviewPage/PullReviewPage.tsx
@@ -137,6 +137,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingTop: theme.spacing(2),
     borderTop: `1px solid ${theme.palette.divider}`,
   },
+  // Colored box around the whole discussion, matching the review-thread box.
+  discussion: {
+    padding: theme.spacing(0.5, 1.5),
+    marginTop: theme.spacing(1),
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${theme.palette.primary.main}`,
+    borderLeft: `4px solid ${theme.palette.primary.main}`,
+    backgroundColor: theme.palette.action.hover,
+  },
   htmlFrame: {
     width: '100%',
     height: '75vh',
@@ -193,9 +202,13 @@ function OverviewPanel(props: { repo: string; pull: PlanPull }) {
           No comments yet. Start the discussion below.
         </Typography>
       )}
-      {data?.comments.map(comment => (
-        <CommentItem key={comment.id} comment={comment} />
-      ))}
+      {data?.comments.length ? (
+        <Box className={classes.discussion}>
+          {data.comments.map(comment => (
+            <CommentItem key={comment.id} comment={comment} />
+          ))}
+        </Box>
+      ) : null}
       <CommentForm onSubmit={body => createComment.mutateAsync(body)} />
     </>
   );


### PR DESCRIPTION
## What

Two fixes to the plans plugin's PR-comment experience:

### Backend — actionable errors instead of opaque 500s
The `plans-backend` GitHub proxy collapsed every non-2xx GitHub response into a generic `Error` → **HTTP 500**. So when the deployed GitHub App lacks `Pull requests` / `Issues` **write** permission, replying to a comment failed with an opaque 500 and no explanation (and was reported to Sentry as a server fault).

Now a GitHub **403** is mapped to a `NotAllowedError` (**HTTP 403**) and GitHub's own message (e.g. *"Resource not accessible by integration"*) is included, so the reply form shows an actionable error. As a 4xx it also no longer pages us via Sentry. Other non-2xx responses still surface GitHub's body in the message.

### Frontend — comment threads stand out
Review threads and the PR discussion now render inside a single primary-colored box (with a left accent) instead of blending into the page, so each conversation reads as one unit.

## Why
While testing comment replies against `giantswarm/bumblebee-plans`, a permissions 403 surfaced as a 500 with no detail. The root cause is a GitHub App permission gap (fixed separately on the App), but the proxy should report it clearly regardless.

## Testing
- `yarn test plugins/plans-backend` — added a test asserting a GitHub 403 → `NotAllowedError` (403) with the message surfaced; 28/28 pass.
- `yarn test plugins/plans` — 73/73 pass.
- Lint clean on changed files.

A changeset is included (both plugin packages, patch).