### PR TITLE
chore(renovate): exempt Giant Swarm npm packages from 14-day minimumReleaseAge

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -35,6 +35,20 @@
       matchPackageNames: ['date-fns', 'date-fns-tz'],
     },
     {
+      // Opt Giant Swarm-owned npm packages out of the 14-day minimumReleaseAge
+      // supply-chain delay from renovate-presets default.json5. That gate
+      // guards against compromised/yanked third-party releases, which does not
+      // apply to our own first-party packages. It also inverts version ordering
+      // for github: deps whose source package.json version never bumps (it is
+      // stuck at 0.1.0 for every tag, e.g. @giantswarm/k8s-types): the two
+      // newest tags get filtered out as "too new" and Renovate proposes the
+      // highest still-eligible older tag, producing a spurious downgrade PR
+      // (see #1923). null unsets the inherited value.
+      matchManagers: ['npm'],
+      matchPackageNames: ['@giantswarm{/,}**'],
+      minimumReleaseAge: null,
+    },
+    {
       // @material-table/core v7 is a React 19 / MUI v5-era release: it
       // peer-requires react >=19.2.0, ships an exports map without a `types`
       // condition (TS2307 under moduleResolution "bundler"), and

--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -36,14 +36,7 @@
     },
     {
       // Opt Giant Swarm-owned npm packages out of the 14-day minimumReleaseAge
-      // supply-chain delay from renovate-presets default.json5. That gate
-      // guards against compromised/yanked third-party releases, which does not
-      // apply to our own first-party packages. It also inverts version ordering
-      // for github: deps whose source package.json version never bumps (it is
-      // stuck at 0.1.0 for every tag, e.g. @giantswarm/k8s-types): the two
-      // newest tags get filtered out as "too new" and Renovate proposes the
-      // highest still-eligible older tag, producing a spurious downgrade PR
-      // (see #1923). null unsets the inherited value.
+      // supply-chain delay from renovate-presets default.json5.
       matchManagers: ['npm'],
       matchPackageNames: ['@giantswarm{/,}**'],
       minimumReleaseAge: null,


### PR DESCRIPTION
### What does this PR do?

Adds a `renovate-custom.json5` package rule that unsets the 14-day `minimumReleaseAge` for `@giantswarm/*` npm packages.

The `default.json5` preset applies a 14-day `minimumReleaseAge` to **all** npm-managed deps as a supply-chain safeguard (avoid pulling in compromised or quickly-yanked releases). That guard adds no value for our own first-party packages, and it actively misbehaves for `github:` deps whose source `package.json` version never bumps.

`@giantswarm/k8s-types` (`github:giantswarm/k8s-typescript-types#<tag>`) is the concrete case: every tag ships `package.json` `version: 0.1.0`, so Renovate can't semver-order the tags. The 14-day gate filters out the two newest tags (`v0.6.0`/`v0.6.1`, both released 6 days ago) as "too new", leaving `v0.5.0` (March) as the highest *eligible* tag — which Renovate then offers as an "update", landing as a real-world **downgrade** of the currently-pinned `v0.6.0`.

### What is the effect of this change to users?

No end-user facing change. Renovate will bump `@giantswarm/*` npm deps without the 14-day delay, and will stop generating spurious downgrade PRs like #1923.

### Any background context you can provide?

Fixes the root cause behind #1923.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. (CI/config-only change, no package affected — no changeset needed.)