### PR TITLE
fix(auth): retry issuer metadata discovery and fail startup when the main login provider is unreachable

### DIFF
--- a/.changeset/auth-retry-main-provider-metadata.md
+++ b/.changeset/auth-retry-main-provider-metadata.md
@@ -2,13 +2,28 @@
 '@giantswarm/backstage-plugin-auth-backend-module-gs': patch
 ---
 
-Retry OIDC issuer metadata discovery for the main login provider and fail
-backend startup if it stays unreachable.
+Retry OIDC issuer metadata discovery for the main login provider, fail backend
+startup if it stays unreachable, and stop caching a failed discovery for the
+lifetime of the process.
 
 Previously a transient Dex outage during backend startup made the module skip
 registering the main login provider entirely: the portal came up healthy but
 every login returned `404 Unknown auth provider` until the pod was manually
-restarted. Metadata discovery is now retried with exponential backoff (5
-attempts over ~15s), and if the issuer is still unreachable the module throws
-so the backend exits and the orchestrator restarts it until Dex is reachable
-again — the portal self-heals instead of silently serving without login.
+restarted.
+
+- Metadata discovery is now checked at startup through openid-client's
+  `Issuer.discover` — the same code path and validation the oidc authenticator
+  uses, bounded by its built-in HTTP timeout — and retried with exponential
+  backoff (5 attempts over ~15s). If the issuer is still unreachable the
+  module throws so the backend exits and the orchestrator restarts it until
+  Dex is reachable again — the portal self-heals instead of silently serving
+  without login. A malformed `metadataUrl` fails immediately without retries.
+- The registered provider now uses `gsOidcAuthenticator`, a wrapper around the
+  upstream oidc authenticator that memoizes issuer discovery only on success.
+  If Dex becomes unreachable after startup, each login attempt triggers a
+  fresh discovery instead of the upstream behaviour of caching the first
+  rejection until the process restarts.
+- Note on scope: configuration errors for the main login provider (missing
+  environment block or `metadataUrl`) now also fail startup instead of
+  starting the portal without login — broken required-login config should be
+  loud.

--- a/.changeset/auth-retry-main-provider-metadata.md
+++ b/.changeset/auth-retry-main-provider-metadata.md
@@ -1,0 +1,14 @@
+---
+'@giantswarm/backstage-plugin-auth-backend-module-gs': patch
+---
+
+Retry OIDC issuer metadata discovery for the main login provider and fail
+backend startup if it stays unreachable.
+
+Previously a transient Dex outage during backend startup made the module skip
+registering the main login provider entirely: the portal came up healthy but
+every login returned `404 Unknown auth provider` until the pod was manually
+restarted. Metadata discovery is now retried with exponential backoff (5
+attempts over ~15s), and if the issuer is still unreachable the module throws
+so the backend exits and the orchestrator restarts it until Dex is reachable
+again — the portal self-heals instead of silently serving without login.

--- a/plugins/auth-backend-module-gs/package.json
+++ b/plugins/auth-backend-module-gs/package.json
@@ -32,7 +32,7 @@
     "@backstage/plugin-auth-node": "backstage:^",
     "express": "^5.0.0",
     "express-promise-router": "^4.1.1",
