### PR TITLE
fix(gs): don't reset resolved cluster-access states to connecting on mute toggle

### DIFF
--- a/.changeset/cluster-access-no-reseed-on-mute.md
+++ b/.changeset/cluster-access-no-reseed-on-mute.md
@@ -1,0 +1,11 @@
+---
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Fix a grey-flicker regression in the sidebar Cluster access widget: muting or
+un-muting one installation reset every other installation's dot back to
+"connecting" (grey) until it re-probed. The connector re-runs its probe effect
+on every muted-set change and was re-seeding all installations to `connecting`
+each time; it now seeds only installations not already tracked, so
+already-resolved (healthy/degraded) clusters keep their state when another
+installation is toggled.

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.reseed.test.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.reseed.test.tsx
@@ -1,0 +1,81 @@
+import { act, waitFor } from '@testing-library/react';
+import {
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
+import { gsAuthProvidersApiRef } from '../../apis/auth';
+import {
+  clusterAccessStatusApiRef,
+  ClusterAccessStatusStore,
+} from '../../apis/clusterAccessStatus';
+import {
+  mutedInstallationsApiRef,
+  MutedInstallationsStore,
+} from '../../apis/mutedInstallations';
+import { ClusterAccessConnector } from './ClusterAccessConnector';
+
+function fakeAuthProviders(broker: string[]) {
+  return {
+    getBrokerCoveredInstallations: () => broker,
+    getKubernetesAuthApis: () => ({}),
+    getProviders: () => [],
+  } as any;
+}
+
+function stateByInstallation(store: ClusterAccessStatusStore) {
+  return Object.fromEntries(
+    store.getSnapshot().map(entry => [entry.installation, entry.state]),
+  );
+}
+
+describe('ClusterAccessConnector', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('does not reset already-healthy installations to connecting when another is muted', async () => {
+    const statusApi =
+      ClusterAccessStatusStore.create() as ClusterAccessStatusStore;
+    const mutedApi = MutedInstallationsStore.create();
+    const kubernetesApi = {
+      proxy: jest.fn(async () => ({ ok: true, status: 200 })),
+    } as any;
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [kubernetesApiRef, kubernetesApi],
+          [gsAuthProvidersApiRef, fakeAuthProviders(['alpha', 'beta'])],
+          [clusterAccessStatusApiRef, statusApi],
+          [mutedInstallationsApiRef, mutedApi],
+        ]}
+      >
+        <ClusterAccessConnector />
+      </TestApiProvider>,
+    );
+
+    // Both installations probe healthy.
+    await waitFor(() =>
+      expect(stateByInstallation(statusApi)).toEqual({
+        alpha: 'healthy',
+        beta: 'healthy',
+      }),
+    );
+
+    // From here on, muting one installation must not re-seed the other back to
+    // "connecting" (the reported grey-flicker regression).
+    const recordConnecting = jest.spyOn(statusApi, 'recordConnecting');
+
+    act(() => {
+      mutedApi.setMuted('alpha', true);
+    });
+
+    // alpha drops off the status set; beta stays put and healthy.
+    await waitFor(() =>
+      expect(statusApi.getSnapshot().map(e => e.installation)).toEqual([
+        'beta',
+      ]),
+    );
+    expect(recordConnecting).not.toHaveBeenCalledWith('beta');
+    expect(stateByInstallation(statusApi)).toEqual({ beta: 'healthy' });
+  });
+});

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -153,11 +153,19 @@ export function ClusterAccessConnector() {
     // running, so a refresh tick never stacks a second loop on the same one.
     const inFlight = new Set<string>();
 
-    // Seed once so the sidebar lists every covered installation immediately,
-    // before any probe settles. Re-probes (interval) intentionally do not
-    // reset entries to "connecting", to avoid flicker.
+    // Seed the sidebar so it lists every covered installation immediately,
+    // before any probe settles — but only installations not already tracked.
+    // This effect re-runs whenever the muted set changes, so re-seeding every
+    // installation to "connecting" would reset already-resolved (healthy/
+    // degraded) clusters to grey on every mute/unmute. Seeding only the unknown
+    // ones keeps resolved states stable; the interval re-probe never seeds.
+    const alreadyTracked = new Set(
+      statusApi.getSnapshot().map(entry => entry.installation),
+    );
     for (const installation of installations) {
-      statusApi.recordConnecting(installation);
+      if (!alreadyTracked.has(installation)) {
+        statusApi.recordConnecting(installation);
+      }
     }
 
     const apply = (installation: string, outcome: ProbeOutcome): boolean => {


### PR DESCRIPTION
### What does this PR do?

Fixes a grey-flicker regression in the sidebar **Cluster access** widget introduced with the per-installation mute toggle (#1958).

The `ClusterAccessConnector` re-runs its probe effect whenever the muted set changes (so a muted installation stops being probed and an un-muted one resumes). But its seed loop called `recordConnecting(...)` for **every** non-muted installation on each run — flipping already-resolved `healthy`/`degraded` clusters back to `connecting` (grey) until they re-probed.

Fix: seed `connecting` only for installations **not already tracked** in the status set. Resolved states are left untouched when another installation is toggled; genuinely new/un-muted installations still get seeded and probed.

### What is the effect of this change to users?

Muting or un-muting one installation no longer makes all the other green (healthy) dots blink grey and back. Only the toggled installation changes.

### How does it look like?

No new UI — the Cluster access popover simply stops flickering the other installations when you toggle one.

### Any background context you can provide?

Reported after #1958 shipped: with nothing muted, toggling one installation off briefly reset every other installation's dot to grey. Root cause is the effect re-run re-seeding all installations. Includes a regression test (`ClusterAccessConnector.reseed.test.tsx`) that asserts muting one installation does not call `recordConnecting` for the others (it fails without the fix).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.