### PR TITLE
feat(gs): mute installations app-wide from the Cluster access popover

### DIFF
--- a/plugins/gs/src/apis/auth/GSAuthProviders.ts
+++ b/plugins/gs/src/apis/auth/GSAuthProviders.ts
@@ -229,7 +229,13 @@ export class GSAuthProviders implements GSAuthProvidersApi {
     return async () => {
       try {
         const clusterToken = await mint();
-        statusApi?.recordHealthy(installationName);
+        // A successful token mint only proves the broker is reachable, not that
+        // the cluster's apiserver is — so it must NOT be recorded as healthy here
+        // (that showed a misleading green, e.g. right after un-muting an
+        // unreachable installation, until the real probe corrected it to
+        // degraded). Health is owned by the authoritative `/version` probe in
+        // ClusterAccessConnector; the catch below still records the precise
+        // broker-level failure states, which that probe defers to.
         return clusterToken;
       } catch (error) {
         if (error instanceof ClusterTokenError) {

--- a/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.test.ts
+++ b/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.test.ts
@@ -1,0 +1,104 @@
+import { MutedInstallationsApi } from './types';
+import { MutedInstallationsStore } from './MutedInstallationsStore';
+
+const STORAGE_KEY = 'gs-muted-installations';
+
+// zen-observable delivers the replayed initial value on a microtask, so tests
+// flush with a tick after each subscribe/change before asserting emissions.
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+function collect(api: MutedInstallationsApi): {
+  emissions: string[][];
+  unsubscribe: () => void;
+} {
+  const emissions: string[][] = [];
+  const subscription = api.muted$().subscribe(snapshot => {
+    emissions.push(snapshot);
+  });
+  return { emissions, unsubscribe: () => subscription.unsubscribe() };
+}
+
+describe('MutedInstallationsStore', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('starts empty when nothing is persisted', () => {
+    const store = MutedInstallationsStore.create();
+    expect(store.getSnapshot()).toEqual([]);
+    expect(store.isMuted('alpha')).toBe(false);
+  });
+
+  it('loads a previously-persisted set on construction', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['beta', 'alpha']));
+    const store = MutedInstallationsStore.create();
+    expect(store.getSnapshot()).toEqual(['alpha', 'beta']); // sorted
+    expect(store.isMuted('beta')).toBe(true);
+  });
+
+  it('mutes an installation and persists it', () => {
+    const store = MutedInstallationsStore.create();
+    store.setMuted('alpha', true);
+
+    expect(store.isMuted('alpha')).toBe(true);
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual([
+      'alpha',
+    ]);
+  });
+
+  it('unmutes an installation', () => {
+    const store = MutedInstallationsStore.create();
+    store.setMuted('alpha', true);
+    store.setMuted('alpha', false);
+
+    expect(store.isMuted('alpha')).toBe(false);
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual([]);
+  });
+
+  it('toggles an installation', () => {
+    const store = MutedInstallationsStore.create();
+    store.toggle('alpha');
+    expect(store.isMuted('alpha')).toBe(true);
+    store.toggle('alpha');
+    expect(store.isMuted('alpha')).toBe(false);
+  });
+
+  it('replays the snapshot to a new subscriber and emits on change', async () => {
+    const store = MutedInstallationsStore.create();
+    const { emissions, unsubscribe } = collect(store);
+
+    // Replay on subscribe.
+    await tick();
+    expect(emissions).toEqual([[]]);
+
+    store.setMuted('alpha', true);
+    await tick();
+    expect(emissions[emissions.length - 1]).toEqual(['alpha']);
+    const emitCount = emissions.length;
+
+    // A no-op set must not churn subscribers.
+    store.setMuted('alpha', true);
+    await tick();
+    expect(emissions).toHaveLength(emitCount);
+
+    unsubscribe();
+    store.setMuted('beta', true);
+    await tick();
+    expect(emissions).toHaveLength(emitCount);
+  });
+
+  it('reloads and notifies on a cross-tab write', async () => {
+    const store = MutedInstallationsStore.create();
+    const { emissions } = collect(store);
+    await tick();
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['gamma']));
+    window.dispatchEvent(
+      Object.assign(new Event('storage'), { key: STORAGE_KEY }),
+    );
+    await tick();
+
+    expect(store.isMuted('gamma')).toBe(true);
+    expect(emissions[emissions.length - 1]).toEqual(['gamma']);
+  });
+});

--- a/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.test.ts
+++ b/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.test.ts
@@ -101,4 +101,21 @@ describe('MutedInstallationsStore', () => {
     expect(store.isMuted('gamma')).toBe(true);
     expect(emissions[emissions.length - 1]).toEqual(['gamma']);
   });
+
+  it('reloads when another tab clears storage (event.key === null)', async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(['delta']));
+    const store = MutedInstallationsStore.create();
+    expect(store.isMuted('delta')).toBe(true);
+
+    const { emissions } = collect(store);
+    await tick();
+
+    // localStorage.clear() in another tab fires a storage event with key === null.
+    window.localStorage.clear();
+    window.dispatchEvent(Object.assign(new Event('storage'), { key: null }));
+    await tick();
+
+    expect(store.isMuted('delta')).toBe(false);
+    expect(emissions[emissions.length - 1]).toEqual([]);
+  });
 });

