### PR TITLE
chore(renovate): pin react below v19 until Backstage supports it

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -62,5 +62,22 @@
       matchPackageNames: ['global-agent'],
       allowedVersions: '<4',
     },
+    {
+      // Backstage core packages (v1.52) peer-require react "^17 || ^18" -- no
+      // React 19. A key blocker is MUI v4, still used by Backstage core, which
+      // doesn't support React 19 (upstream tracking:
+      // https://github.com/backstage/backstage/issues/28080). Bumping react to
+      // v19 would violate peer deps across all @backstage/* packages and risks
+      // runtime breakage. Hold on v18 until Backstage upstream moves to React 19
+      // / MUI v5 (see also the @material-table/core hold above). This still
+      // allows React 18.x minor/patch bumps.
+      matchPackageNames: [
+        'react',
+        'react-dom',
+        '@types/react',
+        '@types/react-dom',
+      ],
+      allowedVersions: '<19',
+    },
   ],
 }


### PR DESCRIPTION
### What does this PR do?

Adds a Renovate rule in `renovate-custom.json5` pinning `react`, `react-dom`, `@types/react` and `@types/react-dom` to `<19`.

This blocks the major React 19 bump (the `renovate/major-react-monorepo` PR) while still allowing React 18.x minor/patch updates. Renovate will auto-close the existing v19 PR on its next run.

### What is the effect of this change to users?

(Remove this section if no end-user facing change)

No user-facing change — CI/dependency management only.

### Any background context you can provide?

Backstage 1.52 (our current version) does **not** support React 19. Every `@backstage/*` package peer-requires `react: "^17.0.0 || ^18.0.0"`, e.g. `@backstage/core-components`, `core-plugin-api`, `frontend-plugin-api`, `plugin-catalog`, `plugin-scaffolder` — none allow `^19`.

Merging the React 19 bump would put the whole workspace in peer-dependency violation with Backstage core and risk runtime breakage (React 19 removes APIs and makes the new JSX transform mandatory).

Upstream, React 19 is tracked in backstage/backstage#28080 but is **not yet supported** — a key blocker is that MUI v4, still used by Backstage core, doesn't support React 19. This is the same root cause as the existing `@material-table/core` hold in this file.

This follows the established pattern in `renovate-custom.json5` (`global-agent`, `@material-table/core`).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. (Not applicable — repo config only, no published package changed.)