### PR TITLE
feat(roadmap): add roadmap frontend plugin with board, activity, and detail views

### DIFF
--- a/.changeset/roadmap-frontend-plugin.md
+++ b/.changeset/roadmap-frontend-plugin.md
@@ -1,0 +1,25 @@
+---
+'@giantswarm/backstage-plugin-roadmap': minor
+---
+
+Add the roadmap frontend plugin: a `/roadmap` page over the GitHub Projects
+roadmap board, served by the roadmap-backend plugin.
+
+- **Board** view renders the status lifecycle as columns (Inbox → Backlog →
+  Up Next → In Progress → Validation → Done), filterable by Team, Kind,
+  Quarter, Availability, and keyword. Cards move between columns by drag
+  and drop or a per-card status menu, with an optimistic in-place move.
+- **Team activity** view shows who is working on what: In Progress and
+  Validation items grouped by assignee, unassigned in-flight work called
+  out explicitly, per-status counts, and items updated in the last week.
+- **Item detail** page (`/roadmap/items/<id>`) renders the issue body and
+  comments, board fields editable inline (single-select, iteration, and
+  date fields from the board schema), and the sub-issue tree with
+  link/unlink.
+- Reads go through the backend's shared GitHub App token. Writes send the
+  caller's per-user GitHub OAuth token (from the portal's existing
+  `githubAuthApiRef` session) in the `X-GitHub-Token` header so board
+  mutations are attributed to the person; the classic `project` scope
+  Projects v2 mutations need is requested incrementally on the first write.
+- The page and API extensions are disabled by default and must be enabled
+  via `app.extensions` app-config, so customer portals are unaffected.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -61,6 +61,7 @@
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^",
     "@giantswarm/backstage-plugin-muster": "workspace:^",
     "@giantswarm/backstage-plugin-plans": "workspace:^",
+    "@giantswarm/backstage-plugin-roadmap": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@pagerduty/backstage-plugin": "^0.20.0",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -13,6 +13,7 @@ import { aiChatPluginOverrides } from './modules/ai-chat';
 import musterPlugin from '@giantswarm/backstage-plugin-muster';
 import { musterPluginOverrides } from './modules/muster';
 import plansPlugin from '@giantswarm/backstage-plugin-plans';
+import roadmapPlugin from '@giantswarm/backstage-plugin-roadmap';
 
 // Upstream NFS plugins:
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
@@ -57,6 +58,7 @@ const app = createApp({
     musterPlugin,
     musterPluginOverrides,
     plansPlugin,
+    roadmapPlugin,
 
     // Upstream NFS plugins:
     catalogPlugin,

--- a/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/app/src/modules/nav/Sidebar.tsx
@@ -92,6 +92,7 @@ export const SidebarContent = NavContentBlueprint.make({
         nav.take('page:flux'),
         nav.take('page:muster'),
         nav.take('page:plans'),
+        nav.take('page:roadmap'),
       ].filter(Boolean);
 
       const group3 = [

--- a/plugins/roadmap/.eslintrc.js
+++ b/plugins/roadmap/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/roadmap/README.md
+++ b/plugins/roadmap/README.md
@@ -1,0 +1,49 @@
+# @giantswarm/backstage-plugin-roadmap
+
+Frontend plugin (`pluginId: roadmap`) for the GitHub Projects roadmap board,
+served by the roadmap-backend plugin. New Frontend System plugin; all
+extensions ship `disabled: true` so customer portals never see it --
+internal portals opt in via `app.extensions`.
+
+## Views
+
+- **Board** (`/roadmap`): status-lifecycle columns (Inbox → Backlog → Up
+  Next → In Progress → Validation → Done), filterable by Team, Kind,
+  Quarter, Availability, and keyword. Cards move between columns by drag
+  and drop or a per-card status menu.
+- **Team activity** (`/roadmap?view=activity`): who is working on what --
+  In Progress and Validation items grouped by assignee, with unassigned
+  in-flight work called out explicitly, per-status counts, and items that
+  moved in the last week.
+- **Item detail** (`/roadmap/items/:id`): issue body, comments, board
+  fields editable inline, and the sub-issue tree with link/unlink.
+
+## Writes and GitHub attribution
+
+Reads go through the backend's shared GitHub App token. Writes (status and
+field changes, sub-issue linking) send the caller's per-user GitHub OAuth
+token in the `X-GitHub-Token` header, so every board mutation is attributed
+to the person who made it. The token comes from the portal's existing
+`githubAuthApiRef` session; Projects v2 mutations additionally need the
+classic `project` scope, which is requested incrementally on the first
+write (a one-time consent prompt for roadmap users only).
+
+Users without org access or project write permission get GitHub's 403
+surfaced inline; there is no separate permission model in Backstage.
+
+## Enabling
+
+```yaml
+app:
+  extensions:
+    - page:roadmap
+    - api:roadmap
+
+roadmap:
+  board: roadmap
+  teams:
+    - Bumblebee🐝
+```
+
+See `plugins/roadmap-backend/README.md` for the backend configuration and
+GitHub App permission requirements.

--- a/plugins/roadmap/package.json
+++ b/plugins/roadmap/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@giantswarm/backstage-plugin-roadmap",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin",
+    "pluginId": "roadmap"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --watchAll=false",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/core-components": "backstage:^",
+    "@backstage/core-plugin-api": "backstage:^",
+    "@backstage/frontend-plugin-api": "backstage:^",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3",
+    "@material-ui/lab": "^4.0.0-alpha.61",
+    "@tanstack/react-query": "^5.82.0"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-router-dom": "*"
+  },
+  "devDependencies": {
+    "@backstage/cli": "backstage:^",
+    "@backstage/test-utils": "backstage:^",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.0.0",
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/roadmap/src/apis/RoadmapApiClient.test.ts
+++ b/plugins/roadmap/src/apis/RoadmapApiClient.test.ts
@@ -1,0 +1,177 @@
+import { RoadmapApiClient } from './RoadmapApiClient';
+
+const BASE_URL = 'http://backstage/api/roadmap';
+const USER_TOKEN = 'gho_user-token';
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('RoadmapApiClient', () => {
+  const fetchMock = jest.fn<Promise<Response>, [string]>();
+  const getAccessToken = jest.fn().mockResolvedValue(USER_TOKEN);
+  const client = new RoadmapApiClient({
+    discoveryApi: { getBaseUrl: jest.fn().mockResolvedValue(BASE_URL) },
+    fetchApi: { fetch: fetchMock as unknown as typeof fetch },
+    githubAuthApi: { getAccessToken } as any,
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    getAccessToken.mockClear();
+  });
+
+  it('fetches the schema', async () => {
+    const payload = { board: 'roadmap', defaultTeams: [], fields: [] };
+    fetchMock.mockResolvedValue(jsonResponse(payload));
+
+    await expect(client.getSchema()).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/schema`);
+    expect(getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('lists items without filters', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [] }));
+
+    await client.listItems();
+
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/items`);
+  });
+
+  it('passes filters URL-encoded and drops empty values', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ items: [] }));
+
+    await client.listItems({
+      team: 'Bumblebee🐝',
+      kind: 'Epic 🎯',
+      keyword: '',
+    });
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(url.pathname).toBe('/api/roadmap/items');
+    expect(url.searchParams.get('team')).toBe('Bumblebee🐝');
+    expect(url.searchParams.get('kind')).toBe('Epic 🎯');
+    expect(url.searchParams.has('keyword')).toBe(false);
+  });
+
+  it('fetches item detail by encoded id', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ item: {} }));
+
+    await client.getItem('PVTI_abc/123');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/items/PVTI_abc%2F123`,
+    );
+  });
+
+  it('fetches the overview with a team filter', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ total: 0, byStatus: {}, byRepo: {} }),
+    );
+
+    await client.getOverview('Bumblebee🐝');
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(url.pathname).toBe('/api/roadmap/overview');
+    expect(url.searchParams.get('team')).toBe('Bumblebee🐝');
+  });
+
+  it('fetches sub-issues', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ subIssues: [], parent: null }));
+
+    await client.listSubIssues('giantswarm', 'giantswarm', 35000);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/issues/giantswarm/giantswarm/35000/sub-issues`,
+    );
+  });
+
+  it('sends field updates with the user GitHub token', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: 'ok' }));
+
+    await client.updateItemField('PVTI_abc', 'Status', 'In Progress ⛏️');
+
+    expect(getAccessToken).toHaveBeenCalledWith(['repo', 'project']);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/items/PVTI_abc/field`, {
+      method: 'PATCH',
+      headers: {
+        'X-GitHub-Token': USER_TOKEN,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'Status', value: 'In Progress ⛏️' }),
+    });
+  });
+
+  it('links a sub-issue with the user GitHub token', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ parent: {} }, 201));
+
+    await client.addSubIssue(
+      'giantswarm',
+      'giantswarm',
+      35000,
+      'giantswarm/roadmap#42',
+    );
+
+    expect(getAccessToken).toHaveBeenCalledWith(['repo', 'project']);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/issues/giantswarm/giantswarm/35000/sub-issues`,
+      {
+        method: 'POST',
+        headers: {
+          'X-GitHub-Token': USER_TOKEN,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ child: 'giantswarm/roadmap#42' }),
+      },
+    );
+  });
+
+  it('unlinks a sub-issue and tolerates the 204 response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => {
+        throw new Error('no body');
+      },
+    } as unknown as Response);
+
+    await expect(
+      client.removeSubIssue('giantswarm', 'giantswarm', 35000, 1001),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/issues/giantswarm/giantswarm/35000/sub-issues/1001`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('surfaces the backend error message', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { error: { name: 'InputError', message: 'unknown field' } },
+        400,
+      ),
+    );
+
+    await expect(
+      client.updateItemField('PVTI_abc', 'Nope', 'x'),
+    ).rejects.toThrow('unknown field');
+  });
+
+  it.each([
+    [401, 'UnauthorizedError'],
+    [403, 'ForbiddenError'],
+    [404, 'NotFoundError'],
+    [503, 'ServiceUnavailableError'],
+  ])('names errors for status %i', async (status, name) => {
+    fetchMock.mockResolvedValue(jsonResponse({}, status));
+
+    await expect(client.getSchema()).rejects.toMatchObject({
+      name,
+      message: `Roadmap request failed with status ${status}`,
+    });
+  });
+});

--- a/plugins/roadmap/src/apis/RoadmapApiClient.test.ts
+++ b/plugins/roadmap/src/apis/RoadmapApiClient.test.ts
@@ -63,9 +63,7 @@ describe('RoadmapApiClient', () => {
 
     await client.getItem('PVTI_abc/123');
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      `${BASE_URL}/items/PVTI_abc%2F123`,
-    );
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/items/PVTI_abc%2F123`);
   });
 
   it('fetches the overview with a team filter', async () => {

--- a/plugins/roadmap/src/apis/RoadmapApiClient.ts
+++ b/plugins/roadmap/src/apis/RoadmapApiClient.ts
@@ -1,0 +1,170 @@
+import {
+  createApiRef,
+  DiscoveryApi,
+  FetchApi,
+  OAuthApi,
+} from '@backstage/core-plugin-api';
+import {
+  RoadmapApi,
+  RoadmapItemDetailResponse,
+  RoadmapItemFilters,
+  RoadmapItemsResponse,
+  RoadmapOverviewResponse,
+  RoadmapSchemaResponse,
+  RoadmapSubIssuesResponse,
+} from './types';
+
+export const roadmapApiRef = createApiRef<RoadmapApi>({
+  id: 'plugin.roadmap.api',
+});
+
+/**
+ * GitHub OAuth scopes required for board mutations. Projects v2 field
+ * updates need the classic `project` scope, which is not in the portal's
+ * default scope set -- it is requested incrementally on the first write so
+ * only roadmap users ever see the extra consent prompt.
+ */
+const WRITE_SCOPES = ['repo', 'project'];
+
+export class RoadmapApiClient implements RoadmapApi {
+  private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
+  private readonly githubAuthApi: OAuthApi;
+
+  constructor(options: {
+    discoveryApi: DiscoveryApi;
+    fetchApi: FetchApi;
+    githubAuthApi: OAuthApi;
+  }) {
+    this.discoveryApi = options.discoveryApi;
+    this.fetchApi = options.fetchApi;
+    this.githubAuthApi = options.githubAuthApi;
+  }
+
+  async getSchema(): Promise<RoadmapSchemaResponse> {
+    return this.request<RoadmapSchemaResponse>('/schema', {});
+  }
+
+  async listItems(
+    filters: RoadmapItemFilters = {},
+  ): Promise<RoadmapItemsResponse> {
+    return this.request<RoadmapItemsResponse>('/items', { ...filters });
+  }
+
+  async getItem(id: string): Promise<RoadmapItemDetailResponse> {
+    return this.request<RoadmapItemDetailResponse>(
+      `/items/${encodeURIComponent(id)}`,
+      {},
+    );
+  }
+
+  async getOverview(team?: string): Promise<RoadmapOverviewResponse> {
+    return this.request<RoadmapOverviewResponse>('/overview', { team });
+  }
+
+  async listSubIssues(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+  ): Promise<RoadmapSubIssuesResponse> {
+    return this.request<RoadmapSubIssuesResponse>(
+      `/issues/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${issueNumber}/sub-issues`,
+      {},
+    );
+  }
+
+  async updateItemField(
+    id: string,
+    name: string,
+    value: string,
+  ): Promise<void> {
+    await this.write(`/items/${encodeURIComponent(id)}/field`, {
+      method: 'PATCH',
+      body: { name, value },
+    });
+  }
+
+  async addSubIssue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    child: string,
+  ): Promise<void> {
+    await this.write(
+      `/issues/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${issueNumber}/sub-issues`,
+      { method: 'POST', body: { child } },
+    );
+  }
+
+  async removeSubIssue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    subIssueId: number,
+  ): Promise<void> {
+    await this.write(
+      `/issues/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${issueNumber}/sub-issues/${subIssueId}`,
+      { method: 'DELETE' },
+    );
+  }
+
+  /**
+   * Board mutations run with the caller's GitHub OAuth token (X-GitHub-Token)
+   * so they are attributed to the person, never to the shared App identity.
+   */
+  private async write(
+    path: string,
+    options: { method: string; body?: unknown },
+  ): Promise<unknown> {
+    const token = await this.githubAuthApi.getAccessToken(WRITE_SCOPES);
+    return this.request(
+      path,
+      {},
+      {
+        method: options.method,
+        headers: {
+          'X-GitHub-Token': token,
+          ...(options.body !== undefined && {
+            'Content-Type': 'application/json',
+          }),
+        },
+        ...(options.body !== undefined && {
+          body: JSON.stringify(options.body),
+        }),
+      },
+    );
+  }
+
+  private async request<T>(
+    path: string,
+    query: Record<string, string | undefined>,
+    init?: RequestInit,
+  ): Promise<T> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('roadmap');
+    const url = new URL(`${baseUrl}${path}`);
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    }
+    const response = init
+      ? await this.fetchApi.fetch(url.toString(), init)
+      : await this.fetchApi.fetch(url.toString());
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      const message =
+        (errorData as { error?: { message?: string } })?.error?.message ??
+        `Roadmap request failed with status ${response.status}`;
+      const error = new Error(message);
+      if (response.status === 401) error.name = 'UnauthorizedError';
+      if (response.status === 403) error.name = 'ForbiddenError';
+      if (response.status === 404) error.name = 'NotFoundError';
+      if (response.status === 503) error.name = 'ServiceUnavailableError';
+      throw error;
+    }
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return response.json() as Promise<T>;
+  }
+}

