### PR TITLE
feat(plans,roadmap): cross-link plans and roadmap epics

### DIFF
--- a/.changeset/plans-roadmap-cross-linking.md
+++ b/.changeset/plans-roadmap-cross-linking.md
@@ -1,0 +1,22 @@
+---
+'@giantswarm/backstage-plugin-plans-backend': minor
+'@giantswarm/backstage-plugin-roadmap-backend': minor
+'@giantswarm/backstage-plugin-plans': minor
+'@giantswarm/backstage-plugin-roadmap': minor
+---
+
+Cross-link plans with the roadmap epics they implement, via the
+`**Epic:** [owner/repo#N](url)` PRD header convention.
+
+- plans-backend: new `GET /epics` endpoint parsing the Epic header out of
+  merged plan documents (default branch) and open plan PRs (diff additions),
+  cached for five minutes.
+- roadmap-backend: new `GET /items/by-issue/:owner/:repo/:number` endpoint
+  resolving a GitHub issue reference to its Projects v2 board item.
+- plans frontend: merged plans and open plan PRs show an epic chip with the
+  epic's board Status, linking to the roadmap item detail view (GitHub issue
+  fallback when the roadmap plugin is not deployed). The selected merged plan
+  now lives in `?plan=`, so plans are deep-linkable.
+- roadmap frontend: the epic detail sidebar links back to the plan(s)
+  referencing the epic -- merged plans and open plan PRs ("proposed in
+  owner/repo#N") across all configured plan repositories.

--- a/plugins/plans-backend/src/router.test.ts
+++ b/plugins/plans-backend/src/router.test.ts
@@ -562,4 +562,115 @@ describe('createRouter', () => {
       expect(response.status).toBe(500);
     });
   });
+
+  describe('/epics', () => {
+    const contentResponse = (markdown: string) =>
+      jsonResponse({
+        type: 'file',
+        encoding: 'base64',
+        content: Buffer.from(markdown, 'utf8').toString('base64'),
+      });
+
+    /** Route the mocked fetch by URL suffix, like the real GitHub API. */
+    function mockGithub(routes: Record<string, Response>) {
+      fetchFn.mockImplementation(async url => {
+        for (const [suffix, response] of Object.entries(routes)) {
+          if (String(url).endsWith(suffix)) {
+            return response;
+          }
+        }
+        return jsonResponse({ message: 'Not Found' }, 404);
+      });
+    }
+
+    it('parses Epic headers from merged plans and open PRs', async () => {
+      mockGithub({
+        '/git/trees/HEAD?recursive=1': jsonResponse({
+          tree: [
+            { path: 'agent-platform-mvp/PRD.md', type: 'blob' },
+            { path: 'agent-platform-mvp/index.html', type: 'blob' },
+            { path: 'no-epic-plan/index.md', type: 'blob' },
+            { path: 'README.md', type: 'blob' },
+            { path: 'deep/nested/doc.md', type: 'blob' },
+          ],
+        }),
+        '/contents/agent-platform-mvp/PRD.md?ref=HEAD': contentResponse(
+          '# PRD: Agent Platform MVP\n\n' +
+            '**Epic:** [giantswarm/giantswarm#36625](https://github.com/giantswarm/giantswarm/issues/36625)\n',
+        ),
+        '/contents/no-epic-plan/index.md?ref=HEAD':
+          contentResponse('# No epic here\n'),
+        '/pulls?state=open&per_page=100': jsonResponse([
+          { number: 9, title: 'Add obo plan' },
+          { number: 3, title: 'No plan doc' },
+        ]),
+        '/pulls/9/files?per_page=100': jsonResponse([
+          {
+            filename: 'slack-to-github-obo/PRD.md',
+            patch:
+              '@@ -0,0 +1,3 @@\n+# PRD\n+\n+**Epic**: https://github.com/giantswarm/giantswarm/issues/36700\n',
+          },
+        ]),
+        '/pulls/3/files?per_page=100': jsonResponse([
+          { filename: 'README.md', patch: '' },
+        ]),
+      });
+
+      const response = await request(app).get('/epics');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        merged: [
+          {
+            folder: 'agent-platform-mvp',
+            path: 'agent-platform-mvp/PRD.md',
+            epic: {
+              owner: 'giantswarm',
+              repo: 'giantswarm',
+              number: 36625,
+              url: 'https://github.com/giantswarm/giantswarm/issues/36625',
+            },
+          },
+        ],
+        pulls: [
+          {
+            number: 9,
+            title: 'Add obo plan',
+            epic: {
+              owner: 'giantswarm',
+              repo: 'giantswarm',
+              number: 36700,
+              url: 'https://github.com/giantswarm/giantswarm/issues/36700',
+            },
+          },
+        ],
+      });
+    });
+
+    it('caches the scan between requests', async () => {
+      mockGithub({
+        '/git/trees/HEAD?recursive=1': jsonResponse({ tree: [] }),
+        '/pulls?state=open&per_page=100': jsonResponse([]),
+      });
+
+      await request(app).get('/epics');
+      await request(app).get('/epics');
+
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips plans whose documents cannot be read', async () => {
+      mockGithub({
+        '/git/trees/HEAD?recursive=1': jsonResponse({
+          tree: [{ path: 'broken-plan/PRD.md', type: 'blob' }],
+        }),
+        '/pulls?state=open&per_page=100': jsonResponse([]),
+      });
+
+      const response = await request(app).get('/epics');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ merged: [], pulls: [] });
+    });
+  });
 });

