### PR TITLE
feat: mint muster-signed token for AI chat and muster MCP bearer

### DIFF
--- a/.changeset/aichat-muster-signed-token.md
+++ b/.changeset/aichat-muster-signed-token.md
@@ -1,0 +1,12 @@
+---
+'@giantswarm/backstage-plugin-auth-backend-module-gs': minor
+'@giantswarm/backstage-plugin-ai-chat': patch
+'@giantswarm/backstage-plugin-muster': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Let AI chat and the muster management UI present a muster-signed token to `/mcp` instead of the raw main Dex ID token, so muster's outbound token exchange accepts them.
+
+- `auth-backend-module-gs` gains an authenticated `POST /api/auth/muster-token` route. It takes the user's main Dex ID token from the `gs-subject-token` header and mints a muster-signed session token via muster's self-issued RFC 8693 exchange (no `audience`, no client authentication), cached per user with expiry-aware re-exchange. The route is registered only when `gs.musterToken` is configured.
+- `MCPAuthProviders` (ai-chat) and `MusterAuthProviders` (muster) call the new route when `gs.musterToken.tokenUrl` is set, using the muster-signed token as the MCP bearer and failing closed on error; without the config they keep forwarding the raw main Dex ID token.
+- `gs` config gains `gs.musterToken.tokenUrl`.

--- a/packages/app/src/modules/ai-chat/AiChatApiOverride.ts
+++ b/packages/app/src/modules/ai-chat/AiChatApiOverride.ts
@@ -1,25 +1,40 @@
 import { ApiBlueprint } from '@backstage/frontend-plugin-api';
+import { configApiRef } from '@backstage/core-plugin-api';
 import {
   mcpAuthProvidersApiRef,
   MCPAuthProviders,
 } from '@giantswarm/backstage-plugin-ai-chat';
 import { gsAuthProvidersApiRef } from '@giantswarm/backstage-plugin-gs';
 import { getOptionalMainAuthApi } from '../auth/getOptionalMainAuthApi';
+import { createMusterTokenProvider } from '../auth/createMusterTokenProvider';
 
 export const AiChatApiOverride = ApiBlueprint.make({
   name: 'mcp-auth-providers',
   params: defineParams =>
     defineParams({
       api: mcpAuthProvidersApiRef,
-      deps: { gsAuthProvidersApi: gsAuthProvidersApiRef },
-      factory: ({ gsAuthProvidersApi }) => {
+      deps: {
+        gsAuthProvidersApi: gsAuthProvidersApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ gsAuthProvidersApi, configApi }) => {
         const authProviders = gsAuthProvidersApi.getMCPAuthApis();
         // MCP servers whose authProvider has no dedicated `auth.providers`
         // entry get the main Dex ID token forwarded instead (single
         // sign-on via muster's trusted-audiences validation), so no
-        // separate PKCE login is needed.
+        // separate PKCE login is needed. When gs.musterToken.tokenUrl is set,
+        // the ID token is first exchanged for a muster-signed token so
+        // muster's outbound exchange accepts it.
         const mainAuthApi = getOptionalMainAuthApi(gsAuthProvidersApi);
-        return new MCPAuthProviders(authProviders, mainAuthApi);
+        const musterTokenProvider = createMusterTokenProvider(
+          gsAuthProvidersApi,
+          configApi,
+        );
+        return new MCPAuthProviders(
+          authProviders,
+          mainAuthApi,
+          musterTokenProvider,
+        );
       },
     }),
 });