--- a/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.ts
+++ b/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.ts
@@ -18,10 +18,12 @@ export class MutedInstallationsStore implements MutedInstallationsApi {
 
   private constructor() {
     this.muted = MutedInstallationsStore.load();
-    // Keep multiple tabs consistent: another tab writing the key reloads ours.
+    // Keep multiple tabs consistent: reload when another tab writes our key.
+    // `event.key` is `null` when another tab calls `localStorage.clear()` (and
+    // for some bulk changes), so treat that as "storage changed, re-read".
     if (typeof window !== 'undefined') {
       window.addEventListener('storage', event => {
-        if (event.key === STORAGE_KEY) {
+        if (event.key === STORAGE_KEY || event.key === null) {
           this.muted = MutedInstallationsStore.load();
           this.notify();
         }

--- a/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.ts
+++ b/plugins/gs/src/apis/mutedInstallations/MutedInstallationsStore.ts
@@ -1,0 +1,103 @@
+import { Observable } from '@backstage/types';
+import ObservableImpl from 'zen-observable';
+import { MutedInstallationsApi } from './types';
+
+const STORAGE_KEY = 'gs-muted-installations';
+
+/**
+ * localStorage-backed, multicast implementation of {@link MutedInstallationsApi}.
+ *
+ * Unlike the in-memory cluster-access status store, this holds user intent that
+ * must survive reloads, so it persists to localStorage (and syncs across tabs via
+ * the `storage` event). A single process-wide Set + a Set of subscribers is
+ * enough — the muted set is tiny (a handful of installation names).
+ */
+export class MutedInstallationsStore implements MutedInstallationsApi {
+  private muted: Set<string>;
+  private readonly subscribers = new Set<(snapshot: string[]) => void>();
+
+  private constructor() {
+    this.muted = MutedInstallationsStore.load();
+    // Keep multiple tabs consistent: another tab writing the key reloads ours.
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', event => {
+        if (event.key === STORAGE_KEY) {
+          this.muted = MutedInstallationsStore.load();
+          this.notify();
+        }
+      });
+    }
+  }
+
+  static create(): MutedInstallationsApi {
+    return new MutedInstallationsStore();
+  }
+
+  private static load(): Set<string> {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return new Set();
+      }
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed)
+        ? new Set(parsed.filter((x): x is string => typeof x === 'string'))
+        : new Set();
+    } catch {
+      // Private-mode / quota / parse errors: fall back to "nothing muted".
+      return new Set();
+    }
+  }
+
+  private persist(): void {
+    try {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(this.getSnapshot()),
+      );
+    } catch {
+      // Best-effort; the in-memory set still reflects the change for this tab.
+    }
+  }
+
+  isMuted(installation: string): boolean {
+    return this.muted.has(installation);
+  }
+
+  setMuted(installation: string, muted: boolean): void {
+    if (muted === this.muted.has(installation)) {
+      return;
+    }
+    if (muted) {
+      this.muted.add(installation);
+    } else {
+      this.muted.delete(installation);
+    }
+    this.persist();
+    this.notify();
+  }
+
+  toggle(installation: string): void {
+    this.setMuted(installation, !this.muted.has(installation));
+  }
+
+  getSnapshot(): string[] {
+    return [...this.muted].sort((a, b) => a.localeCompare(b));
+  }
+
+  muted$(): Observable<string[]> {
+    return new ObservableImpl(subscriber => {
+      const notify = (snapshot: string[]) => subscriber.next(snapshot);
+      subscriber.next(this.getSnapshot());
+      this.subscribers.add(notify);
+      return () => {
+        this.subscribers.delete(notify);
+      };
+    });
+  }
+
+  private notify(): void {
+    const snapshot = this.getSnapshot();
+    this.subscribers.forEach(notify => notify(snapshot));
+  }
+}

--- a/plugins/gs/src/apis/mutedInstallations/index.ts
+++ b/plugins/gs/src/apis/mutedInstallations/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './MutedInstallationsStore';

--- a/plugins/gs/src/apis/mutedInstallations/index.ts
+++ b/plugins/gs/src/apis/mutedInstallations/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './MutedInstallationsStore';
+export * from './useMutedInstallations';

--- a/plugins/gs/src/apis/mutedInstallations/types.ts
+++ b/plugins/gs/src/apis/mutedInstallations/types.ts
@@ -1,0 +1,30 @@
+import { Observable } from '@backstage/types';
+import { createApiRef } from '@backstage/core-plugin-api';
+
+/**
+ * User-controlled, app-wide on/off state for installations. A *muted*
+ * installation is treated as switched off everywhere: the `ClusterAccessConnector`
+ * doesn't probe it, and fleet views (Clusters/Deployments pages, agent-platform)
+ * don't fetch from it. This is deliberately distinct from the health-based
+ * `useDisabledInstallations` hook (which auto-detects unreachable backends) — this
+ * is explicit user intent, so it is persisted per-browser rather than derived from
+ * live probes.
+ */
+export interface MutedInstallationsApi {
+  isMuted(installation: string): boolean;
+  /** Turn an installation off (muted=true) or back on (muted=false). */
+  setMuted(installation: string, muted: boolean): void;
+  toggle(installation: string): void;
+  /** Sorted snapshot of currently-muted installation names. */
+  getSnapshot(): string[];
+  /**
+   * Replays the latest snapshot to a new subscriber (on the next tick) and
+   * emits again on every change. Consumers that need the value synchronously at
+   * mount time should seed from {@link getSnapshot}.
+   */
+  muted$(): Observable<string[]>;
+}
+
+export const mutedInstallationsApiRef = createApiRef<MutedInstallationsApi>({
+  id: 'plugin.gs.muted-installations',
+});

