### PR TITLE
fix(agent-platform): query only confirmed-healthy installations for fleet lists

### DIFF
--- a/.changeset/agent-platform-healthy-installations.md
+++ b/.changeset/agent-platform-healthy-installations.md
@@ -1,0 +1,23 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': patch
+'@giantswarm/backstage-plugin-kubernetes-react': minor
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Query only confirmed-healthy installations for the Agent Platform fleet lists,
+and stop flagging kagent-absent clusters as read failures.
+
+- `agent-platform`: `useReachableInstallations` now treats only `healthy` (not
+  `connecting`) cluster-access state as reachable, so the agents list and the
+  create-flow installation select no longer query or flag known-degraded /
+  unreachable installations (the list stops churning wide-then-narrow on load).
+  The "couldn't read" card is refined to `errored ∩ currently-healthy`.
+- `agent-platform`: a `404` — the `kagent.dev` API group isn't installed on an
+  otherwise-reachable cluster — is treated as a successful empty read. Such an
+  installation contributes zero Agents / ModelConfigs and is no longer surfaced
+  as "couldn't read"; only `403` (forbidden) and unreachable clusters are
+  flagged. Applies to both the agents list and the create flow.
+- `kubernetes-react`: add `isNotFoundError(errorInfo)` to classify a 404
+  list/get error, distinct from a 403 or a transport failure.
+- `gs`: raise the cluster-access probe timeout from 2s to 5s so slow-but-healthy
+  clusters aren't transiently flagged degraded during load spikes.

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
@@ -220,6 +220,30 @@ describe('AgentsDataProvider', () => {
     expect(hook.current.isLoadingMore).toBe(false);
   });
 
+  it('drops a failing installation from the card once it leaves the reachable set', async () => {
+    // gaggle fails while still reachable → surfaced in the card.
+    mockUseResources.mockReturnValue(
+      result({ succeeded: { alpha: ['a1'] }, failed: ['gaggle'] }),
+    );
+
+    const { result: hook, rerender } = renderUseAgents();
+
+    await waitFor(() =>
+      expect(hook.current.unreachableInstallations).toEqual(['gaggle']),
+    );
+
+    // gaggle degrades mid-session: it leaves the reachable (healthy) set and is
+    // no longer queried. The sidebar Cluster-access widget owns that state, so it
+    // must drop out of the "couldn't read" card rather than duplicate it.
+    mockReachable = { installations: ['alpha', 'beta'], isProbing: false };
+    mockUseResources.mockReturnValue(result({ succeeded: { alpha: ['a1'] } }));
+    rerender();
+
+    await waitFor(() =>
+      expect(hook.current.unreachableInstallations).toEqual([]),
+    );
+  });
+
   it('does not report an installation as unreachable while its agents are still shown', async () => {
     // alpha succeeded first...
     mockUseResources.mockReturnValue(result({ succeeded: { alpha: ['a1'] } }));

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import { buildResourceErrors } from '../resourceErrorFixtures';
 import { AgentsDataProvider, useAgents } from './AgentsDataProvider';
 
 // Mock the fleet-query plumbing so the test drives the loading/partial-result
@@ -32,6 +33,8 @@ jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
   Agent: class {},
   ModelConfig: class {},
   useResources: (...args: unknown[]) => mockUseResources(...args),
+  isNotFoundError: (e: { type?: string; error?: { name?: string } }) =>
+    e.type !== 'incompatibility' && e.error?.name === 'NotFoundError',
 }));
 
 type AgentSpec = {
@@ -83,13 +86,7 @@ function result({
       metadata: { name: spec.name, resourceVersion: spec.resourceVersion },
     })),
   }));
-  const errors = [
-    ...failed.map(cluster => ({ cluster, error: { name: 'ForbiddenError' } })),
-    ...notFound.map(cluster => ({
-      cluster,
-      error: { name: 'NotFoundError' },
-    })),
-  ];
+  const errors = buildResourceErrors({ failed, notFound });
   return { resources, clustersData, isLoading, errors };
 }
 