-    "node-fetch": "^3.3.2",
+    "openid-client": "^5.7.1",
     "passport-oauth2": "^1.8.0"
   },
   "devDependencies": {

--- a/plugins/auth-backend-module-gs/src/module.ts
+++ b/plugins/auth-backend-module-gs/src/module.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   coreServices,
   createBackendModule,
@@ -17,6 +16,7 @@ import {
 import { oauth2Authenticator } from './oauth2/authenticator';
 import { createCimdRouter } from './oauth2/cimdRouter';
 import { createClusterTokenRouter } from './clusterToken/router';
+import { waitForIssuerMetadata } from './oidc/issuerMetadata';
 
 const OIDC_PROVIDER_NAME_PREFIX = 'oidc-';
 const MCP_PROVIDER_NAME_PREFIX = 'mcp-';
@@ -117,31 +117,27 @@ export const authModuleGsProviders = createBackendModule({
             provider === mainAuthProvider,
         );
         for (const providerName of customOIDCProviders) {
-          try {
-            logger.info(`Configuring auth provider: ${providerName}`);
+          logger.info(`Configuring auth provider: ${providerName}`);
 
-            const providerConfig = providersConfig
-              .getConfig(providerName)
-              .getConfig(config.getString('auth.environment'));
-            const metadataUrl = providerConfig.getString('metadataUrl');
-            const response = await fetch(new URL(metadataUrl));
-            if (!response.ok) {
-              throw new Error(response.statusText);
-            }
+          const providerConfig = providersConfig
+            .getConfig(providerName)
+            .getConfig(config.getString('auth.environment'));
+          const metadataUrl = providerConfig.getString('metadataUrl');
 
-            providersExtensionPoint.registerProvider({
-              providerId: providerName,
-              factory: createOAuthProviderFactory({
-                authenticator: oidcAuthenticator,
-                signInResolver: customSignInResolver,
-              }),
-            });
-          } catch (err) {
-            logger.error(
-              `Failed to fetch issuer metadata for ${providerName} auth provider`,
-            );
-            logger.error((err as Error).toString());
-          }
+          // The main login provider is required: a portal without login is
+          // unusable, and skipping registration here would serve 404s on
+          // every login until the pod is manually restarted. Retry to absorb
+          // transient Dex unavailability, then let the error fail startup so
+          // the orchestrator restarts the backend until Dex is reachable.
+          await waitForIssuerMetadata(providerName, metadataUrl, logger);
+
+          providersExtensionPoint.registerProvider({
+            providerId: providerName,
+            factory: createOAuthProviderFactory({
+              authenticator: oidcAuthenticator,
+              signInResolver: customSignInResolver,
+            }),
+          });
         }
 
         const customMCPProviders = configuredProviders.filter(provider =>

--- a/plugins/auth-backend-module-gs/src/module.ts
+++ b/plugins/auth-backend-module-gs/src/module.ts
@@ -9,13 +9,11 @@ import {
   OAuthAuthenticatorResult,
   SignInResolver,
 } from '@backstage/plugin-auth-node';
-import {
-  oidcAuthenticator,
-  OidcAuthResult,
-} from '@backstage/plugin-auth-backend-module-oidc-provider';
+import { OidcAuthResult } from '@backstage/plugin-auth-backend-module-oidc-provider';
 import { oauth2Authenticator } from './oauth2/authenticator';
 import { createCimdRouter } from './oauth2/cimdRouter';
 import { createClusterTokenRouter } from './clusterToken/router';
+import { gsOidcAuthenticator } from './oidc/authenticator';
 import { waitForIssuerMetadata } from './oidc/issuerMetadata';
 
 const OIDC_PROVIDER_NAME_PREFIX = 'oidc-';
@@ -107,20 +105,19 @@ export const authModuleGsProviders = createBackendModule({
         // Broker-only cluster auth (giantswarm#36902): per-cluster oidc-<mc>
         // providers are no longer used for cluster access -- the frontend mints
         // those tokens via the muster cluster-token broker. Only the main SSO
-        // login provider (gs.authProvider) is registered here. Restricting the
-        // loop to it also prevents a stray oidc-<mc> block from stalling startup
-        // on an unreachable Dex's metadata discovery.
+        // login provider (gs.authProvider) is registered here, so a stray
+        // oidc-<mc> block cannot stall startup on an unreachable Dex's
+        // metadata discovery.
         const mainAuthProvider = config.getOptionalString('gs.authProvider');
-        const customOIDCProviders = configuredProviders.filter(
-          provider =>
-            provider.startsWith(OIDC_PROVIDER_NAME_PREFIX) &&
-            provider === mainAuthProvider,
-        );
-        for (const providerName of customOIDCProviders) {
-          logger.info(`Configuring auth provider: ${providerName}`);
+        if (
+          mainAuthProvider &&
+          mainAuthProvider.startsWith(OIDC_PROVIDER_NAME_PREFIX) &&
+          configuredProviders.includes(mainAuthProvider)
+        ) {
+          logger.info(`Configuring auth provider: ${mainAuthProvider}`);
 
           const providerConfig = providersConfig
-            .getConfig(providerName)
+            .getConfig(mainAuthProvider)
             .getConfig(config.getString('auth.environment'));
           const metadataUrl = providerConfig.getString('metadataUrl');
 
@@ -129,12 +126,16 @@ export const authModuleGsProviders = createBackendModule({
           // every login until the pod is manually restarted. Retry to absorb
           // transient Dex unavailability, then let the error fail startup so
           // the orchestrator restarts the backend until Dex is reachable.
-          await waitForIssuerMetadata(providerName, metadataUrl, logger);
+          await waitForIssuerMetadata(mainAuthProvider, metadataUrl, logger);
 
           providersExtensionPoint.registerProvider({
-            providerId: providerName,
+            providerId: mainAuthProvider,
             factory: createOAuthProviderFactory({
-              authenticator: oidcAuthenticator,
+              // gsOidcAuthenticator wraps the upstream oidc authenticator so
+              // that a discovery failure after this point (e.g. Dex flapping
+              // between the check above and the first login) is retried per
+              // request instead of being cached for the process lifetime.
+              authenticator: gsOidcAuthenticator,
               signInResolver: customSignInResolver,
             }),
           });

--- a/plugins/auth-backend-module-gs/src/oidc/authenticator.test.ts
+++ b/plugins/auth-backend-module-gs/src/oidc/authenticator.test.ts
@@ -1,0 +1,121 @@
+import { oidcAuthenticator } from '@backstage/plugin-auth-backend-module-oidc-provider';
+import { gsOidcAuthenticator } from './authenticator';
+
+jest.mock('@backstage/plugin-auth-backend-module-oidc-provider', () => ({
+  oidcAuthenticator: {
+    initialize: jest.fn(),
+    start: jest.fn(),
+    authenticate: jest.fn(),
+    refresh: jest.fn(),
+    logout: jest.fn(),
+    defaultProfileTransform: jest.fn(),
+    scopes: { persist: true, required: ['openid', 'profile', 'email'] },
+  },
+}));
+
+const mockInitialize = oidcAuthenticator.initialize as jest.Mock;
+
+const input = { callbackUrl: 'https://portal.example/callback' } as Parameters<
+  typeof oidcAuthenticator.initialize
+>[0];
+
+function initializeResult(promise: Promise<unknown>) {
+  return {
+    initializedPrompt: 'auto',
+    searchParams: { connector: 'giantswarm' },
+    promise,
+  };
+}
+
+describe('gsOidcAuthenticator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates request handling to the upstream authenticator', () => {
+    expect(gsOidcAuthenticator.start).toBe(oidcAuthenticator.start);
+    expect(gsOidcAuthenticator.authenticate).toBe(
+      oidcAuthenticator.authenticate,
+    );
+    expect(gsOidcAuthenticator.refresh).toBe(oidcAuthenticator.refresh);
+    expect(gsOidcAuthenticator.logout).toBe(oidcAuthenticator.logout);
+  });
+
+  it('passes through context fields and memoizes a successful discovery', async () => {
+    const discovered = { helper: 'helper' };
+    mockInitialize.mockReturnValue(
+      initializeResult(Promise.resolve(discovered)),
+    );
+
+    const ctx = gsOidcAuthenticator.initialize(input);
+
+    expect(ctx.initializedPrompt).toBe('auto');
+    expect(ctx.searchParams).toEqual({ connector: 'giantswarm' });
+    await expect(ctx.promise).resolves.toBe(discovered);
+    await expect(ctx.promise).resolves.toBe(discovered);
+    // one eager initialize, no re-discovery after success
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries discovery on the next request instead of caching a rejection', async () => {
+    const discovered = { helper: 'helper' };
+    mockInitialize
+      .mockReturnValueOnce(
+        initializeResult(Promise.reject(new Error('ECONNREFUSED'))),
+      )
+      .mockReturnValueOnce(initializeResult(Promise.resolve(discovered)));
+
+    const ctx = gsOidcAuthenticator.initialize(input);
+
+    // the eager discovery fails: the request that awaits it sees the error...
+    await expect(ctx.promise).rejects.toThrow('ECONNREFUSED');
+    // ...and the next request triggers a fresh discovery that succeeds
+    await expect(ctx.promise).resolves.toBe(discovered);
+    expect(mockInitialize).toHaveBeenCalledTimes(2);
+
+    // success is memoized again
+    await expect(ctx.promise).resolves.toBe(discovered);
+    expect(mockInitialize).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares an in-flight discovery between concurrent requests', async () => {
+    let rejectDiscovery: (err: Error) => void;
+    mockInitialize.mockReturnValue(
+      initializeResult(
+        new Promise((_resolve, reject) => {
+          rejectDiscovery = reject;
+        }),
+      ),
+    );
+
+    const ctx = gsOidcAuthenticator.initialize(input);
+
+    const first = ctx.promise;
+    const second = ctx.promise;
+    expect(second).toBe(first);
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+
+    rejectDiscovery!(new Error('ECONNREFUSED'));
+    await expect(first).rejects.toThrow('ECONNREFUSED');
+    await expect(second).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('recovers when the eager discovery fails before any request is in flight', async () => {
+    const discovered = { helper: 'helper' };
+    mockInitialize
+      .mockReturnValueOnce(
+        initializeResult(Promise.reject(new Error('ECONNREFUSED'))),
+      )
+      .mockReturnValueOnce(initializeResult(Promise.resolve(discovered)));
+
+    const ctx = gsOidcAuthenticator.initialize(input);
+
+    // no request awaits the failing eager discovery; flush microtasks so the
+    // rejection settles unobserved (an unhandled rejection would crash node)
+    await new Promise(resolve => setImmediate(resolve));
+
+    // the first request after the failure triggers a fresh discovery
+    await expect(ctx.promise).resolves.toBe(discovered);
+    expect(mockInitialize).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/auth-backend-module-gs/src/oidc/authenticator.ts
+++ b/plugins/auth-backend-module-gs/src/oidc/authenticator.ts
@@ -1,0 +1,60 @@
+import { OAuthAuthenticator } from '@backstage/plugin-auth-node';
+import {
+  oidcAuthenticator,
+  OidcAuthResult,
+} from '@backstage/plugin-auth-backend-module-oidc-provider';
+
+type OidcContext = ReturnType<typeof oidcAuthenticator.initialize>;
+type DiscoveryPromise = OidcContext['promise'];
+
+/**
+ * The upstream oidc authenticator performs issuer discovery once in
+ * initialize() and every request awaits that same promise, so a single failed
+ * discovery (e.g. Dex briefly unreachable right after startup) is cached for
+ * the lifetime of the process and permanently breaks login until the pod is
+ * restarted.
+ *
+ * This wrapper memoizes discovery only on success: while discovery keeps
+ * failing, each login attempt triggers a fresh one, and login recovers as
+ * soon as the issuer is reachable again. Concurrent requests share the
+ * in-flight attempt, so a flapping issuer is not hammered.
+ */
+export const gsOidcAuthenticator: OAuthAuthenticator<
+  OidcContext,
+  OidcAuthResult
+> = {
+  ...oidcAuthenticator,
+  initialize(input) {
+    let discovery: DiscoveryPromise | undefined;
+
+    const track = (promise: DiscoveryPromise): DiscoveryPromise => {
+      const attempt: DiscoveryPromise = promise.catch(err => {
+        if (discovery === attempt) {
+          discovery = undefined;
+        }
+        throw err;
+      });
+      // The rejection reaches whichever request awaits the promise; this
+      // no-op handler only prevents an unhandled rejection when the failure
+      // happens before any request is in flight.
+      attempt.catch(() => {});
+      return attempt;
+    };
+
+    // Initialize eagerly so config errors still fail startup, and use the
+    // resulting discovery as the first attempt.
+    const ctx = oidcAuthenticator.initialize(input);
+    discovery = track(ctx.promise);
+
+    return {
+      initializedPrompt: ctx.initializedPrompt,
+      searchParams: ctx.searchParams,
+      get promise() {
+        if (!discovery) {
+          discovery = track(oidcAuthenticator.initialize(input).promise);
+        }
+        return discovery;
+      },
+    };
+  },
+};

--- a/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.test.ts
+++ b/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.test.ts
@@ -1,0 +1,91 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import fetch from 'node-fetch';
+import { waitForIssuerMetadata } from './issuerMetadata';
+
+jest.mock('node-fetch', () => jest.fn());
+
+const mockFetch = fetch as unknown as jest.Mock;
+
+const logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+} as unknown as LoggerService;
+
+const METADATA_URL =
+  'https://dex.example.gigantic.io/.well-known/openid-configuration';
+
+const sleep = jest.fn().mockResolvedValue(undefined);
+
+describe('waitForIssuerMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves when the metadata endpoint responds ok', async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await expect(
+      waitForIssuerMetadata('oidc-example', METADATA_URL, logger, { sleep }),
+    ).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('retries with exponential backoff and resolves once the endpoint recovers', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValue({ ok: true });
+
+    await expect(
+      waitForIssuerMetadata('oidc-example', METADATA_URL, logger, {
+        sleep,
+        initialDelayMs: 100,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenNthCalledWith(1, 100);
+    expect(sleep).toHaveBeenNthCalledWith(2, 200);
+  });
+
+  it('treats non-ok responses as failures', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+    });
+
+    await expect(
+      waitForIssuerMetadata('oidc-example', METADATA_URL, logger, {
+        sleep,
+        attempts: 2,
+      }),
+    ).rejects.toThrow(
+      'Failed to fetch issuer metadata for oidc-example auth provider after 2 attempts: Error: 502 Bad Gateway',
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting all attempts', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(
+      waitForIssuerMetadata('oidc-example', METADATA_URL, logger, {
+        sleep,
+        attempts: 3,
+      }),
+    ).rejects.toThrow('after 3 attempts');
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    // retry attempts are expected outcomes and must not reach Sentry
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.test.ts
+++ b/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.test.ts
@@ -1,10 +1,12 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
-import fetch from 'node-fetch';
+import { Issuer } from 'openid-client';
 import { waitForIssuerMetadata } from './issuerMetadata';
 
-jest.mock('node-fetch', () => jest.fn());
+jest.mock('openid-client', () => ({
+  Issuer: { discover: jest.fn() },
+}));
 
-const mockFetch = fetch as unknown as jest.Mock;
+const mockDiscover = Issuer.discover as jest.Mock;
 
 const logger = {
   error: jest.fn(),
@@ -24,22 +26,23 @@ describe('waitForIssuerMetadata', () => {
     jest.clearAllMocks();
   });
 
-  it('resolves when the metadata endpoint responds ok', async () => {
-    mockFetch.mockResolvedValue({ ok: true });
+  it('resolves when issuer discovery succeeds', async () => {
+    mockDiscover.mockResolvedValue({});
 
     await expect(
       waitForIssuerMetadata('oidc-example', METADATA_URL, logger, { sleep }),
     ).resolves.toBeUndefined();
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockDiscover).toHaveBeenCalledTimes(1);
+    expect(mockDiscover).toHaveBeenCalledWith(METADATA_URL);
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  it('retries with exponential backoff and resolves once the endpoint recovers', async () => {
-    mockFetch
+  it('retries with exponential backoff and resolves once discovery recovers', async () => {
+    mockDiscover
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
-      .mockResolvedValue({ ok: true });
+      .mockResolvedValue({});
 
     await expect(
       waitForIssuerMetadata('oidc-example', METADATA_URL, logger, {
@@ -48,17 +51,15 @@ describe('waitForIssuerMetadata', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockDiscover).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenNthCalledWith(1, 100);
     expect(sleep).toHaveBeenNthCalledWith(2, 200);
   });
 
-  it('treats non-ok responses as failures', async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 502,
-      statusText: 'Bad Gateway',
-    });
+  it('surfaces the last discovery error after exhausting all attempts', async () => {
+    mockDiscover.mockRejectedValue(
+      new Error('expected 200 OK, got: 502 Bad Gateway'),
+    );
 
     await expect(
       waitForIssuerMetadata('oidc-example', METADATA_URL, logger, {
@@ -66,14 +67,14 @@ describe('waitForIssuerMetadata', () => {
         attempts: 2,
       }),
     ).rejects.toThrow(
-      'Failed to fetch issuer metadata for oidc-example auth provider after 2 attempts: Error: 502 Bad Gateway',
+      'Failed to fetch issuer metadata for oidc-example auth provider after 2 attempts: Error: expected 200 OK, got: 502 Bad Gateway',
     );
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockDiscover).toHaveBeenCalledTimes(2);
   });
 
   it('throws after exhausting all attempts', async () => {
-    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+    mockDiscover.mockRejectedValue(new Error('ECONNREFUSED'));
 
     await expect(
       waitForIssuerMetadata('oidc-example', METADATA_URL, logger, {
@@ -82,10 +83,24 @@ describe('waitForIssuerMetadata', () => {
       }),
     ).rejects.toThrow('after 3 attempts');
 
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockDiscover).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(2);
     // retry attempts are expected outcomes and must not reach Sentry
     expect(logger.warn).not.toHaveBeenCalled();
     expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('fails immediately on a malformed metadataUrl without retrying', async () => {
+    await expect(
+      waitForIssuerMetadata(
+        'oidc-example',
+        'dex.example.gigantic.io/.well-known/openid-configuration',
+        logger,
+        { sleep },
+      ),
+    ).rejects.toThrow('Invalid URL');
+
+    expect(mockDiscover).not.toHaveBeenCalled();
+    expect(sleep).not.toHaveBeenCalled();
   });
 });

--- a/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.ts
+++ b/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import { Issuer } from 'openid-client';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 const DEFAULT_ATTEMPTS = 5;
@@ -11,14 +11,19 @@ export type WaitForIssuerMetadataOptions = {
 };
 
 /**
- * Checks that an OIDC issuer's metadata endpoint is reachable, retrying with
+ * Checks that an OIDC issuer serves a valid metadata document, retrying with
  * exponential backoff. Throws once all attempts are exhausted.
  *
- * The upstream oidc authenticator performs issuer discovery only once and
- * caches a rejected discovery permanently, so registering a provider whose
- * issuer is unreachable produces a provider that fails every request until
- * the process restarts. Callers use this check to decide whether registering
- * is safe, and to fail startup otherwise.
+ * Discovery goes through openid-client's Issuer.discover — the same code path
+ * and validation the oidc authenticator uses — so anything that would break
+ * the authenticator's own discovery (unreachable issuer, but also an ingress
+ * answering 200 with an HTML error page, or truncated JSON) fails this check
+ * too. Each attempt is bounded by openid-client's built-in HTTP timeout, so a
+ * hanging connection cannot stall backend startup indefinitely.
+ *
+ * Callers use this check to fail startup while the issuer is unavailable at
+ * boot: a crash-looping pod is visible and alertable, unlike a portal that
+ * comes up healthy without a login provider.
  */
 export async function waitForIssuerMetadata(
   providerName: string,
@@ -32,13 +37,14 @@ export async function waitForIssuerMetadata(
     options.sleep ??
     ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)));
 
+  // A malformed metadataUrl is a config error that no amount of retrying can
+  // fix — fail immediately instead of burning the retry budget on it.
+  const validatedUrl = new URL(metadataUrl).toString();
+
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
-      const response = await fetch(new URL(metadataUrl));
-      if (!response.ok) {
-        throw new Error(`${response.status} ${response.statusText}`);
-      }
+      await Issuer.discover(validatedUrl);
       return;
     } catch (err) {
       lastError = err as Error;

--- a/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.ts
+++ b/plugins/auth-backend-module-gs/src/oidc/issuerMetadata.ts
@@ -1,0 +1,61 @@
+import fetch from 'node-fetch';
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+const DEFAULT_ATTEMPTS = 5;
+const DEFAULT_INITIAL_DELAY_MS = 1000;
+
+export type WaitForIssuerMetadataOptions = {
+  attempts?: number;
+  initialDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+/**
+ * Checks that an OIDC issuer's metadata endpoint is reachable, retrying with
+ * exponential backoff. Throws once all attempts are exhausted.
+ *
+ * The upstream oidc authenticator performs issuer discovery only once and
+ * caches a rejected discovery permanently, so registering a provider whose
+ * issuer is unreachable produces a provider that fails every request until
+ * the process restarts. Callers use this check to decide whether registering
+ * is safe, and to fail startup otherwise.
+ */
+export async function waitForIssuerMetadata(
+  providerName: string,
+  metadataUrl: string,
+  logger: LoggerService,
+  options: WaitForIssuerMetadataOptions = {},
+): Promise<void> {
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const initialDelayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  const sleep =
+    options.sleep ??
+    ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)));
+
+  let lastError: Error | undefined;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await fetch(new URL(metadataUrl));
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+      return;
+    } catch (err) {
+      lastError = err as Error;
+      if (attempt < attempts) {
+        const delayMs = initialDelayMs * 2 ** (attempt - 1);
+        // info, not warn: a retry that recovers is an expected outcome and
+        // must not create Sentry issues.
+        logger.info(
+          `Failed to fetch issuer metadata for ${providerName} auth provider (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms`,
+          { error: lastError.toString() },
+        );
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  throw new Error(
+    `Failed to fetch issuer metadata for ${providerName} auth provider after ${attempts} attempts: ${lastError}`,
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11529,7 +11529,7 @@ __metadata:
     "@types/supertest": "npm:^7.0.0"
     express: "npm:^5.0.0"
     express-promise-router: "npm:^4.1.1"
-    node-fetch: "npm:^3.3.2"
+    openid-client: "npm:^5.7.1"
     passport-oauth2: "npm:^1.8.0"
     supertest: "npm:^7.0.0"
   languageName: unknown
@@ -41429,7 +41429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openid-client@npm:^5.3.0, openid-client@npm:^5.5.0, openid-client@npm:^5.6.5":
+"openid-client@npm:^5.3.0, openid-client@npm:^5.5.0, openid-client@npm:^5.6.5, openid-client@npm:^5.7.1":
   version: 5.7.1
   resolution: "openid-client@npm:5.7.1"
   dependencies:


### PR DESCRIPTION
## What this PR does

Makes the main OIDC login provider registration self-healing instead of silently skippable.

`auth-backend-module-gs` checks the issuer's metadata endpoint before registering the main login provider (`gs.authProvider`). Previously that check ran once inside a try/catch that logged and **skipped registration** on failure — so a transient Dex outage at pod startup produced a backend that came up healthy but returned `404 Unknown auth provider` for every login until someone manually restarted the pod. This happened on the internal portal today: the pod restarted while Dex was briefly unreachable, and login was broken for ~6 hours.

Changes:

- Extract the metadata check into `waitForIssuerMetadata()`, which retries with exponential backoff (5 attempts, 1s → 8s, ~15s total) to absorb transient blips. Retry attempts log at `info` (not `warn`) so recovered retries don't create Sentry issues.
- If the issuer is still unreachable after all attempts, **throw instead of skipping**: backend startup fails, the orchestrator restarts the pod until Dex is reachable, and the portal self-heals. A portal without login is unusable anyway, and a crash-loop is visible and alertable, unlike the previous silent success.

Simply dropping the pre-check is not an option: the upstream oidc authenticator performs issuer discovery once and caches a rejected discovery promise permanently, which would trade the permanent 404 for a permanent 500.

The swallow-and-continue behaviour remains only conceptually for non-critical providers; the OIDC loop only ever contains the main provider (per the broker-only cluster auth model), and `mcp-*` provider registration is unchanged.

## Testing

- Unit tests for `waitForIssuerMetadata`: immediate success, recovery after retries with backoff sequence, non-ok HTTP responses, exhaustion, and no `warn`/`error` logs from retries.
- `yarn workspace @giantswarm/backstage-plugin-auth-backend-module-gs test` — 16 passed.
- `yarn tsc` clean for the touched package (pre-existing unrelated errors in `ai-chat` on main).