--- a/plugins/roadmap/src/apis/index.ts
+++ b/plugins/roadmap/src/apis/index.ts
@@ -1,0 +1,14 @@
+export { roadmapApiRef, RoadmapApiClient } from './RoadmapApiClient';
+export type {
+  RoadmapApi,
+  RoadmapField,
+  RoadmapSchemaResponse,
+  RoadmapItem,
+  RoadmapItemsResponse,
+  RoadmapOverviewResponse,
+  RoadmapItemDetail,
+  RoadmapItemDetailResponse,
+  RoadmapIssue,
+  RoadmapSubIssuesResponse,
+  RoadmapItemFilters,
+} from './types';

--- a/plugins/roadmap/src/apis/types.ts
+++ b/plugins/roadmap/src/apis/types.ts
@@ -1,0 +1,128 @@
+/**
+ * Types mirroring the roadmap-backend REST proxy responses
+ * (plugins/roadmap-backend/src/router.ts).
+ */
+
+/** Compact field description served by GET /schema for the filter UI. */
+export interface RoadmapField {
+  name: string;
+  type: 'singleSelect' | 'iteration' | 'date' | 'text' | 'other';
+  options?: string[];
+  iterations?: string[];
+}
+
+export interface RoadmapSchemaResponse {
+  board: string;
+  defaultTeams: string[];
+  fields: RoadmapField[];
+}
+
+/** A board item from GET /items (pro's ProListItem shape). */
+export interface RoadmapItem {
+  id: string;
+  title: string;
+  number?: number;
+  url?: string;
+  repo: string | null;
+  private: boolean | null;
+  state?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  closedAt?: string;
+  assignees?: string[];
+  labels?: string[];
+  /** Board field values keyed by human-readable field name (e.g. "Status"). */
+  fields: Record<string, string>;
+}
+
+export interface RoadmapItemsResponse {
+  items: RoadmapItem[];
+}
+
+export interface RoadmapOverviewResponse {
+  total: number;
+  byStatus: Record<string, number>;
+  byRepo: Record<string, number>;
+}
+
+/** Item detail from GET /items/:id (pro's ProItemDetail shape). */
+export interface RoadmapItemDetail {
+  number: number | '';
+  title: string;
+  url: string;
+  repository: {
+    nameWithOwner: string;
+    isPrivate: boolean;
+    url: string;
+  } | null;
+  body: string;
+  author: string;
+  assignees: string[];
+  comments: Array<{ body: string; createdAt: string; author: string }>;
+  labels: string[];
+  projects: string[];
+  /** Board field values as an array (unlike the list shape's map). */
+  fields: Array<{ name: string; value: string }>;
+  createdAt: string | null;
+  updatedAt: string | null;
+  closedAt: string | null;
+}
+
+export interface RoadmapItemDetailResponse {
+  item: RoadmapItemDetail;
+}
+
+/** A GitHub issue in a sub-issue tree (mapped REST shape). */
+export interface RoadmapIssue {
+  /** Integer issue ID -- what DELETE sub-issues expects, not the number. */
+  id: number;
+  number: number;
+  title: string;
+  state: string;
+  htmlUrl: string;
+  assignees: string[];
+  repo?: string;
+}
+
+export interface RoadmapSubIssuesResponse {
+  subIssues: RoadmapIssue[];
+  parent: RoadmapIssue | null;
+}
+
+export interface RoadmapItemFilters {
+  team?: string;
+  status?: string;
+  kind?: string;
+  availability?: string;
+  quarter?: string;
+  assignee?: string;
+  state?: string;
+  updated?: string;
+  repository?: string;
+  keyword?: string;
+}
+
+export interface RoadmapApi {
+  getSchema(): Promise<RoadmapSchemaResponse>;
+  listItems(filters?: RoadmapItemFilters): Promise<RoadmapItemsResponse>;
+  getItem(id: string): Promise<RoadmapItemDetailResponse>;
+  getOverview(team?: string): Promise<RoadmapOverviewResponse>;
+  listSubIssues(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+  ): Promise<RoadmapSubIssuesResponse>;
+  updateItemField(id: string, name: string, value: string): Promise<void>;
+  addSubIssue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    child: string,
+  ): Promise<void>;
+  removeSubIssue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    subIssueId: number,
+  ): Promise<void>;
+}