@@ -241,6 +238,35 @@ describe('AgentsDataProvider', () => {
     await waitFor(() => expect(hook.current.rows).toHaveLength(1));
     // grizzly must not be flagged as "couldn't read".
     expect(hook.current.unreachableInstallations).toEqual([]);
+  });
+
+  it('reclassifies a cluster when its error flips 404 → 403 on a refetch', async () => {
+    // grizzly must be reachable for the card to consider it at all.
+    mockConfigInstallations = ['alpha', 'grizzly'];
+    mockReachable = { installations: ['alpha', 'grizzly'], isProbing: false };
+
+    // First render: grizzly 404s (kagent not installed) → treated as empty.
+    mockUseResources.mockReturnValue(
+      result({ succeeded: { alpha: ['a1'] }, notFound: ['grizzly'] }),
+    );
+
+    const { result: hook, rerender } = renderUseAgents();
+
+    await waitFor(() =>
+      expect(hook.current.unreachableInstallations).toEqual([]),
+    );
+
+    // Same cluster now 403 on a background refetch (RBAC changed). The reconcile
+    // signature must include the error name, or this same-cluster error→error
+    // transition would be invisible and grizzly would stay unflagged.
+    mockUseResources.mockReturnValue(
+      result({ succeeded: { alpha: ['a1'] }, failed: ['grizzly'] }),
+    );
+    rerender();
+
+    await waitFor(() =>
+      expect(hook.current.unreachableInstallations).toEqual(['grizzly']),
+    );
   });
 
   it('drops a failing installation from the card once it leaves the reachable set', async () => {

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
@@ -56,15 +56,19 @@ function fakeAgent(cluster: string, spec: AgentSpec) {
 /**
  * Build a `useResources` return value. `succeeded` maps each successfully-read
  * installation to the agents it returned (a name string, or a spec with
- * resourceVersion/description); `failed` lists installations whose read errored.
+ * resourceVersion/description); `failed` lists installations whose read errored
+ * (403/unreachable); `notFound` lists installations that 404'd (kagent not
+ * installed).
  */
 function result({
   succeeded = {},
   failed = [],
+  notFound = [],
   isLoading = false,
 }: {
   succeeded?: Record<string, Array<string | AgentSpec>>;
   failed?: string[];
+  notFound?: string[];
   isLoading?: boolean;
 }) {
   const specs = (entries: Array<string | AgentSpec>): AgentSpec[] =>
@@ -79,7 +83,13 @@ function result({
       metadata: { name: spec.name, resourceVersion: spec.resourceVersion },
     })),
   }));
-  const errors = failed.map(cluster => ({ cluster }));
+  const errors = [
+    ...failed.map(cluster => ({ cluster, error: { name: 'ForbiddenError' } })),
+    ...notFound.map(cluster => ({
+      cluster,
+      error: { name: 'NotFoundError' },
+    })),
+  ];
   return { resources, clustersData, isLoading, errors };
 }
 
@@ -218,6 +228,19 @@ describe('AgentsDataProvider', () => {
     expect(hook.current.rows).toHaveLength(1);
     expect(hook.current.isLoading).toBe(false);
     expect(hook.current.isLoadingMore).toBe(false);
+  });
+
+  it('treats a 404 (kagent not installed) as zero agents, not a failure', async () => {
+    // grizzly is reachable but kagent isn't deployed there → the list 404s.
+    mockUseResources.mockReturnValue(
+      result({ succeeded: { alpha: ['a1'] }, notFound: ['grizzly'] }),
+    );
+
+    const { result: hook } = renderUseAgents();
+
+    await waitFor(() => expect(hook.current.rows).toHaveLength(1));
+    // grizzly must not be flagged as "couldn't read".
+    expect(hook.current.unreachableInstallations).toEqual([]);
   });
 
   it('drops a failing installation from the card once it leaves the reachable set', async () => {

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
@@ -179,10 +179,16 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
       ),
     );
 
