### PR TITLE
fix(ai-chat): revert ai-sdk providers to ai@6-compatible majors

### DIFF
--- a/.changeset/ai-sdk-provider-v6-compat.md
+++ b/.changeset/ai-sdk-provider-v6-compat.md
@@ -1,0 +1,9 @@
+---
+'@giantswarm/backstage-plugin-ai-chat-backend': patch
+---
+
+Fix AI chat being unavailable for every provider at runtime.
+
+PR #1926 bumped the `@ai-sdk/*` providers a full major (anthropic/azure/openai to `^4`, openai-compatible to `^3`) while the `ai` core stayed on `^6`. The major-4 providers emit language-model specification `v4`, but the entire `ai@6` line only accepts `v2`/`v3` — so every chat request threw `AI_UnsupportedModelVersionError` before reaching the model. The unit tests didn't catch it because they mock the services and never resolve a model through `streamText`.
+
+Revert the providers to the major line compatible with `ai@6` (anthropic `^3.0.76`, azure `^3.0.64`, openai `^3.0.63`, openai-compatible `^2.0.47`), which emit spec `v3`.

--- a/plugins/ai-chat-backend/package.json
+++ b/plugins/ai-chat-backend/package.json
@@ -25,11 +25,11 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^4.0.0",
-    "@ai-sdk/azure": "^4.0.0",
+    "@ai-sdk/anthropic": "^3.0.76",
+    "@ai-sdk/azure": "^3.0.64",
     "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch",
-    "@ai-sdk/openai": "^4.0.0",
-    "@ai-sdk/openai-compatible": "^3.0.0",
+    "@ai-sdk/openai": "^3.0.63",
+    "@ai-sdk/openai-compatible": "^2.0.47",
     "@backstage/backend-defaults": "backstage:^",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/config": "backstage:^",