--- a/plugins/roadmap/src/components/BoardView/BoardView.tsx
+++ b/plugins/roadmap/src/components/BoardView/BoardView.tsx
@@ -143,9 +143,7 @@ export function BoardView(props: {
                 }
               }}
               onDragLeave={() =>
-                setDropColumn(current =>
-                  current === column ? null : current,
-                )
+                setDropColumn(current => (current === column ? null : current))
               }
               onDrop={event => onDrop(event, column)}
             >

--- a/plugins/roadmap/src/components/BoardView/BoardView.tsx
+++ b/plugins/roadmap/src/components/BoardView/BoardView.tsx
@@ -1,0 +1,178 @@
+import { DragEvent, useState } from 'react';
+import {
+  Box,
+  Chip,
+  Paper,
+  Typography,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import { EmptyState, Progress } from '@backstage/core-components';
+import { RoadmapField, RoadmapItemFilters } from '../../apis';
+import { useItems, useUpdateStatus } from '../../hooks';
+import { groupByStatus, NO_STATUS, statusColumns } from '../../lib/board';
+import { ItemCard } from './ItemCard';
+
+const COLUMN_WIDTH = 300;
+
+const useStyles = makeStyles((theme: Theme) => ({
+  board: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(2),
+    overflowX: 'auto',
+    paddingBottom: theme.spacing(2),
+  },
+  column: {
+    width: COLUMN_WIDTH,
+    flexShrink: 0,
+    padding: theme.spacing(1.5),
+    backgroundColor: theme.palette.background.default,
+  },
+  columnDropTarget: {
+    outline: `2px dashed ${theme.palette.primary.main}`,
+    outlineOffset: -2,
+  },
+  columnHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(1.5),
+  },
+  columnTitle: {
+    fontSize: 14,
+    fontWeight: 600,
+  },
+  countChip: {
+    height: 20,
+    fontSize: 11,
+  },
+  columnBody: {
+    minHeight: theme.spacing(6),
+  },
+  mutationError: {
+    marginBottom: theme.spacing(2),
+  },
+}));
+
+/**
+ * The status-column board (goal: oversight). Cards move between columns by
+ * drag and drop or via the per-card status menu; both write through the
+ * caller's GitHub token so the mutation is attributed to them.
+ */
+export function BoardView(props: {
+  filters: RoadmapItemFilters;
+  schemaFields: RoadmapField[];
+}) {
+  const { filters, schemaFields } = props;
+  const classes = useStyles();
+  const [dropColumn, setDropColumn] = useState<string | null>(null);
+  const { data, isLoading, error } = useItems(filters);
+  const updateStatus = useUpdateStatus();
+
+  if (isLoading) {
+    return <Progress />;
+  }
+  if (error) {
+    return <Alert severity="error">{(error as Error).message}</Alert>;
+  }
+
+  const items = data?.items ?? [];
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        missing="content"
+        title="No board items"
+        description="No roadmap items match the current filters."
+      />
+    );
+  }
+
+  const columns = statusColumns(schemaFields);
+  const groups = groupByStatus(items, columns);
+  // Items whose status is not a known column (or missing) still need a home.
+  const extraColumns = [...groups.keys()].filter(
+    column => !columns.includes(column),
+  );
+  const visibleColumns = [...columns, ...extraColumns];
+
+  const moveTo = (itemId: string, status: string) => {
+    // The synthetic bucket is not a real status option; cards can leave it
+    // but not enter it.
+    if (status !== NO_STATUS) {
+      updateStatus.moveTo(itemId, status);
+    }
+  };
+
+  const onDrop = (event: DragEvent, column: string) => {
+    event.preventDefault();
+    setDropColumn(null);
+    const itemId = event.dataTransfer.getData('text/plain');
+    if (itemId) {
+      moveTo(itemId, column);
+    }
+  };
+
+  return (
+    <>
+      {updateStatus.error ? (
+        <Alert
+          className={classes.mutationError}
+          severity="error"
+          onClose={() => updateStatus.reset()}
+        >
+          Failed to update status: {(updateStatus.error as Error).message}
+        </Alert>
+      ) : null}
+      <Box className={classes.board}>
+        {visibleColumns.map(column => {
+          const columnItems = groups.get(column) ?? [];
+          return (
+            <Paper
+              key={column}
+              className={`${classes.column} ${
+                dropColumn === column ? classes.columnDropTarget : ''
+              }`}
+              variant="outlined"
+              onDragOver={event => {
+                if (column !== NO_STATUS) {
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = 'move';
+                  setDropColumn(column);
+                }
+              }}
+              onDragLeave={() =>
+                setDropColumn(current =>
+                  current === column ? null : current,
+                )
+              }
+              onDrop={event => onDrop(event, column)}
+            >
+              <Box className={classes.columnHeader}>
+                <Typography className={classes.columnTitle}>
+                  {column}
+                </Typography>
+                <Chip
+                  className={classes.countChip}
+                  size="small"
+                  label={columnItems.length}
+                />
+              </Box>
+              <Box className={classes.columnBody}>
+                {columnItems.map(item => (
+                  <ItemCard
+                    key={item.id}
+                    item={item}
+                    columns={columns}
+                    onMove={moveTo}
+                  />
+                ))}
+              </Box>
+            </Paper>
+          );
+        })}
+      </Box>
+    </>
+  );
+}