-    // Only surface installations we have *nothing* for; if we're still showing
-    // an installation's last-known agents, don't also claim we couldn't read it.
+    // Surface only the genuinely actionable case: a currently-healthy cluster we
+    // have *nothing* for. Intersecting with the reachable (healthy) set means a
+    // cluster that degrades mid-session drops out of the card immediately — the
+    // sidebar Cluster-access widget owns that state, so we'd otherwise duplicate
+    // it. And if we're still showing an installation's last-known agents, don't
+    // also claim we couldn't read it.
+    const reachableSet = new Set(reachableInstallations);
     const unreachableInstallations = erroredInstallations.filter(
-      cluster => !agentsByInstallation[cluster]?.length,
+      cluster =>
+        reachableSet.has(cluster) && !agentsByInstallation[cluster]?.length,
     );
 
     // The fleet-wide query reports "loading" until every installation settles,
@@ -208,6 +214,7 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
     isProbing,
     modelConfigsFor,
     allInstallationsKey,
+    reachableInstallationsKey,
   ]);
 
   return (

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
@@ -9,6 +9,7 @@ import {
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   Agent,
+  isNotFoundError,
   useResources,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { useReachableInstallations } from '../../hooks/useReachableInstallations';
@@ -113,7 +114,16 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
           )
           .join(',')}`,
     );
-    const failed = errors.map(e => `err:${e.cluster}`);
+    // Include the error discriminator: the reconcile effect classifies by error
+    // name (a 404 is an empty read, anything else is a failure), so a same-cluster
+    // error→error transition that flips the name (404 ⇄ 403) must change the
+    // signature, or the effect wouldn't re-run and would keep the stale verdict.
+    const failed = errors.map(
+      e =>
+        `err:${e.cluster}:${
+          e.type === 'incompatibility' ? 'incompat' : e.error.name
+        }`,
+    );
     return [...ok, ...failed].sort().join('|');
   }, [clustersData, errors]);
 
@@ -124,11 +134,7 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
     // we can list it, there just are no Agents. Genuine failures (403 forbidden,
     // unreachable) still count as errors.
     const notInstalled = new Set(
-      errors
-        .filter(
-          e => e.type !== 'incompatibility' && e.error.name === 'NotFoundError',
-        )
-        .map(e => e.cluster),
+      errors.filter(isNotFoundError).map(e => e.cluster),
     );
 
     // Clusters that responded successfully this render (empty result included),

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
@@ -118,8 +118,25 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
   }, [clustersData, errors]);
 
   useEffect(() => {
-    // Clusters that responded successfully this render (empty result included).
-    const succeeded = new Set(clustersData.map(c => c.cluster));
+    // A 404 means the kagent.dev API group isn't installed on that cluster —
+    // kagent simply isn't deployed there. Treat it as a successful empty read
+    // (zero agents), not a "couldn't read" failure: the cluster is reachable and
+    // we can list it, there just are no Agents. Genuine failures (403 forbidden,
+    // unreachable) still count as errors.
+    const notInstalled = new Set(
+      errors
+        .filter(
+          e => e.type !== 'incompatibility' && e.error.name === 'NotFoundError',
+        )
+        .map(e => e.cluster),
+    );
+
+    // Clusters that responded successfully this render (empty result included),
+    // plus the kagent-not-installed 404s treated as empty.
+    const succeeded = new Set([
+      ...clustersData.map(c => c.cluster),
+      ...notInstalled,
+    ]);
     const nextAgents: Record<string, Agent[]> = {};
     for (const cluster of succeeded) {
       nextAgents[cluster] = [];

--- a/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
+++ b/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ModelConfigsProvider, useModelConfigs } from './ModelConfigsProvider';
+
+// Mock the fleet-query plumbing so the test drives the reachable→with-models
+// narrowing directly. The `mock`-prefixed names are the only out-of-scope
+// references jest allows inside a mock factory.
+const mockUseResources = jest.fn();
+let mockConfigInstallations: string[] = ['alpha', 'beta', 'gaggle'];
+let mockReachable: { installations: string[]; isProbing: boolean } = {
+  installations: ['alpha', 'beta', 'gaggle'],
+  isProbing: false,
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  configApiRef: {},
+  useApi: () => ({
+    getOptionalConfig: () => ({ keys: () => mockConfigInstallations }),
+  }),
+}));
+
+jest.mock('../../hooks/useReachableInstallations', () => ({
+  useReachableInstallations: () => mockReachable,
+}));
+
+jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
+  ModelConfig: class {},
+  useResources: (...args: unknown[]) => mockUseResources(...args),
+}));
+
+// Duck-typed stand-in for a ModelConfig instance — the provider only reads
+// `.cluster`.
+function fakeModelConfig(cluster: string) {
+  return { cluster };
+}
+
+/**
+ * Build a `useResources` return value. `succeeded` maps each installation to how
+ * many ModelConfigs it returned; `failed` lists installations whose read errored.
+ */
+function result({
+  succeeded = {},
+  failed = [],
+  isLoading = false,
+}: {
+  succeeded?: Record<string, number>;
+  failed?: string[];
+  isLoading?: boolean;
+}) {
+  const resources = Object.entries(succeeded).flatMap(([cluster, count]) =>
+    Array.from({ length: count }, () => fakeModelConfig(cluster)),
+  );
+  const errors = failed.map(cluster => ({ cluster }));
+  return { resources, isLoading, errors };
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ModelConfigsProvider>{children}</ModelConfigsProvider>
+);
+
+const renderUseModelConfigs = () =>
+  renderHook(() => useModelConfigs(), { wrapper });
+
+describe('ModelConfigsProvider', () => {
+  beforeEach(() => {
+    mockUseResources.mockReset();
+    mockConfigInstallations = ['alpha', 'beta', 'gaggle'];
+    mockReachable = {
+      installations: ['alpha', 'beta', 'gaggle'],
+      isProbing: false,
+    };
+  });
+
+  it('only queries the reachable installations', () => {
+    mockReachable = { installations: ['alpha', 'beta'], isProbing: false };
+    mockUseResources.mockReturnValue(result({}));
+
+    renderUseModelConfigs();
+
+    // First positional arg to useResources is the installation list.
+    expect(mockUseResources.mock.calls[0][0]).toEqual(['alpha', 'beta']);
+  });
+
+  it('offers only reachable installations that returned a model', () => {
+    mockUseResources.mockReturnValue(
+      result({ succeeded: { alpha: 2, beta: 0 } }),
+    );
+
+    const { result: hook } = renderUseModelConfigs();
+
+    // beta is reachable but returned no ModelConfig; gaggle returned nothing.
+    expect(hook.current.availableInstallations).toEqual(['alpha']);
+    expect(hook.current.modelConfigsFor('alpha')).toHaveLength(2);
+    expect(hook.current.modelConfigsFor('beta')).toHaveLength(0);
+  });
+
+  it('surfaces installations that errored and produced no models', () => {
+    mockUseResources.mockReturnValue(
+      result({ succeeded: { alpha: 1 }, failed: ['gaggle'] }),
+    );
+
+    const { result: hook } = renderUseModelConfigs();
+
+    expect(hook.current.unreachableInstallations).toEqual(['gaggle']);
+    expect(hook.current.availableInstallations).toEqual(['alpha']);
+  });
+
+  it('reports loading while probes are still settling', () => {
+    mockReachable = { installations: [], isProbing: true };
+    mockUseResources.mockReturnValue(result({ isLoading: false }));
+
+    const { result: hook } = renderUseModelConfigs();
+
+    expect(hook.current.isLoading).toBe(true);
+  });
+
+  it('reports hasInstallations from the configured set', () => {
+    mockConfigInstallations = [];
+    mockReachable = { installations: [], isProbing: false };
+    mockUseResources.mockReturnValue(result({}));
+
+    const { result: hook } = renderUseModelConfigs();
+
+    expect(hook.current.hasInstallations).toBe(false);
+  });
+});

--- a/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
+++ b/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import { buildResourceErrors } from '../resourceErrorFixtures';
 import { ModelConfigsProvider, useModelConfigs } from './ModelConfigsProvider';
 
 // Mock the fleet-query plumbing so the test drives the reachable→with-models
@@ -26,6 +27,8 @@ jest.mock('../../hooks/useReachableInstallations', () => ({
 jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
   ModelConfig: class {},
   useResources: (...args: unknown[]) => mockUseResources(...args),
+  isNotFoundError: (e: { type?: string; error?: { name?: string } }) =>
+    e.type !== 'incompatibility' && e.error?.name === 'NotFoundError',
 }));
 
 // Duck-typed stand-in for a ModelConfig instance — the provider only reads
@@ -54,13 +57,7 @@ function result({
   const resources = Object.entries(succeeded).flatMap(([cluster, count]) =>
     Array.from({ length: count }, () => fakeModelConfig(cluster)),
   );
-  const errors = [
-    ...failed.map(cluster => ({ cluster, error: { name: 'ForbiddenError' } })),
-    ...notFound.map(cluster => ({
-      cluster,
-      error: { name: 'NotFoundError' },
-    })),
-  ];
+  const errors = buildResourceErrors({ failed, notFound });
   return { resources, isLoading, errors };
 }
 

--- a/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
+++ b/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
@@ -36,21 +36,31 @@ function fakeModelConfig(cluster: string) {
 
 /**
  * Build a `useResources` return value. `succeeded` maps each installation to how
- * many ModelConfigs it returned; `failed` lists installations whose read errored.
+ * many ModelConfigs it returned; `failed` lists installations whose read errored
+ * (403/unreachable); `notFound` lists installations that 404'd (kagent not
+ * installed).
  */
 function result({
   succeeded = {},
   failed = [],
+  notFound = [],
   isLoading = false,
 }: {
   succeeded?: Record<string, number>;
   failed?: string[];
+  notFound?: string[];
   isLoading?: boolean;
 }) {
   const resources = Object.entries(succeeded).flatMap(([cluster, count]) =>
     Array.from({ length: count }, () => fakeModelConfig(cluster)),
   );
-  const errors = failed.map(cluster => ({ cluster }));
+  const errors = [
+    ...failed.map(cluster => ({ cluster, error: { name: 'ForbiddenError' } })),
+    ...notFound.map(cluster => ({
+      cluster,
+      error: { name: 'NotFoundError' },
+    })),
+  ];
   return { resources, isLoading, errors };
 }
 
@@ -92,6 +102,17 @@ describe('ModelConfigsProvider', () => {
     expect(hook.current.availableInstallations).toEqual(['alpha']);
     expect(hook.current.modelConfigsFor('alpha')).toHaveLength(2);
     expect(hook.current.modelConfigsFor('beta')).toHaveLength(0);
+  });
+
+  it('does not flag a 404 (kagent not installed) as unreachable', () => {
+    mockUseResources.mockReturnValue(
+      result({ succeeded: { alpha: 1 }, notFound: ['grizzly'] }),
+    );
+
+    const { result: hook } = renderUseModelConfigs();
+
+    expect(hook.current.unreachableInstallations).toEqual([]);
+    expect(hook.current.availableInstallations).toEqual(['alpha']);
   });
 
   it('surfaces installations that errored and produced no models', () => {

--- a/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.tsx
+++ b/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.tsx
@@ -64,9 +64,18 @@ export function ModelConfigsProvider({ children }: { children: ReactNode }) {
   const value = useMemo<ModelConfigsContextValue>(() => {
     const withModels = new Set(resources.map(mc => mc.cluster));
 
-    // Distinct installations whose query errored and produced no models.
+    // A 404 means the kagent.dev API group isn't installed on that cluster, so it
+    // simply has no ModelConfigs — not a "couldn't read" failure. Only genuine
+    // failures (403 forbidden, unreachable) that produced no models are surfaced.
     const unreachableInstallations = Array.from(
-      new Set(errors.map(e => e.cluster)),
+      new Set(
+        errors
+          .filter(
+            e =>
+              e.type === 'incompatibility' || e.error.name !== 'NotFoundError',
+          )
+          .map(e => e.cluster),
+      ),
     ).filter(name => !withModels.has(name));
 
     return {

--- a/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.tsx
+++ b/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
+  isNotFoundError,
   ModelConfig,
   useResources,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
@@ -68,14 +69,7 @@ export function ModelConfigsProvider({ children }: { children: ReactNode }) {
     // simply has no ModelConfigs — not a "couldn't read" failure. Only genuine
     // failures (403 forbidden, unreachable) that produced no models are surfaced.
     const unreachableInstallations = Array.from(
-      new Set(
-        errors
-          .filter(
-            e =>
-              e.type === 'incompatibility' || e.error.name !== 'NotFoundError',
-          )
-          .map(e => e.cluster),
-      ),
+      new Set(errors.filter(e => !isNotFoundError(e)).map(e => e.cluster)),
     ).filter(name => !withModels.has(name));
 
     return {

--- a/plugins/agent-platform/src/components/resourceErrorFixtures.ts
+++ b/plugins/agent-platform/src/components/resourceErrorFixtures.ts
@@ -1,0 +1,23 @@
+/**
+ * Test helper: builds the `errors` array shape that `useResources` returns,
+ * mirroring its error contract — a 403 surfaces as `ForbiddenError`, a 404 as
+ * `NotFoundError` (see `useListResources` in kubernetes-react). Shared by the
+ * AgentsDataProvider and ModelConfigsProvider tests so the fixture shape lives in
+ * one place.
+ */
+export type ResourceErrorFixtureOptions = {
+  /** Installations whose read errored with a 403/forbidden-style failure. */
+  failed?: string[];
+  /** Installations whose read 404'd (kagent API group not installed). */
+  notFound?: string[];
+};
+
+export function buildResourceErrors({
+  failed = [],
+  notFound = [],
+}: ResourceErrorFixtureOptions) {
+  return [
+    ...failed.map(cluster => ({ cluster, error: { name: 'ForbiddenError' } })),
+    ...notFound.map(cluster => ({ cluster, error: { name: 'NotFoundError' } })),
+  ];
+}

--- a/plugins/agent-platform/src/hooks/useReachableInstallations.test.tsx
+++ b/plugins/agent-platform/src/hooks/useReachableInstallations.test.tsx
@@ -48,7 +48,7 @@ const entry = (
 ): ClusterAccessStatusEntry => ({ installation, state, lastChecked: 0 });
 
 describe('useReachableInstallations', () => {
-  it('keeps only healthy and connecting installations', () => {
+  it('keeps only healthy installations', () => {
     const { result } = renderWith(
       ['gazelle', 'graveler', 'grizzly', 'gerbil'],
       [
@@ -59,7 +59,9 @@ describe('useReachableInstallations', () => {
       ],
     );
 
-    expect(result.current.installations).toEqual(['gazelle', 'graveler']);
+    // connecting/degraded/session-expired are all excluded now — only a
+    // confirmed apiserver round-trip counts as reachable.
+    expect(result.current.installations).toEqual(['gazelle']);
     // A connecting probe is still in flight, so the set may still grow.
     expect(result.current.isProbing).toBe(true);
   });

--- a/plugins/agent-platform/src/hooks/useReachableInstallations.ts
+++ b/plugins/agent-platform/src/hooks/useReachableInstallations.ts
@@ -5,9 +5,11 @@ import {
   clusterAccessStatusApiRef,
 } from '@giantswarm/backstage-plugin-gs';
 
-/** States we treat as worth querying. `connecting` means a probe is still in
- * flight, so include it optimistically rather than hide the installation. */
-const REACHABLE_STATES = new Set(['healthy', 'connecting']);
+/** States we treat as worth querying. Only `healthy` — a confirmed apiserver
+ * round-trip. `connecting` is deliberately excluded: the cluster-access warm-up
+ * seeds every installation as `connecting` on load, so including it would fan
+ * every fleet query out to installations that turn out to be unreachable. */
+const REACHABLE_STATES = new Set(['healthy']);
 
 export type ReachableInstallations = {
   /** Configured installations the app currently considers reachable. */
@@ -17,17 +19,25 @@ export type ReachableInstallations = {
 };
 
 /**
- * Narrows a list of installations to those the app currently considers
- * reachable, using the shared cluster-access status that the sidebar warm-up
- * maintains app-wide (see gs `ClusterAccessConnector`).
+ * Narrows a list of installations to those the app should query: currently
+ * `healthy` per the shared cluster-access status (see gs `ClusterAccessConnector`).
  *
- * Without this, the fleet-wide ModelConfig query fans out to every configured
- * installation — including unreachable/forbidden ones, each of which hangs for
- * the full proxy timeout and retries before settling, dominating the tail and
- * keeping the whole query "loading". Reachable installations
- * (`healthy`/`connecting`) are kept; `degraded` and `session-expired` are
- * skipped, as are installations absent from the status set (non-broker
- * installations the user is signed out of, or not yet probed).
+ * Only `healthy` installations are kept; `connecting` (probe still in flight),
+ * `degraded`, `session-expired`, and installations absent from the status set
+ * (non-broker installations the user is signed out of, or not yet probed) are
+ * skipped. Relying on the confirmed-healthy set — rather than optimistically
+ * including `connecting` — stops fleet queries fanning out to clusters that turn
+ * out to be down (each otherwise hangs for the full proxy timeout and retries,
+ * dominating the tail) and stops the list churning wide-then-narrow as probes
+ * settle. The sidebar Cluster-access widget owns surfacing degraded/unreachable
+ * clusters, so these pages don't re-discover it. Installations the user has muted
+ * app-wide are also excluded here for free: they are never probed, so they never
+ * become `healthy`.
+ *
+ * Tradeoff: on a cold, direct page load we wait for the first access probe
+ * (~one probe) instead of querying optimistically. In practice the probe runs on
+ * app start, so healthy installations are usually already confirmed by the time
+ * these pages open.
  *
  * Fallback: until the status set has any entry at all (the warm-up seeds
  * `connecting` synchronously on app mount, but a race at first mount is

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -19,13 +19,15 @@ function assertNever(value: never): never {
 const HEALTH_PROBE_PATH = '/version';
 
 /**
- * Per-probe timeout, deliberately shorter than the default proxy timeout. The
- * warm-up probes the whole fleet, so an unreachable cluster must release its
- * concurrency slot quickly instead of holding it for the full default (~10s)
- * and dominating the tail. A genuinely slow-but-healthy cluster recovers via
- * the retry/backoff loop and the refresh interval.
+ * Per-probe timeout, deliberately shorter than the default proxy timeout (~10s).
+ * The warm-up probes the whole fleet, so an unreachable cluster must release its
+ * concurrency slot instead of holding it for the full default and dominating the
+ * tail. Kept at 5s rather than lower because a too-tight budget flagged
+ * slow-but-healthy clusters as `degraded` during load spikes; a genuinely
+ * unreachable cluster still recovers its slot well before the default, and a
+ * transiently slow one recovers via the retry/backoff loop and refresh interval.
  */
-const PROBE_TIMEOUT_MS = 2000;
+const PROBE_TIMEOUT_MS = 5000;
 
 /**
  * Re-probe interval. Keeps the sidebar live (a recovered or newly-broken

--- a/plugins/kubernetes-react/src/hooks/utils/queries.test.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/queries.test.ts
@@ -1,0 +1,31 @@
+import {
+  ErrorInfoUnion,
+  IncompatibilityErrorInfo,
+  isNotFoundError,
+} from './queries';
+
+function errorInfo(name: string): ErrorInfoUnion {
+  const error = new Error('boom');
+  error.name = name;
+  return { type: 'error', cluster: 'c', error, retry: () => {} };
+}
+
+describe('isNotFoundError', () => {
+  it('is true for a NotFoundError (404)', () => {
+    expect(isNotFoundError(errorInfo('NotFoundError'))).toBe(true);
+  });
+
+  it('is false for a ForbiddenError (403) and generic errors', () => {
+    expect(isNotFoundError(errorInfo('ForbiddenError'))).toBe(false);
+    expect(isNotFoundError(errorInfo('Error'))).toBe(false);
+  });
+
+  it('is false for an incompatibility error (no HTTP status)', () => {
+    const incompatibility: IncompatibilityErrorInfo = {
+      type: 'incompatibility',
+      cluster: 'c',
+      incompatibility: {} as IncompatibilityErrorInfo['incompatibility'],
+    };
+    expect(isNotFoundError(incompatibility)).toBe(false);
+  });
+});

--- a/plugins/kubernetes-react/src/hooks/utils/queries.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/queries.ts
@@ -25,6 +25,20 @@ export type IncompatibilityErrorInfo = {
  */
 export type ErrorInfoUnion = ErrorInfo | IncompatibilityErrorInfo;
 
+/**
+ * True when a list/get failed with a 404 — the resource's API group/CRD is not
+ * served by that cluster (see the `NotFoundError` name set in `useListResources`).
+ * Distinct from a 403 (`ForbiddenError`) or a transport failure, so callers can
+ * treat it as "this resource type isn't installed here" rather than
+ * "couldn't read".
+ */
+export function isNotFoundError(errorInfo: ErrorInfoUnion): boolean {
+  return (
+    errorInfo.type !== 'incompatibility' &&
+    errorInfo.error.name === 'NotFoundError'
+  );
+}
+
 export const mapQueriesToClusters = <T>(
   clusters: string[],
   queries: UseQueryResult<T, unknown>[],


### PR DESCRIPTION
### What does this PR do?

Narrows the agent-platform fleet queries to installations whose cluster access is **confirmed healthy**, distinguishes "kagent isn't installed here" from a real read failure, and gives slow-but-healthy clusters more headroom before they're flagged degraded.

- `useReachableInstallations` now treats **only `healthy`** as reachable (drops `connecting`). On load the `ClusterAccessConnector` seeds every installation as `connecting`, so including it fanned queries out to installations that turn out to be degraded/unreachable — each hanging for the full proxy timeout and duplicating the sidebar Cluster-access widget's signalling.
- The agents "couldn't read" card is refined to `errored ∩ currently-healthy`, so a cluster that degrades mid-session drops out of the card (the sidebar widget owns that state).
- A **404 (`NotFoundError`) is treated as a successful empty read**, not a failure: a cluster can be reachable and listable but simply not have the `kagent.dev` API group installed (kagent isn't deployed there). Such an installation now contributes zero Agents / zero ModelConfigs and is **not** flagged in the "couldn't read" card — on both the agents list and the create-flow installation select (shared `ModelConfigsProvider`). Only genuinely actionable failures remain: `403 ForbiddenError` (no permission) and unreachable clusters.
- Raises the cluster-access probe timeout `2s → 5s` so slow-but-healthy clusters aren't flagged `degraded` during load spikes (still under the 10s default proxy timeout).

### What is the effect of this change to users?

The Agents list and the create-flow installation dropdown no longer query or flag known-degraded/unreachable installations, so the list stops churning wide-then-narrow on load. The "Couldn't read N installations" notice now shows only genuinely actionable cases — a reachable installation that simply doesn't run kagent shows zero agents with no warning, instead of being reported as unreadable. Fewer transient "degraded" blips in the sidebar Cluster access widget.

### How does it look like?

No visual change beyond fewer spurious entries in the "Couldn't read …" card (kagent-absent clusters no longer listed) and steadier loading.

### Any background context you can provide?

Implements giantswarm/giantswarm#37209. Note this refines that issue's original wording, which had listed a missing CRD / 404 as an "actionable" case: in practice an activated installation that just doesn't run kagent returns a 404, so it's treated as silently empty rather than a failure.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.