--- a/plugins/gs/src/apis/mutedInstallations/useMutedInstallations.ts
+++ b/plugins/gs/src/apis/mutedInstallations/useMutedInstallations.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { mutedInstallationsApiRef } from './types';
+
+function sameContents(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  // Both come from getSnapshot(), which returns a sorted array, so an
+  // index-by-index compare is a full equality check.
+  return a.every((value, index) => value === b[index]);
+}
+
+/**
+ * Subscribe to the muted-installations set as a **stable** array reference.
+ *
+ * `muted$()` replays `getSnapshot()` on subscribe, and `getSnapshot()` returns a
+ * fresh array on every call — so naively storing each emission in state churns
+ * the reference even when the contents are unchanged. Consumers that depend on
+ * the array in a `useEffect` (notably `ClusterAccessConnector`, whose probe
+ * effects would otherwise tear down and re-run — restarting the whole fleet
+ * probe on mount) need a reference that only changes when the contents change.
+ * Returning the previous array when contents are equal gives them that.
+ */
+export function useMutedInstallations(): string[] {
+  const api = useApi(mutedInstallationsApiRef);
+  const [muted, setMuted] = useState<string[]>(() => api.getSnapshot());
+
+  useEffect(() => {
+    const subscription = api
+      .muted$()
+      .subscribe(next =>
+        setMuted(prev => (sameContents(prev, next) ? prev : next)),
+      );
+    return () => subscription.unsubscribe();
+  }, [api]);
+
+  return muted;
+}

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useApi, SessionState } from '@backstage/core-plugin-api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
 import { ClusterTokenError } from '../../apis/auth/DefaultAuthConnector';
 import { clusterAccessStatusApiRef } from '../../apis/clusterAccessStatus';
