### PR TITLE
perf(roadmap): fast board loads via SWR cache, warming, targeted by-issue lookup

### DIFF
--- a/.changeset/roadmap-board-performance.md
+++ b/.changeset/roadmap-board-performance.md
@@ -1,0 +1,11 @@
+---
+'@giantswarm/backstage-plugin-roadmap-backend': patch
+---
+
+Make roadmap board loads fast: the items cache is now stale-while-revalidate
+with a five-minute TTL (an expired entry is served instantly while one
+background refresh updates it), the default team view is warmed on startup
+and kept warm, field writes patch the cached lists in place instead of
+forcing a full board rescan, and `GET /items/by-issue` resolves an issue via
+one targeted issue->projectItems GraphQL call instead of paginating the
+entire board.

--- a/plugins/roadmap-backend/src/router.test.ts
+++ b/plugins/roadmap-backend/src/router.test.ts
@@ -79,6 +79,30 @@ function buildProMock() {
         ) ?? null,
     ),
     updateItemField: jest.fn().mockResolvedValue({}),
+    graphQLWithAuth: jest.fn().mockResolvedValue({
+      repository: {
+        issue: {
+          title: ITEM.title,
+          url: ITEM.url,
+          state: 'OPEN',
+          projectItems: {
+            nodes: [
+              {
+                id: ITEM.id,
+                project: { id: BOARD_ID },
+                fieldValues: {
+                  nodes: [
+                    { name: 'In Progress ⛏️', field: { name: 'Status' } },
+                    { title: 'Q3 2026', field: { name: 'Quarter' } },
+                  ],
+                },
+              },
+              { id: 'PVTI_other', project: { id: 'PVT_other' } },
+            ],
+          },
+        },
+      },
+    }),
     listSubIssues: jest.fn().mockResolvedValue([REST_ISSUE]),
     getParentIssue: jest.fn().mockResolvedValue(null),
     addSubIssue: jest.fn().mockResolvedValue(REST_ISSUE),
@@ -113,6 +137,9 @@ describe('createRouter', () => {
       httpAuth: mockServices.httpAuth(),
       credentialsProvider,
       pro: pro as unknown as RouterOptions['pro'],
+      // Warming fires an untracked background listItems call that would
+      // race the per-test call-count assertions; covered by its own test.
+      warmCache: false,
       ...options,
     });
     const builtApp = express();
@@ -278,22 +305,62 @@ describe('createRouter', () => {
     });
   });
 
