### PR TITLE
test(ai-chat): guard provider/core spec-version compatibility

### DIFF
--- a/plugins/ai-chat-backend/src/router.ts
+++ b/plugins/ai-chat-backend/src/router.ts
@@ -6,11 +6,6 @@ import {
 } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { InputError } from '@backstage/errors';
-import { createOpenAI } from '@ai-sdk/openai';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import { createAnthropic } from '@ai-sdk/anthropic';
-import { createAzure } from '@ai-sdk/azure';
-import { createVertex } from '@ai-sdk/google-vertex';
 import {
   convertToModelMessages,
   stepCountIs,
@@ -19,6 +14,11 @@ import {
   UIMessage,
   SystemModelMessage,
 } from 'ai';
+import {
+  selectModel,
+  isAzureConfigured,
+  type SelectModelOptions,
+} from './selectModel';
 import { z } from 'zod/v3';
 import express from 'express';
 import Router from 'express-promise-router';
@@ -179,10 +179,14 @@ export async function createRouter(
   );
   const azureBaseUrl = config.getOptionalString('aiChat.azure.baseUrl');
   const azureApiVersion = config.getOptionalString('aiChat.azure.apiVersion');
-  const isAzureConfigured = !!(
-    azureApiKey &&
-    (azureResourceName || azureBaseUrl)
-  );
+  // Reuse the same "Azure configured" predicate that drives provider selection
+  // so the config-validation warnings below can never disagree with which
+  // provider `selectModel` actually picks.
+  const azureConfigured = isAzureConfigured({
+    apiKey: azureApiKey,
+    resourceName: azureResourceName,
+    baseUrl: azureBaseUrl,
+  });
 
   // Get Google Vertex AI configuration. Vertex is not authenticated with a
   // static API key: `@ai-sdk/google-vertex` uses google-auth-library to read
@@ -219,12 +223,7 @@ export async function createRouter(
     );
   }
 
