### PR TITLE
chore: group PagerDuty Renovate updates

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -65,6 +65,17 @@
       matchPackageNames: ['@backstage{/,}**'],
     },
     {
+      // Group the PagerDuty frontend plugin together with its backend
+      // counterpart so they are always proposed in one PR. The two packages
+      // are released in lockstep and share the same integration surface, so
+      // bumping one without the other risks a version mismatch.
+      groupName: 'pagerduty packages',
+      matchPackageNames: [
+        '@pagerduty/backstage-plugin',
+        '@pagerduty/backstage-plugin-backend',
+      ],
+    },
+    {
       groupName: 'testing-library packages',
       matchPackageNames: ['@testing-library{/,}**'],
     },


### PR DESCRIPTION
### What does this PR do?

Adds a new grouping to `renovate-custom.json5` so that `@pagerduty/backstage-plugin` (frontend) and `@pagerduty/backstage-plugin-backend` are always proposed together in a single Renovate PR.

### What is the effect of this change to users?

(Remove this section if no end-user facing change)

### Any background context you can provide?

The two PagerDuty packages are released in lockstep and share the same integration surface, so bumping one without the other risks a version mismatch. Grouping them mirrors how we already group related package families (backstage, ai-sdk, assistant-ui, testing-library, date-fns).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

_No changeset — this only affects Renovate config, not a published package._