--- a/packages/app/src/modules/auth/createMusterTokenProvider.ts
+++ b/packages/app/src/modules/auth/createMusterTokenProvider.ts
@@ -1,0 +1,56 @@
+import { ConfigApi } from '@backstage/core-plugin-api';
+import { gsAuthProvidersApiRef } from '@giantswarm/backstage-plugin-gs';
+
+const SUBJECT_TOKEN_HEADER = 'gs-subject-token';
+
+/**
+ * Returns a function that mints a muster-signed session token from the user's
+ * main Dex ID token through the backend's `/api/auth/muster-token` route, or
+ * undefined when muster's token endpoint is not configured
+ * (`gs.musterToken.tokenUrl`), in which case callers keep forwarding the raw
+ * main Dex ID token.
+ *
+ * The minted token replaces the raw Dex ID token as the MCP bearer so that
+ * muster's outbound exchange, which only accepts a muster-signed subject,
+ * succeeds. Minting targets the deployment's local muster; a token minted
+ * elsewhere would not be trusted here.
+ */
+export function createMusterTokenProvider(
+  gsAuthProvidersApi: typeof gsAuthProvidersApiRef.T,
+  configApi: ConfigApi,
+): (() => Promise<string | undefined>) | undefined {
+  const tokenUrl = configApi.getOptionalString('gs.musterToken.tokenUrl');
+  if (!tokenUrl) {
+    return undefined;
+  }
+
+  // The muster token route is served by the main backend, not by
+  // per-installation backend overrides.
+  const backendBaseUrl = configApi.getString('backend.baseUrl');
+
+  return async () => {
+    const mainAuthApi = gsAuthProvidersApi.getMainAuthApi();
+
+    // The non-optional getters return silently when the main Dex session
+    // exists and trigger the single main SSO login when it is gone.
+    const idToken = await mainAuthApi.getIdToken();
+    const identity = await mainAuthApi.getBackstageIdentity();
+    if (!idToken || !identity) {
+      return undefined;
+    }
+
+    const response = await fetch(`${backendBaseUrl}/api/auth/muster-token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${identity.token}`,
+        [SUBJECT_TOKEN_HEADER]: idToken,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Muster token request failed: ${response.status}`);
+    }
+
+    const { token } = await response.json();
+    return token;
+  };
+}

--- a/packages/app/src/modules/muster/MusterApiOverride.ts
+++ b/packages/app/src/modules/muster/MusterApiOverride.ts
@@ -1,24 +1,38 @@
 import { ApiBlueprint } from '@backstage/frontend-plugin-api';
+import { configApiRef } from '@backstage/core-plugin-api';
 import {
   musterAuthProvidersApiRef,
   MusterAuthProviders,
 } from '@giantswarm/backstage-plugin-muster';
 import { gsAuthProvidersApiRef } from '@giantswarm/backstage-plugin-gs';
 import { getOptionalMainAuthApi } from '../auth/getOptionalMainAuthApi';
+import { createMusterTokenProvider } from '../auth/createMusterTokenProvider';
 
 export const MusterApiOverride = ApiBlueprint.make({
   name: 'auth-providers',
   params: defineParams =>
     defineParams({
       api: musterAuthProvidersApiRef,
-      deps: { gsAuthProvidersApi: gsAuthProvidersApiRef },
-      factory: ({ gsAuthProvidersApi }) => {
+      deps: {
+        gsAuthProvidersApi: gsAuthProvidersApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ gsAuthProvidersApi, configApi }) => {
         const authProviders = gsAuthProvidersApi.getMCPAuthApis();
         // Same single sign-on fallback as the ai-chat MCP auth providers:
         // without a dedicated provider entry, the main Dex ID token is
-        // forwarded as the muster bearer token.
+        // forwarded as the muster bearer token, or exchanged for a
+        // muster-signed token first when gs.musterToken.tokenUrl is set.
         const mainAuthApi = getOptionalMainAuthApi(gsAuthProvidersApi);
-        return new MusterAuthProviders(authProviders, mainAuthApi);
+        const musterTokenProvider = createMusterTokenProvider(
+          gsAuthProvidersApi,
+          configApi,
+        );
+        return new MusterAuthProviders(
+          authProviders,
+          mainAuthApi,
+          musterTokenProvider,
+        );
       },
     }),
 });

--- a/plugins/ai-chat/src/api/MCPAuthProviders.test.ts
+++ b/plugins/ai-chat/src/api/MCPAuthProviders.test.ts
@@ -65,4 +65,47 @@ describe('MCPAuthProviders', () => {
 
     await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
   });
+
+  it('mints a muster token instead of forwarding the raw ID token when configured', async () => {
+    const main = oidcApi('main-id-token');
+    const musterTokenProvider = jest.fn().mockResolvedValue('muster-token');
+    const providers = new MCPAuthProviders({}, main, musterTokenProvider);
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'muster-token',
+    });
+    // The raw main ID token must not be forwarded once minting is configured.
+    expect(main.getIdToken).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when minting fails, without falling back to the raw ID token', async () => {
+    const main = oidcApi('main-id-token');
+    const musterTokenProvider = jest.fn().mockRejectedValue(new Error('boom'));
+    const providers = new MCPAuthProviders({}, main, musterTokenProvider);
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+    expect(main.getIdToken).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when minting yields no token', async () => {
+    const main = oidcApi('main-id-token');
+    const musterTokenProvider = jest.fn().mockResolvedValue(undefined);
+    const providers = new MCPAuthProviders({}, main, musterTokenProvider);
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+  });
+
+  it('still prefers a dedicated provider over minting', async () => {
+    const musterTokenProvider = jest.fn().mockResolvedValue('muster-token');
+    const providers = new MCPAuthProviders(
+      { 'mcp-muster': oauthApi('access-token') },
+      undefined,
+      musterTokenProvider,
+    );
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'access-token',
+    });
+    expect(musterTokenProvider).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/ai-chat/src/api/MCPAuthProviders.ts
+++ b/plugins/ai-chat/src/api/MCPAuthProviders.ts
@@ -4,6 +4,7 @@ import { MCPAuthProvidersApi, MCPAuthCredentials } from './types';
 export class MCPAuthProviders implements MCPAuthProvidersApi {
   private readonly authProviders: { [providerName: string]: OAuthApi };
   private readonly mainAuthApi?: OpenIdConnectApi;
+  private readonly musterTokenProvider?: () => Promise<string | undefined>;
 
   /**
    * @param authProviders - Dedicated OAuth providers, keyed by the
@@ -14,13 +15,21 @@ export class MCPAuthProviders implements MCPAuthProvidersApi {
    *   forwarded as the MCP bearer token. This enables single sign-on for MCP
    *   servers (e.g. muster) that trust the main issuer, without a separate
    *   login.
+   * @param musterTokenProvider - Optional minter of a muster-signed session
+   *   token from the main Dex ID token. When set (`gs.musterToken.tokenUrl`
+   *   configured), a provider name without a dedicated entry gets the
+   *   muster-signed token instead of the raw main Dex ID token, so muster's
+   *   outbound exchange accepts it. Minting failure is fail-closed (no token),
+   *   not a fall back to the raw token.
    */
   constructor(
     authProviders: { [providerName: string]: OAuthApi } = {},
     mainAuthApi?: OpenIdConnectApi,
+    musterTokenProvider?: () => Promise<string | undefined>,
   ) {
     this.authProviders = authProviders;
     this.mainAuthApi = mainAuthApi;
+    this.musterTokenProvider = musterTokenProvider;
   }
 
   async getCredentials(authProvider: string): Promise<MCPAuthCredentials> {
@@ -38,6 +47,15 @@ export class MCPAuthProviders implements MCPAuthProvidersApi {
   }
 
   private async getMainCredentials(): Promise<MCPAuthCredentials> {
+    if (this.musterTokenProvider) {
+      try {
+        const token = await this.musterTokenProvider();
+        return token ? { token } : {};
+      } catch {
+        return {};
+      }
+    }
+
     if (!this.mainAuthApi) {
       return {};
     }

--- a/plugins/auth-backend-module-gs/src/clusterToken/router.ts
+++ b/plugins/auth-backend-module-gs/src/clusterToken/router.ts
@@ -6,48 +6,16 @@ import {
   RootConfigService,
 } from '@backstage/backend-plugin-api';
 import { InputError, NotFoundError } from '@backstage/errors';
+import {
+  DEFAULT_EXPIRES_IN_SECONDS,
+  ID_TOKEN_TYPE,
+  parseOAuthError,
+  SUBJECT_TOKEN_HEADER,
+  TOKEN_EXCHANGE_GRANT_TYPE,
+  TokenExchangeCache,
+} from '../tokenExchange/tokenExchange';
 
-/**
- * Header used by the frontend to forward the user's main Dex ID token, which
- * the broker exchanges for a per-management-cluster token. Backstage does not
- * expose provider sessions server-side, so the token travels alongside the
- * regular Backstage credentials (same pattern the AI chat uses for MCP auth).
- */
-export const SUBJECT_TOKEN_HEADER = 'gs-subject-token';
-
-const TOKEN_EXCHANGE_GRANT_TYPE =
-  'urn:ietf:params:oauth:grant-type:token-exchange';
-const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
-
-/**
- * Minimum remaining lifetime before a cached token is re-exchanged. Must be
- * larger than the frontend's session refresh margin (3 minutes in OAuth2's
- * sessionShouldRefresh), so a refresh-triggering request never gets a token
- * that immediately triggers another refresh.
- */
-const EXPIRY_SKEW_SECONDS = 240;
-
-/** Fallback lifetime when the broker response carries no expires_in. */
-const DEFAULT_EXPIRES_IN_SECONDS = 300;
-
-type CachedToken = {
-  token: string;
-  expiresAt: number;
-};
-
-/**
- * Extracts the OAuth 2.0 `error` code (RFC 6749 section 5.2) from a broker
- * error response body. Returns undefined for non-JSON bodies (e.g. an HTML
- * error page from a proxy sitting in front of the broker).
- */
-function parseOAuthError(body: string): string | undefined {
-  try {
-    const parsed = JSON.parse(body) as { error?: unknown };
-    return typeof parsed.error === 'string' ? parsed.error : undefined;
-  } catch {
-    return undefined;
-  }
-}
+export { SUBJECT_TOKEN_HEADER } from '../tokenExchange/tokenExchange';
 
 export interface ClusterTokenRouterOptions {
   config: RootConfigService;
@@ -83,15 +51,7 @@ export function createClusterTokenRouter(
   const clientSecret = brokerConfig.getString('clientSecret');
   const scope = brokerConfig.getOptionalString('scope');
 
-  const tokenCache = new Map<string, CachedToken>();
-
-  const pruneExpired = (now: number) => {
-    for (const [key, value] of tokenCache) {
-      if (value.expiresAt <= now) {
-        tokenCache.delete(key);
-      }
-    }
-  };
+  const tokenCache = new TokenExchangeCache();
 
   const router = Router();
 
@@ -122,15 +82,10 @@ export function createClusterTokenRouter(
       res.setHeader('Cache-Control', 'no-store');
 
       const now = Date.now();
-      pruneExpired(now);
-
       const cacheKey = `${userEntityRef}:${installation}`;
-      const cached = tokenCache.get(cacheKey);
-      if (cached && cached.expiresAt - now > EXPIRY_SKEW_SECONDS * 1000) {
-        res.json({
-          token: cached.token,
-          expiresInSeconds: Math.floor((cached.expiresAt - now) / 1000),
-        });
+      const cached = tokenCache.getFresh(cacheKey, now);
+      if (cached) {
+        res.json(cached);
         return;
       }
 
@@ -266,10 +221,12 @@ export function createClusterTokenRouter(
 
       const expiresInSeconds =
         tokenResponse.expires_in ?? DEFAULT_EXPIRES_IN_SECONDS;
-      tokenCache.set(cacheKey, {
-        token: tokenResponse.access_token,
-        expiresAt: now + expiresInSeconds * 1000,
-      });
+      tokenCache.set(
+        cacheKey,
+        tokenResponse.access_token,
+        expiresInSeconds,
+        now,
+      );
 
       logger.debug(
         `Minted cluster token for ${userEntityRef} on installation "${installation}" (audience "${audience}", expires in ${expiresInSeconds}s)`,

--- a/plugins/auth-backend-module-gs/src/module.ts
+++ b/plugins/auth-backend-module-gs/src/module.ts
@@ -13,6 +13,7 @@ import { OidcAuthResult } from '@backstage/plugin-auth-backend-module-oidc-provi
 import { oauth2Authenticator } from './oauth2/authenticator';
 import { createCimdRouter } from './oauth2/cimdRouter';
 import { createClusterTokenRouter } from './clusterToken/router';
+import { createMusterTokenRouter } from './musterToken/router';
 import { gsOidcAuthenticator } from './oidc/authenticator';
 import { waitForIssuerMetadata } from './oidc/issuerMetadata';
 
@@ -182,6 +183,18 @@ export const authModuleGsProviders = createBackendModule({
             'Cluster token broker is configured, registering cluster token route',
           );
           httpRouter.use(clusterTokenRouter);
+        }
+
+        const musterTokenRouter = createMusterTokenRouter({
+          config,
+          logger,
+          httpAuth,
+        });
+        if (musterTokenRouter) {
+          logger.info(
+            'Muster token endpoint is configured, registering muster token route',
+          );
+          httpRouter.use(musterTokenRouter);
         }
       },
     });

--- a/plugins/auth-backend-module-gs/src/musterToken/router.test.ts
+++ b/plugins/auth-backend-module-gs/src/musterToken/router.test.ts
@@ -1,0 +1,254 @@
+import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
+import { ConfigReader } from '@backstage/config';
+import express from 'express';
+import request from 'supertest';
+import { createMusterTokenRouter, SUBJECT_TOKEN_HEADER } from './router';
+
+const logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+} as unknown as LoggerService;
+
+const httpAuth = {
+  credentials: jest.fn().mockResolvedValue({
+    principal: { type: 'user', userEntityRef: 'user:default/mock' },
+  }),
+} as unknown as HttpAuthService;
+
+const MUSTER_CONFIG = {
+  gs: {
+    musterToken: {
+      tokenUrl: 'https://muster.example.com/oauth/token',
+    },
+  },
+};
+
+function buildApp(configData: object = MUSTER_CONFIG) {
+  const router = createMusterTokenRouter({
+    config: new ConfigReader(configData),
+    logger,
+    httpAuth,
+  });
+  if (!router) {
+    return undefined;
+  }
+  const app = express();
+  app.use(router);
+  app.use(
+    (
+      err: Error & { name: string },
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      const statusByErrorName: Record<string, number> = {
+        NotFoundError: 404,
+        InputError: 400,
+      };
+      const status = statusByErrorName[err.name] ?? 500;
+      res.status(status).json({ error: err.message });
+    },
+  );
+  return app;
+}
+
+function mockMusterResponse(
+  body: object,
+  init: { status?: number } = {},
+): jest.SpyInstance {
+  return jest.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: init.status ?? 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('createMusterTokenRouter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns undefined when muster token endpoint is not configured', () => {
+    expect(buildApp({ gs: {} })).toBeUndefined();
+  });
+
+  it('returns 400 when the subject token header is missing', async () => {
+    const res = await request(buildApp()!).post('/muster-token');
+    expect(res.status).toBe(400);
+  });
+
+  it('exchanges the subject token with no audience and no client auth', async () => {
+    const fetchSpy = mockMusterResponse({
+      access_token: 'muster-token',
+      token_type: 'Bearer',
+      expires_in: 1800,
+    });
+
+    const res = await request(buildApp()!)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ token: 'muster-token', expiresInSeconds: 1800 });
+    expect(res.headers['cache-control']).toBe('no-store');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://muster.example.com/oauth/token');
+    // The self-issued path is unauthenticated: no client credentials.
+    expect(init.headers.Authorization).toBeUndefined();
+    const params = new URLSearchParams(init.body);
+    expect(params.get('grant_type')).toBe(
+      'urn:ietf:params:oauth:grant-type:token-exchange',
+    );
+    expect(params.get('subject_token')).toBe('subject-token');
+    expect(params.get('subject_token_type')).toBe(
+      'urn:ietf:params:oauth:token-type:id_token',
+    );
+    // An audience would route muster to the brokered path.
+    expect(params.get('audience')).toBeNull();
+    expect(params.get('scope')).toBeNull();
+  });
+
+  it('sends the configured scope', async () => {
+    const fetchSpy = mockMusterResponse({
+      access_token: 'muster-token',
+      expires_in: 1800,
+    });
+
+    const configWithScope = JSON.parse(JSON.stringify(MUSTER_CONFIG));
+    configWithScope.gs.musterToken.scope = 'openid profile';
+
+    const res = await request(buildApp(configWithScope)!)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(200);
+    const params = new URLSearchParams(fetchSpy.mock.calls[0][1].body);
+    expect(params.get('scope')).toBe('openid profile');
+  });
+
+  it('serves cached tokens until close to expiry', async () => {
+    const fetchSpy = mockMusterResponse({
+      access_token: 'muster-token',
+      expires_in: 1800,
+    });
+    const app = buildApp()!;
+
+    const first = await request(app)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+    const second = await request(app)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.token).toBe('muster-token');
+    expect(second.body.expiresInSeconds).toBeLessThanOrEqual(1800);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-exchanges when the cached token is close to expiry', async () => {
+    const fetchSpy = mockMusterResponse({
+      access_token: 'short-lived',
+      expires_in: 60,
+    });
+    const app = buildApp()!;
+
+    await request(app)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+    await request(app)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps a rejected subject token to a subject_invalid reason at debug', async () => {
+    mockMusterResponse(
+      { error: 'invalid_grant', error_description: 'subject token expired' },
+      { status: 400 },
+    );
+
+    const res = await request(buildApp()!)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({
+      error: 'Token exchange failed',
+      reason: 'subject_invalid',
+    });
+    // Routine, already-handled outcome; must NOT reach Sentry.
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a bare 401 to subject_invalid', async () => {
+    mockMusterResponse({ error_description: 'unauthorized' }, { status: 401 });
+
+    const res = await request(buildApp()!)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body.reason).toBe('subject_invalid');
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a muster-side exchange failure to exchange_failed at warn', async () => {
+    mockMusterResponse(
+      { error: 'server_error', error_description: 'unexpected' },
+      { status: 500 },
+    );
+
+    const res = await request(buildApp()!)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({
+      error: 'Token exchange failed',
+      reason: 'exchange_failed',
+    });
+    // A non-subject failure is an actionable muster-side fault -> warn.
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('maps an unreachable muster to 502 with the underlying cause', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValue(
+        new TypeError('fetch failed', { cause: new Error('ECONNREFUSED') }),
+      );
+
+    const res = await request(buildApp()!)
+      .post('/muster-token')
+      .set(SUBJECT_TOKEN_HEADER, 'subject-token');
+
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({
+      error: 'Muster is unreachable',
+      reason: 'broker_unreachable',
+    });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        cause: expect.stringContaining('ECONNREFUSED'),
+      }),
+    );
+  });
+});

--- a/plugins/auth-backend-module-gs/src/musterToken/router.ts
+++ b/plugins/auth-backend-module-gs/src/musterToken/router.ts
@@ -1,0 +1,194 @@
+import express from 'express';
+import Router from 'express-promise-router';
+import {
+  HttpAuthService,
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
+import { InputError } from '@backstage/errors';
+import {
+  DEFAULT_EXPIRES_IN_SECONDS,
+  ID_TOKEN_TYPE,
+  parseOAuthError,
+  SUBJECT_TOKEN_HEADER,
+  TOKEN_EXCHANGE_GRANT_TYPE,
+  TokenExchangeCache,
+} from '../tokenExchange/tokenExchange';
+
+export { SUBJECT_TOKEN_HEADER } from '../tokenExchange/tokenExchange';
+
+export interface MusterTokenRouterOptions {
+  config: RootConfigService;
+  logger: LoggerService;
+  httpAuth: HttpAuthService;
+}
+
+/**
+ * Creates the muster token service router, exposed as
+ * `POST /api/auth/muster-token`.
+ *
+ * Given the caller's authenticated Backstage session and their main Dex ID
+ * token (forwarded in the `gs-subject-token` header), it mints a short-lived
+ * muster-signed session token through muster's self-issued RFC 8693 exchange
+ * (no `audience`, no client authentication) and caches it per user with
+ * expiry-aware re-exchange. The token replaces the raw Dex ID token as the
+ * MCP bearer so that muster's outbound exchange, which only accepts a
+ * muster-signed subject, succeeds. Exchanged tokens are never persisted.
+ *
+ * Returns undefined when muster's token endpoint is not configured
+ * (`gs.musterToken`).
+ */
+export function createMusterTokenRouter(
+  options: MusterTokenRouterOptions,
+): express.Router | undefined {
+  const { config, logger, httpAuth } = options;
+
+  const musterTokenConfig = config.getOptionalConfig('gs.musterToken');
+  if (!musterTokenConfig) {
+    return undefined;
+  }
+
+  const tokenUrl = musterTokenConfig.getString('tokenUrl');
+  const scope = musterTokenConfig.getOptionalString('scope');
+
+  const tokenCache = new TokenExchangeCache();
+
+  const router = Router();
+
+  router.post(
+    '/muster-token',
+    async (req: express.Request, res: express.Response) => {
+      const credentials = await httpAuth.credentials(req, { allow: ['user'] });
+      const userEntityRef = credentials.principal.userEntityRef;
+
+      const subjectToken = req.header(SUBJECT_TOKEN_HEADER);
+      if (!subjectToken) {
+        throw new InputError(`Missing ${SUBJECT_TOKEN_HEADER} header`);
+      }
+
+      res.setHeader('Cache-Control', 'no-store');
+
+      const now = Date.now();
+      const cached = tokenCache.getFresh(userEntityRef, now);
+      if (cached) {
+        res.json(cached);
+        return;
+      }
+
+      // Self-issued path: no `audience` (an audience routes muster to the
+      // brokered exchange) and no client authentication.
+      const params = new URLSearchParams({
+        grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+        subject_token: subjectToken,
+        subject_token_type: ID_TOKEN_TYPE,
+      });
+      if (scope) {
+        params.set('scope', scope);
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(tokenUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: params.toString(),
+        });
+      } catch (error) {
+        logger.warn('Muster token exchange failed: muster unreachable', {
+          error: String(error),
+          // undici puts the actionable code (ECONNREFUSED/ENOTFOUND) on
+          // error.cause; String(error) alone collapses to "TypeError: fetch
+          // failed".
+          cause:
+            error instanceof Error && error.cause !== undefined
+              ? String(error.cause)
+              : null,
+        });
+        res.status(502).json({
+          error: 'Muster is unreachable',
+          reason: 'broker_unreachable',
+        });
+        return;
+      }
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        tokenCache.delete(userEntityRef);
+
+        const oauthError = parseOAuthError(body);
+        const meta = {
+          status: response.status,
+          oauthError: oauthError ?? null,
+          body,
+        };
+
+        // An OAuth invalid_grant/invalid_token/invalid_request (or a bare 401)
+        // means the forwarded subject token was rejected, i.e. the user's main
+        // session is the problem. This is routine (expired sessions), handled
+        // with 0 user impact, so it logs at `debug` and stays out of Sentry.
+        const subjectRejected =
+          response.status === 401 ||
+          oauthError === 'invalid_grant' ||
+          oauthError === 'invalid_token' ||
+          oauthError === 'invalid_request';
+        if (subjectRejected) {
+          logger.debug(
+            'Muster token exchange rejected: subject token invalid or expired',
+            meta,
+          );
+          res.status(502).json({
+            error: 'Token exchange failed',
+            reason: 'subject_invalid',
+          });
+          return;
+        }
+
+        // Everything else is a muster-side exchange failure, e.g. the subject
+        // issuer is not in muster's trustedIssuers (a config gap). Actionable,
+        // stays at `warn`.
+        logger.warn(
+          'Muster token exchange failed: muster rejected the exchange',
+          meta,
+        );
+        res.status(502).json({
+          error: 'Token exchange failed',
+          reason: 'exchange_failed',
+        });
+        return;
+      }
+
+      const tokenResponse = (await response.json()) as {
+        access_token?: string;
+        expires_in?: number;
+      };
+      if (!tokenResponse.access_token) {
+        logger.warn(
+          'Muster token exchange failed: muster returned no access_token',
+        );
+        res
+          .status(502)
+          .json({ error: 'Token exchange failed', reason: 'exchange_failed' });
+        return;
+      }
+
+      const expiresInSeconds =
+        tokenResponse.expires_in ?? DEFAULT_EXPIRES_IN_SECONDS;
+      tokenCache.set(
+        userEntityRef,
+        tokenResponse.access_token,
+        expiresInSeconds,
+        now,
+      );
+
+      logger.debug(
+        `Minted muster token for ${userEntityRef} (expires in ${expiresInSeconds}s)`,
+      );
+
+      res.json({ token: tokenResponse.access_token, expiresInSeconds });
+    },
+  );
+
+  return router;
+}

--- a/plugins/auth-backend-module-gs/src/tokenExchange/tokenExchange.ts
+++ b/plugins/auth-backend-module-gs/src/tokenExchange/tokenExchange.ts
@@ -1,0 +1,86 @@
+/**
+ * Header used by the frontend to forward the user's main Dex ID token, which
+ * the backend exchanges for a downstream token. Backstage does not expose
+ * provider sessions server-side, so the token travels alongside the regular
+ * Backstage credentials.
+ */
+export const SUBJECT_TOKEN_HEADER = 'gs-subject-token';
+
+export const TOKEN_EXCHANGE_GRANT_TYPE =
+  'urn:ietf:params:oauth:grant-type:token-exchange';
+export const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
+
+/**
+ * Minimum remaining lifetime before a cached token is re-exchanged. Larger than
+ * the frontend's session refresh margin (3 minutes) so a refresh-triggering
+ * request never gets a token that immediately triggers another refresh.
+ */
+export const EXPIRY_SKEW_SECONDS = 240;
+
+/** Fallback lifetime when the exchange response carries no expires_in. */
+export const DEFAULT_EXPIRES_IN_SECONDS = 300;
+
+/**
+ * Extracts the OAuth 2.0 `error` code (RFC 6749 section 5.2) from an error
+ * response body. Returns undefined for non-JSON bodies (e.g. an HTML error page
+ * from a proxy sitting in front of the token endpoint).
+ */
+export function parseOAuthError(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown };
+    return typeof parsed.error === 'string' ? parsed.error : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+type CacheEntry = {
+  token: string;
+  expiresAt: number;
+};
+
+/**
+ * In-memory cache of exchanged tokens keyed by an arbitrary string (per user,
+ * or per user and installation). Serves a token only while it stays beyond the
+ * re-exchange skew, and prunes expired entries on every read. Tokens are never
+ * persisted.
+ */
+export class TokenExchangeCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  /**
+   * Returns a still-fresh token for `key` (remaining lifetime above the
+   * re-exchange skew), or undefined when absent or too close to expiry. Prunes
+   * fully expired entries as a side effect.
+   */
+  getFresh(
+    key: string,
+    now: number,
+  ): { token: string; expiresInSeconds: number } | undefined {
+    for (const [entryKey, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(entryKey);
+      }
+    }
+
+    const cached = this.entries.get(key);
+    if (cached && cached.expiresAt - now > EXPIRY_SKEW_SECONDS * 1000) {
+      return {
+        token: cached.token,
+        expiresInSeconds: Math.floor((cached.expiresAt - now) / 1000),
+      };
+    }
+    return undefined;
+  }
+
+  set(key: string, token: string, expiresInSeconds: number, now: number): void {
+    this.entries.set(key, {
+      token,
+      expiresAt: now + expiresInSeconds * 1000,
+    });
+  }
+
+  delete(key: string): void {
+    this.entries.delete(key);
+  }
+}

--- a/plugins/gs/config.d.ts
+++ b/plugins/gs/config.d.ts
@@ -36,6 +36,30 @@ export interface Config {
       scope?: string;
     };
 
+    /**
+     * Muster's self-issued token endpoint. When set, MCP servers without a
+     * dedicated auth provider (AI chat, muster management UI) present a
+     * muster-signed session token as their bearer instead of the raw main Dex
+     * ID token: the backend exchanges the user's main Dex ID token for a
+     * muster-signed token (RFC 8693, no audience, no client authentication) so
+     * muster's outbound exchange, which only accepts a muster-signed subject,
+     * succeeds. Points at the deployment's local muster.
+     */
+    musterToken?: {
+      /**
+       * OAuth token endpoint of the local muster, e.g.
+       * https://muster.example.com/oauth/token. Its presence enables minting
+       * in the frontend.
+       * @visibility frontend
+       */
+      tokenUrl: string;
+      /**
+       * Optional scope sent with the RFC 8693 exchange request. Usually unset.
+       * @visibility backend
+       */
+      scope?: string;
+    };
+
     /** @deepVisibility frontend */
     clusterDetails?: {
       resources?: {

--- a/plugins/muster/src/apis/MusterAuthProviders.test.ts
+++ b/plugins/muster/src/apis/MusterAuthProviders.test.ts
@@ -55,4 +55,38 @@ describe('MusterAuthProviders', () => {
 
     await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
   });
+
+  it('mints a muster token instead of forwarding the raw ID token when configured', async () => {
+    const main = oidcApi('main-id-token');
+    const musterTokenProvider = jest.fn().mockResolvedValue('muster-token');
+    const providers = new MusterAuthProviders({}, main, musterTokenProvider);
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'muster-token',
+    });
+    expect(main.getIdToken).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when minting fails, without falling back to the raw ID token', async () => {
+    const main = oidcApi('main-id-token');
+    const musterTokenProvider = jest.fn().mockRejectedValue(new Error('boom'));
+    const providers = new MusterAuthProviders({}, main, musterTokenProvider);
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({});
+    expect(main.getIdToken).not.toHaveBeenCalled();
+  });
+
+  it('still prefers a dedicated provider over minting', async () => {
+    const musterTokenProvider = jest.fn().mockResolvedValue('muster-token');
+    const providers = new MusterAuthProviders(
+      { 'mcp-muster': oauthApi('access-token') },
+      undefined,
+      musterTokenProvider,
+    );
+
+    await expect(providers.getCredentials('mcp-muster')).resolves.toEqual({
+      token: 'access-token',
+    });
+    expect(musterTokenProvider).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/muster/src/apis/MusterAuthProviders.ts
+++ b/plugins/muster/src/apis/MusterAuthProviders.ts
@@ -17,6 +17,7 @@ export const musterAuthProvidersApiRef = createApiRef<MusterAuthProvidersApi>({
 export class MusterAuthProviders implements MusterAuthProvidersApi {
   private readonly authProviders: { [providerName: string]: OAuthApi };
   private readonly mainAuthApi?: OpenIdConnectApi;
+  private readonly musterTokenProvider?: () => Promise<string | undefined>;
 
   /**
    * @param authProviders - Dedicated OAuth providers, keyed by `authProvider`
@@ -24,13 +25,22 @@ export class MusterAuthProviders implements MusterAuthProvidersApi {
    * @param mainAuthApi - Optional fallback for provider names without a
    *   dedicated entry: the user's main identity provider, whose ID token is
    *   forwarded as the bearer token (single sign-on, no separate login).
+   * @param musterTokenProvider - Optional minter of a muster-signed session
+   *   token from the main Dex ID token. When set (`gs.musterToken.tokenUrl`
+   *   configured), a provider name without a dedicated entry gets the
+   *   muster-signed token instead of the raw main Dex ID token, so muster's
+   *   outbound exchange accepts it. Minting failure is fail-closed (no token),
+   *   not a fall back to the raw token. The token targets the local muster;
+   *   remote installations in the management UI keep failing on their own Dex.
    */
   constructor(
     authProviders: { [providerName: string]: OAuthApi } = {},
     mainAuthApi?: OpenIdConnectApi,
+    musterTokenProvider?: () => Promise<string | undefined>,
   ) {
     this.authProviders = authProviders;
     this.mainAuthApi = mainAuthApi;
+    this.musterTokenProvider = musterTokenProvider;
   }
 
   async getCredentials(authProvider: string): Promise<MusterAuthCredentials> {
@@ -48,6 +58,15 @@ export class MusterAuthProviders implements MusterAuthProvidersApi {
   }
 
   private async getMainCredentials(): Promise<MusterAuthCredentials> {
+    if (this.musterTokenProvider) {
+      try {
+        const token = await this.musterTokenProvider();
+        return token ? { token } : {};
+      } catch {
+        return {};
+      }
+    }
+
     if (!this.mainAuthApi) {
       return {};
     }


### PR DESCRIPTION
Closes #1915. Part of #1737 (epic giantswarm/giantswarm#36840).

## What

AI chat (`MCPAuthProviders`) and the muster management UI (`MusterAuthProviders`) forward the user's **raw main Dex ID token** as the `/mcp` bearer when an MCP server has no dedicated `authProvider` (since #1746). That works today only because muster's `trustedAudiences` lists the Backstage client.

Once same-cluster mcp-kubernetes moves to `auth.mode: exchange` (giantswarm-configs#750), muster's outbound hop exchanges the caller's session token at the MC's own Dex and only accepts a **muster-signed** subject. A raw Dex token is not muster-signed, so the outbound mint fails and AI chat k8s tools break fail-closed on gazelle and graveler. glean has no Backstage AI chat and is unaffected.

This makes those callers present a muster-signed token instead.

## How

- **`auth-backend-module-gs`**: new authenticated `POST /api/auth/muster-token`. It takes the user's main Dex ID token from the `gs-subject-token` header and mints a muster-signed session token via muster's self-issued RFC 8693 exchange (`grant_type=token-exchange`, `subject_token_type=id_token`, **no `audience`**, **no client authentication**), cached per user with expiry-aware re-exchange, never persisted. Registered only when `gs.musterToken` is configured. This mirrors the cluster-token route (#1747); the shared exchange glue (grant/token-type constants, OAuth error parsing, the TTL cache) is extracted to `tokenExchange/` and used by both.
- **Frontend (`ai-chat`, `muster`)**: `MCPAuthProviders`/`MusterAuthProviders` call the new route (forwarding the main Dex ID token plus the Backstage identity token, same as the cluster-token minting in `GSAuthProviders`) and use the muster-signed token as the MCP bearer when `gs.musterToken.tokenUrl` is set, failing closed on error. Without the config they keep forwarding the raw ID token, so current deployments are unchanged.
- **Config**: `gs.musterToken.tokenUrl` added to `plugins/gs/config.d.ts`. Activation is a per-deployment gmc app-config change pointing at the deployment's local muster token endpoint.

The minted token is only valid at the muster that signs it, and a muster only self-issues from a subject it trusts, so minting always targets the deployment's local muster (one `tokenUrl`). The muster management UI's remote-installation entries stay gated on their own Dex, unchanged by this PR.

## Muster-side prerequisite: already satisfied

The exchange validates the subject against muster's `trustedIssuers`. The `dex.<mc>` entry on both gazelle and graveler already lists the Backstage client in `allowedAudiences` with `subjectClaim: email` (added for the muster#831 broker subject-validation path, which validates the same token). No giantswarm-configs change is required for this PR. This is a different knob than `trustedAudiences` (the `/mcp` inbound list that makes raw forwarding work today).

## Tests

- `auth-backend-module-gs`: exchange request shape (no audience, no client auth, scope), per-user caching with expiry-aware re-exchange, error mapping (subject rejection at `debug`, muster-side fault at `warn`, unreachable with cause) — all green, and the shared-glue extraction keeps the existing cluster-token suite passing.
- `ai-chat`/`muster`: minting precedence over the raw token, fail-closed on mint error, dedicated provider still wins.
- `yarn tsc`, `yarn lint`, `yarn prettier:check` clean.

## Rollout

Config-only per deployment: set `gs.musterToken.tokenUrl` to the local muster's token endpoint on the gazelle and graveler portals. The follow-up removal of the agentgateway `jwt.extraProviders` raw-Dex acceptance (giantswarm-configs) is deliberately sequenced after this is deployed and verified.