-  if (
-    !isAnthropicModel &&
-    !isGoogleModel &&
-    isAzureConfigured &&
-    !azureApiKey
-  ) {
+  if (!isAnthropicModel && !isGoogleModel && azureConfigured && !azureApiKey) {
     logger.warn(
       'Azure OpenAI configured but no API key set. Set aiChat.azure.apiKey in app-config.yaml',
     );
@@ -233,7 +232,7 @@ export async function createRouter(
   if (
     !isAnthropicModel &&
     !isGoogleModel &&
-    !isAzureConfigured &&
+    !azureConfigured &&
     !openaiApiKey
   ) {
     // Expected when a customer hasn't set up the AI chat feature: the default
@@ -275,65 +274,41 @@ export async function createRouter(
     effort: anthropicEffort,
   });
 
-  // Create provider clients
-  const openai = createOpenAI({
-    apiKey: openaiApiKey,
-    baseURL: openaiBaseUrl,
-  });
-
-  // OpenAI-compatible provider for `aiChat.openai.api: chat` (vLLM and similar
-  // OpenAI-compatible servers). Unlike `@ai-sdk/openai`'s chat path, this
-  // provider handles the `delta.reasoning` / `delta.reasoning_content` SSE
-  // fields that vLLM emits when `--reasoning-parser` is configured (e.g.
-  // `nemotron_v3` for Nemotron-Super), and forwards them as proper
-  // `reasoning-start` / `reasoning-delta` / `reasoning-end` LanguageModelV3
-  // stream parts. Without this, the reasoning phase appears as silence to
-  // the chat UI and only the post-think answer text streams through.
-  const openaiCompatible = createOpenAICompatible({
-    name: 'openai-compatible',
-    baseURL: openaiBaseUrl ?? '',
-    apiKey: openaiApiKey,
-    // Ask vLLM/KServe (and other OpenAI-compatible chat-completions
-    // servers) to include token usage in streaming responses by adding
-    // `stream_options: { include_usage: true }` to the request body.
-    // Without this, vLLM emits no usage chunk and `getContextUsage` has
-    // no data to show.
-    includeUsage: true,
-    // `min_p` is not part of the AI SDK CallSettings, but vLLM accepts it
-    // as a top-level field on `/v1/chat/completions`. When configured
-    // under `aiChat.sampling.minP`, splice it into the outgoing request
-    // body. Recommended for Qwen3 thinking-mode (Qwen team's recipe is
-    // `temperature=0.6, topP=0.95, topK=20, minP=0`).
-    transformRequestBody:
-      samplingMinP !== undefined
-        ? args => ({ ...args, min_p: samplingMinP })
-        : undefined,
-  });
-
-  const anthropic = createAnthropic({
-    apiKey: anthropicApiKey,
-    baseURL: anthropicBaseUrl,
-  });
-
-  const azure = createAzure({
-    apiKey: azureApiKey,
-    resourceName: azureResourceName,
-    baseURL: azureBaseUrl,
-    apiVersion: azureApiVersion,
-    useDeploymentBasedUrls: true,
-  });
-
-  // Google Vertex AI provider. `googleAuthOptions.keyFilename` points at the
-  // mounted service-account JSON; when omitted, google-auth-library falls back
-  // to Application Default Credentials (GOOGLE_APPLICATION_CREDENTIALS). Tokens
-  // are minted and refreshed by the library, so no static API key is involved.
-  const vertex = createVertex({
-    project: googleProject,
-    location: googleLocation,
-    googleAuthOptions: googleKeyFile
-      ? { keyFilename: googleKeyFile }
-      : undefined,
-  });
+  // Provider selection (precedence + client construction) lives in the pure
+  // `selectModel` helper so the exact `ai` core + `@ai-sdk/*` resolution path can
+  // be unit tested offline -- this is the path that threw
+  // `AI_UnsupportedModelVersionError` for every request in #1926 when the
+  // providers and core disagreed on the language-model spec version.
+  //
+  // Called per request (inside the handler's try/catch below) rather than here:
+  // some provider factories validate eagerly (e.g. Vertex requires a location),
+  // and building the model at router-creation time would turn a misconfiguration
+  // into a hard `createRouter` failure instead of the graceful warning +
+  // per-request error the rest of this setup is careful to produce.
+  const selectModelOptions = {
+    modelName,
+    openai: {
+      apiKey: openaiApiKey,
+      baseUrl: openaiBaseUrl,
+      api: openaiApi,
+    },
+    anthropic: {
+      apiKey: anthropicApiKey,
+      baseUrl: anthropicBaseUrl,
+    },
+    azure: {
+      apiKey: azureApiKey,
+      resourceName: azureResourceName,
+      baseUrl: azureBaseUrl,
+      apiVersion: azureApiVersion,
+    },
+    google: {
+      project: googleProject,
+      location: googleLocation,
+      keyFilename: googleKeyFile,
+    },
+    samplingMinP,
+  } satisfies SelectModelOptions;
 
   router.post('/chat', async (req, res) => {
     // Verify user is authenticated
@@ -450,30 +425,10 @@ export async function createRouter(
       req.headers['x-ai-chat-debug'] === 'true';
 
     try {
-      // Select the appropriate provider based on model type
-      // When Azure is configured, non-Anthropic models route through Azure
-      let openaiCompatibleModel;
-      if (isAzureConfigured) {
-        openaiCompatibleModel = azure.chat(modelName);
-      } else if (openaiApi === 'chat') {
-        // Use @ai-sdk/openai-compatible for vLLM-style chat-completions servers
-        // so reasoning chunks are surfaced (see provider construction above).
-        openaiCompatibleModel = openaiCompatible.chatModel(modelName);
-      } else {
-        openaiCompatibleModel = openai(modelName);
-      }
-      // Provider precedence: claude- -> Anthropic; gemini- -> Vertex (kept
-      // ahead of the Azure/OpenAI chain so a gemini model isn't swallowed by
-      // isAzureConfigured); else the existing Azure / openai-compatible / openai
-      // selection.
-      let selectedModel;
-      if (isAnthropicModel) {
-        selectedModel = anthropic(modelName);
-      } else if (isGoogleModel) {
-        selectedModel = vertex(modelName);
-      } else {
-        selectedModel = openaiCompatibleModel;
-      }
+      // Build the language model and resolve which provider backs it (see the
+      // note at `selectModelOptions` for why this is per request).
+      const { model: selectedModel, providerName } =
+        selectModel(selectModelOptions);
 
       // Convert UI messages to model messages
       const modelMessages = await convertToModelMessages(
@@ -620,12 +575,6 @@ export async function createRouter(
       // the backend sends to the LLM so it can be logged in the browser console.
       // Gated to non-production above, so header size is not a concern here.
       if (isDebugRequest) {
-        let providerName = 'openai';
-        if (isAnthropicModel) providerName = 'anthropic';
-        else if (isGoogleModel) providerName = 'google-vertex';
-        else if (isAzureConfigured) providerName = 'azure';
-        else if (openaiApi === 'chat') providerName = 'openai-compatible';
-
         const toolEntries = Object.entries(allTools).map(([name, t]) => ({
           name,
           description: (t as { description?: string }).description,
@@ -735,10 +684,10 @@ export async function createRouter(
 
   // Health check endpoint
   router.get('/health', (_, res) => {
-    const openaiCompatibleProvider = isAzureConfigured
+    const openaiCompatibleProvider = azureConfigured
       ? 'azure-openai'
       : 'openai';
-    const openaiCompatibleConfigured = isAzureConfigured
+    const openaiCompatibleConfigured = azureConfigured
       ? !!azureApiKey
       : !!openaiApiKey;
     const googleConfigured =
@@ -764,7 +713,7 @@ export async function createRouter(
       configured,
       openaiConfigured: !!openaiApiKey,
       anthropicConfigured: !!anthropicApiKey,
-      azureConfigured: isAzureConfigured,
+      azureConfigured,
       googleConfigured,
     });
   });

--- a/plugins/ai-chat-backend/src/selectModel.test.ts
+++ b/plugins/ai-chat-backend/src/selectModel.test.ts
@@ -1,0 +1,257 @@
+import { streamText, type LanguageModel } from 'ai';
+import {
+  selectModel,
+  type ProviderName,
+  type SelectModelOptions,
+} from './selectModel';
+
+/**
+ * Identify `AI_UnsupportedModelVersionError` by its stable public name.
+ *
+ * NB: the SDK's `UnsupportedModelVersionError.isInstance()` cannot be used here
+ * -- on ai@7 it matches *any* `AISDKError` (it checks the shared base-class
+ * marker), so it would flag the benign offline errors (empty-body
+ * `NoOutputGeneratedError`, a stub's `doStream` throw) as version mismatches.
+ * The `AI_`-prefixed `name` is the specific, documented identifier for this
+ * error (see #37199) and is what the runtime failure in #1926 reported.
+ */
+function isUnsupportedModelVersionError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.name === 'AI_UnsupportedModelVersionError'
+  );
+}
+
+/**
+ * A `fetch` that never touches the network. The compatibility check below only
+ * needs model *resolution* (which happens before any HTTP request), so the
+ * response body is irrelevant -- any real request would be a bug in the test.
+ */
+const fakeFetch: typeof globalThis.fetch = async () =>
+  new Response('', {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+
+/**
+ * Stub google-auth `AuthClient`. `@ai-sdk/google-vertex` mints an OAuth2 token
+ * via google-auth-library before every request; injecting a client that returns
+ * a static token keeps the Vertex branch fully offline (no service-account file,
+ * no metadata-server lookup, no token exchange).
+ */
+const vertexAuthStub = {
+  getAccessToken: async () => ({ token: 'test-token' }),
+  getRequestHeaders: async () => ({ Authorization: 'Bearer test-token' }),
+  request: async () => ({ data: {} }),
+};
+
+/** Baseline options; each test overrides only what it needs. */
+function baseOptions(): SelectModelOptions {
+  return {
+    modelName: 'gpt-4o-mini',
+    openai: { api: 'responses' },
+    anthropic: {},
+    azure: {},
+    google: {},
+    fetch: fakeFetch,
+    googleAuthOptions: { authClient: vertexAuthStub },
+  };
+}
+
+/**
+ * Drive real model resolution through `streamText` and return the
+ * `AI_UnsupportedModelVersionError` it produced, if any -- this is the error the
+ * `ai` core raises when it and the `@ai-sdk/*` provider disagree on the
+ * language-model spec version (the #1926 regression).
+ *
+ * The error is collected from *every* channel, not just a synchronous throw:
+ * `streamText` today validates the spec version synchronously, but that's an
+ * implementation detail -- a future SDK could surface it asynchronously through
+ * the stream's `onError` instead. We record errors from the synchronous throw
+ * and from both `onError` callbacks, then look for the version error among them,
+ * so the guard can't silently pass if resolution ever moves off the sync path.
+ *
+ * Other errors (the fake fetch's empty body producing no finish chunk, a stub's
+ * unreachable `doStream`, ...) are expected offline noise and ignored.
+ */
+async function collectVersionError(
+  model: LanguageModel,
+): Promise<unknown | undefined> {
+  const errors: unknown[] = [];
+  try {
+    const result = streamText({
+      model,
+      messages: [{ role: 'user', content: 'ping' }],
+      onError: ({ error }) => {
+        errors.push(error);
+      },
+    });
+    // Consume so resolution is driven end-to-end.
+    await result.consumeStream({
+      onError: error => {
+        errors.push(error);
+      },
+    });
+  } catch (error) {
+    errors.push(error);
+  }
+  return errors.find(isUnsupportedModelVersionError);
+}
+
+async function expectResolvesWithoutVersionError(model: LanguageModel) {
+  const error = await collectVersionError(model);
+  if (error) {
+    // Surface the SDK's own message -- it names the offending provider, model
+    // and spec version, which is exactly what a bad bump needs to report.
+    throw new Error(
+      `streamText rejected the model on a spec-version mismatch: ${
+        (error as Error).message
+      }`,
+    );
+  }
+}
+
+describe('selectModel provider precedence', () => {
+  const cases: Array<{
+    name: string;
+    options: Partial<SelectModelOptions> & { modelName: string };
+    expected: ProviderName;
+  }> = [
+    {
+      name: 'routes claude- models to Anthropic',
+      options: { modelName: 'claude-sonnet-4-5', anthropic: { apiKey: 'k' } },
+      expected: 'anthropic',
+    },
+    {
+      name: 'routes claude- models to Anthropic even when Azure is configured',
+      options: {
+        modelName: 'claude-sonnet-4-5',
+        anthropic: { apiKey: 'k' },
+        azure: { apiKey: 'k', resourceName: 'r' },
+      },
+      expected: 'anthropic',
+    },
+    {
+      name: 'routes gemini- models to Vertex ahead of the Azure branch',
+      options: {
+        modelName: 'gemini-2.5-flash',
+        google: { project: 'p', location: 'l' },
+        // Azure fully configured: gemini must NOT be swallowed by it.
+        azure: { apiKey: 'k', resourceName: 'r' },
+      },
+      expected: 'google-vertex',
+    },
+    {
+      name: 'routes non-claude/gemini models to Azure when Azure is configured',
+      options: {
+        modelName: 'gpt-4o',
+        azure: { apiKey: 'k', resourceName: 'r' },
+      },
+      expected: 'azure',
+    },
+    {
+      name: 'routes to openai-compatible when openai.api is chat',
+      options: {
+        modelName: 'some-open-model',
+        openai: { api: 'chat', baseUrl: 'http://localhost:8000/v1' },
+      },
+      expected: 'openai-compatible',
+    },
+    {
+      name: 'falls back to OpenAI by default',
+      options: { modelName: 'gpt-4o-mini', openai: { api: 'responses' } },
+      expected: 'openai',
+    },
+  ];
+
+  it.each(cases)('$name', ({ options, expected }) => {
+    const { providerName } = selectModel({ ...baseOptions(), ...options });
+    expect(providerName).toBe(expected);
+  });
+});
+
+describe('selectModel core/provider spec-version compatibility', () => {
+  // These exercise the exact `ai` + `@ai-sdk/*` resolution path that threw
+  // `AI_UnsupportedModelVersionError` for every request in #1926. They are
+  // hermetic (injected fetch, stubbed Vertex auth) so they run in normal CI,
+  // and intentionally couple to the installed AI-SDK generation: a provider
+  // major bump that outpaces the `ai` core will fail these loudly.
+  const providerCases: Array<{
+    name: ProviderName;
+    options: Partial<SelectModelOptions> & { modelName: string };
+  }> = [
+    {
+      name: 'anthropic',
+      options: { modelName: 'claude-sonnet-4-5', anthropic: { apiKey: 'k' } },
+    },
+    {
+      name: 'openai',
+      options: { modelName: 'gpt-4o-mini', openai: { api: 'responses' } },
+    },
+    {
+      name: 'openai-compatible',
+      options: {
+        modelName: 'some-open-model',
+        openai: { api: 'chat', baseUrl: 'http://localhost:8000/v1' },
+      },
+    },
+    {
+      name: 'azure',
+      options: {
+        modelName: 'gpt-4o',
+        azure: { apiKey: 'k', resourceName: 'r' },
+      },
+    },
+    {
+      name: 'google-vertex',
+      options: {
+        modelName: 'gemini-2.5-flash',
+        google: { project: 'p', location: 'europe-west1' },
+      },
+    },
+  ];
+
+  it.each(providerCases)(
+    'resolves the $name model through streamText without a version error',
+    async ({ name, options }) => {
+      const merged = { ...baseOptions(), ...options };
+      const { model, providerName } = selectModel(merged);
+      // Sanity-check the case actually selects the provider under test, so a
+      // future precedence change can't silently skip a branch here.
+      expect(providerName).toBe(name);
+      await expectResolvesWithoutVersionError(model);
+    },
+  );
+
+  it('detects a provider that outruns the core (the guard is not vacuous)', async () => {
+    // Guard against the guard silently passing: reproduce the #1926 shape by
+    // handing `streamText` a model whose spec version is one generation *ahead*
+    // of what the installed core accepts, and assert `collectVersionError`
+    // actually surfaces the `AI_UnsupportedModelVersionError`. Deriving the
+    // "ahead" version from a real provider's current spec keeps this correct
+    // across the next `ai` major bump instead of hardcoding a spec string.
+    const { model } = selectModel({
+      ...baseOptions(),
+      modelName: 'claude-sonnet-4-5',
+      anthropic: { apiKey: 'k' },
+    });
+    const currentSpec = (model as { specificationVersion: string })
+      .specificationVersion;
+    const aheadSpec = `v${Number(currentSpec.replace(/^v/, '')) + 1}`;
+    const aheadModel = {
+      specificationVersion: aheadSpec,
+      provider: 'simulated',
+      modelId: 'simulated-ahead-model',
+      supportedUrls: {},
+      doStream: async () => {
+        throw new Error('resolution should reject before doStream');
+      },
+      doGenerate: async () => {
+        throw new Error('resolution should reject before doGenerate');
+      },
+    } as unknown as LanguageModel;
+
+    const error = await collectVersionError(aheadModel);
+    expect(error).toBeDefined();
+    expect(isUnsupportedModelVersionError(error)).toBe(true);
+  });
+});

--- a/plugins/ai-chat-backend/src/selectModel.ts
+++ b/plugins/ai-chat-backend/src/selectModel.ts
@@ -1,0 +1,163 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createAzure } from '@ai-sdk/azure';
+import { createVertex } from '@ai-sdk/google-vertex';
+import type { LanguageModel } from 'ai';
+
+/**
+ * Provider label matching the values reported in the /chat debug metadata and
+ * used to describe which AI-SDK provider a model was built from.
+ */
+export type ProviderName =
+  'anthropic' | 'google-vertex' | 'azure' | 'openai-compatible' | 'openai';
+
+/**
+ * Resolved AI chat provider configuration, as read from `aiChat.*`. Kept as a
+ * plain value object (rather than a Backstage `Config`) so provider selection
+ * is a pure, dependency-free function that can be unit tested offline.
+ */
+export interface SelectModelOptions {
+  /** `aiChat.model` — drives which provider branch is selected. */
+  modelName: string;
+  openai: {
+    apiKey?: string;
+    baseUrl?: string;
+    /** `aiChat.openai.api`: `chat` routes through @ai-sdk/openai-compatible. */
+    api: 'chat' | 'responses';
+  };
+  anthropic: {
+    apiKey?: string;
+    baseUrl?: string;
+  };
+  azure: {
+    apiKey?: string;
+    resourceName?: string;
+    baseUrl?: string;
+    apiVersion?: string;
+  };
+  google: {
+    project?: string;
+    location?: string;
+    keyFilename?: string;
+  };
+  /**
+   * `aiChat.sampling.minP` — not part of the SDK CallSettings, spliced into the
+   * openai-compatible request body via `transformRequestBody`.
+   */
+  samplingMinP?: number;
+  /**
+   * Test seam: a custom `fetch` forwarded to every provider factory. Lets unit
+   * tests drive model resolution through `streamText` with no real network.
+   */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Test seam: forwarded to `createVertex`'s `googleAuthOptions`. Passing a stub
+   * auth client here keeps the Vertex branch offline (no service-account read,
+   * no token minting). When omitted, the mounted service-account JSON at
+   * `google.keyFilename` is used, matching production.
+   */
+  googleAuthOptions?: Record<string, unknown>;
+}
+
+export interface SelectedModel {
+  model: LanguageModel;
+  providerName: ProviderName;
+}
+
+/**
+ * Determine whether the Azure OpenAI branch is usable. Azure needs an API key
+ * plus either a resource name or an explicit base URL.
+ */
+export function isAzureConfigured(azure: SelectModelOptions['azure']): boolean {
+  return !!(azure.apiKey && (azure.resourceName || azure.baseUrl));
+}
+
+/**
+ * Build the AI-SDK language model for the configured `aiChat.model` and report
+ * which provider it came from.
+ *
+ * Provider precedence (kept identical to the /chat handler):
+ *   `claude-*`  -> Anthropic
+ *   `gemini-*`  -> Google Vertex (ahead of the Azure/OpenAI chain so a gemini
+ *                  model isn't swallowed by an Azure configuration)
+ *   otherwise   -> Azure (if configured) / openai-compatible (`openai.api: chat`)
+ *                  / OpenAI
+ *
+ * This is a pure function so the exact `ai` core + `@ai-sdk/*` provider
+ * resolution path that `streamText` exercises can be unit tested offline — the
+ * spec-version mismatch that broke #1926 throws during that resolution, before
+ * any HTTP request.
+ */
+export function selectModel(options: SelectModelOptions): SelectedModel {
+  const { modelName, fetch } = options;
+  const isAnthropicModel = modelName.startsWith('claude-');
+  const isGoogleModel = modelName.startsWith('gemini-');
+
+  if (isAnthropicModel) {
+    const anthropic = createAnthropic({
+      apiKey: options.anthropic.apiKey,
+      baseURL: options.anthropic.baseUrl,
+      fetch,
+    });
+    return { model: anthropic(modelName), providerName: 'anthropic' };
+  }
+
+  if (isGoogleModel) {
+    // Vertex is not authenticated with a static API key: `@ai-sdk/google-vertex`
+    // uses google-auth-library to read the mounted service-account JSON and mint
+    // short-lived OAuth2 tokens.
+    const vertex = createVertex({
+      project: options.google.project,
+      location: options.google.location,
+      googleAuthOptions:
+        options.googleAuthOptions ??
+        (options.google.keyFilename
+          ? { keyFilename: options.google.keyFilename }
+          : undefined),
+      fetch,
+    });
+    return { model: vertex(modelName), providerName: 'google-vertex' };
+  }
+
+  if (isAzureConfigured(options.azure)) {
+    const azure = createAzure({
+      apiKey: options.azure.apiKey,
+      resourceName: options.azure.resourceName,
+      baseURL: options.azure.baseUrl,
+      apiVersion: options.azure.apiVersion,
+      useDeploymentBasedUrls: true,
+      fetch,
+    });
+    return { model: azure.chat(modelName), providerName: 'azure' };
+  }
+
+  if (options.openai.api === 'chat') {
+    // Use @ai-sdk/openai-compatible for vLLM-style chat-completions servers so
+    // reasoning chunks are surfaced and token usage is included in the stream.
+    const openaiCompatible = createOpenAICompatible({
+      name: 'openai-compatible',
+      baseURL: options.openai.baseUrl ?? '',
+      apiKey: options.openai.apiKey,
+      includeUsage: true,
+      // `min_p` is not part of the AI SDK CallSettings, but vLLM accepts it as a
+      // top-level field on `/v1/chat/completions`.
+      transformRequestBody:
+        options.samplingMinP !== undefined
+          ? args => ({ ...args, min_p: options.samplingMinP })
+          : undefined,
+      fetch,
+    });
+    return {
+      model: openaiCompatible.chatModel(modelName),
+      providerName: 'openai-compatible',
+    };
+  }
+
+  const openai = createOpenAI({
+    apiKey: options.openai.apiKey,
+    baseURL: options.openai.baseUrl,
+    fetch,
+  });
+  return { model: openai(modelName), providerName: 'openai' };
+}


### PR DESCRIPTION
### What does this PR do?

Adds defense-in-depth test coverage for the AI-SDK provider ↔ core language-model **spec-version** compatibility in `plugins/ai-chat-backend`.

- **Enabling refactor:** extracts provider selection out of the `/chat` handler into a pure `selectModel()` helper (`selectModel.ts`) that builds the AI-SDK model and reports which provider backs it. Selection precedence is unchanged (`claude-` → Anthropic, `gemini-` → Vertex ahead of Azure, else Azure / openai-compatible / OpenAI).
- **New test (`selectModel.test.ts`):** drives each selectable provider model (Anthropic, OpenAI, Azure, openai-compatible, Vertex) through `streamText` and asserts it resolves **without** `AI_UnsupportedModelVersionError`, plus covers the selection precedence. Fully hermetic — injected `fetch`, stubbed Vertex auth client; no network, no credentials — so it runs in the normal `yarn test` suite.

The test does not hardcode a spec-version string — it only asserts the core *accepts* the provider's model — so it's correct across generations and needed no change when rebased onto the `ai@7` migration below.

`selectModel()` is called per request inside the handler's `try/catch` (not at router-creation time) so an incomplete provider config still produces the existing graceful warning + per-request error rather than a hard `createRouter` failure.

### What is the effect of this change to users?

No end-user-facing change. Internal refactor + test coverage only.

### How does it look like?

```
Tests:       100 passed, 100 total   (11 new)
```

Rebased on top of **#1945** (backend `ai@6 → ai@7` migration), so this now guards the current stack: `ai@7` (spec `v4`) + providers at their `v4`-spec majors (`@ai-sdk/anthropic@4`, `azure@4`, `openai@4`, `openai-compatible@3`, `google-vertex@5`). All five resolve cleanly through `streamText`. This is exactly the migration the issue flagged as the moment such a guard earns its keep.

The test intentionally couples to the installed AI-SDK generation and fails loudly on a mismatch. Verified locally by driving a model whose advertised spec version the core rejects → `streamText` throws `AI_UnsupportedModelVersionError` during resolution, before any HTTP request — exactly the #1926 shape.

### Any background context you can provide?

In #1926 a Renovate bump moved the `@ai-sdk/*` providers a spec version ahead of the `ai` core, so **every** chat request failed at runtime with `AI_UnsupportedModelVersionError`. It was reverted in #1944 (+ a Renovate major-hold). CI missed it because `router.test.ts` only inspects the logger — it never builds a provider model or calls `streamText`, which is where the error is thrown (during model resolution, before any HTTP request). This test exercises that exact path.

Implements giantswarm/giantswarm#37199. Related: #1926, #1943, #1944, #1945. Complements, does not replace, the Renovate major-hold from #1944.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.

No changeset: `@giantswarm/backstage-plugin-ai-chat-backend` is a private package (not published to npm), and this is a test/internal-refactor change with no runtime behavior change.