### PR TITLE
fix: keep self-managed Kustomizations as Flux tree roots and guard empty tree

### DIFF
--- a/.changeset/calm-orchard-learn.md
+++ b/.changeset/calm-orchard-learn.md
@@ -2,4 +2,4 @@
 '@giantswarm/backstage-plugin-flux-react': patch
 ---
 
-Fix the Flux resources tree crashing with "TreeWalker must yield at least one root node" when the tree is empty. Two causes fixed: a self-managed Kustomization (one that lists itself in its own inventory, the Flux bootstrap pattern) no longer disqualifies itself as a tree root — previously this could collapse the whole tree to zero roots; and an empty tree (also reachable via the "Failing only" filter on a healthy cluster) now renders an empty state instead of crashing. Inventory references are now matched by namespace and name instead of name only, and a self-managed Kustomization no longer appears as its own child.
+Fix the Flux resources tree crashing with "TreeWalker must yield at least one root node". Root detection now matches inventory references by namespace and name instead of name only — previously any inventory entry disqualified unrelated Kustomizations sharing its name in other namespaces, which could collapse the tree to zero roots on multi-org clusters. An empty tree (also reachable via the "Failing only" filter on a cluster without failures) now renders an empty state instead of crashing.

--- a/.changeset/calm-orchard-learn.md
+++ b/.changeset/calm-orchard-learn.md
@@ -1,0 +1,5 @@
+---
+'@giantswarm/backstage-plugin-flux-react': patch
+---
+
+Fix the Flux resources tree crashing with "TreeWalker must yield at least one root node" when the tree is empty. Two causes fixed: a self-managed Kustomization (one that lists itself in its own inventory, the Flux bootstrap pattern) no longer disqualifies itself as a tree root — previously this could collapse the whole tree to zero roots; and an empty tree (also reachable via the "Failing only" filter on a healthy cluster) now renders an empty state instead of crashing. Inventory references are now matched by namespace and name instead of name only, and a self-managed Kustomization no longer appears as its own child.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ### Fixed
 