--- a/plugins/roadmap/src/components/BoardView/ItemCard.tsx
+++ b/plugins/roadmap/src/components/BoardView/ItemCard.tsx
@@ -1,0 +1,175 @@
+import { MouseEvent, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  IconButton,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Typography,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import CheckIcon from '@material-ui/icons/Check';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { RoadmapItem } from '../../apis';
+import { KIND_FIELD, STATUS_FIELD } from '../../lib/board';
+import { itemRouteRef } from '../../routes';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  card: {
+    marginBottom: theme.spacing(1),
+    cursor: 'grab',
+    '&:active': {
+      cursor: 'grabbing',
+    },
+  },
+  content: {
+    padding: theme.spacing(1.5),
+    '&:last-child': {
+      paddingBottom: theme.spacing(1.5),
+    },
+  },
+  titleRow: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(0.5),
+  },
+  title: {
+    flexGrow: 1,
+    fontSize: 14,
+    fontWeight: 500,
+    lineHeight: 1.35,
+    color: 'inherit',
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+  menuButton: {
+    marginTop: theme.spacing(-0.5),
+    marginRight: theme.spacing(-0.5),
+  },
+  meta: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.75),
+    marginTop: theme.spacing(1),
+  },
+  metaText: {
+    fontSize: 12,
+    color: theme.palette.text.secondary,
+  },
+  kindChip: {
+    height: 20,
+    fontSize: 11,
+  },
+}));
+
+/**
+ * One board card: title linking to the item detail, Kind badge, issue
+ * reference and assignees, plus a status menu for moving the item without
+ * dragging. The whole card is draggable; the drop target is the column.
+ */
+export function ItemCard(props: {
+  item: RoadmapItem;
+  columns: string[];
+  onMove: (itemId: string, status: string) => void;
+}) {
+  const { item, columns, onMove } = props;
+  const classes = useStyles();
+  const itemLink = useRouteRef(itemRouteRef);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+
+  const status = item.fields[STATUS_FIELD];
+  const kind = item.fields[KIND_FIELD];
+  const reference = item.repo
+    ? `${item.repo}#${item.number ?? ''}`
+    : 'draft item';
+  const assignees = item.assignees ?? [];
+
+  const openMenu = (event: MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    setMenuAnchor(event.currentTarget);
+  };
+
+  const selectStatus = (nextStatus: string) => {
+    setMenuAnchor(null);
+    if (nextStatus !== status) {
+      onMove(item.id, nextStatus);
+    }
+  };
+
+  return (
+    <Card
+      className={classes.card}
+      variant="outlined"
+      draggable
+      onDragStart={event => {
+        event.dataTransfer.setData('text/plain', item.id);
+        event.dataTransfer.effectAllowed = 'move';
+      }}
+    >
+      <CardContent className={classes.content}>
+        <Box className={classes.titleRow}>
+          <Typography
+            className={classes.title}
+            component={RouterLink}
+            to={itemLink?.({ id: item.id }) ?? '#'}
+          >
+            {item.title}
+          </Typography>
+          <IconButton
+            className={classes.menuButton}
+            size="small"
+            aria-label="Set status"
+            onClick={openMenu}
+          >
+            <MoreVertIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <Box className={classes.meta}>
+          {kind && (
+            <Chip
+              className={classes.kindChip}
+              size="small"
+              variant="outlined"
+              label={kind}
+            />
+          )}
+          <span className={classes.metaText}>{reference}</span>
+          {assignees.length > 0 && (
+            <Tooltip title={assignees.join(', ')}>
+              <span className={classes.metaText}>
+                @{assignees[0]}
+                {assignees.length > 1 && ` +${assignees.length - 1}`}
+              </span>
+            </Tooltip>
+          )}
+        </Box>
+      </CardContent>
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={() => setMenuAnchor(null)}
+      >
+        {columns.map(column => (
+          <MenuItem
+            key={column}
+            dense
+            selected={column === status}
+            onClick={() => selectStatus(column)}
+          >
+            {column === status && <CheckIcon fontSize="small" />}
+            {column}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Card>
+  );
+}

--- a/plugins/roadmap/src/components/BoardView/index.ts
+++ b/plugins/roadmap/src/components/BoardView/index.ts
@@ -1,0 +1,1 @@
+export { BoardView } from './BoardView';

--- a/plugins/roadmap/src/components/ItemDetailPage/FieldEditor.tsx
+++ b/plugins/roadmap/src/components/ItemDetailPage/FieldEditor.tsx
@@ -1,0 +1,104 @@
+import {
+  MenuItem,
+  TextField,
+  Typography,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import { RoadmapField } from '../../apis';
+
+const NOT_SET = '';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  readOnlyValue: {
+    marginBottom: theme.spacing(2),
+  },
+}));
+
+/**
+ * Inline editor for one board field on the detail page. Single-select and
+ * iteration fields render as dropdowns over the schema's values, date
+ * fields as a date input; anything else is read-only (the backend rejects
+ * updates to other field types anyway).
+ */
+export function FieldEditor(props: {
+  field: RoadmapField;
+  value: string | undefined;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  const { field, value, disabled, onChange } = props;
+  const classes = useStyles();
+
+  const values = field.options ?? field.iterations ?? [];
+  const editable =
+    field.type === 'singleSelect' ||
+    field.type === 'iteration' ||
+    field.type === 'date';
+
+  if (!editable) {
+    return (
+      <div className={classes.readOnlyValue}>
+        <Typography variant="caption" color="textSecondary">
+          {field.name}
+        </Typography>
+        <Typography variant="body2">{value ?? 'Not set'}</Typography>
+      </div>
+    );
+  }
+
+  if (field.type === 'date') {
+    return (
+      <TextField
+        fullWidth
+        size="small"
+        variant="outlined"
+        margin="dense"
+        type="date"
+        label={field.name}
+        value={value ?? NOT_SET}
+        disabled={disabled}
+        InputLabelProps={{ shrink: true }}
+        onChange={event => {
+          if (event.target.value) {
+            onChange(event.target.value);
+          }
+        }}
+      />
+    );
+  }
+
+  // The board's current value may not be among the schema's values (e.g. a
+  // past iteration); keep it selectable so the control shows the truth.
+  const selectValues =
+    value && !values.includes(value) ? [value, ...values] : values;
+
+  return (
+    <TextField
+      fullWidth
+      select
+      size="small"
+      variant="outlined"
+      margin="dense"
+      label={field.name}
+      value={value ?? NOT_SET}
+      disabled={disabled}
+      onChange={event => {
+        if (event.target.value !== NOT_SET) {
+          onChange(event.target.value);
+        }
+      }}
+    >
+      {!value && (
+        <MenuItem value={NOT_SET} disabled>
+          Not set
+        </MenuItem>
+      )}
+      {selectValues.map(option => (
+        <MenuItem key={option} value={option}>
+          {option}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+}

--- a/plugins/roadmap/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/plugins/roadmap/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -1,0 +1,285 @@
+import { useParams } from 'react-router-dom';
+import {
+  Box,
+  Chip,
+  Divider,
+  Paper,
+  Typography,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import {
+  Content,
+  EmptyState,
+  Link,
+  MarkdownContent,
+  Progress,
+} from '@backstage/core-components';
+import { useApi, useRouteRef } from '@backstage/frontend-plugin-api';
+import { useQuery } from '@tanstack/react-query';
+import { roadmapApiRef } from '../../apis';
+import { useSchema, useUpdateItemField } from '../../hooks';
+import { issueRefOf } from '../../lib/board';
+import { formatDate } from '../../lib/dates';
+import { rootRouteRef } from '../../routes';
+import { FieldEditor } from './FieldEditor';
+import { SubIssuesPanel } from './SubIssuesPanel';
+
+const SIDEBAR_WIDTH = 300;
+const READING_WIDTH = 860;
+
+const useStyles = makeStyles((theme: Theme) => ({
+  backLink: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    fontSize: 13,
+    marginBottom: theme.spacing(1),
+  },
+  header: {
+    marginBottom: theme.spacing(2),
+  },
+  headerMeta: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(0.5),
+  },
+  layout: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(3),
+  },
+  main: {
+    flexGrow: 1,
+    maxWidth: READING_WIDTH,
+    minWidth: 0,
+  },
+  panel: {
+    padding: theme.spacing(3),
+    marginBottom: theme.spacing(3),
+  },
+  sidebar: {
+    width: SIDEBAR_WIDTH,
+    flexShrink: 0,
+    position: 'sticky',
+    top: theme.spacing(2),
+    padding: theme.spacing(2),
+  },
+  sidebarTitle: {
+    marginBottom: theme.spacing(1),
+  },
+  sidebarDivider: {
+    margin: theme.spacing(2, 0),
+  },
+  sectionTitle: {
+    marginBottom: theme.spacing(1.5),
+  },
+  comment: {
+    marginBottom: theme.spacing(2),
+  },
+  commentMeta: {
+    fontSize: 12,
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(0.5),
+  },
+  labelChip: {
+    marginRight: theme.spacing(0.5),
+  },
+}));
+
+/**
+ * Epic/item detail: issue body and comments in the reading column; board
+ * fields (editable inline) and the sub-issue tree in the sidebar. Field
+ * updates and sub-issue linking are writes attributed to the caller via
+ * their GitHub token.
+ */
+export function ItemDetailPage() {
+  const classes = useStyles();
+  const roadmapApi = useApi(roadmapApiRef);
+  const rootLink = useRouteRef(rootRouteRef);
+  const { id } = useParams();
+
+  const schema = useSchema();
+  const updateField = useUpdateItemField();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['roadmap', 'item', id],
+    queryFn: () => roadmapApi.getItem(id!),
+    enabled: !!id,
+  });
+
+  const boardPath = rootLink ? rootLink() : '..';
+
+  if (isLoading || schema.isLoading) {
+    return (
+      <Content>
+        <Progress />
+      </Content>
+    );
+  }
+  const loadError = error ?? schema.error;
+  if (loadError) {
+    return (
+      <Content>
+        <Alert severity="error">{(loadError as Error).message}</Alert>
+      </Content>
+    );
+  }
+
+  const item = data?.item;
+  if (!id || !item) {
+    return (
+      <Content>
+        <EmptyState
+          missing="content"
+          title="Board item not found"
+          description="This roadmap item does not exist or was removed from the board."
+          action={<Link to={boardPath}>Back to the board</Link>}
+        />
+      </Content>
+    );
+  }
+
+  const fieldValues = new Map(
+    item.fields.map(field => [field.name, field.value]),
+  );
+  const schemaFields = schema.data?.fields ?? [];
+  // Title is a text field on every Projects board but is edited on the
+  // issue itself, not here.
+  const sidebarFields = schemaFields.filter(field => field.name !== 'Title');
+
+  const repository = item.repository?.nameWithOwner;
+  const issueRef = issueRefOf({ repo: repository, number: item.number });
+
+  const updated = formatDate(item.updatedAt);
+
+  return (
+    <Content>
+      <Box className={classes.header}>
+        <Link className={classes.backLink} to={boardPath}>
+          <ArrowBackIcon fontSize="inherit" /> Roadmap board
+        </Link>
+        <Typography variant="h4">{item.title}</Typography>
+        <Box className={classes.headerMeta}>
+          {fieldValues.get('Status') && (
+            <Chip size="small" label={fieldValues.get('Status')} />
+          )}
+          {fieldValues.get('Kind') && (
+            <Chip
+              size="small"
+              variant="outlined"
+              label={fieldValues.get('Kind')}
+            />
+          )}
+          <Typography variant="body2" color="textSecondary">
+            {repository && item.url ? (
+              <Link to={item.url}>
+                {repository}#{item.number}
+              </Link>
+            ) : (
+              'draft item'
+            )}
+            {item.author && ` by ${item.author}`}
+            {item.assignees.length > 0 &&
+              ` · assigned to ${item.assignees
+                .map(login => `@${login}`)
+                .join(', ')}`}
+            {updated && ` · updated ${updated}`}
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box className={classes.layout}>
+        <Box className={classes.main}>
+          <Paper className={classes.panel} variant="outlined">
+            {item.body ? (
+              <MarkdownContent content={item.body} dialect="gfm" />
+            ) : (
+              <Typography variant="body2" color="textSecondary">
+                This item has no description.
+              </Typography>
+            )}
+          </Paper>
+
+          {item.comments.length > 0 && (
+            <Paper className={classes.panel} variant="outlined">
+              <Typography className={classes.sectionTitle} variant="h6">
+                Comments
+              </Typography>
+              {item.comments.map((comment, index) => (
+                <Box key={index} className={classes.comment}>
+                  <Typography className={classes.commentMeta}>
+                    {comment.author}
+                    {formatDate(comment.createdAt, { time: true }) &&
+                      ` · ${formatDate(comment.createdAt, { time: true })}`}
+                  </Typography>
+                  <MarkdownContent content={comment.body} dialect="gfm" />
+                </Box>
+              ))}
+            </Paper>
+          )}
+        </Box>
+
+        <Paper className={classes.sidebar} variant="outlined">
+          <Typography className={classes.sidebarTitle} variant="subtitle1">
+            Board fields
+          </Typography>
+          {updateField.error ? (
+            <Alert severity="error" onClose={() => updateField.reset()}>
+              {(updateField.error as Error).message}
+            </Alert>
+          ) : null}
+          {sidebarFields.map(field => (
+            <FieldEditor
+              key={field.name}
+              field={field}
+              value={fieldValues.get(field.name)}
+              disabled={updateField.isPending}
+              onChange={value =>
+                updateField.mutate({ itemId: id, name: field.name, value })
+              }
+            />
+          ))}
+          {item.labels.length > 0 && (
+            <>
+              <Divider className={classes.sidebarDivider} />
+              <Typography className={classes.sidebarTitle} variant="subtitle1">
+                Labels
+              </Typography>
+              <Box>
+                {item.labels.map(label => (
+                  <Chip
+                    key={label}
+                    className={classes.labelChip}
+                    size="small"
+                    variant="outlined"
+                    label={label}
+                  />
+                ))}
+              </Box>
+            </>
+          )}
+          <Divider className={classes.sidebarDivider} />
+          <Typography className={classes.sidebarTitle} variant="subtitle1">
+            Sub-issues
+          </Typography>
+          {issueRef ? (
+            <SubIssuesPanel
+              owner={issueRef.owner}
+              repo={issueRef.repo}
+              issueNumber={issueRef.number}
+            />
+          ) : (
+            <Typography variant="body2" color="textSecondary">
+              Draft items have no sub-issues.
+            </Typography>
+          )}
+        </Paper>
+      </Box>
+    </Content>
+  );
+}

--- a/plugins/roadmap/src/components/ItemDetailPage/SubIssuesPanel.tsx
+++ b/plugins/roadmap/src/components/ItemDetailPage/SubIssuesPanel.tsx
@@ -17,11 +17,7 @@ import { Alert } from '@material-ui/lab';
 import LinkOffIcon from '@material-ui/icons/LinkOff';
 import { Link, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/frontend-plugin-api';
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { roadmapApiRef } from '../../apis';
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/plugins/roadmap/src/components/ItemDetailPage/SubIssuesPanel.tsx
+++ b/plugins/roadmap/src/components/ItemDetailPage/SubIssuesPanel.tsx
@@ -1,0 +1,197 @@
+import { FormEvent, useState } from 'react';
+import {
+  Button,
+  Chip,
+  IconButton,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  TextField,
+  Tooltip,
+  Typography,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import LinkOffIcon from '@material-ui/icons/LinkOff';
+import { Link, Progress } from '@backstage/core-components';
+import { useApi } from '@backstage/frontend-plugin-api';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { roadmapApiRef } from '../../apis';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  addForm: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1.5),
+  },
+  addInput: {
+    flexGrow: 1,
+  },
+  stateChip: {
+    height: 20,
+    fontSize: 11,
+    marginRight: theme.spacing(1),
+  },
+  parentNote: {
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+/**
+ * The sub-issue tree of an epic: parent link, children with state and
+ * assignees, unlink buttons, and a form to link an existing issue (URL or
+ * owner/repo#N). Link/unlink are writes and run with the caller's GitHub
+ * token; GitHub's own permission errors surface inline.
+ */
+export function SubIssuesPanel(props: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+}) {
+  const { owner, repo, issueNumber } = props;
+  const classes = useStyles();
+  const roadmapApi = useApi(roadmapApiRef);
+  const queryClient = useQueryClient();
+  const [child, setChild] = useState('');
+
+  const queryKey = ['roadmap', 'sub-issues', owner, repo, issueNumber];
+  const { data, isLoading, error } = useQuery({
+    queryKey,
+    queryFn: () => roadmapApi.listSubIssues(owner, repo, issueNumber),
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey });
+
+  const addSubIssue = useMutation({
+    mutationFn: (reference: string) =>
+      roadmapApi.addSubIssue(owner, repo, issueNumber, reference),
+    onSuccess: () => {
+      setChild('');
+      invalidate();
+    },
+  });
+
+  const removeSubIssue = useMutation({
+    mutationFn: (subIssueId: number) =>
+      roadmapApi.removeSubIssue(owner, repo, issueNumber, subIssueId),
+    onSuccess: invalidate,
+  });
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const reference = child.trim();
+    if (reference) {
+      addSubIssue.mutate(reference);
+    }
+  };
+
+  if (isLoading) {
+    return <Progress />;
+  }
+  if (error) {
+    return <Alert severity="error">{(error as Error).message}</Alert>;
+  }
+
+  const subIssues = data?.subIssues ?? [];
+  const parent = data?.parent;
+  const mutationError = addSubIssue.error ?? removeSubIssue.error;
+
+  return (
+    <>
+      {parent && (
+        <Typography
+          className={classes.parentNote}
+          variant="body2"
+          color="textSecondary"
+        >
+          Part of{' '}
+          <Link to={parent.htmlUrl}>
+            {parent.repo ?? ''}#{parent.number} {parent.title}
+          </Link>
+        </Typography>
+      )}
+      {mutationError ? (
+        <Alert
+          severity="error"
+          onClose={() => {
+            addSubIssue.reset();
+            removeSubIssue.reset();
+          }}
+        >
+          {(mutationError as Error).message}
+        </Alert>
+      ) : null}
+      {subIssues.length === 0 ? (
+        <Typography variant="body2" color="textSecondary">
+          No sub-issues linked yet.
+        </Typography>
+      ) : (
+        <List dense disablePadding>
+          {subIssues.map(issue => (
+            <ListItem key={issue.id} divider disableGutters>
+              <ListItemText
+                primary={
+                  <>
+                    <Chip
+                      className={classes.stateChip}
+                      size="small"
+                      variant="outlined"
+                      label={issue.state}
+                    />
+                    <Link to={issue.htmlUrl}>
+                      {issue.repo ?? ''}#{issue.number} {issue.title}
+                    </Link>
+                  </>
+                }
+                secondary={
+                  issue.assignees.length > 0
+                    ? issue.assignees.map(login => `@${login}`).join(', ')
+                    : undefined
+                }
+              />
+              <ListItemSecondaryAction>
+                <Tooltip title="Unlink sub-issue">
+                  <IconButton
+                    edge="end"
+                    size="small"
+                    aria-label="Unlink sub-issue"
+                    disabled={removeSubIssue.isPending}
+                    onClick={() => removeSubIssue.mutate(issue.id)}
+                  >
+                    <LinkOffIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </ListItemSecondaryAction>
+            </ListItem>
+          ))}
+        </List>
+      )}
+      <form className={classes.addForm} onSubmit={onSubmit}>
+        <TextField
+          className={classes.addInput}
+          size="small"
+          variant="outlined"
+          label="Link existing issue"
+          placeholder="https://github.com/owner/repo/issues/N or owner/repo#N"
+          value={child}
+          onChange={event => setChild(event.target.value)}
+        />
+        <Button
+          type="submit"
+          variant="outlined"
+          color="primary"
+          disabled={!child.trim() || addSubIssue.isPending}
+        >
+          Link
+        </Button>
+      </form>
+    </>
+  );
+}

--- a/plugins/roadmap/src/components/ItemDetailPage/index.ts
+++ b/plugins/roadmap/src/components/ItemDetailPage/index.ts
@@ -1,0 +1,1 @@
+export { ItemDetailPage } from './ItemDetailPage';

--- a/plugins/roadmap/src/components/RoadmapPage/RoadmapPage.tsx
+++ b/plugins/roadmap/src/components/RoadmapPage/RoadmapPage.tsx
@@ -1,0 +1,200 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Box,
+  MenuItem,
+  Tab,
+  Tabs,
+  TextField,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import { Content, Progress } from '@backstage/core-components';
+import { Alert } from '@material-ui/lab';
+import { RoadmapField, RoadmapItemFilters } from '../../apis';
+import { useSchema } from '../../hooks';
+import { BoardView } from '../BoardView';
+import { TeamActivityView } from '../TeamActivityView';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    paddingBottom: theme.spacing(1),
+  },
+  filters: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1.5),
+    marginLeft: 'auto',
+  },
+  filter: {
+    minWidth: 150,
+  },
+  keyword: {
+    minWidth: 200,
+  },
+  viewBody: {
+    paddingTop: theme.spacing(1),
+  },
+}));
+
+const ALL = '';
+
+/** The filter fields the toolbar offers, in display order. */
+const FILTER_FIELDS: Array<{
+  param: keyof RoadmapItemFilters;
+  field: string;
+}> = [
+  { param: 'team', field: 'Team' },
+  { param: 'kind', field: 'Kind' },
+  { param: 'quarter', field: 'Quarter' },
+  { param: 'availability', field: 'Availability' },
+];
+
+function fieldValues(field: RoadmapField | undefined): string[] {
+  return field?.options ?? field?.iterations ?? [];
+}
+
+/**
+ * Roadmap board viewer: the status-column board and the per-assignee team
+ * activity view over the GitHub Projects roadmap board. All filters travel
+ * as query params so any view is shareable.
+ */
+export function RoadmapPage() {
+  const classes = useStyles();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { data: schema, isLoading, error } = useSchema();
+
+  const tab = searchParams.get('view') === 'activity' ? 'activity' : 'board';
+
+  // The configured default team scopes the initial view; an explicit
+  // `team=` param (including the empty "all teams" value) wins.
+  const defaultTeam = schema?.defaultTeams[0] ?? ALL;
+  const filters: RoadmapItemFilters = useMemo(() => {
+    const result: RoadmapItemFilters = {
+      team: searchParams.has('team')
+        ? (searchParams.get('team') ?? ALL)
+        : defaultTeam,
+    };
+    for (const { param } of FILTER_FIELDS) {
+      if (param === 'team') {
+        continue;
+      }
+      const value = searchParams.get(param);
+      if (value) {
+        result[param] = value;
+      }
+    }
+    const keyword = searchParams.get('keyword');
+    if (keyword) {
+      result.keyword = keyword;
+    }
+    if (!result.team) {
+      delete result.team;
+    }
+    return result;
+  }, [searchParams, defaultTeam]);
+
+  const setParam = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    // `team` keeps an explicit empty value so "All teams" can override the
+    // configured default; the other filters just drop out of the URL.
+    if (value === ALL && key !== 'team') {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  if (isLoading) {
+    return (
+      <Content>
+        <Progress />
+      </Content>
+    );
+  }
+  if (error) {
+    return (
+      <Content>
+        <Alert severity="error">{(error as Error).message}</Alert>
+      </Content>
+    );
+  }
+
+  const fields = schema?.fields ?? [];
+  const fieldByName = new Map(fields.map(field => [field.name, field]));
+
+  return (
+    <Content>
+      <Box className={classes.toolbar}>
+        <Tabs
+          value={tab}
+          onChange={(_, value) => setParam('view', value)}
+          indicatorColor="primary"
+        >
+          <Tab label="Board" value="board" />
+          <Tab label="Team activity" value="activity" />
+        </Tabs>
+        <Box className={classes.filters}>
+          {FILTER_FIELDS.map(({ param, field }) => {
+            const values = fieldValues(fieldByName.get(field));
+            if (values.length === 0) {
+              return null;
+            }
+            return (
+              <TextField
+                key={param}
+                className={classes.filter}
+                select
+                size="small"
+                variant="outlined"
+                label={field}
+                value={filters[param] ?? ALL}
+                onChange={event => setParam(param, event.target.value)}
+              >
+                <MenuItem value={ALL}>
+                  All {field.toLowerCase()}s
+                </MenuItem>
+                {values.map(value => (
+                  <MenuItem key={value} value={value}>
+                    {value}
+                  </MenuItem>
+                ))}
+              </TextField>
+            );
+          })}
+          <TextField
+            className={classes.keyword}
+            size="small"
+            variant="outlined"
+            label="Search"
+            defaultValue={filters.keyword ?? ''}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                setParam(
+                  'keyword',
+                  (event.target as HTMLInputElement).value.trim(),
+                );
+              }
+            }}
+            onBlur={event => setParam('keyword', event.target.value.trim())}
+          />
+        </Box>
+      </Box>
+      <Box className={classes.viewBody}>
+        {tab === 'board' ? (
+          <BoardView filters={filters} schemaFields={fields} />
+        ) : (
+          <TeamActivityView filters={filters} />
+        )}
+      </Box>
+    </Content>
+  );
+}

