### PR TITLE
fix: restore Flux/Muster page tab navigation via custom PageLayout

### DIFF
--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -42,7 +42,10 @@ Common primitives already in the codebase (import from `@backstage/ui`):
 - **Overlay/menu**: `Tooltip`, `TooltipTrigger`, `MenuTrigger`, `Menu`, `MenuItem`
 - **Data display**: `Table` + `Cell` / `CellText` / `ColumnConfig`, `List`, `ListRow`, `Avatar`
 - **Page chrome**: `PluginHeader`, `Header` (the two-tier header pattern — plugin-level
-  `PluginHeader` above an entity-level `Header`)
+  `PluginHeader` above an entity-level `Header`). NFS page headers and
+  `SubPageBlueprint` tabs are rendered by the custom `GSPageLayout` swappable
+  component, not directly — see "Page headers and tabs" in `docs/ui.md` before
+  building a tabbed page.
 
 ### Cards: use the shared `InfoCard` wrapper
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -21,6 +21,38 @@ There are three UI layers in this repo, in order of preference for new work:
 Mixing all three in one file is normal during the migration. Reach for bui
 first and fall back only when a piece is missing.
 
+## Page headers and tabs (New Frontend System)
+
+Every NFS page header is rendered by a **custom `PageLayout` swappable
+component**, `GSPageLayout`
+(`packages/app/src/modules/app/GSPageLayout.tsx`), registered in
+`AppOverrides.tsx` via `SwappableComponentBlueprint`. It wraps the bui
+`PluginHeader`, so page titles and tabs get the bui look plus active-tab
+highlighting.
+
+`PageBlueprint` uses this component for the header of **every** page, and — when
+a page has `SubPageBlueprint` sub-pages — to render those sub-pages as **tabs**
+(e.g. the flux `list`/`tree` tabs, the muster section). Backstage ships only a
+stub default for `PageLayout`; **if `GSPageLayout` is removed the app falls back
+to that stub, whose tabs are plain relative `<a href="list">` anchors with no
+active state.** That regresses tabbed pages: from `/flux/list`, clicking a tab
+appends (`/flux/list/tree`) instead of switching, and no tab is highlighted.
+`GSPageLayout` fixes this by turning each sub-page's relative `path` into an
+absolute href.
+
+Guidelines when building pages:
+
+- **Tabbed pages** — declare a `PageBlueprint` (no loader) plus one
+  `SubPageBlueprint` per tab, each with a **relative** `path` (`list`, `tree`).
+  Keep the paths relative; `GSPageLayout` resolves them. See
+  `plugins/flux/src/plugin.tsx` and `plugins/muster/src/plugin.tsx`.
+- **Pages that render their own bui `PluginHeader`** (e.g. the clusters and
+  deployments sections, which use the `useLayoutTabs` hook in `plugins/gs`)
+  must pass `noHeader: true` to `PageBlueprint` so `GSPageLayout` skips its
+  header and just renders the content — otherwise you get a double header.
+- Do **not** reintroduce a classic `<Page>`/`<Header>` scaffold on an NFS page;
+  it causes a double scrollbar and duplicate header under the app shell.
+
 ## Storybook
 
 The [Backstage Storybook](https://backstage.io/storybook/) allows to explore the

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -10,10 +10,12 @@ import {
   analyticsApiRef,
   ApiBlueprint,
   AppRootElementBlueprint,
+  PageLayout,
 } from '@backstage/frontend-plugin-api';
 import {
   IconBundleBlueprint,
   SignInPageBlueprint,
+  SwappableComponentBlueprint,
   ThemeBlueprint,
 } from '@backstage/plugin-app-react';
 import DarkIcon from '@material-ui/icons/Brightness2';
@@ -53,6 +55,7 @@ import {
 } from '../../assets/icons/CustomIcons';
 import { BrandingFavicon } from '../branding';
 import { DarkThemeProvider, LightThemeProvider } from './customThemes';
+import { GSPageLayout } from './GSPageLayout';
 
 // The Grafana plugin is a legacy plugin whose API factory is not
 // auto-registered in the NFS. Extract it and provide via ApiBlueprint.
@@ -180,6 +183,21 @@ export const appOverrides = createFrontendModule({
       params: {
         element: <BrandingFavicon />,
       },
+    }),
+    /**
+     * Override the NFS `PageLayout` swappable component so every page header —
+     * and, crucially, the sub-page tabs rendered by `PageBlueprint` (flux
+     * list/tree, muster, …) — uses the bui `PluginHeader` with absolute tab
+     * links and active-state highlighting, instead of the upstream stub whose
+     * relative `<a href>` tabs break navigation.
+     */
+    SwappableComponentBlueprint.make({
+      name: 'page-layout',
+      params: define =>
+        define({
+          component: PageLayout,
+          loader: () => GSPageLayout,
+        }),
     }),
     /**
      * Override the built-in `theme:app/light` and `theme:app/dark` extensions

--- a/packages/app/src/modules/app/GSPageLayout.test.tsx
+++ b/packages/app/src/modules/app/GSPageLayout.test.tsx
@@ -35,6 +35,21 @@ describe('GSPageLayout', () => {
     );
   });
 
+  it('resolves absolute hrefs when the sub-route contains encoded characters', async () => {
+    // `location.pathname` stays percent-encoded while the splat param is
+    // decoded; the base path must still resolve to `/flux`, not the deep path.
+    await renderAt('/flux/tree/some%20nested%20id');
+
+    expect(screen.getByRole('tab', { name: 'List view' })).toHaveAttribute(
+      'href',
+      '/flux/list',
+    );
+    expect(screen.getByRole('tab', { name: 'Tree view' })).toHaveAttribute(
+      'href',
+      '/flux/tree',
+    );
+  });
+
   it('marks the tab for the current sub-route as active', async () => {
     await renderAt('/flux/tree');
 

--- a/packages/app/src/modules/app/GSPageLayout.test.tsx
+++ b/packages/app/src/modules/app/GSPageLayout.test.tsx
@@ -1,0 +1,61 @@
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { screen } from '@testing-library/react';
+import { GSPageLayout } from './GSPageLayout';
+
+const tabs = [
+  { id: 'list', label: 'List view', href: 'list' },
+  { id: 'tree', label: 'Tree view', href: 'tree' },
+];
+
+// PageBlueprint mounts the page at a splat route (`/flux/*`); `mountPath` makes
+// renderInTestApp do the same, so GSPageLayout can derive the base path from
+// the splat remainder just like it does in the real app.
+function renderAt(pathname: string) {
+  return renderInTestApp(
+    <GSPageLayout title="Flux" tabs={tabs}>
+      <div>content</div>
+    </GSPageLayout>,
+    { mountPath: '/flux', initialRouteEntries: [pathname] },
+  );
+}
+
+describe('GSPageLayout', () => {
+  it('renders sub-page tabs with absolute hrefs, not relative ones', async () => {
+    await renderAt('/flux/list');
+
+    // Relative hrefs (`list`/`tree`) would append to the URL and break tab
+    // navigation; they must resolve to absolute paths under the page base.
+    expect(screen.getByRole('tab', { name: 'List view' })).toHaveAttribute(
+      'href',
+      '/flux/list',
+    );
+    expect(screen.getByRole('tab', { name: 'Tree view' })).toHaveAttribute(
+      'href',
+      '/flux/tree',
+    );
+  });
+
+  it('marks the tab for the current sub-route as active', async () => {
+    await renderAt('/flux/tree');
+
+    expect(screen.getByRole('tab', { name: 'Tree view' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: 'List view' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('renders only the content when noHeader is set', async () => {
+    await renderInTestApp(
+      <GSPageLayout title="Flux" tabs={tabs} noHeader>
+        <div>content</div>
+      </GSPageLayout>,
+    );
+
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app/src/modules/app/GSPageLayout.tsx
+++ b/packages/app/src/modules/app/GSPageLayout.tsx
@@ -1,0 +1,65 @@
+import { useLocation, useParams } from 'react-router-dom';
+import type { PageLayoutProps } from '@backstage/frontend-plugin-api';
+import { PluginHeader } from '@backstage/ui';
+import type { HeaderTab } from '@backstage/ui';
+
+/**
+ * Custom implementation of the NFS `PageLayout` swappable component, rendered
+ * via the bui `PluginHeader` (matching the clusters/deployments sections and
+ * the `useLayoutTabs` hook in the `gs` plugin).
+ *
+ * `PageBlueprint` uses this component to render the header of every page. When
+ * a page has sub-pages (`SubPageBlueprint`), it also passes them as `tabs`.
+ * Without this override the app falls back to the upstream stub `PageLayout`,
+ * which renders tabs as plain relative `<a href="list">` anchors with no active
+ * state — so from `/flux/list` clicking "Tree view" navigates to
+ * `/flux/list/tree` (append) instead of `/flux/tree`, and no tab is ever
+ * highlighted. Turning the relative sub-page paths into absolute hrefs here
+ * fixes both.
+ */
+export function GSPageLayout(props: PageLayoutProps) {
+  const { title, icon, noHeader, titleLink, headerActions, tabs, children } =
+    props;
+
+  const { pathname } = useLocation();
+  const params = useParams();
+
+  // The page is mounted at a splat route (e.g. `/flux/*`), so the base path is
+  // the current pathname with the matched remainder removed. Sub-page tab paths
+  // (`list`, `tree`) are relative to that base.
+  const splat = params['*'] ?? '';
+  let basePath =
+    splat && pathname.endsWith(splat)
+      ? pathname.slice(0, pathname.length - splat.length)
+      : pathname;
+  basePath = basePath.replace(/\/+$/, '');
+
+  const headerTabs: HeaderTab[] | undefined = tabs?.map(tab => {
+    const cleanPath = tab.href.replace(/^\//, '');
+    return {
+      id: tab.id,
+      label: tab.label,
+      href: cleanPath ? `${basePath}/${cleanPath}` : basePath,
+      // Keep the tab active for nested sub-routes (e.g. muster's
+      // `workflows/:id`); the sub-page paths here never prefix one another.
+      matchStrategy: 'prefix',
+    };
+  });
+
+  if (noHeader) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      <PluginHeader
+        title={title}
+        icon={icon}
+        titleLink={titleLink}
+        customActions={headerActions}
+        tabs={headerTabs}
+      />
+      {children}
+    </>
+  );
+}

--- a/packages/app/src/modules/app/GSPageLayout.tsx
+++ b/packages/app/src/modules/app/GSPageLayout.tsx
@@ -24,15 +24,22 @@ export function GSPageLayout(props: PageLayoutProps) {
   const { pathname } = useLocation();
   const params = useParams();
 
+  // Pages that render their own header (clusters/deployments/ai-chat/home)
+  // opt out; skip the tab/base-path work entirely for them.
+  if (noHeader) {
+    return <>{children}</>;
+  }
+
   // The page is mounted at a splat route (e.g. `/flux/*`), so the base path is
-  // the current pathname with the matched remainder removed. Sub-page tab paths
-  // (`list`, `tree`) are relative to that base.
-  const splat = params['*'] ?? '';
-  let basePath =
-    splat && pathname.endsWith(splat)
-      ? pathname.slice(0, pathname.length - splat.length)
-      : pathname;
-  basePath = basePath.replace(/\/+$/, '');
+  // the current pathname with the matched remainder removed. Work by path
+  // *segment* rather than string length: `location.pathname` stays
+  // percent-encoded while `useParams()['*']` is decoded, so comparing lengths
+  // would break on encoded chars — but the `/` separator count is unaffected.
+  const splatSegments = (params['*'] ?? '').split('/').filter(Boolean).length;
+  const segments = pathname.split('/').filter(Boolean);
+  const basePath = `/${segments
+    .slice(0, Math.max(0, segments.length - splatSegments))
+    .join('/')}`;
 
   const headerTabs: HeaderTab[] | undefined = tabs?.map(tab => {
     const cleanPath = tab.href.replace(/^\//, '');
@@ -45,10 +52,6 @@ export function GSPageLayout(props: PageLayoutProps) {
       matchStrategy: 'prefix',
     };
   });
-
-  if (noHeader) {
-    return <>{children}</>;
-  }
 
   return (
     <>


### PR DESCRIPTION
### What does this PR do?

Registers a custom NFS `PageLayout` swappable component (`GSPageLayout`) that renders the bui `PluginHeader`, so page headers and — crucially — the tabs rendered by `PageBlueprint` for `SubPageBlueprint` sub-pages (Flux **List view**/**Tree view**, the Muster section) work correctly.

The app never overrode the `PageLayout` swappable component, so it fell back to the upstream stub whose tabs are plain **relative** `<a href="list">` anchors with **no active state**. On the `/flux` page this produced three regressions:

1. On `/flux/list`, the **List view** tab was not highlighted.
2. Clicking **Tree view** navigated to `/flux/list/tree` (relative append) instead of `/flux/tree` — the page stayed on the list view.
3. Clicking **List view** again went to `/flux/list/tree/list`.

`GSPageLayout` resolves each sub-page's relative `path` to an absolute href and uses segment-aware prefix matching for the active tab (the same mechanism the working Clusters/Deployments sections use via `useLayoutTabs`). Pages that render their own `PluginHeader` pass `noHeader: true`, which the component honors.

### What is the effect of this change to users?

Tab navigation on the Flux and Muster pages works again: tabs switch views correctly and the active tab is highlighted.

### Any background context you can provide?

Regression introduced by #1712 ("migrate pages to the new frontend system page header"), which switched Flux from a classic `RoutedTabs`-based `FluxPageLayout` to `SubPageBlueprint` tabs but never added the assumed bui `PageLayout` swap. The upstream `PageLayout` docstring explicitly invites this override: *"Apps can override this with a custom implementation (e.g., using @backstage/ui)."*

Verified with a unit test (`GSPageLayout.test.tsx`) that mounts the component at a splat route and asserts absolute tab hrefs, active-tab state, and the `noHeader` path.

### Do the docs need to be updated?

Yes — done in this PR. Added a "Page headers and tabs (New Frontend System)" section to `docs/ui.md` and a pointer from the `ui` Claude Code skill.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.

Not applicable — the change is in `packages/app`, which is released via the app image/Helm chart flow (git-cliff from the PR title), not the Changesets-published `@giantswarm/backstage-plugin-*` packages.