### PR TITLE
fix(deps): bump websocket-driver to 0.7.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -49910,13 +49910,13 @@ __metadata:
   linkType: hard
 
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10c0/5f09547912b27bdc57bac17b7b6527d8993aa4ac8a2d10588bb74aebaf785fdcf64fea034aae0c359b7adff2044dd66f3d03866e4685571f81b13e548f9021f1
+  checksum: 10c0/843a3c9f529ce07f2721829f70f62986247525ab22625e857b69da13dc90967bacfe57b85e196801b565cd797e309ddd5b06fa8435732e34e8a8ab6201d7abed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Bumps the transitive dependency `websocket-driver` from 0.7.4 to 0.7.5 to resolve [Dependabot alert #504](https://github.com/giantswarm/backstage/security/dependabot/504).

Only `yarn.lock` changed. `websocket-driver` is pulled in transitively by `faye-websocket` (`>=0.5.1`) and `sockjs` (`^0.7.4`); both ranges already permit 0.7.5, so the bump was applied with `yarn up -R websocket-driver`. `yarn install --immutable` passes.

Dependabot reported it could not go past 0.7.4 — 0.7.5 was published on 2026-06-04, after the alert was opened, and Dependabot did not perform the recursive transitive resolution needed.

### What is the effect of this change to users?

None

### Any background context you can provide?

Resolves Dependabot alert No. 504 (CVE-2026-54466)

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

No changeset needed — this is a lockfile-only transitive dependency bump and does not affect any published `@giantswarm/backstage-plugin-*` package.