--- a/plugins/roadmap/src/components/RoadmapPage/RoadmapPage.tsx
+++ b/plugins/roadmap/src/components/RoadmapPage/RoadmapPage.tsx
@@ -159,9 +159,7 @@ export function RoadmapPage() {
                 value={filters[param] ?? ALL}
                 onChange={event => setParam(param, event.target.value)}
               >
-                <MenuItem value={ALL}>
-                  All {field.toLowerCase()}s
-                </MenuItem>
+                <MenuItem value={ALL}>All {field.toLowerCase()}s</MenuItem>
                 {values.map(value => (
                   <MenuItem key={value} value={value}>
                     {value}

--- a/plugins/roadmap/src/components/RoadmapPage/index.ts
+++ b/plugins/roadmap/src/components/RoadmapPage/index.ts
@@ -1,0 +1,1 @@
+export { RoadmapPage } from './RoadmapPage';

--- a/plugins/roadmap/src/components/RoadmapProviders.tsx
+++ b/plugins/roadmap/src/components/RoadmapProviders.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from 'react';
+import {
+  QueryClient,
+  QueryClientProvider as TanstackQueryClientProvider,
+} from '@tanstack/react-query';
+
+// Module-level client so all roadmap views share one cache across remounts.
+// The backend already caches board reads for a minute; matching that here
+// avoids refetching the full board on every view switch.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 60_000,
+      retry: (failureCount, error) => {
+        const name = (error as Error).name;
+        if (
+          name === 'NotFoundError' ||
+          name === 'UnauthorizedError' ||
+          name === 'ForbiddenError' ||
+          name === 'ServiceUnavailableError'
+        ) {
+          return false;
+        }
+        return failureCount <= 2;
+      },
+    },
+  },
+});
+
+export const RoadmapProviders = ({ children }: { children: ReactNode }) => (
+  <TanstackQueryClientProvider client={queryClient}>
+    {children}
+  </TanstackQueryClientProvider>
+);