--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -15,8 +15,26 @@
   ],
   packageRules: [
     {
+      // Group the `ai` core together with the @ai-sdk/* providers so they are
+      // always proposed in one PR -- they are version-locked (see the major
+      // hold below) and must move together.
       groupName: 'ai-sdk packages',
-      matchPackageNames: ['@ai-sdk{/,}**'],
+      matchPackageNames: ['ai', '@ai-sdk{/,}**'],
+    },
+    {
+      // Hold the AI SDK (core `ai` + all @ai-sdk/* providers) at their current
+      // majors. The core and providers are locked together by language-model
+      // spec version: ai@6 speaks provider spec v2/v3 (@ai-sdk/provider@3),
+      // ai@7 speaks v4 (@ai-sdk/provider@4). Renovate bumping the providers to
+      // a new major without the matching `ai` core major (or vice versa) breaks
+      // AI chat at runtime with AI_UnsupportedModelVersionError -- and the unit
+      // tests don't catch it because they mock the model (that is exactly what
+      // #1926 did, fixed in #1944). Do the ai@6 -> ai@7 migration deliberately,
+      // bumping core + all providers together in one reviewed PR, then lift
+      // this rule. Minor/patch updates still flow.
+      matchPackageNames: ['ai', '@ai-sdk{/,}**'],
+      matchUpdateTypes: ['major'],
+      enabled: false,
     },
     {
       groupName: 'assistant-ui packages',

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,41 +62,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/anthropic@npm:^4.0.0":
-  version: 4.0.12
-  resolution: "@ai-sdk/anthropic@npm:4.0.12"
+"@ai-sdk/anthropic@npm:^3.0.76":
+  version: 3.0.97
+  resolution: "@ai-sdk/anthropic@npm:3.0.97"
   dependencies:
-    "@ai-sdk/provider": "npm:4.0.3"
-    "@ai-sdk/provider-utils": "npm:5.0.7"
+    "@ai-sdk/provider": "npm:3.0.14"
+    "@ai-sdk/provider-utils": "npm:4.0.39"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/df281deb927ac030130901505ae879c29b2505d4bc062d7a4dbd9f0a15b0c8fde5b8b0bb7ec4ed33ec5b922a5aea54659b209e4e0a35c5e2104badc811b39693
+  checksum: 10c0/001a741d8d037afd01e5738cac3c7105fd7363f9a2d7c282c73f8107216344947f47a275a1159cb224da2c8bfce90442e62067b1c590a30aac541fa21bdd1a75
   languageName: node
   linkType: hard
 
-"@ai-sdk/azure@npm:^4.0.0":
-  version: 4.0.11
-  resolution: "@ai-sdk/azure@npm:4.0.11"
+"@ai-sdk/azure@npm:^3.0.64":
+  version: 3.0.90
+  resolution: "@ai-sdk/azure@npm:3.0.90"
   dependencies:
-    "@ai-sdk/deepseek": "npm:3.0.7"
-    "@ai-sdk/openai": "npm:4.0.11"
-    "@ai-sdk/provider": "npm:4.0.3"
-    "@ai-sdk/provider-utils": "npm:5.0.7"
+    "@ai-sdk/deepseek": "npm:2.0.49"
+    "@ai-sdk/openai": "npm:3.0.85"
+    "@ai-sdk/provider": "npm:3.0.14"
+    "@ai-sdk/provider-utils": "npm:4.0.39"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/05e61fbdf30fbc1f224b2b2540aa5a60524ceb43f50d68694e25562d4e187f09c71916e02856f71378ed1381bea18ba55e767b1f9cb6f072a34b5feffbff7ba9
+  checksum: 10c0/2f071d3fc4340f7293d18210c5b8dcfdae8b2758574df5ef277b40e814c41d76a23d48515af637368900eab2a0db0bc7bec687c323eb9fb904aaf6e299e391d1
   languageName: node
   linkType: hard
 
-"@ai-sdk/deepseek@npm:3.0.7":
-  version: 3.0.7
-  resolution: "@ai-sdk/deepseek@npm:3.0.7"
+"@ai-sdk/deepseek@npm:2.0.49":
+  version: 2.0.49
+  resolution: "@ai-sdk/deepseek@npm:2.0.49"
   dependencies:
-    "@ai-sdk/provider": "npm:4.0.3"
-    "@ai-sdk/provider-utils": "npm:5.0.7"
+    "@ai-sdk/provider": "npm:3.0.14"
+    "@ai-sdk/provider-utils": "npm:4.0.39"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/1ec329103a4ebdb0d0f644169e5e2f1af6b88f34f733ee7593820641e0b1ad22e6ed563828e779d8674bcae8d1e7b0cde757e14b54093adf2b18d169bf7e3014
+  checksum: 10c0/a1c7ca04f74fb847c0a4253d0ddf0c846800f1794197083da316df6b89628b18c8d4730d13466d70e071840f0e325c3839d6d817f0df6f044d5cdf9957b733b3
   languageName: node
   linkType: hard
 
@@ -152,27 +152,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/openai-compatible@npm:^3.0.0":
-  version: 3.0.7
-  resolution: "@ai-sdk/openai-compatible@npm:3.0.7"
+"@ai-sdk/openai-compatible@npm:^2.0.47":
+  version: 2.0.60
+  resolution: "@ai-sdk/openai-compatible@npm:2.0.60"
   dependencies:
-    "@ai-sdk/provider": "npm:4.0.3"
-    "@ai-sdk/provider-utils": "npm:5.0.7"
+    "@ai-sdk/provider": "npm:3.0.14"
+    "@ai-sdk/provider-utils": "npm:4.0.39"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/d7e10484da334bd1468007114339ca45978e721612e766aff5f653939b04dc534b2fb58cdbfe2ecdbb7d3a5bf81ad46e2ea402f45497fc0aae9cef72e701c293
+  checksum: 10c0/1e86ffae97532fd821276bd43ec01acef197978759324e1bee0b1aa657399c90671c61fa42718c815f0eae125af981aa204e6b37be424562ec7718c80d3bfb62
   languageName: node
   linkType: hard
 
-"@ai-sdk/openai@npm:4.0.11, @ai-sdk/openai@npm:^4.0.0":
-  version: 4.0.11
-  resolution: "@ai-sdk/openai@npm:4.0.11"
+"@ai-sdk/openai@npm:3.0.85, @ai-sdk/openai@npm:^3.0.63":
+  version: 3.0.85
+  resolution: "@ai-sdk/openai@npm:3.0.85"
   dependencies:
-    "@ai-sdk/provider": "npm:4.0.3"
-    "@ai-sdk/provider-utils": "npm:5.0.7"
+    "@ai-sdk/provider": "npm:3.0.14"
+    "@ai-sdk/provider-utils": "npm:4.0.39"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/88a52bb8001ff6ca3edea0d857232838a7de12f279f1d58afbe6847e45e118d0b1aa799fba197c53d81d341d1b3371bd807086ab94e0df83caffcbb590e7399c
+  checksum: 10c0/7d3ddc871756418e929e1855bd2b9c38bba4a0aa0bf4ebf1310f1638ed6b0de2c03ebb55b8ff52a49a62298ca486da7e35831569885f6d90d1e34c6ed0e6265e
   languageName: node
   linkType: hard
 
@@ -215,17 +215,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:5.0.7":
-  version: 5.0.7
-  resolution: "@ai-sdk/provider-utils@npm:5.0.7"
+"@ai-sdk/provider-utils@npm:4.0.39":
+  version: 4.0.39
+  resolution: "@ai-sdk/provider-utils@npm:4.0.39"
   dependencies:
-    "@ai-sdk/provider": "npm:4.0.3"
+    "@ai-sdk/provider": "npm:3.0.14"
     "@standard-schema/spec": "npm:^1.1.0"
-    "@workflow/serde": "npm:4.1.0"
     eventsource-parser: "npm:^3.0.8"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/129edc733a2d4c3cd47a59f9125b71a5577940c5d5a814e43bc13ee86894b5a86decbad461ddf3ce546ce5c2c47627d2efbdf3921478cfe843ab4aced3248a22
+  checksum: 10c0/67404233e0819f549e35cd200773f29aff8387f568e713d6900ede483ae0b851b81ec210434a62b3bf3dbc91137abee13d2e3d58812f53614822d7c752005418
   languageName: node
   linkType: hard
 
@@ -247,12 +246,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider@npm:4.0.3":
-  version: 4.0.3
-  resolution: "@ai-sdk/provider@npm:4.0.3"
+"@ai-sdk/provider@npm:3.0.14":
+  version: 3.0.14
+  resolution: "@ai-sdk/provider@npm:3.0.14"
   dependencies:
     json-schema: "npm:^0.4.0"
-  checksum: 10c0/4af0a9592baffbde5b4bb04668a2dfe41750405f0f35f7df86ba0ef3ba46e505d3ad1352cc4cfbe9580ac82d60f11fbb2bf1b55761deb268d99a611d146f3d7f
+  checksum: 10c0/4a533f0c7e98c3f7a3b75119b3f1855fd1ae759d696f7ee9c07b9bd4feaed57716f3e0d81586333e621a501dc0b99d3a103def3e063a45970a653ab027a8f163
   languageName: node
   linkType: hard
 
@@ -11424,11 +11423,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@giantswarm/backstage-plugin-ai-chat-backend@workspace:plugins/ai-chat-backend"
   dependencies:
-    "@ai-sdk/anthropic": "npm:^4.0.0"
-    "@ai-sdk/azure": "npm:^4.0.0"
+    "@ai-sdk/anthropic": "npm:^3.0.76"
+    "@ai-sdk/azure": "npm:^3.0.64"
     "@ai-sdk/mcp": "patch:@ai-sdk/mcp@npm%3A1.0.46#~/.yarn/patches/@ai-sdk-mcp-npm-1.0.46-b48c61b836.patch"
-    "@ai-sdk/openai": "npm:^4.0.0"
-    "@ai-sdk/openai-compatible": "npm:^3.0.0"
+    "@ai-sdk/openai": "npm:^3.0.63"
+    "@ai-sdk/openai-compatible": "npm:^2.0.47"
     "@backstage/backend-defaults": "backstage:^"
     "@backstage/backend-plugin-api": "backstage:^"
     "@backstage/backend-test-utils": "backstage:^"
@@ -26087,13 +26086,6 @@ __metadata:
   version: 1.0.2
   resolution: "@wmhilton/crypto-hash@npm:1.0.2"
   checksum: 10c0/8484f90a61615ade87ffd7fc9079b0350ea9a574a9b0414542b1ce0342c47c2b2a5d711a6f95ef883ea2958985ef619957cb350cd4ff314a444910c08aeb233c
-  languageName: node
-  linkType: hard
-
-"@workflow/serde@npm:4.1.0":
-  version: 4.1.0
-  resolution: "@workflow/serde@npm:4.1.0"
-  checksum: 10c0/8ec68cd9448b486bc8244d1f2b33d64d4af4b0fc18d33417699ce29345b21e4359d880c5ea5d66872def4576c0cddcfa2a63282d1f4d661c455663c075595e81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Reverts the `@ai-sdk/*` provider packages to the major line compatible with the `ai@6` core, fixing AI chat being **broken at runtime for every provider**.

[PR #1926](https://github.com/giantswarm/backstage/pull/1926) bumped the providers a full major (`@ai-sdk/anthropic`, `@ai-sdk/azure`, `@ai-sdk/openai` → `^4`; `@ai-sdk/openai-compatible` → `^3`) while the `ai` core stayed on `^6`. The major-4 providers implement language-model specification **`v4`**, but the entire `ai@6` line only accepts **`v2`/`v3`** (it depends on `@ai-sdk/provider@3`). As a result every chat request throws `AI_UnsupportedModelVersionError` before the model is ever called.

This reverts the four provider ranges to their pre-#1926 values:

| package                     | broken (main) | fixed     |
| --------------------------- | ------------- | --------- |
| `@ai-sdk/anthropic`         | `^4.0.0`      | `^3.0.76` |
| `@ai-sdk/azure`             | `^4.0.0`      | `^3.0.64` |
| `@ai-sdk/openai`            | `^4.0.0`      | `^3.0.63` |
| `@ai-sdk/openai-compatible` | `^3.0.0`      | `^2.0.47` |

It also **guards against recurrence** in `renovate-custom.json5`: the `ai` core is added to the existing "ai-sdk packages" group (so core + providers are always proposed together), and **major** updates for `ai` + `@ai-sdk/*` are disabled until the `ai@6 → ai@7` migration is done deliberately in one reviewed PR. Minor/patch updates still flow.

### What is the effect of this change to users?

AI chat works again. Without this, every provider (Anthropic, Azure, OpenAI, OpenAI-compatible) returns a 500 on the first message.

### How does it look like?

Before (on `main`): `streamText` throws `AI_UnsupportedModelVersionError: Unsupported model version v4 ... only supports specification version "v2"` for any provider.

After: providers resolve to spec `v3` and reach the API call. Verified locally — an Anthropic and an OpenAI model both get past model resolution (failing only on the dummy API key, as expected). `yarn workspace @giantswarm/backstage-plugin-ai-chat-backend test` passes (86/86); `yarn tsc` clean.

### Any background context you can provide?

CI didn't catch the regression because `router.test.ts` mocks the backend services and never resolves a real model through `streamText`. Discovered while adding the Google Vertex provider (giantswarm/giantswarm#37197): the Gemini feature branch depends on this fix landing first. A follow-up could re-attempt the AI SDK v6→v7 upgrade properly (core + providers together), but that's a larger, separate change.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