-import { mutedInstallationsApiRef } from '../../apis/mutedInstallations';
+import { useMutedInstallations } from '../../apis/mutedInstallations';
 import { KubernetesClient } from '../../apis/kubernetes';
 
 function assertNever(value: never): never {
@@ -122,17 +122,13 @@ export function ClusterAccessConnector() {
   const kubernetesApi = useApi(kubernetesApiRef);
   const authProvidersApi = useApi(gsAuthProvidersApiRef);
   const statusApi = useApi(clusterAccessStatusApiRef);
-  const mutedApi = useApi(mutedInstallationsApiRef);
 
   // Track the user's muted set reactively so muting/unmuting re-runs the probe
-  // effects (a muted installation must stop being probed and drop off the
-  // status set; unmuting must resume probing). The store emits only on real
-  // changes, so `muted`'s identity is stable between changes.
-  const [muted, setMuted] = useState<string[]>(() => mutedApi.getSnapshot());
-  useEffect(() => {
-    const subscription = mutedApi.muted$().subscribe(setMuted);
-    return () => subscription.unsubscribe();
-  }, [mutedApi]);
+  // effects (a muted installation must stop being probed and drop off the status
+  // set; unmuting must resume probing). `useMutedInstallations` returns a stable
+  // reference that only changes when the contents change, so the initial replay
+  // doesn't spuriously re-run these effects and restart the fleet probe.
+  const muted = useMutedInstallations();
 
   useEffect(() => {
     const mutedSet = new Set(muted);

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useApi, SessionState } from '@backstage/core-plugin-api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
 import { ClusterTokenError } from '../../apis/auth/DefaultAuthConnector';
 import { clusterAccessStatusApiRef } from '../../apis/clusterAccessStatus';
+import { mutedInstallationsApiRef } from '../../apis/mutedInstallations';
 import { KubernetesClient } from '../../apis/kubernetes';
 
 function assertNever(value: never): never {
@@ -121,9 +122,30 @@ export function ClusterAccessConnector() {
   const kubernetesApi = useApi(kubernetesApiRef);
   const authProvidersApi = useApi(gsAuthProvidersApiRef);
   const statusApi = useApi(clusterAccessStatusApiRef);
+  const mutedApi = useApi(mutedInstallationsApiRef);
+
+  // Track the user's muted set reactively so muting/unmuting re-runs the probe
+  // effects (a muted installation must stop being probed and drop off the
+  // status set; unmuting must resume probing). The store emits only on real
+  // changes, so `muted`'s identity is stable between changes.
+  const [muted, setMuted] = useState<string[]>(() => mutedApi.getSnapshot());
+  useEffect(() => {
+    const subscription = mutedApi.muted$().subscribe(setMuted);
+    return () => subscription.unsubscribe();
+  }, [mutedApi]);
 
   useEffect(() => {
-    const installations = authProvidersApi.getBrokerCoveredInstallations();
+    const mutedSet = new Set(muted);
+    // Drop any muted installation from the status set — it may have been probed
+    // and recorded before being muted, and it must not linger in the widget as
+    // healthy/degraded once switched off.
+    for (const installation of muted) {
+      statusApi.remove(installation);
+    }
+
+    const installations = authProvidersApi
+      .getBrokerCoveredInstallations()
+      .filter(installation => !mutedSet.has(installation));
     if (installations.length === 0) {
       return undefined;
     }
@@ -210,7 +232,7 @@ export function ClusterAccessConnector() {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [kubernetesApi, authProvidersApi, statusApi]);
+  }, [kubernetesApi, authProvidersApi, statusApi, muted]);
 
   // Non-broker installations can't be probed proactively: a proxy call on one
   // without a live session would pop up a per-cluster login. So instead of
@@ -219,19 +241,27 @@ export function ClusterAccessConnector() {
   // the widget when signed out. This is the "different logic" from the broker
   // path above, which probes real apiserver health.
   useEffect(() => {
+    const mutedSet = new Set(muted);
+    // A muted non-broker installation must also drop off the status set.
+    for (const installation of muted) {
+      statusApi.remove(installation);
+    }
+
     const kubernetesAuthApis = authProvidersApi.getKubernetesAuthApis();
     const brokerCovered = new Set(
       authProvidersApi.getBrokerCoveredInstallations(),
     );
     // getProviders() already excludes broker-covered installations; the
-    // kubernetesAuthApis check drops MCP providers, and the brokerCovered guard
-    // is belt-and-suspenders so the two paths never both own an installation.
+    // kubernetesAuthApis check drops MCP providers, the brokerCovered guard is
+    // belt-and-suspenders so the two paths never both own an installation, and
+    // muted installations are switched off app-wide.
     const nonBrokerProviders = authProvidersApi
       .getProviders()
       .filter(
         provider =>
           Boolean(kubernetesAuthApis[provider.providerName]) &&
-          !brokerCovered.has(provider.installationName),
+          !brokerCovered.has(provider.installationName) &&
+          !mutedSet.has(provider.installationName),
       );
 
     const subscriptions = nonBrokerProviders.map(provider =>
@@ -250,7 +280,7 @@ export function ClusterAccessConnector() {
     return () => {
       subscriptions.forEach(subscription => subscription.unsubscribe());
     };
-  }, [authProvidersApi, statusApi]);
+  }, [authProvidersApi, statusApi, muted]);
 
   return null;
 }

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.test.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.test.tsx
@@ -143,4 +143,13 @@ describe('ClusterAccessStatusSidebarItem', () => {
 
     await waitFor(() => expect(mutedStore.isMuted('alpha')).toBe(true));
   });
+
+  it('does not claim "All 0 healthy" when everything is muted', async () => {
+    // No live entries, only muted installations: the summary must reflect the
+    // muted count, not a green "All 0 healthy".
+    await renderSidebar({ entries: [], muted: ['alpha', 'beta'] });
+
+    expect(screen.getByText(/2 off/)).toBeInTheDocument();
+    expect(screen.queryByText(/All 0 healthy/)).not.toBeInTheDocument();
+  });
 });

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.test.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.test.tsx
@@ -1,5 +1,23 @@
-import { ClusterAccessStatusEntry } from '../../apis/clusterAccessStatus';
-import { summarize } from './ClusterAccessStatusSidebarItem';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { errorApiRef } from '@backstage/core-plugin-api';
+import {
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+import {
+  ClusterAccessStatusApi,
+  ClusterAccessStatusEntry,
+  clusterAccessStatusApiRef,
+} from '../../apis/clusterAccessStatus';
+import {
+  mutedInstallationsApiRef,
+  MutedInstallationsStore,
+} from '../../apis/mutedInstallations';
+import { gsAuthApiRef } from '../../apis/auth/types';
+import {
+  ClusterAccessStatusSidebarItem,
+  summarize,
+} from './ClusterAccessStatusSidebarItem';
 
 function entry(
   installation: string,
@@ -7,6 +25,47 @@ function entry(
   reason?: string,
 ): ClusterAccessStatusEntry {
   return { installation, state, reason, lastChecked: 0 };
+}
+
+function fakeStatusApi(
+  snapshot: ClusterAccessStatusEntry[],
+): ClusterAccessStatusApi {
+  return {
+    getSnapshot: () => snapshot,
+    status$: () => ({ subscribe: () => ({ unsubscribe() {} }) }),
+    recordConnecting() {},
+    recordHealthy() {},
+    recordDegraded() {},
+    recordSessionExpired() {},
+    remove() {},
+  } as unknown as ClusterAccessStatusApi;
+}
+
+async function renderSidebar({
+  entries = [],
+  muted = [],
+}: {
+  entries?: ClusterAccessStatusEntry[];
+  muted?: string[];
+}) {
+  const mutedStore = MutedInstallationsStore.create();
+  muted.forEach(name => mutedStore.setMuted(name, true));
+
+  await renderInTestApp(
+    <TestApiProvider
+      apis={[
+        [clusterAccessStatusApiRef, fakeStatusApi(entries)],
+        [mutedInstallationsApiRef, mutedStore],
+        [gsAuthApiRef, { signIn: jest.fn() } as any],
+        [errorApiRef, { post: jest.fn(), error$: jest.fn() } as any],
+      ]}
+    >
+      <ClusterAccessStatusSidebarItem />
+    </TestApiProvider>,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /cluster access/i }));
+  return { mutedStore };
 }
 
 describe('summarize', () => {
@@ -41,5 +100,47 @@ describe('summarize', () => {
     const parts = summarize([entry('a', 'connecting'), entry('b', 'degraded')]);
 
     expect(parts.map(p => p.key)).toEqual(['degraded', 'connecting']);
+  });
+});
+
+describe('ClusterAccessStatusSidebarItem', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('lists accessed installations with an on toggle', async () => {
+    await renderSidebar({ entries: [entry('alpha', 'healthy')] });
+
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    const toggle = screen.getByRole('switch', {
+      name: 'Enable installation alpha',
+    });
+    expect(toggle).toBeChecked();
+  });
+
+  it('lists a muted installation (not probed) as an off row', async () => {
+    // gremlin is muted, so it has no status entry but must still be listed.
+    await renderSidebar({
+      entries: [entry('alpha', 'healthy')],
+      muted: ['gremlin'],
+    });
+
+    expect(screen.getByText('gremlin')).toBeInTheDocument();
+    expect(screen.getByText('Off')).toBeInTheDocument();
+    expect(
+      screen.getByRole('switch', { name: 'Enable installation gremlin' }),
+    ).not.toBeChecked();
+  });
+
+  it('mutes an installation when its toggle is switched off', async () => {
+    const { mutedStore } = await renderSidebar({
+      entries: [entry('alpha', 'healthy')],
+    });
+
+    fireEvent.click(
+      screen.getByRole('switch', { name: 'Enable installation alpha' }),
+    );
+
+    await waitFor(() => expect(mutedStore.isMuted('alpha')).toBe(true));
   });
 });

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
@@ -17,7 +17,10 @@ import {
   ClusterAccessStatusEntry,
   clusterAccessStatusApiRef,
 } from '../../apis/clusterAccessStatus';
-import { mutedInstallationsApiRef } from '../../apis/mutedInstallations';
+import {
+  mutedInstallationsApiRef,
+  useMutedInstallations,
+} from '../../apis/mutedInstallations';
 import { gsAuthApiRef } from '../../apis/auth/types';
 
 const STATE_COLORS: Record<ClusterAccessState, string> = {
@@ -170,7 +173,7 @@ export function ClusterAccessStatusSidebarItem() {
   const [entries, setEntries] = useState<ClusterAccessStatusEntry[]>(
     statusApi.getSnapshot(),
   );
-  const [muted, setMuted] = useState<string[]>(() => mutedApi.getSnapshot());
+  const muted = useMutedInstallations();
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   useEffect(() => {
@@ -178,15 +181,17 @@ export function ClusterAccessStatusSidebarItem() {
     return () => subscription.unsubscribe();
   }, [statusApi]);
 
-  useEffect(() => {
-    const subscription = mutedApi.muted$().subscribe(setMuted);
-    return () => subscription.unsubscribe();
-  }, [mutedApi]);
-
   const state = useMemo(() => overallState(entries), [entries]);
-  const summary = useMemo(() => summarize(entries), [entries]);
+  // `summarize`/`overallState` only know about *probed* entries. With no live
+  // entries but some muted installations, they'd report a green "All 0 healthy" —
+  // the opposite of reality — so drive the badge and summary off the muted set in
+  // that case (the muted count is appended to the summary in render).
+  const summary = useMemo(
+    () => (entries.length > 0 ? summarize(entries) : []),
+    [entries],
+  );
   const sessionExpired = state === 'session-expired';
-  const color = STATE_COLORS[state];
+  const badgeColor = entries.length === 0 ? MUTED_COLOR : STATE_COLORS[state];
 
   // One row per accessed *or* muted installation, sorted by name. A muted
   // installation isn't probed (so it has no status entry) but is still listed so
@@ -231,7 +236,10 @@ export function ClusterAccessStatusSidebarItem() {
   const icon = () => (
     <Box position="relative" display="flex">
       <CloudIcon />
-      <FiberManualRecordIcon className={classes.badge} style={{ color }} />
+      <FiberManualRecordIcon
+        className={classes.badge}
+        style={{ color: badgeColor }}
+      />
     </Box>
   );
 
@@ -271,6 +279,12 @@ export function ClusterAccessStatusSidebarItem() {
                 </span>
               </span>
             ))}
+            {muted.length > 0 && (
+              <span>
+                {summary.length > 0 && ' · '}
+                {muted.length} off
+              </span>
+            )}
           </Typography>
         </div>
         <Divider />

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessStatusSidebarItem.tsx
@@ -1,6 +1,7 @@
 import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import { SidebarItem } from '@backstage/core-components';
 import { useApi, errorApiRef } from '@backstage/core-plugin-api';
+import { Switch } from '@backstage/ui';
 import {
   Box,
   Button,
@@ -16,6 +17,7 @@ import {
   ClusterAccessStatusEntry,
   clusterAccessStatusApiRef,
 } from '../../apis/clusterAccessStatus';
+import { mutedInstallationsApiRef } from '../../apis/mutedInstallations';
 import { gsAuthApiRef } from '../../apis/auth/types';
 
 const STATE_COLORS: Record<ClusterAccessState, string> = {
@@ -24,6 +26,11 @@ const STATE_COLORS: Record<ClusterAccessState, string> = {
   degraded: '#f9a825',
   'session-expired': '#c62828',
 };
+
+// A muted installation is switched off app-wide: not probed, not fetched. Shown
+// greyed with an "Off" caption and its toggle in the off position.
+const MUTED_COLOR = '#bdbdbd';
+const MUTED_LABEL = 'Off';
 
 const STATE_LABELS: Record<ClusterAccessState, string> = {
   connecting: 'Connecting…',
@@ -72,7 +79,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1),
-    padding: theme.spacing(0.5, 2),
+    padding: theme.spacing(0.5, 1, 0.5, 2),
   },
   name: {
     flexShrink: 0,
@@ -87,6 +94,11 @@ const useStyles = makeStyles(theme => ({
     // baseline lines up with the installation name instead of sitting high.
     position: 'relative',
     top: 2,
+  },
+  toggle: {
+    // Right-align the switch even when a row has no reason caption to fill the
+    // gap.
+    marginLeft: 'auto',
   },
   actions: {
     padding: theme.spacing(1, 2, 2, 2),
@@ -151,12 +163,14 @@ function StatusDot({ color }: { color: string }) {
 export function ClusterAccessStatusSidebarItem() {
   const classes = useStyles();
   const statusApi = useApi(clusterAccessStatusApiRef);
+  const mutedApi = useApi(mutedInstallationsApiRef);
   const mainAuthApi = useApi(gsAuthApiRef);
   const errorApi = useApi(errorApiRef);
 
   const [entries, setEntries] = useState<ClusterAccessStatusEntry[]>(
     statusApi.getSnapshot(),
   );
+  const [muted, setMuted] = useState<string[]>(() => mutedApi.getSnapshot());
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   useEffect(() => {
@@ -164,13 +178,53 @@ export function ClusterAccessStatusSidebarItem() {
     return () => subscription.unsubscribe();
   }, [statusApi]);
 
+  useEffect(() => {
+    const subscription = mutedApi.muted$().subscribe(setMuted);
+    return () => subscription.unsubscribe();
+  }, [mutedApi]);
+
   const state = useMemo(() => overallState(entries), [entries]);
   const summary = useMemo(() => summarize(entries), [entries]);
   const sessionExpired = state === 'session-expired';
   const color = STATE_COLORS[state];
 
-  // Nothing has been accessed yet -- keep the sidebar uncluttered.
-  if (entries.length === 0) {
+  // One row per accessed *or* muted installation, sorted by name. A muted
+  // installation isn't probed (so it has no status entry) but is still listed so
+  // it can be switched back on.
+  const rows = useMemo(() => {
+    const mutedSet = new Set(muted);
+    const entryByInstallation = new Map(
+      entries.map(entry => [entry.installation, entry]),
+    );
+    const installations = Array.from(
+      new Set([...entryByInstallation.keys(), ...muted]),
+    ).sort((a, b) => a.localeCompare(b));
+
+    return installations.map(installation => {
+      if (mutedSet.has(installation)) {
+        return {
+          installation,
+          dotColor: MUTED_COLOR,
+          caption: MUTED_LABEL,
+          enabled: false,
+        };
+      }
+      const entry = entryByInstallation.get(installation)!;
+      const caption =
+        entry.state === 'degraded' || entry.state === 'session-expired'
+          ? (entry.reason ?? STATE_LABELS[entry.state])
+          : undefined;
+      return {
+        installation,
+        dotColor: STATE_COLORS[entry.state],
+        caption,
+        enabled: true,
+      };
+    });
+  }, [entries, muted]);
+
+  // Nothing accessed and nothing muted -- keep the sidebar uncluttered.
+  if (entries.length === 0 && muted.length === 0) {
     return null;
   }
 
@@ -221,30 +275,32 @@ export function ClusterAccessStatusSidebarItem() {
         </div>
         <Divider />
         <div className={classes.list}>
-          {entries.map(entry => {
-            const reason =
-              entry.state === 'degraded' || entry.state === 'session-expired'
-                ? (entry.reason ?? STATE_LABELS[entry.state])
-                : undefined;
-            return (
-              <div key={entry.installation} className={classes.row}>
-                <StatusDot color={STATE_COLORS[entry.state]} />
-                <Typography variant="body2" noWrap className={classes.name}>
-                  {entry.installation}
+          {rows.map(({ installation, dotColor, caption, enabled }) => (
+            <div key={installation} className={classes.row}>
+              <StatusDot color={dotColor} />
+              <Typography variant="body2" noWrap className={classes.name}>
+                {installation}
+              </Typography>
+              {caption && (
+                <Typography
+                  variant="caption"
+                  color="textSecondary"
+                  className={classes.reason}
+                  title={caption}
+                >
+                  {caption}
                 </Typography>
-                {reason && (
-                  <Typography
-                    variant="caption"
-                    color="textSecondary"
-                    className={classes.reason}
-                    title={reason}
-                  >
-                    {reason}
-                  </Typography>
-                )}
-              </div>
-            );
-          })}
+              )}
+              <Switch
+                className={classes.toggle}
+                aria-label={`Enable installation ${installation}`}
+                isSelected={enabled}
+                onChange={isSelected =>
+                  mutedApi.setMuted(installation, !isSelected)
+                }
+              />
+            </div>
+          ))}
         </div>
         {sessionExpired && (
           <>

--- a/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.test.tsx
+++ b/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.test.tsx
@@ -1,0 +1,54 @@
+import { waitFor } from '@testing-library/react';
+import {
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+import { mutedInstallationsApiRef } from '../../../../apis/mutedInstallations';
+import { MutedInstallationsStore } from '../../../../apis/mutedInstallations/MutedInstallationsStore';
+import { InstallationPicker } from './InstallationPicker';
+
+// Capture the props MultipleClustersSelector receives so we can assert the
+// disabledClusters union without rendering its heavy internals.
+const mockSelector = jest.fn();
+jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
+  MultipleClustersSelector: (props: unknown) => {
+    mockSelector(props);
+    return null;
+  },
+  useClustersInfo: () => ({
+    clusters: ['alpha', 'beta', 'gamma'],
+    isLoading: false,
+  }),
+}));
+
+// Health-based disabled installations (distinct from user-muted).
+jest.mock('../../../hooks', () => ({
+  useDisabledInstallations: () => ({
+    disabledInstallations: ['beta'],
+    isLoading: false,
+  }),
+}));
+
+describe('InstallationPicker', () => {
+  beforeEach(() => {
+    mockSelector.mockClear();
+    window.localStorage.clear();
+  });
+
+  it('unions user-muted installations into disabledClusters', async () => {
+    const mutedStore = MutedInstallationsStore.create();
+    mutedStore.setMuted('gamma', true);
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[mutedInstallationsApiRef, mutedStore]]}>
+        <InstallationPicker onActiveInstallationsChange={() => {}} />
+      </TestApiProvider>,
+    );
+
+    await waitFor(() => {
+      const props = mockSelector.mock.calls.at(-1)?.[0];
+      // beta (health-disabled) ∪ gamma (user-muted).
+      expect([...props.disabledClusters].sort()).toEqual(['beta', 'gamma']);
+    });
+  });
+});

--- a/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.tsx
+++ b/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.tsx
@@ -1,12 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Box } from '@material-ui/core';
-import { useApi } from '@backstage/core-plugin-api';
 import {
   MultipleClustersSelector,
   useClustersInfo,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { useDisabledInstallations } from '../../../hooks';
-import { mutedInstallationsApiRef } from '../../../../apis/mutedInstallations';
+import { useMutedInstallations } from '../../../../apis/mutedInstallations';
 
 type InstallationPickerProps = {
   onActiveInstallationsChange: (installations: string[]) => void;
@@ -24,12 +23,7 @@ export const InstallationPicker = ({
   // Installations the user has muted app-wide are excluded from fleet fetches
   // exactly like health-disabled ones: fold them into disabledClusters, which
   // MultipleClustersSelector both greys out and drops from the active set.
-  const mutedApi = useApi(mutedInstallationsApiRef);
-  const [muted, setMuted] = useState<string[]>(() => mutedApi.getSnapshot());
-  useEffect(() => {
-    const subscription = mutedApi.muted$().subscribe(setMuted);
-    return () => subscription.unsubscribe();
-  }, [mutedApi]);
+  const muted = useMutedInstallations();
 
   const disabledClusters = useMemo(
     () => Array.from(new Set([...disabledInstallations, ...muted])),

--- a/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.tsx
+++ b/plugins/gs/src/components/installations/filters/InstallationPicker/InstallationPicker.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useMemo, useState } from 'react';
 import { Box } from '@material-ui/core';
+import { useApi } from '@backstage/core-plugin-api';
 import {
   MultipleClustersSelector,
   useClustersInfo,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { useDisabledInstallations } from '../../../hooks';
+import { mutedInstallationsApiRef } from '../../../../apis/mutedInstallations';
 
 type InstallationPickerProps = {
   onActiveInstallationsChange: (installations: string[]) => void;
@@ -18,6 +21,21 @@ export const InstallationPicker = ({
   const { disabledInstallations, isLoading: isLoadingDisabledInstallations } =
     useDisabledInstallations();
 
+  // Installations the user has muted app-wide are excluded from fleet fetches
+  // exactly like health-disabled ones: fold them into disabledClusters, which
+  // MultipleClustersSelector both greys out and drops from the active set.
+  const mutedApi = useApi(mutedInstallationsApiRef);
+  const [muted, setMuted] = useState<string[]>(() => mutedApi.getSnapshot());
+  useEffect(() => {
+    const subscription = mutedApi.muted$().subscribe(setMuted);
+    return () => subscription.unsubscribe();
+  }, [mutedApi]);
+
+  const disabledClusters = useMemo(
+    () => Array.from(new Set([...disabledInstallations, ...muted])),
+    [disabledInstallations, muted],
+  );
+
   return (
     <Box py={clusters.length > 1 ? 1 : 0}>
       <MultipleClustersSelector
@@ -25,7 +43,7 @@ export const InstallationPicker = ({
         persistToURL={persistToURL}
         urlParameterName="installations"
         clusters={clusters}
-        disabledClusters={disabledInstallations}
+        disabledClusters={disabledClusters}
         isLoadingDisabledClusters={isLoadingDisabledInstallations}
         disabled={isLoading}
         onActiveClustersChange={onActiveInstallationsChange}

--- a/plugins/gs/src/index.ts
+++ b/plugins/gs/src/index.ts
@@ -16,6 +16,10 @@ export {
   type ClusterAccessState,
 } from './apis/clusterAccessStatus';
 export {
+  mutedInstallationsApiRef,
+  type MutedInstallationsApi,
+} from './apis/mutedInstallations';
+export {
   ClusterAccessStatusSidebarItem,
   ClusterAccessConnector,
 } from './components/ClusterAccessStatus';

--- a/plugins/gs/src/plugin.tsx
+++ b/plugins/gs/src/plugin.tsx
@@ -48,6 +48,10 @@ import {
   clusterAccessStatusApiRef,
   ClusterAccessStatusStore,
 } from './apis/clusterAccessStatus';
+import {
+  mutedInstallationsApiRef,
+  MutedInstallationsStore,
+} from './apis/mutedInstallations';
 import { DiscoveryApiClient } from './apis/discovery/DiscoveryApiClient';
 import {
   ContainerRegistryClient,
@@ -117,6 +121,16 @@ const clusterAccessStatusApi = ApiBlueprint.make({
       api: clusterAccessStatusApiRef,
       deps: {},
       factory: () => ClusterAccessStatusStore.create(),
+    }),
+});
+
+const mutedInstallationsApi = ApiBlueprint.make({
+  name: 'muted-installations',
+  params: defineParams =>
+    defineParams({
+      api: mutedInstallationsApiRef,
+      deps: {},
+      factory: () => MutedInstallationsStore.create(),
     }),
 });
 
@@ -591,6 +605,7 @@ export const gsPlugin = createFrontendPlugin({
     deploymentsPage,
     installationsPage,
     clusterAccessStatusApi,
+    mutedInstallationsApi,
     gsAuthProvidersApi,
     gsAuthApi,
     containerRegistryApi,


### PR DESCRIPTION
### What does this PR do?

Adds a per-installation **on/off toggle** to the sidebar **Cluster access** popover. A *muted* installation is switched off for the whole app:

- the `ClusterAccessConnector` stops probing it (and drops it from the access-status set);
- fleet views stop fetching from it — the shared `InstallationPicker` folds the muted set into `disabledClusters` (which `MultipleClustersSelector` already excludes from the active/fetched set), covering the **Clusters** and **Deployments** pages; and the **agent-platform** lists exclude it automatically (muted → not probed → not `healthy` → not reachable).

The preference is user intent, so it is persisted per-browser (`localStorage`, key `gs-muted-installations`) and synced across tabs — deliberately distinct from the health-based `useDisabledInstallations` hook, which auto-detects unreachable backends.

Implemented as a new `MutedInstallationsApi` / `MutedInstallationsStore` (mirrors the cluster-access status store, but persisted), registered in the gs plugin and exported. The toggle itself is a bui (`@backstage/ui`) `Switch`.

Also fixes a pre-existing quirk surfaced by the toggle: a successful broker cluster-token mint recorded the installation as **healthy** (green) even when the apiserver was unreachable, so un-muting an unreachable installation flashed green before the `/version` probe corrected it to degraded. Health is now owned solely by the authoritative `/version` probe; the mint still records the precise broker-level failure states (session-expired / degraded), which the probe defers to.

### What is the effect of this change to users?

Users can turn individual installations off from the Cluster access popover. A muted installation is no longer probed and no longer appears / is fetched in the Clusters, Deployments, or Agent Platform views. It shows as an "Off" row in the popover and can be switched back on at any time. The setting persists across reloads. Un-muting an unreachable installation now shows connecting → degraded, with no misleading green flash (this also removes the brief false-green during initial app load).

### How does it look like?

<img width="467" height="355" alt="image" src="https://github.com/user-attachments/assets/9c81fefc-9e4c-4e78-aa96-afc22424fea1" />


### Any background context you can provide?

Follow-up to the agent-platform reachability work (#1957). The toggle deliberately lives in the shared Cluster access widget rather than the agent-platform page so it applies app-wide.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. (`@giantswarm/backstage-plugin-gs` is `private: true`, not published to npm — no changeset needed; released via the app image/chart auto-release.)