--- a/plugins/roadmap/src/components/RoadmapRouter/RoadmapRouter.tsx
+++ b/plugins/roadmap/src/components/RoadmapRouter/RoadmapRouter.tsx
@@ -1,0 +1,18 @@
+import { Routes, Route } from 'react-router-dom';
+import { RoadmapPage } from '../RoadmapPage';
+import { ItemDetailPage } from '../ItemDetailPage';
+
+/**
+ * Routing within the roadmap page: the board/activity views and the
+ * per-item detail page. Mounted inside RoadmapProviders by the page loader
+ * in plugin.tsx, so all views share one query cache. Filter selections
+ * travel as query params so URLs are shareable.
+ */
+export const RoadmapRouter = () => {
+  return (
+    <Routes>
+      <Route index element={<RoadmapPage />} />
+      <Route path="items/:id" element={<ItemDetailPage />} />
+    </Routes>
+  );
+};

--- a/plugins/roadmap/src/components/RoadmapRouter/index.ts
+++ b/plugins/roadmap/src/components/RoadmapRouter/index.ts
@@ -1,0 +1,1 @@
+export { RoadmapRouter } from './RoadmapRouter';

--- a/plugins/roadmap/src/components/TeamActivityView/TeamActivityView.tsx
+++ b/plugins/roadmap/src/components/TeamActivityView/TeamActivityView.tsx
@@ -65,9 +65,7 @@ function isActive(item: RoadmapItem): boolean {
   const status = item.fields[STATUS_FIELD];
   return (
     !!status &&
-    ACTIVE_STATUS_KEYWORDS.some(keyword =>
-      findStatusOption([status], keyword),
-    )
+    ACTIVE_STATUS_KEYWORDS.some(keyword => findStatusOption([status], keyword))
   );
 }
 
@@ -213,9 +211,7 @@ export function TeamActivityView(props: { filters: RoadmapItemFilters }) {
         </Box>
         {recentItems.isLoading && <Progress />}
         {recentItems.error ? (
-          <Alert severity="error">
-            {(recentItems.error as Error).message}
-          </Alert>
+          <Alert severity="error">{(recentItems.error as Error).message}</Alert>
         ) : null}
         {!recentItems.isLoading && recent.length === 0 && (
           <Typography variant="body2" color="textSecondary">

--- a/plugins/roadmap/src/components/TeamActivityView/TeamActivityView.tsx
+++ b/plugins/roadmap/src/components/TeamActivityView/TeamActivityView.tsx
@@ -1,0 +1,229 @@
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Box,
+  Chip,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  Typography,
+  makeStyles,
+  Theme,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import { EmptyState, Progress } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { RoadmapItem, RoadmapItemFilters } from '../../apis';
+import { useItems } from '../../hooks';
+import { formatDate } from '../../lib/dates';
+import {
+  findStatusOption,
+  groupByAssignee,
+  KIND_FIELD,
+  STATUS_FIELD,
+} from '../../lib/board';
+import { itemRouteRef } from '../../routes';
+
+/**
+ * The statuses that mean "someone is actively on this". Status names carry
+ * emoji suffixes on the board (e.g. "In Progress ⛏️"), so they are matched
+ * by keyword via findStatusOption.
+ */
+const ACTIVE_STATUS_KEYWORDS = ['In Progress', 'Validation'];
+
+const RECENT_WINDOW = '>@today-7d';
+
+const UNASSIGNED = 'Unassigned';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  summary: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(3),
+  },
+  section: {
+    marginBottom: theme.spacing(3),
+  },
+  sectionHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+  statusChip: {
+    height: 20,
+    fontSize: 11,
+  },
+  itemTitle: {
+    fontSize: 14,
+  },
+}));
+
+function isActive(item: RoadmapItem): boolean {
+  const status = item.fields[STATUS_FIELD];
+  return (
+    !!status &&
+    ACTIVE_STATUS_KEYWORDS.some(keyword =>
+      findStatusOption([status], keyword),
+    )
+  );
+}
+
+function ItemList(props: { items: RoadmapItem[] }) {
+  const classes = useStyles();
+  const itemLink = useRouteRef(itemRouteRef);
+  return (
+    <Paper variant="outlined">
+      <List dense disablePadding>
+        {props.items.map(item => {
+          const updated = formatDate(item.updatedAt);
+          const secondary = [
+            item.repo ? `${item.repo}#${item.number ?? ''}` : 'draft item',
+            item.fields[KIND_FIELD],
+            updated ? `updated ${updated}` : undefined,
+          ]
+            .filter(Boolean)
+            .join(' · ');
+          return (
+            <ListItem
+              key={item.id}
+              button
+              divider
+              component={RouterLink}
+              to={itemLink?.({ id: item.id }) ?? '#'}
+            >
+              <ListItemText
+                primary={
+                  <Box display="flex" alignItems="center" gridGap={8}>
+                    <span className={classes.itemTitle}>{item.title}</span>
+                    {item.fields[STATUS_FIELD] && (
+                      <Chip
+                        className={classes.statusChip}
+                        size="small"
+                        variant="outlined"
+                        label={item.fields[STATUS_FIELD]}
+                      />
+                    )}
+                  </Box>
+                }
+                secondary={secondary}
+              />
+            </ListItem>
+          );
+        })}
+      </List>
+    </Paper>
+  );
+}
+
+/**
+ * "Who is working on what" (goal: communication): active items grouped by
+ * assignee -- with unassigned in-flight work called out as a smell -- plus
+ * status counts and the items that moved in the last week.
+ */
+export function TeamActivityView(props: { filters: RoadmapItemFilters }) {
+  const { filters } = props;
+  const classes = useStyles();
+
+  const allItems = useItems(filters);
+  const recentItems = useItems({ ...filters, updated: RECENT_WINDOW });
+
+  if (allItems.isLoading) {
+    return <Progress />;
+  }
+  if (allItems.error) {
+    return <Alert severity="error">{(allItems.error as Error).message}</Alert>;
+  }
+
+  const items = allItems.data?.items ?? [];
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        missing="content"
+        title="No board items"
+        description="No roadmap items match the current filters."
+      />
+    );
+  }
+
+  const statusCounts = new Map<string, number>();
+  for (const item of items) {
+    const status = item.fields[STATUS_FIELD] ?? 'No status';
+    statusCounts.set(status, (statusCounts.get(status) ?? 0) + 1);
+  }
+
+  const { groups: activeGroups, unassigned } = groupByAssignee(
+    items.filter(isActive),
+  );
+  const recent = recentItems.data?.items ?? [];
+
+  return (
+    <>
+      <Box className={classes.summary}>
+        {[...statusCounts.entries()].map(([status, count]) => (
+          <Chip
+            key={status}
+            size="small"
+            variant="outlined"
+            label={`${status}: ${count}`}
+          />
+        ))}
+      </Box>
+
+      {activeGroups.length === 0 && unassigned.length === 0 && (
+        <Box className={classes.section}>
+          <Typography variant="body2" color="textSecondary">
+            Nothing is currently in progress or in validation.
+          </Typography>
+        </Box>
+      )}
+      {activeGroups.map(({ assignee, items: assigneeItems }) => (
+        <Box key={assignee} className={classes.section}>
+          <Box className={classes.sectionHeader}>
+            <Typography variant="h6">@{assignee}</Typography>
+            <Chip size="small" label={assigneeItems.length} />
+          </Box>
+          <ItemList items={assigneeItems} />
+        </Box>
+      ))}
+      {unassigned.length > 0 && (
+        <Box className={classes.section}>
+          <Box className={classes.sectionHeader}>
+            <Typography variant="h6">{UNASSIGNED}</Typography>
+            <Chip size="small" label={unassigned.length} />
+            <Chip
+              size="small"
+              variant="outlined"
+              color="secondary"
+              label="in flight without an owner"
+            />
+          </Box>
+          <ItemList items={unassigned} />
+        </Box>
+      )}
+
+      <Box className={classes.section}>
+        <Box className={classes.sectionHeader}>
+          <Typography variant="h6">Recently moved</Typography>
+          <Typography variant="body2" color="textSecondary">
+            updated in the last 7 days
+          </Typography>
+        </Box>
+        {recentItems.isLoading && <Progress />}
+        {recentItems.error ? (
+          <Alert severity="error">
+            {(recentItems.error as Error).message}
+          </Alert>
+        ) : null}
+        {!recentItems.isLoading && recent.length === 0 && (
+          <Typography variant="body2" color="textSecondary">
+            Nothing moved in the last week.
+          </Typography>
+        )}
+        {recent.length > 0 && <ItemList items={recent} />}
+      </Box>
+    </>
+  );
+}