--- a/plugins/plans-backend/src/router.ts
+++ b/plugins/plans-backend/src/router.ts
@@ -19,6 +19,72 @@ const GITHUB_API_BASE_URL = 'https://api.github.com';
 /** `owner/repo` slug, e.g. `giantswarm/bumblebee-plans`. */
 const REPO_SLUG_PATTERN = /^[\w.-]+\/[\w.-]+$/;
 
+/**
+ * Scanning a repo for Epic headers is one GitHub call per plan document;
+ * cache the result so the plans page and the roadmap epic view don't
+ * re-crawl on every render.
+ */
+const EPICS_TTL_MS = 5 * 60_000;
+
+/** Roadmap epic referenced by a plan's `**Epic:** [owner/repo#N](url)` header. */
+interface EpicRef {
+  owner: string;
+  repo: string;
+  number: number;
+  url: string;
+}
+
+/**
+ * Parse the Epic header convention out of plan markdown: a line like
+ * `**Epic:** [giantswarm/giantswarm#36625](https://github.com/...)`.
+ * Accepts an `owner/repo#N` reference or a GitHub issue URL anywhere on
+ * that line; the first Epic line wins.
+ */
+export function parseEpicRef(markdown: string): EpicRef | null {
+  const line = markdown.match(/^[ \t]*\*\*Epic:?\*\*:?(.*)$/im)?.[1];
+  if (!line) {
+    return null;
+  }
+  const ref = line.match(/([\w.-]+)\/([\w.-]+)#(\d+)/);
+  if (ref) {
+    const [, owner, repo, number] = ref;
+    return {
+      owner,
+      repo,
+      number: parseInt(number, 10),
+      url:
+        line.match(/\((https?:\/\/[^)\s]+)\)/)?.[1] ??
+        `https://github.com/${owner}/${repo}/issues/${number}`,
+    };
+  }
+  const url = line.match(/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)/);
+  if (url) {
+    const [, owner, repo, number] = url;
+    return {
+      owner,
+      repo,
+      number: parseInt(number, 10),
+      url: `https://github.com/${owner}/${repo}/issues/${number}`,
+    };
+  }
+  return null;
+}
+
+/**
+ * A plan document eligible for Epic parsing: a direct child of a top-level
+ * plan folder (one folder per plan by convention, same as the frontend's
+ * grouping).
+ */
+const isPlanDoc = (path: string) => /^[^/]+\/[^/]+\.md$/i.test(path);
+
+/** The added lines of a unified diff, for parsing headers out of PR patches. */
+const patchAdditions = (patch: string) =>
+  patch
+    .split('\n')
+    .filter(diffLine => diffLine.startsWith('+'))
+    .map(diffLine => diffLine.slice(1))
+    .join('\n');
+
 export interface RouterOptions {
   logger: LoggerService;
   config: Config;
@@ -180,6 +246,33 @@ export async function createRouter(
     return response.json();
   };
   const githubGet = (repo: string, path: string) => githubRequest(repo, path);
+
+  /** Fetch a file's decoded UTF-8 content via the GitHub contents API. */
+  const getFileContent = async (
+    repo: string,
+    path: string,
+    ref: string,
+  ): Promise<string> => {
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    const result = (await githubGet(
+      repo,
+      `/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`,
+    )) as {
+      type?: string;
+      content?: string;
+      encoding?: string;
+    };
+
+    if (Array.isArray(result) || result.type !== 'file') {
+      throw new InputError(`'${path}' is not a file`);
+    }
+    if (result.encoding !== 'base64' || typeof result.content !== 'string') {
+      throw new Error(
+        `Unexpected content encoding '${result.encoding}' for ${path}`,
+      );
+    }
+    return Buffer.from(result.content, 'base64').toString('utf8');
+  };
 
   const parsePullNumber = (raw: string): number => {
     const pullNumber = parseInt(raw, 10);
@@ -393,30 +486,93 @@ export async function createRouter(
     if (!path) {
       throw new InputError('path query parameter is required');
     }
-    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
-    const result = (await githubGet(
+    res.json({ path, ref, content: await getFileContent(repo, path, ref) });
+  });
+
+  const epicsCache = new Map<string, { expires: number; data: unknown }>();
+
+  /**
+   * The epic each plan references, for cross-linking plans with the roadmap
+   * board: merged plans scanned on the default branch, proposed plans parsed
+   * from their PR diffs.
+   */
+  router.get('/epics', async (req, res) => {
+    const repo = resolveRepo(req);
+    const hit = epicsCache.get(repo);
+    if (hit && hit.expires > Date.now()) {
+      res.json(hit.data);
+      return;
+    }
+
+    // Merged plans: scan each plan folder's direct-child markdown files
+    // (PRD.md first) until one carries an Epic header.
+    const treeResult = (await githubGet(
       repo,
-      `/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`,
+      `/repos/${repo}/git/trees/HEAD?recursive=1`,
     )) as {
-      type?: string;
-      content?: string;
-      encoding?: string;
+      tree?: Array<{ path?: string; type?: string }> | null;
     };
-
-    if (Array.isArray(result) || result.type !== 'file') {
-      throw new InputError(`'${path}' is not a file`);
+    const byFolder = new Map<string, string[]>();
+    for (const entry of treeResult.tree ?? []) {
+      if (entry.type !== 'blob' || !entry.path || !isPlanDoc(entry.path)) {
+        continue;
+      }
+      const folder = entry.path.slice(0, entry.path.indexOf('/'));
+      byFolder.set(folder, [...(byFolder.get(folder) ?? []), entry.path]);
     }
-    if (result.encoding !== 'base64' || typeof result.content !== 'string') {
-      throw new Error(
-        `Unexpected content encoding '${result.encoding}' for ${path}`,
-      );
-    }
+    const docRank = (path: string) =>
+      path.toLowerCase().endsWith('/prd.md') ? 0 : 1;
+    const merged = (
+      await Promise.all(
+        [...byFolder.entries()].map(async ([folder, files]) => {
+          const candidates = [...files].sort(
+            (a, b) => docRank(a) - docRank(b) || a.localeCompare(b),
+          );
+          for (const path of candidates) {
+            const epic = parseEpicRef(
+              await getFileContent(repo, path, 'HEAD').catch(() => ''),
+            );
+            if (epic) {
+              return { folder, path, epic };
+            }
+          }
+          return null;
+        }),
+      )
+    ).filter(entry => entry !== null);
 
-    res.json({
-      path,
-      ref,
-      content: Buffer.from(result.content, 'base64').toString('utf8'),
-    });
+    // Proposed plans: the Epic header of a new plan document shows up in
+    // the added lines of the PR diff.
+    // ponytail: patch-only parse -- misses a PRD whose patch GitHub omits
+    // (oversized file); fetch content at the head branch if that ever happens.
+    const openPulls = (await githubGet(
+      repo,
+      `/repos/${repo}/pulls?state=open&per_page=100`,
+    )) as Array<{ number: number; title: string }>;
+    const pulls = (
+      await Promise.all(
+        openPulls.map(async pull => {
+          const files = (await githubGet(
+            repo,
+            `/repos/${repo}/pulls/${pull.number}/files?per_page=100`,
+          )) as Array<{ filename?: string; patch?: string }>;
+          for (const file of files) {
+            if (!file.filename || !isPlanDoc(file.filename) || !file.patch) {
+              continue;
+            }
+            const epic = parseEpicRef(patchAdditions(file.patch));
+            if (epic) {
+              return { number: pull.number, title: pull.title, epic };
+            }
+          }
+          return null;
+        }),
+      )
+    ).filter(entry => entry !== null);
+
+    const data = { merged, pulls };
+    epicsCache.set(repo, { expires: Date.now() + EPICS_TTL_MS, data });
+    res.json(data);
   });
 
   return router;

--- a/plugins/plans/src/apis/PlansApiClient.ts
+++ b/plugins/plans/src/apis/PlansApiClient.ts
@@ -10,6 +10,7 @@ import {
   PlansApi,
   PlansCommentsResponse,
   PlansContentResponse,
+  PlansEpicsResponse,
   PlansPullFilesResponse,
   PlansPullsResponse,
   PlansReposResponse,
@@ -49,6 +50,10 @@ export class PlansApiClient implements PlansApi {
 
   async getTree(ref?: string, repo?: string): Promise<PlansTreeResponse> {
     return this.get<PlansTreeResponse>('/tree', { ref, repo });
+  }
+
+  async listEpics(repo?: string): Promise<PlansEpicsResponse> {
+    return this.get<PlansEpicsResponse>('/epics', { repo });
   }
 
   async getContent(

--- a/plugins/plans/src/apis/types.ts
+++ b/plugins/plans/src/apis/types.ts
@@ -87,6 +87,33 @@ export interface NewReviewComment {
   inReplyTo?: number;
 }
 
+/** Roadmap epic referenced by a plan's `**Epic:** [owner/repo#N](url)` header. */
+export interface EpicRef {
+  owner: string;
+  repo: string;
+  number: number;
+  url: string;
+}
+
+/** A merged plan folder that references an epic. */
+export interface PlanEpic {
+  folder: string;
+  path: string;
+  epic: EpicRef;
+}
+
+/** An open plan PR that references an epic. */
+export interface PullEpic {
+  number: number;
+  title: string;
+  epic: EpicRef;
+}
+
+export interface PlansEpicsResponse {
+  merged: PlanEpic[];
+  pulls: PullEpic[];
+}
+
 export interface PlansApi {
   listRepos(): Promise<PlansReposResponse>;
   listPulls(repo?: string): Promise<PlansPullsResponse>;
@@ -95,6 +122,7 @@ export interface PlansApi {
     repo?: string,
   ): Promise<PlansPullFilesResponse>;
   getTree(ref?: string, repo?: string): Promise<PlansTreeResponse>;
+  listEpics(repo?: string): Promise<PlansEpicsResponse>;
   getContent(
     path: string,
     ref?: string,

--- a/plugins/plans/src/components/EpicChip/EpicChip.tsx
+++ b/plugins/plans/src/components/EpicChip/EpicChip.tsx
@@ -1,0 +1,64 @@
+import { Chip, Tooltip } from '@material-ui/core';
+import { Link } from '@backstage/core-components';
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+  useRouteRef,
+} from '@backstage/frontend-plugin-api';
+import { useQuery } from '@tanstack/react-query';
+import { EpicRef } from '../../apis';
+import { roadmapItemExternalRouteRef } from '../../routes';
+
+/** The slice of a roadmap board item the chip needs. */
+interface BoardItem {
+  id: string;
+  title: string;
+  fields: Record<string, string>;
+}
+
+/**
+ * Chip linking a plan to the roadmap epic it implements. When the roadmap
+ * plugin can resolve the epic's board item, the chip shows its Status and
+ * links to the epic detail view; otherwise it links to the GitHub issue.
+ */
+export function EpicChip({ epic }: { epic: EpicRef }) {
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const itemLink = useRouteRef(roadmapItemExternalRouteRef);
+
+  // The roadmap plugin's backend is queried directly (instead of through its
+  // frontend API) to avoid coupling the plugin packages; portals without the
+  // roadmap plugin get the GitHub fallback via the failed query.
+  const { data: item } = useQuery({
+    queryKey: ['plans', 'epic-item', epic.owner, epic.repo, epic.number],
+    queryFn: async (): Promise<BoardItem> => {
+      const baseUrl = await discoveryApi.getBaseUrl('roadmap');
+      const response = await fetchApi.fetch(
+        `${baseUrl}/items/by-issue/${encodeURIComponent(epic.owner)}/${encodeURIComponent(epic.repo)}/${epic.number}`,
+      );
+      if (!response.ok) {
+        throw new Error(`Epic lookup failed with status ${response.status}`);
+      }
+      return (await response.json()).item;
+    },
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const status = item?.fields?.Status;
+  const to = item && itemLink ? itemLink({ id: item.id }) : epic.url;
+
+  return (
+    <Tooltip title={item?.title ?? `${epic.owner}/${epic.repo}#${epic.number}`}>
+      <Link to={to} underline="none">
+        <Chip
+          size="small"
+          variant="outlined"
+          clickable
+          label={status ? `Epic · ${status}` : `Epic #${epic.number}`}
+        />
+      </Link>
+    </Tooltip>
+  );
+}

--- a/plugins/plans/src/components/EpicChip/index.ts
+++ b/plugins/plans/src/components/EpicChip/index.ts
@@ -1,0 +1,1 @@
+export { EpicChip } from './EpicChip';

--- a/plugins/plans/src/components/MergedTab/MergedTab.tsx
+++ b/plugins/plans/src/components/MergedTab/MergedTab.tsx
@@ -1,9 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Box,
   Grid,
   List,
   ListItem,
+  ListItemSecondaryAction,
   ListItemText,
   Paper,
   Typography,
@@ -16,6 +18,7 @@ import { useApi } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
 import { plansApiRef } from '../../apis';
 import { compareDisplayPaths, isRenderableFile } from '../../lib/files';
+import { EpicChip } from '../EpicChip';
 import { PlanFileContent } from '../PlanFileContent';
 
 const ROOT_GROUP = '(repository root)';
@@ -54,12 +57,33 @@ interface PlanGroup {
 export function MergedTab({ repo }: { repo: string }) {
   const classes = useStyles();
   const plansApi = useApi(plansApiRef);
-  const [selected, setSelected] = useState<string | undefined>(undefined);
+  // The selected plan lives in `?plan=` so the roadmap epic view (and
+  // anyone with the URL) can deep-link a specific plan.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selected = searchParams.get('plan') ?? undefined;
+  const selectPlan = (name: string) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('plan', name);
+    setSearchParams(params, { replace: true });
+  };
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['plans', 'tree', repo],
     queryFn: () => plansApi.getTree(undefined, repo),
   });
+
+  // Epic references per plan folder, for the cross-link chips. Failure just
+  // means no chips (e.g. the backend still rolling out).
+  const { data: epicsData } = useQuery({
+    queryKey: ['plans', 'epics', repo],
+    queryFn: () => plansApi.listEpics(repo),
+    retry: false,
+  });
+  const epicByFolder = useMemo(
+    () =>
+      new Map((epicsData?.merged ?? []).map(entry => [entry.folder, entry])),
+    [epicsData],
+  );
 
   const groups = useMemo<PlanGroup[]>(() => {
     const byFolder = new Map<string, string[]>();
@@ -116,7 +140,7 @@ export function MergedTab({ repo }: { repo: string }) {
                 button
                 divider
                 selected={group.name === selectedGroup.name}
-                onClick={() => setSelected(group.name)}
+                onClick={() => selectPlan(group.name)}
               >
                 <ListItemText
                   primary={group.name}
@@ -124,6 +148,11 @@ export function MergedTab({ repo }: { repo: string }) {
                     group.files.length === 1 ? '' : 's'
                   }`}
                 />
+                {epicByFolder.has(group.name) && (
+                  <ListItemSecondaryAction>
+                    <EpicChip epic={epicByFolder.get(group.name)!.epic} />
+                  </ListItemSecondaryAction>
+                )}
               </ListItem>
             ))}
           </List>

--- a/plugins/plans/src/components/PlansPage/PlansPage.tsx
+++ b/plugins/plans/src/components/PlansPage/PlansPage.tsx
@@ -43,12 +43,16 @@ const useStyles = makeStyles((theme: Theme) => ({
 export function PlansPage() {
   const classes = useStyles();
   const plansApi = useApi(plansApiRef);
-  const [tab, setTab] = useState<'proposed' | 'merged'>('proposed');
   // The selected repository lives in `?repo=` (the same param the review
   // page uses), so it survives navigating into a PR and back and the list
   // URL is shareable.
   const [searchParams, setSearchParams] = useSearchParams();
   const repo = searchParams.get('repo') ?? undefined;
+  // Deep links to a merged plan (`?plan=`, e.g. from the roadmap epic view)
+  // land on the merged tab directly.
+  const [tab, setTab] = useState<'proposed' | 'merged'>(
+    searchParams.has('plan') ? 'merged' : 'proposed',
+  );
 
   const selectRepo = (next: string) => {
     const params = new URLSearchParams(searchParams);

--- a/plugins/plans/src/components/ProposedTab/ProposedTab.tsx
+++ b/plugins/plans/src/components/ProposedTab/ProposedTab.tsx
@@ -2,6 +2,7 @@ import {
   Chip,
   List,
   ListItem,
+  ListItemSecondaryAction,
   ListItemText,
   Paper,
   makeStyles,
@@ -15,6 +16,7 @@ import { useQueries, useQuery } from '@tanstack/react-query';
 import { plansApiRef } from '../../apis';
 import { formatDate } from '../../lib/dates';
 import { pullRouteRef } from '../../routes';
+import { EpicChip } from '../EpicChip';
 
 const useStyles = makeStyles((theme: Theme) => ({
   listPanel: {
@@ -42,6 +44,17 @@ export function ProposedTab({ repo }: { repo: string }) {
   });
 
   const pulls = data?.pulls ?? [];
+
+  // Epic references per open PR, for the cross-link chips. Failure just
+  // means no chips.
+  const { data: epicsData } = useQuery({
+    queryKey: ['plans', 'epics', repo],
+    queryFn: () => plansApi.listEpics(repo),
+    retry: false,
+  });
+  const epicByPull = new Map(
+    (epicsData?.pulls ?? []).map(entry => [entry.number, entry]),
+  );
 
   // Changed-file counts for the list. Same query keys as the review page,
   // so opening a PR reuses these cache entries instead of refetching.
@@ -110,6 +123,11 @@ export function ProposedTab({ repo }: { repo: string }) {
                 }
                 secondary={secondary}
               />
+              {epicByPull.has(pull.number) && (
+                <ListItemSecondaryAction>
+                  <EpicChip epic={epicByPull.get(pull.number)!.epic} />
+                </ListItemSecondaryAction>
+              )}
             </ListItem>
           );
         })}

--- a/plugins/plans/src/index.ts
+++ b/plugins/plans/src/index.ts
@@ -8,6 +8,9 @@ export type {
   PlanComment,
   PlanReviewComment,
   NewReviewComment,
+  EpicRef,
+  PlanEpic,
+  PullEpic,
   PlansReposResponse,
   PlansPullsResponse,
   PlansPullFilesResponse,
@@ -15,4 +18,5 @@ export type {
   PlansContentResponse,
   PlansCommentsResponse,
   PlansReviewCommentsResponse,
+  PlansEpicsResponse,
 } from './apis';

--- a/plugins/plans/src/plugin.tsx
+++ b/plugins/plans/src/plugin.tsx
@@ -8,7 +8,11 @@ import {
 import AssignmentIcon from '@material-ui/icons/Assignment';
 
 import { plansApiRef, PlansApiClient } from './apis';
-import { pullRouteRef, rootRouteRef } from './routes';
+import {
+  pullRouteRef,
+  roadmapItemExternalRouteRef,
+  rootRouteRef,
+} from './routes';
 
 // Disabled by default: the plans page serves internal planning documents and
 // must not appear in customer portals. Deployments opt in via app-config
@@ -54,5 +58,8 @@ export const plansPlugin = createFrontendPlugin({
   routes: {
     root: rootRouteRef,
     pull: pullRouteRef,
+  },
+  externalRoutes: {
+    roadmapItem: roadmapItemExternalRouteRef,
   },
 });

--- a/plugins/plans/src/routes.ts
+++ b/plugins/plans/src/routes.ts
@@ -1,4 +1,5 @@
 import {
+  createExternalRouteRef,
   createRouteRef,
   createSubRouteRef,
 } from '@backstage/frontend-plugin-api';
@@ -8,4 +9,14 @@ export const rootRouteRef = createRouteRef();
 export const pullRouteRef = createSubRouteRef({
   path: '/pr/:number',
   parent: rootRouteRef,
+});
+
+/**
+ * The roadmap plugin's item detail page, for linking a plan's epic chip to
+ * the epic's board view. Resolves automatically when the roadmap plugin is
+ * enabled; unbound otherwise (the chip falls back to the GitHub issue).
+ */
+export const roadmapItemExternalRouteRef = createExternalRouteRef({
+  params: ['id'],
+  defaultTarget: 'roadmap.item',
 });

--- a/plugins/roadmap-backend/src/router.test.ts
+++ b/plugins/roadmap-backend/src/router.test.ts
@@ -278,6 +278,40 @@ describe('createRouter', () => {
     });
   });
 
+  describe('/items/by-issue/:owner/:repo/:number', () => {
+    it('resolves an issue reference to its board item', async () => {
+      const response = await request(app).get(
+        '/items/by-issue/giantswarm/giantswarm/42',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ item: ITEM });
+      expect(pro.listItems).toHaveBeenCalledWith({
+        boardId: BOARD_ID,
+        filters: {},
+        token: APP_TOKEN,
+      });
+    });
+
+    it('returns 404 for an issue that is not on the board', async () => {
+      const response = await request(app).get(
+        '/items/by-issue/giantswarm/giantswarm/999',
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.name).toBe('NotFoundError');
+    });
+
+    it('rejects a non-numeric issue number', async () => {
+      const response = await request(app).get(
+        '/items/by-issue/giantswarm/giantswarm/abc',
+      );
+
+      expect(response.status).toBe(400);
+      expect(pro.listItems).not.toHaveBeenCalled();
+    });
+  });
+
   describe('GET /issues/:owner/:repo/:number/sub-issues', () => {
     it('returns the mapped sub-issue tree and parent', async () => {
       pro.getParentIssue.mockResolvedValue({

--- a/plugins/roadmap-backend/src/router.ts
+++ b/plugins/roadmap-backend/src/router.ts
@@ -263,6 +263,27 @@ export async function createRouter(
     res.json({ total: items.length, byStatus, byRepo });
   });
 
+  /**
+   * Resolve a GitHub issue reference to its board item. Plan documents
+   * reference epics as `owner/repo#N`, but the detail route needs the
+   * Projects v2 item node id -- this is the bridge for cross-links from
+   * the plans plugin.
+   */
+  router.get('/items/by-issue/:owner/:repo/:number', async (req, res) => {
+    const number = parsePositiveInt(req.params.number, 'number');
+    const repoSlug = `${req.params.owner}/${req.params.repo}`;
+    const items = await listItemsCached({ filters: {} });
+    const item = items.find(
+      boardItem => boardItem.repo === repoSlug && boardItem.number === number,
+    );
+    if (!item) {
+      throw new NotFoundError(
+        `No board item found for issue ${repoSlug}#${number}`,
+      );
+    }
+    res.json({ item });
+  });
+
   router.get('/items/:id', async (req, res) => {
     const item = await cached(`item:${req.params.id}`, ITEMS_TTL_MS, () =>
       mapGithubError(async () =>

--- a/plugins/roadmap/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/plugins/roadmap/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -25,6 +25,7 @@ import { issueRefOf } from '../../lib/board';
 import { formatDate } from '../../lib/dates';
 import { rootRouteRef } from '../../routes';
 import { FieldEditor } from './FieldEditor';
+import { PlanPanel } from './PlanPanel';
 import { SubIssuesPanel } from './SubIssuesPanel';
 
 const SIDEBAR_WIDTH = 300;
@@ -262,6 +263,13 @@ export function ItemDetailPage() {
                 ))}
               </Box>
             </>
+          )}
+          {issueRef && (
+            <PlanPanel
+              owner={issueRef.owner}
+              repo={issueRef.repo}
+              issueNumber={issueRef.number}
+            />
           )}
           <Divider className={classes.sidebarDivider} />
           <Typography className={classes.sidebarTitle} variant="subtitle1">

--- a/plugins/roadmap/src/components/ItemDetailPage/PlanPanel.tsx
+++ b/plugins/roadmap/src/components/ItemDetailPage/PlanPanel.tsx
@@ -1,0 +1,146 @@
+import { Box, Divider, Typography, makeStyles, Theme } from '@material-ui/core';
+import { Link } from '@backstage/core-components';
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+  useRouteRef,
+} from '@backstage/frontend-plugin-api';
+import { useQuery } from '@tanstack/react-query';
+import {
+  plansPullExternalRouteRef,
+  plansRootExternalRouteRef,
+} from '../../routes';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  divider: {
+    margin: theme.spacing(2, 0),
+  },
+  title: {
+    marginBottom: theme.spacing(1),
+  },
+  entry: {
+    marginBottom: theme.spacing(0.5),
+  },
+}));
+
+/** Epic reference parsed by plans-backend from a plan's PRD header. */
+interface EpicRef {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+interface RepoEpics {
+  repo: string;
+  merged: Array<{ folder: string; epic: EpicRef }>;
+  pulls: Array<{ number: number; title: string; epic: EpicRef }>;
+}
+
+/**
+ * Sidebar section linking an epic to the plan(s) that reference it via the
+ * `**Epic:**` PRD header -- merged plans and open plan PRs across all
+ * configured plan repositories. Renders nothing when no plan matches or the
+ * plans plugin is not deployed.
+ */
+export function PlanPanel({
+  owner,
+  repo,
+  issueNumber,
+}: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+}) {
+  const classes = useStyles();
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const plansRoot = useRouteRef(plansRootExternalRouteRef);
+  const plansPull = useRouteRef(plansPullExternalRouteRef);
+
+  // The plans plugin's backend is queried directly (instead of through its
+  // frontend API) to avoid coupling the plugin packages; portals without
+  // the plans plugin just get a failed query and no panel.
+  const { data } = useQuery({
+    queryKey: ['roadmap', 'plan-epics'],
+    queryFn: async (): Promise<RepoEpics[]> => {
+      const baseUrl = await discoveryApi.getBaseUrl('plans');
+      const reposResponse = await fetchApi.fetch(`${baseUrl}/repos`);
+      if (!reposResponse.ok) {
+        throw new Error(
+          `Plans lookup failed with status ${reposResponse.status}`,
+        );
+      }
+      const { repositories } = (await reposResponse.json()) as {
+        repositories: string[];
+      };
+      const results = await Promise.all(
+        repositories.map(async planRepo => {
+          const response = await fetchApi.fetch(
+            `${baseUrl}/epics?repo=${encodeURIComponent(planRepo)}`,
+          );
+          if (!response.ok) {
+            return null;
+          }
+          const epics = (await response.json()) as Omit<RepoEpics, 'repo'>;
+          return { repo: planRepo, ...epics };
+        }),
+      );
+      return results.filter(result => result !== null);
+    },
+    retry: false,
+    staleTime: 5 * 60_000,
+  });
+
+  const matchesEpic = (epic: EpicRef) =>
+    epic.owner === owner && epic.repo === repo && epic.number === issueNumber;
+  const merged = (data ?? []).flatMap(repoEpics =>
+    repoEpics.merged
+      .filter(entry => matchesEpic(entry.epic))
+      .map(entry => ({ repo: repoEpics.repo, folder: entry.folder })),
+  );
+  const proposed = (data ?? []).flatMap(repoEpics =>
+    repoEpics.pulls
+      .filter(entry => matchesEpic(entry.epic))
+      .map(entry => ({ repo: repoEpics.repo, number: entry.number })),
+  );
+
+  if (merged.length === 0 && proposed.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Divider className={classes.divider} />
+      <Typography className={classes.title} variant="subtitle1">
+        Plan
+      </Typography>
+      {merged.map(plan => (
+        <Box key={`${plan.repo}/${plan.folder}`} className={classes.entry}>
+          <Link
+            to={
+              plansRoot
+                ? `${plansRoot()}?repo=${encodeURIComponent(plan.repo)}&plan=${encodeURIComponent(plan.folder)}`
+                : `https://github.com/${plan.repo}/tree/HEAD/${plan.folder}`
+            }
+          >
+            {plan.folder}
+          </Link>
+        </Box>
+      ))}
+      {proposed.map(pull => (
+        <Box key={`${pull.repo}#${pull.number}`} className={classes.entry}>
+          <Link
+            to={
+              plansPull
+                ? `${plansPull({ number: String(pull.number) })}?repo=${encodeURIComponent(pull.repo)}`
+                : `https://github.com/${pull.repo}/pull/${pull.number}`
+            }
+          >
+            proposed in {pull.repo}#{pull.number}
+          </Link>
+        </Box>
+      ))}
+    </>
+  );
+}

--- a/plugins/roadmap/src/plugin.tsx
+++ b/plugins/roadmap/src/plugin.tsx
@@ -9,7 +9,12 @@ import {
 import TimelineIcon from '@material-ui/icons/Timeline';
 
 import { roadmapApiRef, RoadmapApiClient } from './apis';
-import { itemRouteRef, rootRouteRef } from './routes';
+import {
+  itemRouteRef,
+  plansPullExternalRouteRef,
+  plansRootExternalRouteRef,
+  rootRouteRef,
+} from './routes';
 
 // Disabled by default: the roadmap board is internal and must not appear in
 // customer portals. Deployments opt in via app.extensions (and configure
@@ -55,5 +60,9 @@ export const roadmapPlugin = createFrontendPlugin({
   routes: {
     root: rootRouteRef,
     item: itemRouteRef,
+  },
+  externalRoutes: {
+    plansRoot: plansRootExternalRouteRef,
+    plansPull: plansPullExternalRouteRef,
   },
 });

--- a/plugins/roadmap/src/routes.ts
+++ b/plugins/roadmap/src/routes.ts
@@ -1,4 +1,5 @@
 import {
+  createExternalRouteRef,
   createRouteRef,
   createSubRouteRef,
 } from '@backstage/frontend-plugin-api';
@@ -8,4 +9,18 @@ export const rootRouteRef = createRouteRef();
 export const itemRouteRef = createSubRouteRef({
   path: '/items/:id',
   parent: rootRouteRef,
+});
+
+/**
+ * The plans plugin's pages, for linking an epic to the plan that implements
+ * it. Resolve automatically when the plans plugin is enabled; unbound
+ * otherwise (the panel then simply renders nothing).
+ */
+export const plansRootExternalRouteRef = createExternalRouteRef({
+  defaultTarget: 'plans.root',
+});
+
+export const plansPullExternalRouteRef = createExternalRouteRef({
+  params: ['number'],
+  defaultTarget: 'plans.pull',
 });


### PR DESCRIPTION
Plans reference the epic they implement via the `**Epic:** [owner/repo#N](url)` PRD header convention (see `agent-platform-mvp/PRD.md` in bumblebee-plans). This PR surfaces that link in both directions between the plans and roadmap plugins.

## Backend

- **plans-backend**: new `GET /epics` endpoint. Parses the Epic header out of merged plan documents (direct-child markdown of each plan folder on the default branch, `PRD.md` first) and open plan PRs (from the diff's added lines). Result cached for five minutes — the scan is one GitHub call per plan document.
- **roadmap-backend**: new `GET /items/by-issue/:owner/:repo/:number` endpoint resolving a GitHub issue reference to its Projects v2 board item, using the same cached board listing as `/items`. This bridges plan epic references (`owner/repo#N`) to the item detail route, which needs the item node id.

## Frontend

- **plans**: merged plans and open plan PRs show an epic chip with the epic's board Status, linking to the roadmap item detail view. The link uses an external route ref with `defaultTarget: 'roadmap.item'`, so it resolves automatically where the roadmap plugin is enabled and falls back to the GitHub issue elsewhere. The selected merged plan now lives in `?plan=`, making individual plans deep-linkable.
- **roadmap**: the epic detail sidebar gains a "Plan" section linking to the plan(s) that reference the epic — merged plans (deep link via `?plan=`) and open plan PRs ("proposed in owner/repo#N") across all configured plan repositories.

The two frontends talk to each other's backends via `discoveryApi` + `fetchApi` directly instead of importing each other's API clients, so the plugin packages stay uncoupled and portals with only one of the two plugins degrade gracefully (failed query → no chip/panel).

## Testing

- Router tests for both new endpoints (Epic header parse variants, caching, unreadable documents, board miss → 404, non-numeric issue number → 400).
- `yarn tsc`, repo lint, prettier, and all four plugin test suites pass.
- Not exercised against a live portal in this session; the chip/panel fallbacks make a partial rollout safe (plans-backend without the new endpoint just means no chips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)