+  it('warms the default team view on startup', async () => {
+    await buildApp(
+      { roadmap: { board: 'roadmap', teams: ['Bumblebee🐝'] } },
+      { warmCache: true },
+    );
+    // Let the fire-and-forget warm call settle.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(pro.listItems).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: { team: 'Bumblebee🐝' },
+        token: APP_TOKEN,
+      }),
+    );
+  });
+
   describe('/items/by-issue/:owner/:repo/:number', () => {
-    it('resolves an issue reference to its board item', async () => {
+    it('resolves an issue reference via a targeted query, not a board scan', async () => {
       const response = await request(app).get(
         '/items/by-issue/giantswarm/giantswarm/42',
       );
 
       expect(response.status).toBe(200);
-      expect(response.body).toEqual({ item: ITEM });
-      expect(pro.listItems).toHaveBeenCalledWith({
-        boardId: BOARD_ID,
-        filters: {},
-        token: APP_TOKEN,
+      expect(response.body).toEqual({
+        item: {
+          id: ITEM.id,
+          title: ITEM.title,
+          number: 42,
+          url: ITEM.url,
+          repo: 'giantswarm/giantswarm',
+          state: 'OPEN',
+          fields: { Status: 'In Progress ⛏️', Quarter: 'Q3 2026' },
+        },
       });
+      expect(pro.graphQLWithAuth).toHaveBeenCalledWith(
+        expect.stringContaining('projectItems'),
+        { owner: 'giantswarm', repo: 'giantswarm', number: 42 },
+        APP_TOKEN,
+      );
+      expect(pro.listItems).not.toHaveBeenCalled();
     });
 
     it('returns 404 for an issue that is not on the board', async () => {
+      pro.graphQLWithAuth.mockResolvedValue({
+        repository: {
+          issue: {
+            title: 'Off-board issue',
+            url: 'https://github.com/giantswarm/giantswarm/issues/999',
+            state: 'OPEN',
+            projectItems: {
+              nodes: [{ id: 'PVTI_other', project: { id: 'PVT_other' } }],
+            },
+          },
+        },
+      });
+
       const response = await request(app).get(
         '/items/by-issue/giantswarm/giantswarm/999',
       );
@@ -308,7 +375,7 @@ describe('createRouter', () => {
       );
 
       expect(response.status).toBe(400);
-      expect(pro.listItems).not.toHaveBeenCalled();
+      expect(pro.graphQLWithAuth).not.toHaveBeenCalled();
     });
   });
 
@@ -456,15 +523,28 @@ describe('createRouter', () => {
       expect(response.status).toBe(403);
     });
 
-    it('invalidates the read cache after a write', async () => {
+    it('patches cached lists in place after a write instead of rescanning', async () => {
       await request(app).get('/items');
       await request(app)
         .patch('/items/PVTI_1/field')
         .set('X-GitHub-Token', USER_TOKEN)
         .send({ name: 'Status', value: 'Done ✅' });
-      await request(app).get('/items');
+      const response = await request(app).get('/items');
 
-      expect(pro.listItems).toHaveBeenCalledTimes(2);
+      // No second board scan -- the cached list already carries the update.
+      expect(pro.listItems).toHaveBeenCalledTimes(1);
+      expect(response.body.items[0].fields.Status).toBe('Done ✅');
+    });
+
+    it('drops the cached item detail after a write', async () => {
+      await request(app).get('/items/PVTI_1');
+      await request(app)
+        .patch('/items/PVTI_1/field')
+        .set('X-GitHub-Token', USER_TOKEN)
+        .send({ name: 'Status', value: 'Done ✅' });
+      await request(app).get('/items/PVTI_1');
+
+      expect(pro.getItemByID).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/plugins/roadmap-backend/src/router.ts
+++ b/plugins/roadmap-backend/src/router.ts
@@ -15,8 +15,46 @@ import type { ProField, ProListItem, ProRestIssue } from '@giantswarm-io/pro';
 
 const GITHUB_ORG_URL = 'https://github.com/giantswarm';
 
-/** Board items and sub-issue trees change often; keep reads fresh. */
-const ITEMS_TTL_MS = 60_000;
+/**
+ * Targeted lookup for one issue's board item -- the single-select and
+ * iteration field values are all the cross-link chip needs.
+ */
+const ISSUE_PROJECT_ITEM_QUERY = `
+  query IssueProjectItem($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        title
+        url
+        state
+        projectItems(first: 20, includeArchived: false) {
+          nodes {
+            id
+            project { id }
+            fieldValues(first: 30) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field { ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldIterationValue {
+                  title
+                  field { ... on ProjectV2FieldCommon { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Board items and sub-issue trees: five minutes is fresh enough for other
+ * people's changes (the caller's own writes patch the cache immediately),
+ * and the cache is served stale-while-revalidate anyway.
+ */
+const ITEMS_TTL_MS = 5 * 60_000;
 /** The board schema (fields/options) rarely changes. */
 const SCHEMA_TTL_MS = 10 * 60_000;
 
@@ -31,6 +69,8 @@ export interface RouterOptions {
    * the plugin init loads it with a dynamic import. Also the seam for tests.
    */
   pro: typeof ProModule;
+  /** Disable the startup/interval cache warming (tests only). */
+  warmCache?: boolean;
 }
 
 function singleQueryValue(value: unknown, name: string): string | undefined {
@@ -153,10 +193,12 @@ export async function createRouter(
     return token;
   };
 
-  // Board reads paginate the full project, so identical requests within the
-  // TTL share one result. Writes clear the cache so their effect is visible
-  // immediately.
+  // Board reads paginate the full project (~430 items for one team is five
+  // sequential GraphQL pages, >10s), so the cache is stale-while-revalidate:
+  // an expired entry is served immediately while one background refresh per
+  // key brings it up to date. Only a cold key ever blocks on GitHub.
   const cache = new Map<string, { expires: number; data: unknown }>();
+  const inflight = new Map<string, Promise<unknown>>();
   const cached = async <T>(
     key: string,
     ttlMs: number,
@@ -166,19 +208,48 @@ export async function createRouter(
     if (hit && hit.expires > Date.now()) {
       return hit.data as T;
     }
-    const data = await load();
-    cache.set(key, { expires: Date.now() + ttlMs, data });
-    return data;
+    let refresh = inflight.get(key) as Promise<T> | undefined;
+    if (!refresh) {
+      refresh = load().then(
+        data => {
+          cache.set(key, { expires: Date.now() + ttlMs, data });
+          inflight.delete(key);
+          return data;
+        },
+        error => {
+          inflight.delete(key);
+          throw error;
+        },
+      );
+      inflight.set(key, refresh);
+    }
+    if (hit) {
+      // Serve stale, let the refresh land in the background.
+      refresh.catch(() => {});
+      return hit.data as T;
+    }
+    return refresh;
   };
 
-  const listItemsCached = async (listOptions: {
-    filters: Record<string, string>;
-    assignee?: string | null;
-    state?: string | null;
-    updated?: string | null;
-    repository?: string | null;
-    keyword?: string | null;
-  }): Promise<ProListItem[]> => {
+  const itemsListOptions = (
+    filters: Record<string, string>,
+    query: Partial<
+      Record<'assignee' | 'state' | 'updated' | 'keyword', string>
+    > & {
+      repository?: string;
+    } = {},
+  ) => ({
+    filters,
+    assignee: query.assignee ?? null,
+    state: query.state ?? null,
+    updated: query.updated ?? null,
+    repository: query.repository ?? null,
+    keyword: query.keyword ?? null,
+  });
+
+  const listItemsCached = async (
+    listOptions: ReturnType<typeof itemsListOptions>,
+  ): Promise<ProListItem[]> => {
     const cacheKey = `items:${JSON.stringify(listOptions)}`;
     const result = await cached(cacheKey, ITEMS_TTL_MS, async () =>
       pro.listItems({ boardId, ...listOptions, token: await appToken() }),
@@ -189,6 +260,50 @@ export async function createRouter(
     }
     return result.data ?? [];
   };
+
+  /**
+   * After a successful field write, update the item inside every cached
+   * list and drop its cached detail -- instead of clearing the cache, which
+   * would force the next board load into a full multi-page rescan.
+   */
+  const patchCachedItem = (itemId: string, name: string, value: string) => {
+    for (const [key, entry] of cache) {
+      if (key.startsWith('items:')) {
+        const result = entry.data as { data?: ProListItem[] };
+        for (const item of result.data ?? []) {
+          if (item.id === itemId) {
+            item.fields = { ...item.fields, [name]: value };
+          }
+        }
+      }
+    }
+    cache.delete(`item:${itemId}`);
+  };
+
+  const dropSubIssueCaches = () => {
+    for (const key of cache.keys()) {
+      if (key.startsWith('sub-issues:')) {
+        cache.delete(key);
+      }
+    }
+  };
+
+  // Warm the default board view (and keep it warm) so the first visitor
+  // after a pod restart -- deploys are frequent -- doesn't pay the cold
+  // multi-page scan. With stale-while-revalidate above, this makes board
+  // loads effectively instant for everyone.
+  if (enabled && (options.warmCache ?? true)) {
+    const warm = () => {
+      const filters: Record<string, string> = defaultTeams[0]
+        ? { team: defaultTeams[0] }
+        : {};
+      listItemsCached(itemsListOptions(filters)).catch(error =>
+        logger.warn(`Roadmap cache warming failed: ${error}`),
+      );
+    };
+    warm();
+    setInterval(warm, ITEMS_TTL_MS).unref();
+  }
 
   const router = Router();
   router.use(express.json());
@@ -233,14 +348,15 @@ export async function createRouter(
       keywordTerms.push(keyword);
     }
 
-    const items = await listItemsCached({
-      filters,
-      assignee: singleQueryValue(req.query.assignee, 'assignee') ?? null,
-      state: singleQueryValue(req.query.state, 'state') ?? null,
-      updated: singleQueryValue(req.query.updated, 'updated') ?? null,
-      repository: singleQueryValue(req.query.repository, 'repository') ?? null,
-      keyword: keywordTerms.length > 0 ? keywordTerms.join(' ') : null,
-    });
+    const items = await listItemsCached(
+      itemsListOptions(filters, {
+        assignee: singleQueryValue(req.query.assignee, 'assignee'),
+        state: singleQueryValue(req.query.state, 'state'),
+        updated: singleQueryValue(req.query.updated, 'updated'),
+        repository: singleQueryValue(req.query.repository, 'repository'),
+        keyword: keywordTerms.length > 0 ? keywordTerms.join(' ') : undefined,
+      }),
+    );
     res.json({ items });
   });
 
@@ -250,7 +366,7 @@ export async function createRouter(
     if (team) {
       filters.team = team;
     }
-    const items = await listItemsCached({ filters });
+    const items = await listItemsCached(itemsListOptions(filters));
 
     const byStatus: Record<string, number> = {};
     const byRepo: Record<string, number> = {};
@@ -267,18 +383,71 @@ export async function createRouter(
    * Resolve a GitHub issue reference to its board item. Plan documents
    * reference epics as `owner/repo#N`, but the detail route needs the
    * Projects v2 item node id -- this is the bridge for cross-links from
-   * the plans plugin.
+   * the plans plugin. A targeted issue->projectItems query: one GraphQL
+   * call instead of paginating the whole board (~2000 items, ~1min).
    */
   router.get('/items/by-issue/:owner/:repo/:number', async (req, res) => {
     const number = parsePositiveInt(req.params.number, 'number');
-    const repoSlug = `${req.params.owner}/${req.params.repo}`;
-    const items = await listItemsCached({ filters: {} });
-    const item = items.find(
-      boardItem => boardItem.repo === repoSlug && boardItem.number === number,
+    const { owner, repo } = req.params;
+    const item = await cached(
+      `by-issue:${owner}/${repo}#${number}`,
+      ITEMS_TTL_MS,
+      () =>
+        mapGithubError(async () => {
+          const result = await pro.graphQLWithAuth<{
+            repository?: {
+              issue?: {
+                title: string;
+                url: string;
+                state: string;
+                projectItems?: {
+                  nodes?: Array<{
+                    id: string;
+                    project?: { id: string };
+                    fieldValues?: {
+                      nodes?: Array<{
+                        name?: string;
+                        title?: string;
+                        field?: { name?: string };
+                      }>;
+                    };
+                  } | null>;
+                };
+              } | null;
+            } | null;
+          }>(
+            ISSUE_PROJECT_ITEM_QUERY,
+            { owner, repo, number },
+            await appToken(),
+          );
+          const issue = result.repository?.issue;
+          const node = issue?.projectItems?.nodes?.find(
+            projectItem => projectItem?.project?.id === boardId,
+          );
+          if (!issue || !node) {
+            return null;
+          }
+          const fields: Record<string, string> = {};
+          for (const fieldValue of node.fieldValues?.nodes ?? []) {
+            const value = fieldValue?.name ?? fieldValue?.title;
+            if (fieldValue?.field?.name && value) {
+              fields[fieldValue.field.name] = value;
+            }
+          }
+          return {
+            id: node.id,
+            title: issue.title,
+            number,
+            url: issue.url,
+            repo: `${owner}/${repo}`,
+            state: issue.state,
+            fields,
+          };
+        }),
     );
     if (!item) {
       throw new NotFoundError(
-        `No board item found for issue ${repoSlug}#${number}`,
+        `No board item found for issue ${owner}/${repo}#${number}`,
       );
     }
     res.json({ item });
@@ -340,6 +509,7 @@ export async function createRouter(
     }
 
     let mutationValue: Record<string, string>;
+    let canonicalValue = value;
     if (field.__typename === 'ProjectV2SingleSelectField') {
       const option = pro.findMatchingOption(field.options ?? [], value);
       if (!option) {
@@ -351,6 +521,7 @@ export async function createRouter(
         );
       }
       mutationValue = { singleSelectOptionId: option.id };
+      canonicalValue = option.name;
     } else if (field.__typename === 'ProjectV2IterationField') {
       const iteration = pro.findMatchingIteration(field, value);
       if (!iteration) {
@@ -362,6 +533,7 @@ export async function createRouter(
         );
       }
       mutationValue = { iterationId: iteration.id };
+      canonicalValue = iteration.title;
     } else if (field.dataType === 'DATE') {
       if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
         throw new InputError(
@@ -384,7 +556,7 @@ export async function createRouter(
         token,
       ),
     );
-    cache.clear();
+    patchCachedItem(req.params.id, field.name, canonicalValue);
     logger.info(`Updated field '${field.name}' on item ${req.params.id}`);
     res.json({ status: 'ok' });
   });
@@ -410,7 +582,7 @@ export async function createRouter(
     const parent = await mapGithubError(() =>
       pro.addSubIssue({ ...target, subIssueId: resolved.id }, token),
     );
-    cache.clear();
+    dropSubIssueCaches();
     logger.info(
       `Linked ${child} as sub-issue of ${target.owner}/${target.repo}#${target.issue_number}`,
     );
@@ -428,7 +600,7 @@ export async function createRouter(
         subIssueId: parsePositiveInt(req.params.subIssueId, 'subIssueId'),
       };
       await mapGithubError(() => pro.removeSubIssue(target, token));
-      cache.clear();
+      dropSubIssueCaches();
       logger.info(
         `Unlinked sub-issue ${target.subIssueId} from ${target.owner}/${target.repo}#${target.issue_number}`,
       );

--- a/plugins/roadmap-backend/src/router.ts
+++ b/plugins/roadmap-backend/src/router.ts
@@ -137,6 +137,16 @@ async function mapGithubError<T>(operation: () => Promise<T>): Promise<T> {
   } catch (error) {
     const status = (error as { status?: number }).status;
     const message = (error as Error).message ?? String(error);
+    // User tokens are GitHub App user-to-server tokens, so they are capped
+    // by the auth App's own permissions -- this error means the App itself
+    // lacks org Projects write, not that the user does.
+    if (/Resource not accessible by integration/i.test(message)) {
+      throw new NotAllowedError(
+        `GitHub rejected the request: ${message}. The portal's GitHub auth ` +
+          'App is missing the "Projects: Read and write" organization ' +
+          'permission; it must be granted on the App and approved for the org.',
+      );
+    }
     if (status === 401 || status === 403 || /FORBIDDEN/.test(message)) {
       throw new NotAllowedError(`GitHub rejected the request: ${message}`);
     }


### PR DESCRIPTION
Follow-up to #1906 after first real use: the board took >10s to load.

Measured against the live board: the default (team-filtered) view is ~430 items = 5 sequential GraphQL pages ≈ 13s; the unfiltered scan behind `GET /items/by-issue` (plans-page epic chips) is ~2000 items ≈ 56s. The 60s cache TTL and `cache.clear()` on every write meant users hit those scans constantly.

- **Stale-while-revalidate cache, 5-minute TTL**: an expired entry is served instantly while one deduplicated background refresh per key updates it. Only a completely cold key blocks on GitHub.
- **Cache warming**: the default team view (from `roadmap.teams`) is fetched at startup and refreshed every TTL, so the first visitor after a pod restart gets a hot cache.
- **Writes patch instead of clear**: a field update rewrites the item inside every cached list (using the canonical option/iteration name) and drops only that item's detail entry; sub-issue writes drop only sub-issue caches. A status drag no longer forces the next board load into a full rescan.
- **`GET /items/by-issue`** now resolves via one targeted `issue → projectItems` GraphQL call (filtered to the configured board) instead of paginating the entire project.

Net effect: board loads are served from cache in ~ms after the first fetch, and the plans-page epic chips resolve in ~1s instead of ~1min.

## Testing

- Router tests updated/extended: SWR write-path behavior (no rescan after write, detail dropped), warming on startup, targeted by-issue query incl. off-board 404. `warmCache: false` test seam keeps call-count assertions deterministic.
- `yarn tsc`, lint, prettier, and the plugin test suite pass.
- Query shapes and timings verified against the live roadmap board via the pro library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)