--- a/plugins/roadmap/src/components/TeamActivityView/index.ts
+++ b/plugins/roadmap/src/components/TeamActivityView/index.ts
@@ -1,0 +1,1 @@
+export { TeamActivityView } from './TeamActivityView';

--- a/plugins/roadmap/src/hooks.ts
+++ b/plugins/roadmap/src/hooks.ts
@@ -1,9 +1,5 @@
 import { useApi } from '@backstage/frontend-plugin-api';
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   roadmapApiRef,
   RoadmapItemFilters,
@@ -64,8 +60,7 @@ export function useUpdateItemField() {
           },
       );
     },
-    onSettled: () =>
-      queryClient.invalidateQueries({ queryKey: ['roadmap'] }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['roadmap'] }),
   });
 }
 

--- a/plugins/roadmap/src/hooks.ts
+++ b/plugins/roadmap/src/hooks.ts
@@ -1,0 +1,80 @@
+import { useApi } from '@backstage/frontend-plugin-api';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import {
+  roadmapApiRef,
+  RoadmapItemFilters,
+  RoadmapItemsResponse,
+} from './apis';
+import { STATUS_FIELD } from './lib/board';
+
+export function useSchema() {
+  const roadmapApi = useApi(roadmapApiRef);
+  return useQuery({
+    queryKey: ['roadmap', 'schema'],
+    queryFn: () => roadmapApi.getSchema(),
+    staleTime: 10 * 60_000,
+  });
+}
+
+export function useItems(filters: RoadmapItemFilters, enabled = true) {
+  const roadmapApi = useApi(roadmapApiRef);
+  return useQuery({
+    queryKey: ['roadmap', 'items', filters],
+    queryFn: () => roadmapApi.listItems(filters),
+    enabled,
+  });
+}
+
+/**
+ * Board field mutation with an optimistic status move: dropping a card in
+ * another column (or picking a status from the card menu) re-buckets it
+ * immediately in every cached list, then the refetch settles the truth.
+ */
+export function useUpdateItemField() {
+  const roadmapApi = useApi(roadmapApiRef);
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (variables: { itemId: string; name: string; value: string }) =>
+      roadmapApi.updateItemField(
+        variables.itemId,
+        variables.name,
+        variables.value,
+      ),
+    onMutate: async variables => {
+      await queryClient.cancelQueries({ queryKey: ['roadmap', 'items'] });
+      queryClient.setQueriesData<RoadmapItemsResponse>(
+        { queryKey: ['roadmap', 'items'] },
+        current =>
+          current && {
+            items: current.items.map(item =>
+              item.id === variables.itemId
+                ? {
+                    ...item,
+                    fields: {
+                      ...item.fields,
+                      [variables.name]: variables.value,
+                    },
+                  }
+                : item,
+            ),
+          },
+      );
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: ['roadmap'] }),
+  });
+}
+
+/** Convenience wrapper for the most common mutation: moving Status. */
+export function useUpdateStatus() {
+  const updateField = useUpdateItemField();
+  return {
+    ...updateField,
+    moveTo: (itemId: string, status: string) =>
+      updateField.mutate({ itemId, name: STATUS_FIELD, value: status }),
+  };
+}

--- a/plugins/roadmap/src/index.ts
+++ b/plugins/roadmap/src/index.ts
@@ -1,0 +1,15 @@
+export { roadmapPlugin as default, roadmapPlugin } from './plugin';
+export { roadmapApiRef, RoadmapApiClient } from './apis';
+export type {
+  RoadmapApi,
+  RoadmapField,
+  RoadmapSchemaResponse,
+  RoadmapItem,
+  RoadmapItemsResponse,
+  RoadmapOverviewResponse,
+  RoadmapItemDetail,
+  RoadmapItemDetailResponse,
+  RoadmapIssue,
+  RoadmapSubIssuesResponse,
+  RoadmapItemFilters,
+} from './apis';

--- a/plugins/roadmap/src/lib/board.test.ts
+++ b/plugins/roadmap/src/lib/board.test.ts
@@ -1,0 +1,65 @@
+import { findStatusOption, groupByAssignee, issueRefOf } from './board';
+import { RoadmapItem } from '../apis';
+
+function item(overrides: Partial<RoadmapItem>): RoadmapItem {
+  return {
+    id: 'PVTI_x',
+    title: 'An item',
+    repo: 'giantswarm/giantswarm',
+    private: true,
+    fields: {},
+    ...overrides,
+  };
+}
+
+describe('findStatusOption', () => {
+  const options = [
+    'Inbox 📥',
+    'Backlog 📦',
+    'Up Next ➡️',
+    'In Progress ⛏️',
+    'Validation ☑️',
+    'Done ✅',
+  ];
+
+  it('matches the board value with emoji by keyword', () => {
+    expect(findStatusOption(options, 'in progress')).toBe('In Progress ⛏️');
+    expect(findStatusOption(options, 'validation')).toBe('Validation ☑️');
+  });
+
+  it('returns undefined for unknown keywords and missing options', () => {
+    expect(findStatusOption(options, 'review')).toBeUndefined();
+    expect(findStatusOption(undefined, 'in progress')).toBeUndefined();
+  });
+});
+
+describe('issueRefOf', () => {
+  it('splits repo and number', () => {
+    expect(issueRefOf({ repo: 'giantswarm/giantswarm', number: 1234 })).toEqual(
+      { owner: 'giantswarm', repo: 'giantswarm', number: 1234 },
+    );
+  });
+
+  it('returns undefined for draft items without an issue', () => {
+    expect(issueRefOf({ repo: null, number: 12 })).toBeUndefined();
+    expect(
+      issueRefOf({ repo: 'giantswarm/giantswarm', number: '' }),
+    ).toBeUndefined();
+  });
+});
+
+describe('groupByAssignee', () => {
+  it('groups items per assignee and collects unassigned separately', () => {
+    const shared = item({ id: 'a', assignees: ['anna', 'ben'] });
+    const solo = item({ id: 'b', assignees: ['ben'] });
+    const orphan = item({ id: 'c', assignees: [] });
+
+    const { groups, unassigned } = groupByAssignee([shared, solo, orphan]);
+
+    expect(groups).toEqual([
+      { assignee: 'anna', items: [shared] },
+      { assignee: 'ben', items: [shared, solo] },
+    ]);
+    expect(unassigned).toEqual([orphan]);
+  });
+});