-- Flux: fixed the resources tree crashing with "TreeWalker must yield at least one root node" when a self-managed Kustomization (one that lists itself in its own inventory) collapsed the tree to zero roots. Self-managed Kustomizations now stay tree roots without showing up as their own child, inventory references are matched by namespace and name, and an empty tree (e.g. "Failing only" on a healthy cluster) renders an empty state instead of crashing (#1951).
+- Flux: fixed the resources tree crashing with "TreeWalker must yield at least one root node". Tree root detection now matches inventory references by namespace and name instead of name only — name collisions across namespaces could disqualify every root and collapse the tree — and an empty tree (e.g. "Failing only" on a cluster without failures) renders an empty state instead of crashing (#1951).
 
 ## [0.138.0] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 
 ### Fixed
 
-- Flux: fixed the resources tree crashing with "TreeWalker must yield at least one root node" when a self-managed Kustomization (one that lists itself in its own inventory) collapsed the tree to zero roots. Self-managed Kustomizations now stay tree roots without showing up as their own child, inventory references are matched by namespace and name, and an empty tree (e.g. "Failing only" on a healthy cluster) renders an empty state instead of crashing (#1949).
+- Flux: fixed the resources tree crashing with "TreeWalker must yield at least one root node" when a self-managed Kustomization (one that lists itself in its own inventory) collapsed the tree to zero roots. Self-managed Kustomizations now stay tree roots without showing up as their own child, inventory references are matched by namespace and name, and an empty tree (e.g. "Failing only" on a healthy cluster) renders an empty state instead of crashing (#1951).
 
 ## [0.138.0] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Package specific changes (for packages from `packages/*` and `plugins/*`) can be
 - Flux: the resources tree search now also matches the Ready condition error messages of failing resources. Flux embeds the names of resources it fails to apply in its build/apply errors, so searching for a service that never got created leads to the Kustomization that is blocking it (#1934).
 - AI chat: let users ask the AI to explain Flux error messages. The Flux resource card's "Troubleshoot with AI" button now sends the actual failing condition message (instead of asking the AI to look the resource up), and the HelmRelease conditions card on the deployment details page gets an "Explain this error" button on failing conditions. The buttons render nothing on installations without ai-chat enabled (#1935).
 
+### Fixed
+
+- Flux: fixed the resources tree crashing with "TreeWalker must yield at least one root node" when a self-managed Kustomization (one that lists itself in its own inventory) collapsed the tree to zero roots. Self-managed Kustomizations now stay tree roots without showing up as their own child, inventory references are matched by namespace and name, and an empty tree (e.g. "Failing only" on a healthy cluster) renders an empty state instead of crashing (#1949).
+
 ## [0.138.0] - 2026-06-21
 
 ### Changed

--- a/plugins/flux-react/src/components/FluxOverview/FluxOverview.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/FluxOverview.tsx
@@ -63,40 +63,40 @@ export const FluxOverview = ({
         />
       ) : null}
 
-      {/* An empty tree must not reach OverviewTree — react-vtree throws when
-          the tree walker yields no root node. */}
-      {tree && tree.length === 0 ? (
-        <EmptyState
-          missing="content"
-          title={
-            statusFilter === 'failing'
-              ? 'No failing resources'
-              : 'No resources to display'
-          }
-          description={
-            statusFilter === 'failing'
-              ? 'All Flux resources on this cluster are healthy.'
-              : 'No Flux resources were found on this cluster.'
-          }
-        />
-      ) : null}
-
-      {tree && tree.length > 0 ? (
-        <ContentContainer
-          renderContent={containerHeight => (
-            <OverviewTree
-              ref={treeRef}
-              tree={tree}
-              compactView={compactView}
-              selectedResourceRef={selectedResourceRef}
-              height={containerHeight}
-              onSelectResource={onSelectResource}
-              searchMatchIds={searchMatchIds}
-              currentMatchId={currentMatchId}
-              pathsToExpand={pathsToExpand}
-            />
-          )}
-        />
+      {tree ? (
+        // An empty tree must not reach OverviewTree — react-vtree throws
+        // when the tree walker yields no root node.
+        tree.length === 0 ? (
+          <EmptyState
+            missing="content"
+            title={
+              statusFilter === 'failing'
+                ? 'No failing resources'
+                : 'No resources to display'
+            }
+            description={
+              statusFilter === 'failing'
+                ? 'No Flux resources are currently failing.'
+                : 'No Flux resources were found on this cluster.'
+            }
+          />
+        ) : (
+          <ContentContainer
+            renderContent={containerHeight => (
+              <OverviewTree
+                ref={treeRef}
+                tree={tree}
+                compactView={compactView}
+                selectedResourceRef={selectedResourceRef}
+                height={containerHeight}
+                onSelectResource={onSelectResource}
+                searchMatchIds={searchMatchIds}
+                currentMatchId={currentMatchId}
+                pathsToExpand={pathsToExpand}
+              />
+            )}
+          />
+        )
       ) : null}
     </Box>
   );

--- a/plugins/flux-react/src/components/FluxOverview/FluxOverview.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/FluxOverview.tsx
@@ -28,6 +28,7 @@ export const FluxOverview = ({
     tree,
     isLoading,
     resourceType,
+    statusFilter,
     searchMatches,
     currentMatchId,
     pathsToExpand,
@@ -62,7 +63,25 @@ export const FluxOverview = ({
         />
       ) : null}
 
-      {tree ? (
+      {/* An empty tree must not reach OverviewTree — react-vtree throws when
+          the tree walker yields no root node. */}
+      {tree && tree.length === 0 ? (
+        <EmptyState
+          missing="content"
+          title={
+            statusFilter === 'failing'
+              ? 'No failing resources'
+              : 'No resources to display'
+          }
+          description={
+            statusFilter === 'failing'
+              ? 'All Flux resources on this cluster are healthy.'
+              : 'No Flux resources were found on this cluster.'
+          }
+        />
+      ) : null}
+
+      {tree && tree.length > 0 ? (
         <ContentContainer
           renderContent={containerHeight => (
             <OverviewTree

--- a/plugins/flux-react/src/components/FluxOverview/FluxOverview.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/FluxOverview.tsx
@@ -51,6 +51,45 @@ export const FluxOverview = ({
     return undefined;
   }, [currentMatchId]);
 
+  // Deriving the content from `tree` in one place keeps the empty state and
+  // the tree mutually exclusive. An empty tree must not reach OverviewTree —
+  // react-vtree throws when the tree walker yields no root node.
+  let treeContent = null;
+  if (tree) {
+    treeContent =
+      tree.length === 0 ? (
+        <EmptyState
+          missing="content"
+          title={
+            statusFilter === 'failing'
+              ? 'No failing resources'
+              : 'No resources to display'
+          }
+          description={
+            statusFilter === 'failing'
+              ? 'No Flux resources are currently failing.'
+              : 'No Flux resources were found on this cluster.'
+          }
+        />
+      ) : (
+        <ContentContainer
+          renderContent={containerHeight => (
+            <OverviewTree
+              ref={treeRef}
+              tree={tree}
+              compactView={compactView}
+              selectedResourceRef={selectedResourceRef}
+              height={containerHeight}
+              onSelectResource={onSelectResource}
+              searchMatchIds={searchMatchIds}
+              currentMatchId={currentMatchId}
+              pathsToExpand={pathsToExpand}
+            />
+          )}
+        />
+      );
+  }
+
   return (
     <Box display="flex" flexDirection="column" height="100%">
       {isLoading ? <Progress /> : null}
@@ -63,41 +102,7 @@ export const FluxOverview = ({
         />
       ) : null}
 
-      {tree ? (
-        // An empty tree must not reach OverviewTree — react-vtree throws
-        // when the tree walker yields no root node.
-        tree.length === 0 ? (
-          <EmptyState
-            missing="content"
-            title={
-              statusFilter === 'failing'
-                ? 'No failing resources'
-                : 'No resources to display'
-            }
-            description={
-              statusFilter === 'failing'
-                ? 'No Flux resources are currently failing.'
-                : 'No Flux resources were found on this cluster.'
-            }
-          />
-        ) : (
-          <ContentContainer
-            renderContent={containerHeight => (
-              <OverviewTree
-                ref={treeRef}
-                tree={tree}
-                compactView={compactView}
-                selectedResourceRef={selectedResourceRef}
-                height={containerHeight}
-                onSelectResource={onSelectResource}
-                searchMatchIds={searchMatchIds}
-                currentMatchId={currentMatchId}
-                pathsToExpand={pathsToExpand}
-              />
-            )}
-          />
-        )
-      ) : null}
+      {treeContent}
     </Box>
   );
 };

--- a/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.test.ts
+++ b/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.test.ts
@@ -172,11 +172,13 @@ describe('KustomizationTreeBuilder', () => {
     expect(findNode(tree, 'my-app')).toBeDefined();
   });
 
-  describe('self-managed root kustomizations', () => {
+  describe('root detection', () => {
     it('keeps a self-referencing kustomization as root and hides the self-child', () => {
       // A self-managed root (Flux bootstrap pattern) lists itself in its own
-      // inventory. It must still be a root — otherwise the whole tree
-      // disappears — and it must not show up as its own child.
+      // inventory. The self-entry is stripped at parse time by
+      // parseInventoryEntries, not by the builder — this test guards the
+      // combined invariant so a parser change cannot silently collapse the
+      // tree (a disqualified root disappears together with its subtree).
       const root = createMockKustomization({
         name: 'gitops',
         readyCondition: { status: 'True' },

--- a/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.test.ts
+++ b/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.test.ts
@@ -172,6 +172,94 @@ describe('KustomizationTreeBuilder', () => {
     expect(findNode(tree, 'my-app')).toBeDefined();
   });
 
+  describe('self-managed root kustomizations', () => {
+    it('keeps a self-referencing kustomization as root and hides the self-child', () => {
+      // A self-managed root (Flux bootstrap pattern) lists itself in its own
+      // inventory. It must still be a root — otherwise the whole tree
+      // disappears — and it must not show up as its own child.
+      const root = createMockKustomization({
+        name: 'gitops',
+        readyCondition: { status: 'True' },
+        inventory: [
+          {
+            namespace: 'flux-system',
+            name: 'gitops',
+            group: KUSTOMIZATION_GROUP,
+            kind: 'Kustomization',
+          },
+          {
+            namespace: 'flux-system',
+            name: 'child',
+            group: KUSTOMIZATION_GROUP,
+            kind: 'Kustomization',
+          },
+        ],
+      });
+      const child = createMockKustomization({
+        name: 'child',
+        readyCondition: { status: 'True' },
+      });
+
+      const builder = new KustomizationTreeBuilder(
+        [root, child],
+        [],
+        [],
+        [],
+        [],
+      );
+      const tree = builder.buildTree();
+
+      expect(tree).toHaveLength(1);
+      expect(tree[0].nodeData.name).toEqual('gitops');
+      expect(tree[0].children.map(c => c.nodeData.name)).toEqual(['child']);
+    });
+
+    it('matches inventory references by namespace and name', () => {
+      // A kustomization in another namespace that happens to share a name
+      // with an inventory entry must not lose its root status.
+      const root = createMockKustomization({
+        name: 'apps',
+        namespace: 'org-a',
+        readyCondition: { status: 'True' },
+        inventory: [
+          {
+            namespace: 'org-a',
+            name: 'child',
+            group: KUSTOMIZATION_GROUP,
+            kind: 'Kustomization',
+          },
+        ],
+      });
+      const sameNameOtherNamespace = createMockKustomization({
+        name: 'child',
+        namespace: 'org-b',
+        readyCondition: { status: 'True' },
+      });
+      const child = createMockKustomization({
+        name: 'child',
+        namespace: 'org-a',
+        readyCondition: { status: 'True' },
+      });
+
+      const builder = new KustomizationTreeBuilder(
+        [root, child, sameNameOtherNamespace],
+        [],
+        [],
+        [],
+        [],
+      );
+      const tree = builder.buildTree();
+
+      expect(tree.map(node => node.nodeData.name).sort()).toEqual([
+        'apps',
+        'child',
+      ]);
+      expect(
+        tree.find(node => node.nodeData.name === 'child')?.nodeData.namespace,
+      ).toEqual('org-b');
+    });
+  });
+
   describe('failing status rollup', () => {
     it('marks a failing leaf and all its ancestors', () => {
       const tree = buildFixtureTree({ helmReleaseReadyStatus: 'False' });

--- a/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.ts
+++ b/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.ts
@@ -157,23 +157,22 @@ export class KustomizationTreeBuilder {
 
   private findRoots(): Kustomization[] {
     // Find kustomizations that are not listed in another kustomization's
-    // inventory. A kustomization that lists itself in its own inventory
-    // (a self-managed root, e.g. the Flux bootstrap pattern) still counts
-    // as a root — otherwise a self-managed top-level kustomization would
-    // make itself and its whole subtree disappear from the tree.
+    // inventory. References are matched by namespace and name — name-only
+    // matching would let any inventory entry disqualify unrelated
+    // kustomizations that share its name in other namespaces, which can
+    // collapse the whole tree to zero roots on multi-org clusters.
+    // (A kustomization's own self-reference — the self-managed bootstrap
+    // pattern — is already stripped at parse time by parseInventoryEntries.)
     const referencedKeys = new Set(
-      Array.from(this.inventories.entries()).flatMap(
-        ([ownerKey, inventoryEntries]) => {
-          if (!inventoryEntries) {
-            return [];
-          }
+      Array.from(this.inventories.values()).flatMap(inventoryEntries => {
+        if (!inventoryEntries) {
+          return [];
+        }
 
-          return inventoryEntries
-            .filter(e => e.kind === Kustomization.kind)
-            .map(e => this.getKey(e.name, e.namespace))
-            .filter(entryKey => entryKey !== ownerKey);
-        },
-      ),
+        return inventoryEntries
+          .filter(e => e.kind === Kustomization.kind)
+          .map(e => this.getKey(e.name, e.namespace));
+      }),
     );
 
     return Array.from(this.kustomizations.entries())
@@ -274,18 +273,8 @@ export class KustomizationTreeBuilder {
 
     visited.add(key);
 
-    // Find children - kustomizations that depend on this one. A self-managed
-    // kustomization lists itself in its own inventory; skip that entry so it
-    // does not appear as its own child.
-    const childResources = this.sortChildResources(
-      this.findChildren(key).filter(
-        child =>
-          !(
-            child.kind === Kustomization.kind &&
-            this.getKey(child.name, child.namespace) === key
-          ),
-      ),
-    );
+    // Find children - kustomizations that depend on this one
+    const childResources = this.sortChildResources(this.findChildren(key));
 
     // Filter out ImagePolicies that have a parent ImageRepository in the same inventory
     // (they will be shown as children of the ImageRepository instead)

--- a/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.ts
+++ b/plugins/flux-react/src/components/FluxOverview/utils/KustomizationTreeBuilder/KustomizationTreeBuilder.ts
@@ -156,23 +156,29 @@ export class KustomizationTreeBuilder {
   }
 
   private findRoots(): Kustomization[] {
-    // Find kustomizations that are not listed in other kustomizations inventory
-    const kustomizationInventoryEntries = Array.from(
-      this.inventories.values(),
-    ).flatMap(inventoryEntries => {
-      if (!inventoryEntries) {
-        return [];
-      }
+    // Find kustomizations that are not listed in another kustomization's
+    // inventory. A kustomization that lists itself in its own inventory
+    // (a self-managed root, e.g. the Flux bootstrap pattern) still counts
+    // as a root — otherwise a self-managed top-level kustomization would
+    // make itself and its whole subtree disappear from the tree.
+    const referencedKeys = new Set(
+      Array.from(this.inventories.entries()).flatMap(
+        ([ownerKey, inventoryEntries]) => {
+          if (!inventoryEntries) {
+            return [];
+          }
 
-      return inventoryEntries.filter(e => e.kind === 'Kustomization');
-    });
-
-    return Array.from(this.kustomizations.values()).filter(
-      k =>
-        !Boolean(
-          kustomizationInventoryEntries.find(e => e.name === k.getName()),
-        ),
+          return inventoryEntries
+            .filter(e => e.kind === Kustomization.kind)
+            .map(e => this.getKey(e.name, e.namespace))
+            .filter(entryKey => entryKey !== ownerKey);
+        },
+      ),
     );
+
+    return Array.from(this.kustomizations.entries())
+      .filter(([key]) => !referencedKeys.has(key))
+      .map(([, k]) => k);
   }
 
   private findChildren(parentKey: string): ObjectMetadata[] {
@@ -268,8 +274,18 @@ export class KustomizationTreeBuilder {
 
     visited.add(key);
 
-    // Find children - kustomizations that depend on this one
-    const childResources = this.sortChildResources(this.findChildren(key));
+    // Find children - kustomizations that depend on this one. A self-managed
+    // kustomization lists itself in its own inventory; skip that entry so it
+    // does not appear as its own child.
+    const childResources = this.sortChildResources(
+      this.findChildren(key).filter(
+        child =>
+          !(
+            child.kind === Kustomization.kind &&
+            this.getKey(child.name, child.namespace) === key
+          ),
+      ),
+    );
 
     // Filter out ImagePolicies that have a parent ImageRepository in the same inventory
     // (they will be shown as children of the ImageRepository instead)


### PR DESCRIPTION
### What does this PR do?

Fixes the Flux resources tree view crashing with `Error: TreeWalker must yield at least one root node on the first iteration`.

Two fixes (reframed after review — thanks @marians):

1. **Namespace-aware root detection.** `findRoots` matched inventory references by **name only**, so any inventory entry disqualified every Kustomization sharing that name in *any* namespace. On multi-org clusters with cross-namespace name reuse this can disqualify all Kustomizations, collapsing the tree to zero roots. References are now matched by namespace **and** name.
2. **Empty-tree crash guard.** `FluxOverview` guarded rendering with `{tree ? ...}` — an empty array is truthy — so a zero-root tree reached react-vtree, which throws when the tree walker yields nothing. An empty tree (also reachable via the "Failing only" filter on a cluster without failures) now renders an `EmptyState` instead.

Not in this PR (dropped after review): self-reference guards for self-managed Kustomizations — `parseInventoryEntries` already strips a Kustomization's own inventory self-entry at parse time, so those guards were dead code. A test remains that pins the combined invariant (self-managed root stays a root, no self-child), so a future parser change can't silently collapse the tree.

### What is the effect of this change to users?

The Flux tree view no longer crashes on clusters where root detection previously found no roots, and the "Failing only" filter shows a friendly empty state on clusters without failures instead of an error.

### Any background context you can provide?

Observed on the internal devportal (error reported on the tree view; the error boundary showed react-vtree's TreeWalker error). The empty-tree guard also hardens the "Failing only" filter added in #1933. Related to the https://github.com/giantswarm/giantswarm/issues/35859 series.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
