### PR TITLE
fix(agent-platform): top-align content in selectable cards

### DIFF
--- a/.changeset/skill-card-top-align.md
+++ b/.changeset/skill-card-top-align.md
@@ -1,0 +1,9 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': patch
+---
+
+Top-align the content in selectable model and skill cards on the new-agent
+page. The grid stretches every card in a row to the tallest card's height, and
+the native `<button>` cards were centering their content in that extra space.
+The cards now lay their content out as a flex column so it stays pinned to the
+top.

--- a/plugins/agent-platform/src/components/SelectableCard/SelectableCard.tsx
+++ b/plugins/agent-platform/src/components/SelectableCard/SelectableCard.tsx
@@ -15,7 +15,10 @@ const useStyles = makeStyles(theme => ({
     gap: theme.spacing(1.5),
   },
   card: {
-    display: 'block',
+    // Flex column so content stays pinned to the top when the grid stretches
+    // cards to equal row height (native buttons otherwise center content).
+    display: 'flex',
+    flexDirection: 'column',
     width: '100%',
     textAlign: 'left',
     cursor: 'pointer',


### PR DESCRIPTION
### What does this PR do?

Fixes a small style glitch on the new-agent page (`/agent-platform/agents/new`): the model and skill cards had their content vertically centered.

The `SelectableCardGrid` stretches every card in a row to the tallest card's height (default `align-items: stretch`), and the cards are native `<button>` elements which center their content in the resulting extra vertical space. The card now lays its content out as a flex column, so content stays pinned to the top regardless of row height.

Affects both the model picker and the skill picker, since both use `SelectableCard`.

### What is the effect of this change to users?

Skill and model cards read more cleanly — their title/description/source align to the top of each card instead of floating in the middle of taller cards in the same row.

### How does it look like?

Before, the "demo" card's content sat centered (equal gap top and bottom); after, it's flush to the top with the slack falling to the bottom. Verified in the running app via DevTools: all cards now share the same content top-offset (~13px card padding).

### Any background context you can provide?

None.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.