--- a/plugins/roadmap/src/lib/board.ts
+++ b/plugins/roadmap/src/lib/board.ts
@@ -1,0 +1,99 @@
+import { RoadmapField, RoadmapItem } from '../apis';
+
+/** Board field names this plugin gives special treatment. */
+export const STATUS_FIELD = 'Status';
+export const KIND_FIELD = 'Kind';
+
+/** Bucket for items without a status, shown as the last board column. */
+export const NO_STATUS = 'No status';
+
+/**
+ * Status column order comes from the board schema (the single source of
+ * truth for the lifecycle); an empty result means the schema has no Status
+ * field at all.
+ */
+export function statusColumns(fields: RoadmapField[]): string[] {
+  const statusField = fields.find(field => field.name === STATUS_FIELD);
+  return statusField?.options ?? [];
+}
+
+/**
+ * Find the board's actual status value for a plain keyword: option names
+ * carry emoji suffixes (e.g. "In Progress ⛏️"), so "in progress" resolves
+ * to the full name. Undefined when no option starts with the keyword.
+ */
+export function findStatusOption(
+  options: string[] | undefined,
+  keyword: string,
+): string | undefined {
+  const needle = keyword.trim().toLowerCase();
+  if (!needle) {
+    return undefined;
+  }
+  return options?.find(option => option.toLowerCase().startsWith(needle));
+}
+
+export function groupByStatus(
+  items: RoadmapItem[],
+  columns: string[],
+): Map<string, RoadmapItem[]> {
+  const groups = new Map<string, RoadmapItem[]>();
+  for (const column of columns) {
+    groups.set(column, []);
+  }
+  for (const item of items) {
+    const status = item.fields[STATUS_FIELD] ?? NO_STATUS;
+    const bucket = groups.get(status);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      groups.set(status, [item]);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Group items per assignee (an item with two assignees appears under
+ * both), with unassigned items collected separately -- in-flight work
+ * without an owner is a signal the activity view calls out explicitly.
+ * Groups are sorted alphabetically by assignee.
+ */
+export function groupByAssignee(items: RoadmapItem[]): {
+  groups: Array<{ assignee: string; items: RoadmapItem[] }>;
+  unassigned: RoadmapItem[];
+} {
+  const byAssignee = new Map<string, RoadmapItem[]>();
+  const unassigned: RoadmapItem[] = [];
+  for (const item of items) {
+    if (!item.assignees?.length) {
+      unassigned.push(item);
+      continue;
+    }
+    for (const assignee of item.assignees) {
+      byAssignee.set(assignee, [...(byAssignee.get(assignee) ?? []), item]);
+    }
+  }
+  const groups = [...byAssignee.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([assignee, assigneeItems]) => ({ assignee, items: assigneeItems }));
+  return { groups, unassigned };
+}
+
+/**
+ * The issue reference (owner, repo, number) behind a board item, for the
+ * sub-issue endpoints. Undefined for draft items, which have no issue.
+ */
+export function issueRefOf(item: {
+  repo?: string | null;
+  number?: number | '' | null;
+}): { owner: string; repo: string; number: number } | undefined {
+  if (typeof item.number !== 'number' || !item.repo) {
+    return undefined;
+  }
+  const [owner, repo] = item.repo.split('/');
+  if (!owner || !repo) {
+    return undefined;
+  }
+  return { owner, repo, number: item.number };
+}

--- a/plugins/roadmap/src/lib/dates.ts
+++ b/plugins/roadmap/src/lib/dates.ts
@@ -1,0 +1,22 @@
+/**
+ * Locale-formatted date ("Jul 8, 2026"), optionally with time, for item
+ * and comment timestamps. Undefined for missing or unparsable input.
+ */
+export function formatDate(
+  value: string | null | undefined,
+  options: { time?: boolean } = {},
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    ...(options.time && { hour: '2-digit', minute: '2-digit' }),
+  });
+}

--- a/plugins/roadmap/src/plugin.tsx
+++ b/plugins/roadmap/src/plugin.tsx
@@ -22,9 +22,8 @@ const roadmapPage = PageBlueprint.make({
     path: '/roadmap',
     routeRef: rootRouteRef,
     loader: async () => {
-      const { RoadmapProviders } = await import(
-        './components/RoadmapProviders'
-      );
+      const { RoadmapProviders } =
+        await import('./components/RoadmapProviders');
       const { RoadmapRouter } = await import('./components/RoadmapRouter');
       return (
         <RoadmapProviders>

--- a/plugins/roadmap/src/plugin.tsx
+++ b/plugins/roadmap/src/plugin.tsx
@@ -1,0 +1,60 @@
+import {
+  ApiBlueprint,
+  createFrontendPlugin,
+  discoveryApiRef,
+  fetchApiRef,
+  githubAuthApiRef,
+  PageBlueprint,
+} from '@backstage/frontend-plugin-api';
+import TimelineIcon from '@material-ui/icons/Timeline';
+
+import { roadmapApiRef, RoadmapApiClient } from './apis';
+import { itemRouteRef, rootRouteRef } from './routes';
+
+// Disabled by default: the roadmap board is internal and must not appear in
+// customer portals. Deployments opt in via app.extensions (and configure
+// roadmap.board for the backend).
+const roadmapPage = PageBlueprint.make({
+  disabled: true,
+  params: {
+    title: 'Roadmap',
+    icon: <TimelineIcon />,
+    path: '/roadmap',
+    routeRef: rootRouteRef,
+    loader: async () => {
+      const { RoadmapProviders } = await import(
+        './components/RoadmapProviders'
+      );
+      const { RoadmapRouter } = await import('./components/RoadmapRouter');
+      return (
+        <RoadmapProviders>
+          <RoadmapRouter />
+        </RoadmapProviders>
+      );
+    },
+  },
+});
+
+const roadmapApi = ApiBlueprint.make({
+  disabled: true,
+  params: defineParams =>
+    defineParams({
+      api: roadmapApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+        githubAuthApi: githubAuthApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi, githubAuthApi }) =>
+        new RoadmapApiClient({ discoveryApi, fetchApi, githubAuthApi }),
+    }),
+});
+
+export const roadmapPlugin = createFrontendPlugin({
+  pluginId: 'roadmap',
+  extensions: [roadmapPage, roadmapApi],
+  routes: {
+    root: rootRouteRef,
+    item: itemRouteRef,
+  },
+});

--- a/plugins/roadmap/src/routes.ts
+++ b/plugins/roadmap/src/routes.ts
@@ -1,0 +1,11 @@
+import {
+  createRouteRef,
+  createSubRouteRef,
+} from '@backstage/frontend-plugin-api';
+
+export const rootRouteRef = createRouteRef();
+
+export const itemRouteRef = createSubRouteRef({
+  path: '/items/:id',
+  parent: rootRouteRef,
+});

--- a/plugins/roadmap/src/setupTests.ts
+++ b/plugins/roadmap/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11886,6 +11886,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@giantswarm/backstage-plugin-roadmap@workspace:^, @giantswarm/backstage-plugin-roadmap@workspace:plugins/roadmap":
+  version: 0.0.0-use.local
+  resolution: "@giantswarm/backstage-plugin-roadmap@workspace:plugins/roadmap"
+  dependencies:
+    "@backstage/cli": "backstage:^"
+    "@backstage/core-components": "backstage:^"
+    "@backstage/core-plugin-api": "backstage:^"
+    "@backstage/frontend-plugin-api": "backstage:^"
+    "@backstage/test-utils": "backstage:^"
+    "@material-ui/core": "npm:^4.12.4"
+    "@material-ui/icons": "npm:^4.11.3"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@tanstack/react-query": "npm:^5.82.0"
+    "@testing-library/jest-dom": "npm:^6.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@testing-library/user-event": "npm:^14.0.0"
+    react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: "*"
+  languageName: unknown
+  linkType: soft
+
 "@giantswarm/backstage-plugin-scaffolder-backend-module-gs@npm:^0.12.0, @giantswarm/backstage-plugin-scaffolder-backend-module-gs@workspace:plugins/scaffolder-backend-module-gs":
   version: 0.0.0-use.local
   resolution: "@giantswarm/backstage-plugin-scaffolder-backend-module-gs@workspace:plugins/scaffolder-backend-module-gs"
@@ -26591,6 +26614,7 @@ __metadata:
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^"
     "@giantswarm/backstage-plugin-muster": "workspace:^"
     "@giantswarm/backstage-plugin-plans": "workspace:^"
+    "@giantswarm/backstage-plugin-roadmap": "workspace:^"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@pagerduty/backstage-plugin": "npm:^0.20.0"


### PR DESCRIPTION
## Summary

Frontend counterpart to #1898: a New Frontend System plugin (`pluginId: roadmap`) surfacing the GitHub Projects roadmap board in the portal, mirroring the plans plugin's structure (disabled-by-default extensions, tanstack-query, MUI v4).

- **Board view** (`/roadmap`): status lifecycle as columns (Inbox → Backlog → Up Next → In Progress → Validation → Done) from the board schema, filterable by Team (defaults to the configured `roadmap.teams`), Kind, Quarter, Availability, and keyword. Cards move between columns by drag and drop or a per-card status menu, with an optimistic in-place move.
- **Team activity view** (`/roadmap?view=activity`): In Progress + Validation items grouped by assignee, unassigned in-flight work called out explicitly, per-status counts, and items updated in the last 7 days.
- **Item detail** (`/roadmap/items/:id`): issue body and comments, board fields editable inline (single-select/iteration/date editors driven by the schema), and the sub-issue tree with link/unlink.
- **Write attribution**: reads use the backend's GitHub App token; writes fetch the caller's GitHub OAuth token from the existing `githubAuthApiRef` session and send it as `X-GitHub-Token`. The classic `project` scope is requested incrementally on the first write, so only roadmap users see the extra consent prompt. GitHub 403s surface inline.
- Extensions ship `disabled: true`; internal portals opt in via `app.extensions` (`page:roadmap`, `api:roadmap`). Customer portals are unaffected.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn workspace @giantswarm/backstage-plugin-roadmap lint` and `test` (19 tests: API client incl. write-token header, board helpers)
- [ ] CI green

Made with [Cursor](https://cursor.com)