### PR TITLE
fix(gs): load installations configuration from an authenticated backend endpoint

### DIFF
--- a/.changeset/installations-config-backend.md
+++ b/.changeset/installations-config-backend.md
@@ -1,0 +1,12 @@
+---
+'@giantswarm/backstage-plugin-gs': minor
+'@giantswarm/backstage-plugin-gs-backend': minor
+'@giantswarm/backstage-plugin-agent-platform': patch
+---
+
+Serve installation configuration (`gs.installations`) from the `gs-backend`
+plugin through a new authenticated endpoint, and load it in the frontend after
+sign-in instead of reading it from static frontend config. The boot-time
+frontend APIs (Kubernetes, discovery, auth) now obtain installation data
+asynchronously from a shared source, and per-installation auth providers
+initialize lazily once the main sign-in completes.

--- a/packages/app/src/modules/app/AppOverrides.tsx
+++ b/packages/app/src/modules/app/AppOverrides.tsx
@@ -42,6 +42,7 @@ import {
 import {
   GSDiscoveryApiClient,
   gsAuthApiRef,
+  InstallationsConfigLoader,
 } from '@giantswarm/backstage-plugin-gs';
 import { errorReporterApiRef } from '@giantswarm/backstage-plugin-error-reporter-react';
 import { grafanaPlugin } from '@backstage-community/plugin-grafana';
@@ -118,8 +119,14 @@ export const appOverrides = createFrontendModule({
                 FetchMiddlewares.injectIdentityAuth({
                   identityApi,
                   config: configApi,
-                  urlPrefixAllowlist:
-                    GSDiscoveryApiClient.getUrlPrefixAllowlist(configApi),
+                  // Per-request matcher (not a static allowlist): the
+                  // per-installation `backendUrl` overrides are loaded from the
+                  // backend after sign-in, so the set of URLs needing the
+                  // Backstage token grows after app boot.
+                  allowUrl:
+                    GSDiscoveryApiClient.createUrlPrefixAllowlistMatcher(
+                      configApi,
+                    ),
                   header: {
                     name: 'X-Backstage-Token',
                     value: (token: string) => `Bearer ${token}`,
@@ -182,6 +189,18 @@ export const appOverrides = createFrontendModule({
       name: 'branding-favicon',
       params: {
         element: <BrandingFavicon />,
+      },
+    }),
+    /**
+     * Loads the `gs.installations` config from the authenticated backend
+     * endpoint once, after sign-in, and publishes it to the module-level source
+     * consumed by the boot-time APIs and UI. The block is no longer shipped in
+     * the unauthenticated frontend config (it deanonymized customers).
+     */
+    AppRootElementBlueprint.make({
+      name: 'installations-config-loader',
+      params: {
+        element: <InstallationsConfigLoader />,
       },
     }),
     /**

--- a/packages/app/src/modules/kubernetes/KubernetesApiOverrides.ts
+++ b/packages/app/src/modules/kubernetes/KubernetesApiOverrides.ts
@@ -10,12 +10,79 @@ import {
   kubernetesApiRef,
   KubernetesAuthProviders,
   kubernetesAuthProvidersApiRef,
+  KubernetesAuthProvidersApi,
 } from '@backstage/plugin-kubernetes-react';
 import {
   gsAuthProvidersApiRef,
+  GSAuthProvidersApi,
   GSDiscoveryApiClient,
   KubernetesClient,
 } from '@giantswarm/backstage-plugin-gs';
+
+const OIDC_AUTH_PROVIDER_PREFIX = 'oidc.';
+
+type KubernetesRequestBody = Parameters<
+  KubernetesAuthProvidersApi['decorateRequestBodyForAuth']
+>[1];
+
+/**
+ * Kubernetes auth-providers implementation that resolves OIDC providers lazily
+ * from `GSAuthProvidersApi`.
+ *
+ * The upstream `KubernetesAuthProviders` snapshots its `oidcProviders` map at
+ * construction. Since the per-installation OIDC providers are now built only
+ * after installations load (post sign-in), we cannot pass a complete map at
+ * app-boot. Instead, non-OIDC providers (microsoft/google/…) are delegated to a
+ * base `KubernetesAuthProviders`, while `oidc.<provider>` credentials are
+ * resolved on demand through `gsAuthProvidersApi.getKubernetesAuthApi()` (which
+ * awaits lazy initialization).
+ */
+class GSKubernetesAuthProviders implements KubernetesAuthProvidersApi {
+  constructor(
+    private readonly base: KubernetesAuthProvidersApi,
+    private readonly gsAuthProvidersApi: GSAuthProvidersApi,
+  ) {}
+
+  private isOidc(authProvider: string): boolean {
+    return authProvider.startsWith(OIDC_AUTH_PROVIDER_PREFIX);
+  }
+
+  private async resolveOidcToken(authProvider: string): Promise<string> {
+    const providerName = authProvider.slice(OIDC_AUTH_PROVIDER_PREFIX.length);
+    const authApi =
+      await this.gsAuthProvidersApi.getKubernetesAuthApi(providerName);
+    if (!authApi) {
+      throw new Error(
+        `OIDC auth provider "${providerName}" is not configured.`,
+      );
+    }
+    return authApi.getIdToken();
+  }
+
+  async getCredentials(authProvider: string): Promise<{ token?: string }> {
+    if (this.isOidc(authProvider)) {
+      return { token: await this.resolveOidcToken(authProvider) };
+    }
+    return this.base.getCredentials(authProvider);
+  }
+
+  async decorateRequestBodyForAuth(
+    authProvider: string,
+    requestBody: KubernetesRequestBody,
+  ): Promise<KubernetesRequestBody> {
+    if (this.isOidc(authProvider)) {
+      const providerName = authProvider.slice(OIDC_AUTH_PROVIDER_PREFIX.length);
+      const token = await this.resolveOidcToken(authProvider);
+      const auth = { ...(requestBody.auth ?? {}) } as {
+        oidc?: { [key: string]: string };
+      };
+      auth.oidc = { ...(auth.oidc ?? {}), [providerName]: token };
+      requestBody.auth = auth;
+      return requestBody;
+    }
+    return this.base.decorateRequestBodyForAuth(authProvider, requestBody);
+  }
+}
 
 export const KubernetesAuthProvidersOverride = ApiBlueprint.make({
   name: 'auth-providers',
@@ -28,14 +95,11 @@ export const KubernetesAuthProvidersOverride = ApiBlueprint.make({
         gsAuthProvidersApi: gsAuthProvidersApiRef,
       },
       factory: ({ microsoftAuthApi, googleAuthApi, gsAuthProvidersApi }) => {
-        const oidcProviders = {
-          ...gsAuthProvidersApi.getKubernetesAuthApis(),
-        };
-        return new KubernetesAuthProviders({
+        const base = new KubernetesAuthProviders({
           microsoftAuthApi,
           googleAuthApi,
-          oidcProviders,
         });
+        return new GSKubernetesAuthProviders(base, gsAuthProvidersApi);
       },
     }),
 });

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
@@ -14,10 +14,10 @@ let mockReachable: { installations: string[]; isProbing: boolean } = {
   isProbing: false,
 };
 
-jest.mock('@backstage/core-plugin-api', () => ({
-  configApiRef: {},
-  useApi: () => ({
-    getOptionalConfig: () => ({ keys: () => mockConfigInstallations }),
+jest.mock('@giantswarm/backstage-plugin-gs', () => ({
+  useInstallations: () => ({
+    installations: mockConfigInstallations.map(name => ({ name })),
+    isLoading: false,
   }),
 }));
 

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
@@ -6,12 +6,12 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   Agent,
   isNotFoundError,
   useResources,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
+import { useInstallations } from '@giantswarm/backstage-plugin-gs';
 import { useReachableInstallations } from '../../hooks/useReachableInstallations';
 import { useModelConfigs } from '../ModelConfigsProvider';
 import { AgentRow, sortAgentRows, toAgentRow } from './helpers';
@@ -50,9 +50,8 @@ const AgentsContext = createContext<AgentsContextValue | undefined>(undefined);
  * inside one.
  */
 export function AgentsDataProvider({ children }: { children: ReactNode }) {
-  const configApi = useApi(configApiRef);
-  const allInstallations =
-    configApi.getOptionalConfig('gs.installations')?.keys() ?? [];
+  const { installations } = useInstallations();
+  const allInstallations = installations.map(installation => installation.name);
 
   // Only query reachable installations so the fleet-wide query doesn't fan out
   // to unreachable/forbidden clusters (each hangs for the full proxy timeout

--- a/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
+++ b/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.test.tsx
@@ -13,10 +13,10 @@ let mockReachable: { installations: string[]; isProbing: boolean } = {
   isProbing: false,
 };
 
-jest.mock('@backstage/core-plugin-api', () => ({
-  configApiRef: {},
-  useApi: () => ({
-    getOptionalConfig: () => ({ keys: () => mockConfigInstallations }),
+jest.mock('@giantswarm/backstage-plugin-gs', () => ({
+  useInstallations: () => ({
+    installations: mockConfigInstallations.map(name => ({ name })),
+    isLoading: false,
   }),
 }));
 

--- a/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.tsx
+++ b/plugins/agent-platform/src/components/ModelConfigsProvider/ModelConfigsProvider.tsx
@@ -1,10 +1,10 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   isNotFoundError,
   ModelConfig,
   useResources,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
+import { useInstallations } from '@giantswarm/backstage-plugin-gs';
 import { useReachableInstallations } from '../../hooks/useReachableInstallations';
 
 export type ModelConfigsContextValue = {
@@ -38,9 +38,8 @@ const ModelConfigsContext = createContext<ModelConfigsContextValue | undefined>(
  * selected installation's models) so the fleet is only queried once.
  */
 export function ModelConfigsProvider({ children }: { children: ReactNode }) {
-  const configApi = useApi(configApiRef);
-  const allInstallations =
-    configApi.getOptionalConfig('gs.installations')?.keys() ?? [];
+  const { installations } = useInstallations();
+  const allInstallations = installations.map(installation => installation.name);
 
   // Only query installations the app currently considers reachable, so the
   // fleet-wide query doesn't fan out to unreachable/forbidden clusters (each of

--- a/plugins/gs-backend/src/installations.ts
+++ b/plugins/gs-backend/src/installations.ts
@@ -1,0 +1,68 @@
+import { RootConfigService } from '@backstage/backend-plugin-api';
+
+/**
+ * Configuration of a single Giant Swarm installation, as returned by the
+ * authenticated `GET /api/gs/installations` endpoint.
+ */
+export type InstallationConfig = {
+  pipeline?: string;
+  providers?: string[];
+  authProvider?: string;
+  oidcTokenProvider?: string;
+  clusterTokenAudience?: string;
+  backendUrl?: string;
+  baseDomain?: string;
+  region?: string;
+  apiVersionOverrides?: { [pluralKind: string]: string };
+};
+
+export type InstallationsConfig = {
+  [installationName: string]: InstallationConfig;
+};
+
+/**
+ * Reads the full `gs.installations` map from app-config. The backend has
+ * unrestricted access to config regardless of frontend visibility, so this
+ * returns every field for every installation.
+ */
+export function readInstallationsConfig(
+  config: RootConfigService,
+): InstallationsConfig {
+  const installationsConfig = config.getOptionalConfig('gs.installations');
+  if (!installationsConfig) {
+    return {};
+  }
+
+  const result: InstallationsConfig = {};
+  for (const installationName of installationsConfig.keys()) {
+    const installationConfig = installationsConfig.getConfig(installationName);
+
+    const apiVersionOverridesConfig = installationConfig.getOptionalConfig(
+      'apiVersionOverrides',
+    );
+    const apiVersionOverrides = apiVersionOverridesConfig
+      ? Object.fromEntries(
+          apiVersionOverridesConfig
+            .keys()
+            .map(key => [key, apiVersionOverridesConfig.getString(key)]),
+        )
+      : undefined;
+
+    result[installationName] = {
+      pipeline: installationConfig.getOptionalString('pipeline'),
+      providers: installationConfig.getOptionalStringArray('providers'),
+      authProvider: installationConfig.getOptionalString('authProvider'),
+      oidcTokenProvider:
+        installationConfig.getOptionalString('oidcTokenProvider'),
+      clusterTokenAudience: installationConfig.getOptionalString(
+        'clusterTokenAudience',
+      ),
+      backendUrl: installationConfig.getOptionalString('backendUrl'),
+      baseDomain: installationConfig.getOptionalString('baseDomain'),
+      region: installationConfig.getOptionalString('region'),
+      apiVersionOverrides,
+    };
+  }
+
+  return result;
+}

--- a/plugins/gs-backend/src/plugin.ts
+++ b/plugins/gs-backend/src/plugin.ts
@@ -46,6 +46,7 @@ export const gsPlugin = createBackendPlugin({
 
         httpRouter.use(
           await createRouter({
+            config,
             containerRegistry,
             mimir,
             githubCredentialsProvider,

--- a/plugins/gs-backend/src/router.test.ts
+++ b/plugins/gs-backend/src/router.test.ts
@@ -1,0 +1,107 @@
+import { RootConfigService } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
+import { GithubCredentialsProvider } from '@backstage/integration';
+import { JsonObject } from '@backstage/types';
+import express from 'express';
+import request from 'supertest';
+import { createRouter } from './router';
+import { containerRegistryServiceRef } from '@giantswarm/backstage-plugin-gs-node';
+import { mimirServiceRef } from './services/MimirService';
+
+const containerRegistry = {} as unknown as typeof containerRegistryServiceRef.T;
+const mimir = {} as unknown as typeof mimirServiceRef.T;
+const githubCredentialsProvider = {} as unknown as GithubCredentialsProvider;
+
+function makeConfig(data: JsonObject): RootConfigService {
+  return mockServices.rootConfig({ data });
+}
+
+async function buildApp(config: RootConfigService) {
+  const router = await createRouter({
+    config,
+    containerRegistry,
+    mimir,
+    githubCredentialsProvider,
+  });
+  const app = express();
+  app.use(router);
+  return app;
+}
+
+describe('GET /installations', () => {
+  it('returns the full installations map with all fields', async () => {
+    const config = makeConfig({
+      gs: {
+        installations: {
+          golem: {
+            pipeline: 'stable',
+            providers: ['capa'],
+            authProvider: 'oidc',
+            oidcTokenProvider: 'oidc-golem',
+            clusterTokenAudience: 'golem',
+            backendUrl: 'https://golem.example.com',
+            baseDomain: 'golem.example.com',
+            region: 'eu-central-1',
+            apiVersionOverrides: {
+              clusters: 'v1beta1',
+            },
+          },
+        },
+      },
+    });
+
+    const app = await buildApp(config);
+    const response = await request(app).get('/installations');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      golem: {
+        pipeline: 'stable',
+        providers: ['capa'],
+        authProvider: 'oidc',
+        oidcTokenProvider: 'oidc-golem',
+        clusterTokenAudience: 'golem',
+        backendUrl: 'https://golem.example.com',
+        baseDomain: 'golem.example.com',
+        region: 'eu-central-1',
+        apiVersionOverrides: {
+          clusters: 'v1beta1',
+        },
+      },
+    });
+  });
+
+  it('omits unset optional fields', async () => {
+    const config = makeConfig({
+      gs: {
+        installations: {
+          minimal: {
+            pipeline: 'testing',
+            authProvider: 'oidc',
+          },
+        },
+      },
+    });
+
+    const app = await buildApp(config);
+    const response = await request(app).get('/installations');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      minimal: {
+        pipeline: 'testing',
+        authProvider: 'oidc',
+      },
+    });
+  });
+
+  it('returns an empty object when no installations are configured', async () => {
+    const config = makeConfig({ gs: {} });
+
+    const app = await buildApp(config);
+    const response = await request(app).get('/installations');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({});
+  });
+});

--- a/plugins/gs-backend/src/router.ts
+++ b/plugins/gs-backend/src/router.ts
@@ -1,3 +1,4 @@
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { InputError } from '@backstage/errors';
 import { GithubCredentialsProvider } from '@backstage/integration';
 import { z } from 'zod/v3';
@@ -10,18 +11,41 @@ import {
 } from './agentSkills/discoverAgentSkills';
 import { containerRegistryServiceRef } from '@giantswarm/backstage-plugin-gs-node';
 import { mimirServiceRef } from './services/MimirService';
+import { readInstallationsConfig } from './installations';
 
 export async function createRouter({
+  config,
   containerRegistry,
   mimir,
   githubCredentialsProvider,
 }: {
+  config: RootConfigService;
   containerRegistry: typeof containerRegistryServiceRef.T;
   mimir: typeof mimirServiceRef.T;
   githubCredentialsProvider: GithubCredentialsProvider;
 }): Promise<express.Router> {
   const router = Router();
   router.use(express.json());
+
+  /**
+   * GET /installations
+   *
+   * Returns the full Giant Swarm installations map from app-config
+   * (`gs.installations`). This block is intentionally NOT shipped to the
+   * unauthenticated frontend config (it would deanonymize customers via
+   * `baseDomain` and leak the installation topology), so the SPA loads it from
+   * this authenticated endpoint after the user signs in. Authenticated by
+   * default in the new backend system.
+   *
+   * Returns:
+   * - A map keyed by installation name, each value carrying the installation's
+   *   configuration fields (pipeline, providers, authProvider,
+   *   oidcTokenProvider, clusterTokenAudience, backendUrl, baseDomain, region,
+   *   apiVersionOverrides).
+   */
+  router.get('/installations', async (_req, res) => {
+    res.json(readInstallationsConfig(config));
+  });
 
   /**
    * GET /container-registry/tags

--- a/plugins/gs/config.d.ts
+++ b/plugins/gs/config.d.ts
@@ -64,7 +64,13 @@ export interface Config {
       }[];
     };
 
-    /** @deepVisibility frontend */
+    /**
+     * The full installations map is intentionally backend-only: shipping it to
+     * the unauthenticated frontend config deanonymizes customers (via
+     * `baseDomain`) and leaks the installation topology. The SPA loads it from
+     * the authenticated `GET /api/gs/installations` endpoint after sign-in.
+     * @visibility backend
+     */
     installations: {
       [installationName: string]: {
         pipeline: string;

--- a/plugins/gs/src/apis/auth/DefaultAuthConnector.test.ts
+++ b/plugins/gs/src/apis/auth/DefaultAuthConnector.test.ts
@@ -121,4 +121,56 @@ describe('DefaultAuthConnector', () => {
       expect(session).toEqual(legacyRefreshResponse);
     });
   });
+
+  describe('installation scoping (buildUrl)', () => {
+    function createConnectorForProvider(options: {
+      providerId: string;
+      isMainProvider?: boolean;
+    }) {
+      const getBaseUrl = jest.fn().mockResolvedValue('http://backend/api/auth');
+      const scopedDiscoveryApi = {
+        getBaseUrl,
+      } as unknown as DiscoveryApiClient;
+      const connector = new DefaultAuthConnector({
+        configApi,
+        discoveryApi: scopedDiscoveryApi,
+        environment: 'development',
+        provider: {
+          id: options.providerId,
+          title: options.providerId,
+          icon: () => null,
+        },
+        oauthRequestApi,
+        isMainProvider: options.isMainProvider,
+      });
+      return { connector, getBaseUrl };
+    }
+
+    it('does not scope the main sign-in provider to an installation', async () => {
+      // Even though the id follows the `oidc-<name>` shape, the main provider
+      // (id === gs.authProvider) is not installation-scoped, so auth discovery
+      // must be resolved with an undefined installation -- otherwise pre-sign-in
+      // discovery hits the installations-dependent branch and deadlocks.
+      mockLegacyRefresh();
+      const { connector, getBaseUrl } = createConnectorForProvider({
+        providerId: 'oidc-gazelle',
+        isMainProvider: true,
+      });
+
+      await connector.refreshSession({ scopes: new Set(['openid']) });
+
+      expect(getBaseUrl).toHaveBeenCalledWith('auth', undefined);
+    });
+
+    it('scopes a genuine per-installation provider to its installation', async () => {
+      mockLegacyRefresh();
+      const { connector, getBaseUrl } = createConnectorForProvider({
+        providerId: 'oidc-gazelle',
+      });
+
+      await connector.refreshSession({ scopes: new Set(['openid']) });
+
+      expect(getBaseUrl).toHaveBeenCalledWith('auth', 'gazelle');
+    });
+  });
 });

--- a/plugins/gs/src/apis/auth/DefaultAuthConnector.test.ts
+++ b/plugins/gs/src/apis/auth/DefaultAuthConnector.test.ts
@@ -3,7 +3,10 @@ import {
   ClusterTokenError,
   DefaultAuthConnector,
 } from './DefaultAuthConnector';
-import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
+import {
+  DiscoveryApiClient,
+  NO_INSTALLATION,
+} from '../discovery/DiscoveryApiClient';
 
 const configApi = {
   getOptionalBoolean: jest.fn().mockReturnValue(false),
@@ -149,8 +152,10 @@ describe('DefaultAuthConnector', () => {
     it('does not scope the main sign-in provider to an installation', async () => {
       // Even though the id follows the `oidc-<name>` shape, the main provider
       // (id === gs.authProvider) is not installation-scoped, so auth discovery
-      // must be resolved with an undefined installation -- otherwise pre-sign-in
-      // discovery hits the installations-dependent branch and deadlocks.
+      // must be resolved with the NO_INSTALLATION sentinel -- otherwise the
+      // static current-installation fallback could mis-scope it to a
+      // per-installation backend override (and pre-sign-in discovery would hit
+      // the installations-dependent branch).
       mockLegacyRefresh();
       const { connector, getBaseUrl } = createConnectorForProvider({
         providerId: 'oidc-gazelle',
@@ -159,7 +164,7 @@ describe('DefaultAuthConnector', () => {
 
       await connector.refreshSession({ scopes: new Set(['openid']) });
 
-      expect(getBaseUrl).toHaveBeenCalledWith('auth', undefined);
+      expect(getBaseUrl).toHaveBeenCalledWith('auth', NO_INSTALLATION);
     });
 
     it('scopes a genuine per-installation provider to its installation', async () => {

--- a/plugins/gs/src/apis/auth/DefaultAuthConnector.ts
+++ b/plugins/gs/src/apis/auth/DefaultAuthConnector.ts
@@ -31,7 +31,10 @@ import {
   OAuthRequestApi,
   OAuthRequester,
 } from '@backstage/core-plugin-api';
-import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
+import {
+  DiscoveryApiClient,
+  NO_INSTALLATION,
+} from '../discovery/DiscoveryApiClient';
 
 let warned = false;
 
@@ -366,7 +369,14 @@ export class DefaultAuthConnector<
     path: string,
     query?: { [key: string]: string | boolean | undefined },
   ): Promise<string> {
-    const installation = this.installationId();
+    // The main sign-in provider is not installation-scoped: pass the sentinel
+    // so getBaseUrl neither consults the static current-installation fallback
+    // nor applies a per-installation `backendUrl` override (either would
+    // mis-scope its token refresh). Per-installation providers pass their own
+    // installation name (or undefined when the id is not `oidc-`-scoped).
+    const installation = this.isMainProvider
+      ? NO_INSTALLATION
+      : this.installationId();
     const baseUrl = await this.discoveryApi.getBaseUrl('auth', installation);
 
     const queryString = this.buildQueryString({

--- a/plugins/gs/src/apis/auth/DefaultAuthConnector.ts
+++ b/plugins/gs/src/apis/auth/DefaultAuthConnector.ts
@@ -121,6 +121,14 @@ type Options<AuthSession> = {
    * popup. Returning undefined or throwing falls back to the legacy flow.
    */
   clusterTokenProvider?: () => Promise<ClusterToken | undefined>;
+  /**
+   * True for the main sign-in provider (the one whose id equals
+   * `gs.authProvider`). Its id may follow the `oidc-<name>` shape, but it is
+   * NOT installation-scoped, so it must not derive an installation id from its
+   * provider id (doing so wrongly drives auth discovery into the
+   * installation-scoped, installations-dependent branch pre-sign-in).
+   */
+  isMainProvider?: boolean;
 };
 
 function defaultJoinScopes(scopes: Set<string>) {
@@ -146,6 +154,7 @@ export class DefaultAuthConnector<
   private readonly clusterTokenProvider?: () => Promise<
     ClusterToken | undefined
   >;
+  private readonly isMainProvider: boolean;
   constructor(options: Options<AuthSession>) {
     const {
       configApi,
@@ -157,6 +166,7 @@ export class DefaultAuthConnector<
       sessionTransform = id => id,
       popupOptions,
       clusterTokenProvider,
+      isMainProvider = false,
     } = options;
 
     if (!warned && !configApi) {
@@ -189,6 +199,7 @@ export class DefaultAuthConnector<
     this.sessionTransform = sessionTransform;
     this.popupOptions = popupOptions;
     this.clusterTokenProvider = clusterTokenProvider;
+    this.isMainProvider = isMainProvider;
   }
 
   async createSession(
@@ -338,9 +349,16 @@ export class DefaultAuthConnector<
 
   /**
    * Installation name encoded in the provider id (e.g. `oidc-golem` -> `golem`).
-   * Returns undefined when the id does not follow the `oidc-` convention.
+   * Returns undefined when the id does not follow the `oidc-` convention, and
+   * always for the main sign-in provider: even though its id may share the
+   * `oidc-<name>` shape, it is not installation-scoped, so treating it as such
+   * would route pre-sign-in auth discovery through the installations-dependent
+   * branch and deadlock the boot sequence.
    */
   private installationId(): string | undefined {
+    if (this.isMainProvider) {
+      return undefined;
+    }
     return this.provider.id.split('oidc-')[1];
   }
 

--- a/plugins/gs/src/apis/auth/GSAuthProviders.test.ts
+++ b/plugins/gs/src/apis/auth/GSAuthProviders.test.ts
@@ -1,0 +1,99 @@
+import { ConfigApi, OAuthRequestApi } from '@backstage/core-plugin-api';
+import { GSAuthProviders } from './GSAuthProviders';
+import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
+import { InstallationConfig } from '../installations';
+
+// Replace the module-level async installations source so the test drives what
+// `ensureInitialized()` sees (and can make it reject on demand).
+jest.mock('../installations', () => {
+  const actual = jest.requireActual('../installations');
+  return { ...actual, getInstallationsConfig: jest.fn() };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getInstallationsConfig } = require('../installations') as {
+  getInstallationsConfig: jest.Mock<Promise<InstallationConfig[]>>;
+};
+
+const configApi = {
+  // No main provider, no broker: keeps getProviders returning exactly the
+  // built per-installation providers, and avoids the broker filter.
+  getOptionalString: jest.fn().mockReturnValue(undefined),
+  getOptionalConfig: jest.fn().mockReturnValue(undefined),
+  getString: jest.fn().mockReturnValue('http://backend'),
+  getOptionalBoolean: jest.fn().mockReturnValue(false),
+} as unknown as ConfigApi;
+
+const oauthRequestApi: OAuthRequestApi = {
+  createAuthRequester: jest.fn(() => jest.fn()),
+  authRequest$: jest.fn(),
+};
+
+const discoveryApi = {
+  getBaseUrl: jest.fn().mockResolvedValue('http://backend/api/auth'),
+} as unknown as DiscoveryApiClient;
+
+function createApi() {
+  return GSAuthProviders.create({
+    configApi,
+    discoveryApi,
+    oauthRequestApi,
+  });
+}
+
+describe('GSAuthProviders.ensureInitialized', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getInstallationsConfig.mockReset();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('skips malformed installation entries and still builds the valid ones', async () => {
+    getInstallationsConfig.mockResolvedValue([
+      { name: 'valid', authProvider: 'oidc', oidcTokenProvider: 'oidc-valid' },
+      // Non-oidc auth provider -> skipped.
+      { name: 'bad-auth', authProvider: 'saml', oidcTokenProvider: 'oidc-x' },
+      // Missing oidcTokenProvider -> skipped.
+      { name: 'bad-missing', authProvider: 'oidc' },
+      // oidcTokenProvider without the `oidc-` prefix -> skipped.
+      { name: 'bad-prefix', authProvider: 'oidc', oidcTokenProvider: 'weird' },
+    ]);
+
+    const api = createApi();
+    await api.ensureInitialized();
+
+    const providerNames = api.getProviders().map(p => p.providerName);
+    expect(providerNames).toEqual(['oidc-valid']);
+    // One warning per skipped entry.
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not latch a rejected promise: a later call retries and succeeds', async () => {
+    getInstallationsConfig
+      .mockRejectedValueOnce(new Error('installations source failed'))
+      .mockResolvedValueOnce([
+        {
+          name: 'valid',
+          authProvider: 'oidc',
+          oidcTokenProvider: 'oidc-valid',
+        },
+      ]);
+
+    const api = createApi();
+
+    // First init rejects (transient failure).
+    await expect(api.ensureInitialized()).rejects.toThrow(
+      'installations source failed',
+    );
+
+    // A later call must NOT re-await the cached rejection -- it retries.
+    await expect(api.ensureInitialized()).resolves.toBeUndefined();
+    expect(getInstallationsConfig).toHaveBeenCalledTimes(2);
+    expect(api.getProviders().map(p => p.providerName)).toEqual(['oidc-valid']);
+  });
+});

--- a/plugins/gs/src/apis/auth/GSAuthProviders.ts
+++ b/plugins/gs/src/apis/auth/GSAuthProviders.ts
@@ -121,7 +121,12 @@ export class GSAuthProviders implements GSAuthProvidersApi {
       ? mainProviderName.split(OIDC_PROVIDER_NAME_PREFIX)[1]
       : mainProviderName;
 
-    return this.createKubernetesAuthApi(mainProviderName, providerDisplayName);
+    return this.createKubernetesAuthApi(
+      mainProviderName,
+      providerDisplayName,
+      undefined,
+      true,
+    );
   }
 
   /**
@@ -342,6 +347,7 @@ export class GSAuthProviders implements GSAuthProvidersApi {
     providerName: string,
     providerDisplayName: string,
     clusterTokenProvider?: () => Promise<ClusterToken | undefined>,
+    isMainProvider = false,
   ): AuthApi {
     const authConnector = new DefaultAuthConnector({
       configApi: this.configApi,
@@ -355,6 +361,7 @@ export class GSAuthProviders implements GSAuthProvidersApi {
         icon: GiantSwarmIcon,
       },
       clusterTokenProvider,
+      isMainProvider,
       sessionTransform({ backstageIdentity, ...res }): OAuth2Session {
         const session: OAuth2Session = {
           ...res,

--- a/plugins/gs/src/apis/auth/GSAuthProviders.ts
+++ b/plugins/gs/src/apis/auth/GSAuthProviders.ts
@@ -140,13 +140,22 @@ export class GSAuthProviders implements GSAuthProvidersApi {
     }
     if (!this.initPromise) {
       this.initPromise = (async () => {
-        const installations = await getInstallationsConfig();
-        this.kubernetesAuthProviders =
-          this.buildKubernetesAuthProviders(installations);
-        this.kubernetesAuthApis = this.buildKubernetesAuthApis(
-          this.kubernetesAuthProviders,
-        );
-        this.initialized = true;
+        try {
+          const installations = await getInstallationsConfig();
+          this.kubernetesAuthProviders =
+            this.buildKubernetesAuthProviders(installations);
+          this.kubernetesAuthApis = this.buildKubernetesAuthApis(
+            this.kubernetesAuthProviders,
+          );
+          this.initialized = true;
+        } catch (error) {
+          // Never latch a rejected promise: a permanently-cached rejection
+          // would make every later `ensureInitialized()` re-await the same
+          // failure and break k8s OIDC auth fleet-wide. Reset so a later call
+          // can retry.
+          this.initPromise = undefined;
+          throw error;
+        }
       })();
     }
     await this.initPromise;
@@ -155,13 +164,19 @@ export class GSAuthProviders implements GSAuthProvidersApi {
   private buildKubernetesAuthProviders(
     installations: Awaited<ReturnType<typeof getInstallationsConfig>>,
   ): AuthProvider[] {
-    return installations.map(installation => {
+    // A single malformed installation entry must not take down auth for the
+    // whole fleet: skip entries with a non-`oidc` auth provider or a
+    // missing/invalid OIDC token provider (logging a warning) so the valid
+    // installations still build.
+    return installations.flatMap(installation => {
       const installationName = installation.name;
       const authProvider = installation.authProvider;
       if (!authProvider || authProvider !== 'oidc') {
-        throw new Error(
-          `OIDC auth provider is not configured for installation "${installationName}".`,
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Skipping installation "${installationName}": OIDC auth provider is not configured.`,
         );
+        return [];
       }
       const oidcTokenProvider = installation.oidcTokenProvider;
 
@@ -169,21 +184,25 @@ export class GSAuthProviders implements GSAuthProvidersApi {
         !oidcTokenProvider ||
         !oidcTokenProvider.startsWith(OIDC_PROVIDER_NAME_PREFIX)
       ) {
-        throw new Error(
-          `OIDC token provider is not configured for installation "${installationName}".`,
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Skipping installation "${installationName}": OIDC token provider is not configured.`,
         );
+        return [];
       }
 
       const providerDisplayName = oidcTokenProvider.split(
         OIDC_PROVIDER_NAME_PREFIX,
       )[1];
 
-      return {
-        providerName: oidcTokenProvider,
-        providerDisplayName,
-        installationName,
-        clusterTokenAudience: installation.clusterTokenAudience,
-      };
+      return [
+        {
+          providerName: oidcTokenProvider,
+          providerDisplayName,
+          installationName,
+          clusterTokenAudience: installation.clusterTokenAudience,
+        },
+      ];
     });
   }
 

--- a/plugins/gs/src/apis/auth/GSAuthProviders.ts
+++ b/plugins/gs/src/apis/auth/GSAuthProviders.ts
@@ -16,6 +16,7 @@ import {
 } from './DefaultAuthConnector';
 import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
 import { ClusterAccessStatusApi } from '../clusterAccessStatus';
+import { getInstallationsConfig } from '../installations';
 
 const OIDC_PROVIDER_NAME_PREFIX = 'oidc-';
 const MCP_PROVIDER_NAME_PREFIX = 'mcp-';
@@ -66,8 +67,18 @@ export class GSAuthProviders implements GSAuthProvidersApi {
   private readonly discoveryApi: DiscoveryApiClient;
   private readonly oauthRequestApi: OAuthRequestApi;
 
-  private readonly kubernetesAuthProviders: AuthProvider[];
-  private readonly kubernetesAuthApis: { [providerName: string]: AuthApi };
+  // Per-installation kubernetes auth providers/APIs are populated lazily by
+  // `ensureInitialized()` once installations load from the authenticated
+  // backend endpoint (post main sign-in). They start empty.
+  private kubernetesAuthProviders: AuthProvider[] = [];
+  private kubernetesAuthApis: { [providerName: string]: AuthApi } = {};
+  private initialized = false;
+  private initPromise: Promise<void> | undefined;
+
+  // The main sign-in auth API is built synchronously from `gs.authProvider`
+  // alone (which stays frontend-visible). It does NOT need `gs.installations`,
+  // so sign-in works before installations are loaded.
+  private readonly mainAuthApi?: AuthApi;
 
   private readonly mcpAuthProviders: AuthProvider[];
   private readonly mcpAuthApis: { [providerName: string]: AuthApi };
@@ -80,8 +91,7 @@ export class GSAuthProviders implements GSAuthProvidersApi {
     this.oauthRequestApi = options.oauthRequestApi;
     this.clusterAccessStatusApi = options.clusterAccessStatusApi;
 
-    this.kubernetesAuthProviders = this.getKubernetesAuthProvidersFromConfig();
-    this.kubernetesAuthApis = this.createKubernetesAuthApis();
+    this.mainAuthApi = this.createMainAuthApi();
 
     this.mcpAuthProviders = this.getMCPAuthProvidersFromConfig();
     this.mcpAuthApis = this.createMCPAuthApis();
@@ -93,25 +103,62 @@ export class GSAuthProviders implements GSAuthProvidersApi {
     return new GSAuthProviders(options);
   }
 
-  private getKubernetesAuthProvidersFromConfig(): AuthProvider[] {
-    const installationsConfig =
-      this.configApi?.getOptionalConfig('gs.installations');
-    if (!installationsConfig) {
-      return [];
+  /**
+   * Builds the main sign-in OAuth2 client from `gs.authProvider` only, without
+   * touching `gs.installations`. The main provider never uses the cluster-token
+   * broker path (its own session IS the broker's subject token), so no
+   * per-installation config is required.
+   */
+  private createMainAuthApi(): AuthApi | undefined {
+    const mainProviderName =
+      this.configApi?.getOptionalString('gs.authProvider');
+    if (!mainProviderName) {
+      return undefined;
     }
+    const providerDisplayName = mainProviderName.startsWith(
+      OIDC_PROVIDER_NAME_PREFIX,
+    )
+      ? mainProviderName.split(OIDC_PROVIDER_NAME_PREFIX)[1]
+      : mainProviderName;
 
-    const installationNames = installationsConfig.keys();
-    return installationNames.map(installationName => {
-      const installationConfig =
-        installationsConfig.getConfig(installationName);
-      const authProvider = installationConfig.getString('authProvider');
+    return this.createKubernetesAuthApi(mainProviderName, providerDisplayName);
+  }
+
+  /**
+   * Lazily builds the per-installation kubernetes auth providers/APIs once the
+   * installations config has loaded from the backend. Safe to call repeatedly;
+   * the work runs at most once.
+   */
+  async ensureInitialized(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    if (!this.initPromise) {
+      this.initPromise = (async () => {
+        const installations = await getInstallationsConfig();
+        this.kubernetesAuthProviders =
+          this.buildKubernetesAuthProviders(installations);
+        this.kubernetesAuthApis = this.buildKubernetesAuthApis(
+          this.kubernetesAuthProviders,
+        );
+        this.initialized = true;
+      })();
+    }
+    await this.initPromise;
+  }
+
+  private buildKubernetesAuthProviders(
+    installations: Awaited<ReturnType<typeof getInstallationsConfig>>,
+  ): AuthProvider[] {
+    return installations.map(installation => {
+      const installationName = installation.name;
+      const authProvider = installation.authProvider;
       if (!authProvider || authProvider !== 'oidc') {
         throw new Error(
           `OIDC auth provider is not configured for installation "${installationName}".`,
         );
       }
-      const oidcTokenProvider =
-        installationConfig.getOptionalString('oidcTokenProvider');
+      const oidcTokenProvider = installation.oidcTokenProvider;
 
       if (
         !oidcTokenProvider ||
@@ -130,9 +177,7 @@ export class GSAuthProviders implements GSAuthProvidersApi {
         providerName: oidcTokenProvider,
         providerDisplayName,
         installationName,
-        clusterTokenAudience: installationConfig.getOptionalString(
-          'clusterTokenAudience',
-        ),
+        clusterTokenAudience: installation.clusterTokenAudience,
       };
     });
   }
@@ -257,79 +302,102 @@ export class GSAuthProviders implements GSAuthProvidersApi {
     };
   }
 
-  private createKubernetesAuthApis() {
-    const entries = this.kubernetesAuthProviders.map(
-      ({ providerName, providerDisplayName, installationName }) => {
-        const authConnector = new DefaultAuthConnector({
-          configApi: this.configApi,
-          discoveryApi: this.discoveryApi,
-          oauthRequestApi: this.oauthRequestApi,
-          environment:
-            this.configApi?.getOptionalString('auth.environment') ??
-            'development',
-          provider: {
-            id: providerName,
-            title: providerDisplayName,
-            icon: GiantSwarmIcon,
-          },
-          clusterTokenProvider: this.createClusterTokenProvider(
-            installationName,
-            providerName,
-          ),
-          sessionTransform({ backstageIdentity, ...res }): OAuth2Session {
-            const session: OAuth2Session = {
-              ...res,
-              providerInfo: {
-                idToken: res.providerInfo.idToken,
-                accessToken: res.providerInfo.accessToken,
-                scopes: OAuth2.normalizeScopes(res.providerInfo.scope),
-                expiresAt: res.providerInfo.expiresInSeconds
-                  ? new Date(
-                      Date.now() + res.providerInfo.expiresInSeconds * 1000,
-                    )
-                  : undefined,
-              },
-            };
-            if (backstageIdentity) {
-              session.backstageIdentity = {
-                token: backstageIdentity.token,
-                identity: backstageIdentity.identity,
-                expiresAt: backstageIdentity.expiresInSeconds
-                  ? new Date(
-                      Date.now() + backstageIdentity.expiresInSeconds * 1000,
-                    )
-                  : undefined,
-              };
-            }
-            return session;
-          },
-          popupOptions: {
-            size: {
-              width: 600,
-              height: 600,
-            },
-          },
-        });
+  /**
+   * Builds the map of per-installation kubernetes auth APIs. The provider whose
+   * name matches the main provider (`gs.authProvider`) reuses the already-built
+   * main auth API instance, so the sign-in session and the per-cluster
+   * credential source are one and the same OAuth2 client.
+   */
+  private buildKubernetesAuthApis(providers: AuthProvider[]): {
+    [providerName: string]: AuthApi;
+  } {
+    const mainProviderName =
+      this.configApi?.getOptionalString('gs.authProvider');
 
+    const entries = providers.map(
+      ({ providerName, providerDisplayName, installationName }) => {
+        if (providerName === mainProviderName && this.mainAuthApi) {
+          return [providerName, this.mainAuthApi] as const;
+        }
         return [
           providerName,
-          OAuth2.create({
-            authConnector,
-            defaultScopes: [
-              'openid',
-              'profile',
-              'email',
-              'groups',
-              'offline_access',
-              'federated:id',
-              'audience:server:client_id:dex-k8s-authenticator',
-            ],
-          }),
-        ];
+          this.createKubernetesAuthApi(
+            providerName,
+            providerDisplayName,
+            this.createClusterTokenProvider(installationName, providerName),
+          ),
+        ] as const;
       },
     );
 
     return Object.fromEntries(entries);
+  }
+
+  /**
+   * Creates a single kubernetes (OIDC) OAuth2 auth API. Shared by the main
+   * sign-in provider (no cluster-token provider) and the lazily-built
+   * per-installation providers (broker-backed cluster-token provider).
+   */
+  private createKubernetesAuthApi(
+    providerName: string,
+    providerDisplayName: string,
+    clusterTokenProvider?: () => Promise<ClusterToken | undefined>,
+  ): AuthApi {
+    const authConnector = new DefaultAuthConnector({
+      configApi: this.configApi,
+      discoveryApi: this.discoveryApi,
+      oauthRequestApi: this.oauthRequestApi,
+      environment:
+        this.configApi?.getOptionalString('auth.environment') ?? 'development',
+      provider: {
+        id: providerName,
+        title: providerDisplayName,
+        icon: GiantSwarmIcon,
+      },
+      clusterTokenProvider,
+      sessionTransform({ backstageIdentity, ...res }): OAuth2Session {
+        const session: OAuth2Session = {
+          ...res,
+          providerInfo: {
+            idToken: res.providerInfo.idToken,
+            accessToken: res.providerInfo.accessToken,
+            scopes: OAuth2.normalizeScopes(res.providerInfo.scope),
+            expiresAt: res.providerInfo.expiresInSeconds
+              ? new Date(Date.now() + res.providerInfo.expiresInSeconds * 1000)
+              : undefined,
+          },
+        };
+        if (backstageIdentity) {
+          session.backstageIdentity = {
+            token: backstageIdentity.token,
+            identity: backstageIdentity.identity,
+            expiresAt: backstageIdentity.expiresInSeconds
+              ? new Date(Date.now() + backstageIdentity.expiresInSeconds * 1000)
+              : undefined,
+          };
+        }
+        return session;
+      },
+      popupOptions: {
+        size: {
+          width: 600,
+          height: 600,
+        },
+      },
+    });
+
+    return OAuth2.create({
+      authConnector,
+      defaultScopes: [
+        'openid',
+        'profile',
+        'email',
+        'groups',
+        'offline_access',
+        'federated:id',
+        'audience:server:client_id:dex-k8s-authenticator',
+      ],
+    });
   }
 
   private getMCPAuthProvidersFromConfig(): AuthProvider[] {
@@ -464,9 +532,28 @@ export class GSAuthProviders implements GSAuthProvidersApi {
   }
 
   getAuthApi(providerName: string) {
+    if (this.mainAuthApi) {
+      const mainProviderName =
+        this.configApi?.getOptionalString('gs.authProvider');
+      if (providerName === mainProviderName) {
+        return this.mainAuthApi;
+      }
+    }
     return (
       this.kubernetesAuthApis[providerName] || this.mcpAuthApis[providerName]
     );
+  }
+
+  /**
+   * Async lookup of a per-installation kubernetes auth API. Ensures the lazy
+   * initialization (which needs installations loaded) has run first. Returns
+   * `undefined` if the provider is not configured.
+   */
+  async getKubernetesAuthApi(
+    providerName: string,
+  ): Promise<AuthApi | undefined> {
+    await this.ensureInitialized();
+    return this.kubernetesAuthApis[providerName];
   }
 
   getMainAuthApi() {
@@ -479,15 +566,13 @@ export class GSAuthProviders implements GSAuthProvidersApi {
       );
     }
 
-    const authApi = this.getAuthApi(authProviderName);
-
-    if (!authApi) {
+    if (!this.mainAuthApi) {
       throw new Error(
         `Auth provider with name "${authProviderName}" is not configured.`,
       );
     }
 
-    return authApi;
+    return this.mainAuthApi;
   }
 
   getKubernetesAuthApis() {

--- a/plugins/gs/src/apis/auth/types.ts
+++ b/plugins/gs/src/apis/auth/types.ts
@@ -44,6 +44,17 @@ export type GSAuthProvidersApi = {
   getMCPAuthApis: () => { [providerName: string]: AuthApi };
   getProviders: () => AuthProvider[];
   /**
+   * Ensures the lazily-loaded per-installation auth providers/APIs have been
+   * built (they depend on the installations config fetched from the backend
+   * after sign-in). Safe to call repeatedly.
+   */
+  ensureInitialized: () => Promise<void>;
+  /**
+   * Async lookup of a per-installation kubernetes (OIDC) auth API, awaiting
+   * lazy initialization first. Returns `undefined` if not configured.
+   */
+  getKubernetesAuthApi: (providerName: string) => Promise<AuthApi | undefined>;
+  /**
    * Names of installations whose cluster access is fully covered by the token
    * broker (broker configured, `clusterTokenAudience` set, not the main
    * provider). These can be connected to silently -- without a per-cluster

--- a/plugins/gs/src/apis/discovery/DiscoveryApiClient.test.ts
+++ b/plugins/gs/src/apis/discovery/DiscoveryApiClient.test.ts
@@ -1,4 +1,4 @@
-import { DiscoveryApiClient } from './DiscoveryApiClient';
+import { DiscoveryApiClient, NO_INSTALLATION } from './DiscoveryApiClient';
 import {
   __resetInstallationsConfigForTests,
   setInstallationsConfig,
@@ -58,5 +58,28 @@ describe('DiscoveryApiClient.getBaseUrl', () => {
     const url = await client.getBaseUrl('catalog', 'gazelle');
 
     expect(url).toBe('http://backend/api/catalog');
+  });
+
+  it('bypasses the static current-installation fallback (and any override) for the NO_INSTALLATION sentinel', async () => {
+    // A per-installation flow (e.g. ScaffolderApiClient.withInstallation) set
+    // the static current installation, which also carries a backendUrl
+    // override. A main-provider refresh passes the sentinel so it resolves the
+    // default backend rather than being mis-scoped to that override.
+    setInstallationsConfig([
+      { name: 'gazelle', backendUrl: 'http://gazelle.example' },
+    ]);
+    const reset = DiscoveryApiClient.setInstallation('gazelle');
+    try {
+      const client = new DiscoveryApiClient('http://backend');
+
+      const sentinelUrl = await client.getBaseUrl('auth', NO_INSTALLATION);
+      expect(sentinelUrl).toBe('http://backend/api/auth');
+
+      // A genuine per-installation call still applies the override.
+      const scopedUrl = await client.getBaseUrl('auth', 'gazelle');
+      expect(scopedUrl).toBe('http://gazelle.example/api/auth');
+    } finally {
+      reset?.();
+    }
   });
 });

--- a/plugins/gs/src/apis/discovery/DiscoveryApiClient.test.ts
+++ b/plugins/gs/src/apis/discovery/DiscoveryApiClient.test.ts
@@ -1,0 +1,62 @@
+import { DiscoveryApiClient } from './DiscoveryApiClient';
+import {
+  __resetInstallationsConfigForTests,
+  setInstallationsConfig,
+} from '../installations';
+
+describe('DiscoveryApiClient.getBaseUrl', () => {
+  afterEach(() => {
+    __resetInstallationsConfigForTests();
+  });
+
+  it('returns the default backend URL without blocking on the installations promise when the snapshot is not yet loaded', async () => {
+    // Installations are never loaded (the snapshot stays undefined) -- this
+    // mirrors the pre-sign-in boot state. getBaseUrl must resolve to the
+    // default URL immediately instead of awaiting the (unresolved)
+    // installations source, which would deadlock the boot sequence.
+    const client = new DiscoveryApiClient('http://backend');
+
+    const timedOut = Symbol('timed-out');
+    const result = await Promise.race([
+      client.getBaseUrl('auth', 'gazelle'),
+      new Promise<typeof timedOut>(resolve => {
+        setTimeout(() => resolve(timedOut), 50);
+      }),
+    ]);
+
+    // If getBaseUrl had awaited the never-resolving installations promise, the
+    // race would settle to `timedOut` -- proving there is no deadlock.
+    expect(result).toBe('http://backend/api/auth');
+  });
+
+  it('applies a per-installation backendUrl override once installations are loaded', async () => {
+    setInstallationsConfig([
+      { name: 'gazelle', backendUrl: 'http://gazelle.example' },
+    ]);
+    const client = new DiscoveryApiClient('http://backend');
+
+    const url = await client.getBaseUrl('auth', 'gazelle');
+
+    expect(url).toBe('http://gazelle.example/api/auth');
+  });
+
+  it('falls back to the default backend URL for a loaded installation without an override', async () => {
+    setInstallationsConfig([{ name: 'gazelle' }]);
+    const client = new DiscoveryApiClient('http://backend');
+
+    const url = await client.getBaseUrl('auth', 'gazelle');
+
+    expect(url).toBe('http://backend/api/auth');
+  });
+
+  it('never scopes a non-installation plugin id', async () => {
+    setInstallationsConfig([
+      { name: 'gazelle', backendUrl: 'http://gazelle.example' },
+    ]);
+    const client = new DiscoveryApiClient('http://backend');
+
+    const url = await client.getBaseUrl('catalog', 'gazelle');
+
+    expect(url).toBe('http://backend/api/catalog');
+  });
+});

--- a/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
+++ b/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
@@ -1,9 +1,6 @@
 import { UrlPatternDiscovery } from '@backstage/core-app-api';
 import { ConfigApi, DiscoveryApi } from '@backstage/core-plugin-api';
-import {
-  getInstallationsConfig,
-  getInstallationsConfigSnapshot,
-} from '../installations';
+import { getInstallationsConfigSnapshot } from '../installations';
 
 const PLUGINS = ['auth', 'scaffolder', 'kubernetes'];
 
@@ -23,20 +20,19 @@ export class DiscoveryApiClient implements DiscoveryApi {
       installation || DiscoveryApiClient.getInstallation();
 
     // The default backend URL never depends on installations, so this path must
-    // not block on the (post-sign-in) installations fetch -- pre-sign-in auth
-    // discovery relies on it. Only a request explicitly scoped to an
-    // installation can carry a `backendUrl` override, and by then installations
-    // are loaded (post-sign-in); await the source only if it somehow is not.
-    if (selectedInstallation && PLUGINS.includes(pluginId)) {
-      let overrides = DiscoveryApiClient.getBaseUrlOverrides();
-      if (
-        getInstallationsConfigSnapshot() === undefined &&
-        overrides[selectedInstallation] === undefined
-      ) {
-        await getInstallationsConfig();
-        overrides = DiscoveryApiClient.getBaseUrlOverrides();
-      }
-      const baseUrlOverride = overrides[selectedInstallation];
+    // never block on the (post-sign-in) installations fetch. Pre-sign-in auth
+    // discovery relies on it, and the installations loader itself only resolves
+    // after sign-in completes -- awaiting the source here would deadlock the
+    // boot sequence. Per-installation `backendUrl` overrides are therefore
+    // consulted only once the installations snapshot is available (post
+    // -sign-in); until then we fall through to the default backend URL.
+    if (
+      selectedInstallation &&
+      PLUGINS.includes(pluginId) &&
+      getInstallationsConfigSnapshot() !== undefined
+    ) {
+      const baseUrlOverride =
+        DiscoveryApiClient.getBaseUrlOverrides()[selectedInstallation];
       if (baseUrlOverride) {
         const customUrlPatternDiscovery = UrlPatternDiscovery.compile(
           `${baseUrlOverride}/api/{{ pluginId }}`,

--- a/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
+++ b/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
@@ -1,5 +1,9 @@
 import { UrlPatternDiscovery } from '@backstage/core-app-api';
 import { ConfigApi, DiscoveryApi } from '@backstage/core-plugin-api';
+import {
+  getInstallationsConfig,
+  getInstallationsConfigSnapshot,
+} from '../installations';
 
 const PLUGINS = ['auth', 'scaffolder', 'kubernetes'];
 
@@ -7,13 +11,8 @@ export class DiscoveryApiClient implements DiscoveryApi {
   private urlPatternDiscovery: UrlPatternDiscovery;
 
   private static installation: string | null = null;
-  private static baseUrlOverrides: Record<string, string> = {};
-  private static installationsWithBaseUrlOverrides: string[] = [];
 
-  constructor(
-    baseUrl: string,
-    private readonly baseUrlOverrides: Record<string, string> = {},
-  ) {
+  constructor(baseUrl: string) {
     this.urlPatternDiscovery = UrlPatternDiscovery.compile(
       `${baseUrl}/api/{{ pluginId }}`,
     );
@@ -22,15 +21,28 @@ export class DiscoveryApiClient implements DiscoveryApi {
   async getBaseUrl(pluginId: string, installation?: string) {
     const selectedInstallation =
       installation || DiscoveryApiClient.getInstallation();
-    const baseUrlOverride = selectedInstallation
-      ? this.baseUrlOverrides[selectedInstallation]
-      : undefined;
 
-    if (PLUGINS.includes(pluginId) && baseUrlOverride) {
-      const customUrlPatternDiscovery = UrlPatternDiscovery.compile(
-        `${baseUrlOverride}/api/{{ pluginId }}`,
-      );
-      return customUrlPatternDiscovery.getBaseUrl(pluginId);
+    // The default backend URL never depends on installations, so this path must
+    // not block on the (post-sign-in) installations fetch -- pre-sign-in auth
+    // discovery relies on it. Only a request explicitly scoped to an
+    // installation can carry a `backendUrl` override, and by then installations
+    // are loaded (post-sign-in); await the source only if it somehow is not.
+    if (selectedInstallation && PLUGINS.includes(pluginId)) {
+      let overrides = DiscoveryApiClient.getBaseUrlOverrides();
+      if (
+        getInstallationsConfigSnapshot() === undefined &&
+        overrides[selectedInstallation] === undefined
+      ) {
+        await getInstallationsConfig();
+        overrides = DiscoveryApiClient.getBaseUrlOverrides();
+      }
+      const baseUrlOverride = overrides[selectedInstallation];
+      if (baseUrlOverride) {
+        const customUrlPatternDiscovery = UrlPatternDiscovery.compile(
+          `${baseUrlOverride}/api/{{ pluginId }}`,
+        );
+        return customUrlPatternDiscovery.getBaseUrl(pluginId);
+      }
     }
 
     return this.urlPatternDiscovery.getBaseUrl(pluginId);
@@ -38,21 +50,29 @@ export class DiscoveryApiClient implements DiscoveryApi {
 
   static fromConfig(configApi: ConfigApi) {
     const baseUrl = configApi.getString('backend.baseUrl');
-    const baseUrlOverrides =
-      DiscoveryApiClient.calculateBaseUrlOverrides(configApi);
-    DiscoveryApiClient.baseUrlOverrides = baseUrlOverrides;
-    DiscoveryApiClient.installationsWithBaseUrlOverrides =
-      Object.keys(baseUrlOverrides);
-
-    return new DiscoveryApiClient(baseUrl, baseUrlOverrides);
+    return new DiscoveryApiClient(baseUrl);
   }
 
-  static getUrlPrefixAllowlist(configApi: ConfigApi) {
-    const baseUrl = configApi.getString('backend.baseUrl');
-    const baseUrlOverrides =
-      DiscoveryApiClient.calculateBaseUrlOverrides(configApi);
-
-    return [baseUrl, ...Object.values(baseUrlOverrides)];
+  /**
+   * Builds a matcher for the identity-auth fetch middleware. Evaluated per
+   * request so `backendUrl` overrides loaded after app boot are honored without
+   * rebuilding the fetch API.
+   */
+  static createUrlPrefixAllowlistMatcher(
+    configApi: ConfigApi,
+  ): (url: string) => boolean {
+    const baseUrl = configApi.getString('backend.baseUrl').replace(/\/$/, '');
+    return (url: string) => {
+      const prefixes = [
+        baseUrl,
+        ...Object.values(DiscoveryApiClient.getBaseUrlOverrides()).map(prefix =>
+          prefix.replace(/\/$/, ''),
+        ),
+      ];
+      return prefixes.some(
+        prefix => url === prefix || url.startsWith(`${prefix}/`),
+      );
+    };
   }
 
   static setInstallation(installation: string) {
@@ -81,32 +101,21 @@ export class DiscoveryApiClient implements DiscoveryApi {
   }
 
   static getInstallationsWithBaseUrlOverrides() {
-    return DiscoveryApiClient.installationsWithBaseUrlOverrides;
+    return Object.keys(DiscoveryApiClient.getBaseUrlOverrides());
   }
 
-  static getBaseUrlOverrides() {
-    return DiscoveryApiClient.baseUrlOverrides;
-  }
-
-  private static calculateBaseUrlOverrides(
-    configApi: ConfigApi,
-  ): Record<string, string> {
+  /**
+   * Map of installation name -> `backendUrl` override, derived from the loaded
+   * installations snapshot. Empty until installations load.
+   */
+  static getBaseUrlOverrides(): Record<string, string> {
+    const installations = getInstallationsConfigSnapshot() ?? [];
     const baseUrlOverrides: Record<string, string> = {};
-    const installationsConfig = configApi.getOptionalConfig('gs.installations');
-    if (installationsConfig) {
-      const installationNames = installationsConfig.keys();
-      for (const installationName of installationNames) {
-        const installationConfig =
-          installationsConfig.getConfig(installationName);
-
-        const baseUrlOverride =
-          installationConfig.getOptionalString('backendUrl');
-        if (baseUrlOverride) {
-          baseUrlOverrides[installationName] = baseUrlOverride;
-        }
+    for (const installation of installations) {
+      if (installation.backendUrl) {
+        baseUrlOverrides[installation.name] = installation.backendUrl;
       }
     }
-
     return baseUrlOverrides;
   }
 }

--- a/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
+++ b/plugins/gs/src/apis/discovery/DiscoveryApiClient.ts
@@ -4,6 +4,19 @@ import { getInstallationsConfigSnapshot } from '../installations';
 
 const PLUGINS = ['auth', 'scaffolder', 'kubernetes'];
 
+/**
+ * Sentinel passed as the `installation` argument to signal "explicitly no
+ * installation -- and do NOT consult the static `getInstallation()` fallback".
+ *
+ * The main sign-in provider is not installation-scoped, but a per-installation
+ * flow may have set the static current installation (e.g.
+ * `ScaffolderApiClient.withInstallation` / agent-platform). Passing `undefined`
+ * would let that static value leak in and mis-scope a main-provider token
+ * refresh to a per-installation backend that carries a `backendUrl` override.
+ * The sentinel bypasses both the static fallback and any override.
+ */
+export const NO_INSTALLATION = Symbol('gs.discovery.no-installation');
+
 export class DiscoveryApiClient implements DiscoveryApi {
   private urlPatternDiscovery: UrlPatternDiscovery;
 
@@ -15,7 +28,17 @@ export class DiscoveryApiClient implements DiscoveryApi {
     );
   }
 
-  async getBaseUrl(pluginId: string, installation?: string) {
+  async getBaseUrl(
+    pluginId: string,
+    installation?: string | typeof NO_INSTALLATION,
+  ) {
+    // An explicit sentinel means "no installation, and do not fall back to the
+    // static current installation". The main sign-in provider uses this so its
+    // token refresh is never mis-scoped to a per-installation backend override.
+    if (installation === NO_INSTALLATION) {
+      return this.urlPatternDiscovery.getBaseUrl(pluginId);
+    }
+
     const selectedInstallation =
       installation || DiscoveryApiClient.getInstallation();
 

--- a/plugins/gs/src/apis/installations/index.ts
+++ b/plugins/gs/src/apis/installations/index.ts
@@ -1,0 +1,14 @@
+export {
+  getInstallationsConfig,
+  getInstallationsConfigSnapshot,
+  normalizeInstallationsConfig,
+  setInstallationsConfig,
+  subscribeInstallationsConfig,
+  __resetInstallationsConfigForTests,
+  type InstallationConfig,
+  type InstallationsConfigResponse,
+} from './installationsConfig';
+export {
+  useInstallations,
+  type UseInstallationsResult,
+} from './useInstallations';

--- a/plugins/gs/src/apis/installations/installationsConfig.test.ts
+++ b/plugins/gs/src/apis/installations/installationsConfig.test.ts
@@ -1,0 +1,63 @@
+import {
+  __resetInstallationsConfigForTests,
+  getInstallationsConfig,
+  getInstallationsConfigSnapshot,
+  normalizeInstallationsConfig,
+  setInstallationsConfig,
+  subscribeInstallationsConfig,
+} from './installationsConfig';
+
+describe('installationsConfig source', () => {
+  beforeEach(() => {
+    __resetInstallationsConfigForTests();
+  });
+
+  it('normalizes the backend response into a name-carrying array', () => {
+    const normalized = normalizeInstallationsConfig({
+      golem: { pipeline: 'stable', baseDomain: 'golem.example.com' },
+      gaggle: { pipeline: 'testing' },
+    });
+
+    expect(normalized).toEqual([
+      { name: 'golem', pipeline: 'stable', baseDomain: 'golem.example.com' },
+      { name: 'gaggle', pipeline: 'testing' },
+    ]);
+  });
+
+  it('has no snapshot before it is populated', () => {
+    expect(getInstallationsConfigSnapshot()).toBeUndefined();
+  });
+
+  it('resolves awaiters that subscribed before the value was set', async () => {
+    const pending = getInstallationsConfig();
+
+    setInstallationsConfig([{ name: 'golem', pipeline: 'stable' }]);
+
+    await expect(pending).resolves.toEqual([
+      { name: 'golem', pipeline: 'stable' },
+    ]);
+    expect(getInstallationsConfigSnapshot()).toEqual([
+      { name: 'golem', pipeline: 'stable' },
+    ]);
+  });
+
+  it('resolves immediately once already populated', async () => {
+    setInstallationsConfig([{ name: 'gaggle', pipeline: 'testing' }]);
+
+    await expect(getInstallationsConfig()).resolves.toEqual([
+      { name: 'gaggle', pipeline: 'testing' },
+    ]);
+  });
+
+  it('notifies subscribers on set and stops after unsubscribe', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeInstallationsConfig(listener);
+
+    setInstallationsConfig([{ name: 'golem' }]);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    setInstallationsConfig([{ name: 'gaggle' }]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/gs/src/apis/installations/installationsConfig.ts
+++ b/plugins/gs/src/apis/installations/installationsConfig.ts
@@ -1,0 +1,109 @@
+/**
+ * Module-level async source for the Giant Swarm installations configuration.
+ *
+ * The `gs.installations` block is no longer shipped to the (unauthenticated)
+ * frontend config -- it deanonymizes customers and leaks the installation
+ * topology. Instead the SPA fetches it from the authenticated
+ * `GET /api/gs/installations` endpoint once, after the user signs in (see
+ * `InstallationsConfigLoader`).
+ *
+ * Backstage Utility API factories are constructed before React renders, so
+ * React context alone cannot feed them. This module is that bridge: the boot
+ * -time APIs (`DiscoveryApiClient`, `KubernetesClient`, `GSAuthProviders`)
+ * `await getInstallationsConfig()` lazily -- none of them need installations
+ * before the main Dex sign-in completes -- while React consumers subscribe via
+ * `useSyncExternalStore` and re-render once the data arrives.
+ */
+
+export type InstallationConfig = {
+  name: string;
+  pipeline?: string;
+  providers?: string[];
+  authProvider?: string;
+  oidcTokenProvider?: string;
+  clusterTokenAudience?: string;
+  backendUrl?: string;
+  baseDomain?: string;
+  region?: string;
+  apiVersionOverrides?: { [pluralKind: string]: string };
+};
+
+/** Raw shape returned by the backend endpoint (keyed by installation name). */
+export type InstallationsConfigResponse = {
+  [installationName: string]: Omit<InstallationConfig, 'name'>;
+};
+
+let installations: InstallationConfig[] | undefined;
+let deferred:
+  | {
+      promise: Promise<InstallationConfig[]>;
+      resolve: (v: InstallationConfig[]) => void;
+    }
+  | undefined;
+const listeners = new Set<() => void>();
+
+function ensureDeferred() {
+  if (!deferred) {
+    let resolve!: (v: InstallationConfig[]) => void;
+    const promise = new Promise<InstallationConfig[]>(res => {
+      resolve = res;
+    });
+    deferred = { promise, resolve };
+  }
+  return deferred;
+}
+
+/** Normalizes the backend response into a stable, name-carrying array. */
+export function normalizeInstallationsConfig(
+  response: InstallationsConfigResponse,
+): InstallationConfig[] {
+  return Object.entries(response).map(([name, value]) => ({ name, ...value }));
+}
+
+/**
+ * Populates the source and wakes every awaiting API + subscribed component.
+ * Idempotent: calling it again (e.g. a re-fetch) replaces the value and
+ * notifies subscribers.
+ */
+export function setInstallationsConfig(next: InstallationConfig[]): void {
+  installations = next;
+  ensureDeferred().resolve(next);
+  listeners.forEach(listener => listener());
+}
+
+/**
+ * Resolves with the installations once loaded. If already loaded, resolves
+ * immediately; otherwise waits for the post-sign-in fetch. Used by boot-time
+ * APIs that only touch installations after the main sign-in.
+ */
+export function getInstallationsConfig(): Promise<InstallationConfig[]> {
+  if (installations) {
+    return Promise.resolve(installations);
+  }
+  return ensureDeferred().promise;
+}
+
+/**
+ * Synchronous snapshot of the installations, or `undefined` when not yet
+ * loaded. Used by `useSyncExternalStore` and by sync code paths that must not
+ * block (they treat `undefined` as "not loaded yet").
+ */
+export function getInstallationsConfigSnapshot():
+  InstallationConfig[] | undefined {
+  return installations;
+}
+
+/** Subscribe to load/refresh notifications. Returns an unsubscribe fn. */
+export function subscribeInstallationsConfig(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Test-only: clears the module state between tests. */
+export function __resetInstallationsConfigForTests(): void {
+  installations = undefined;
+  deferred = undefined;
+  listeners.clear();
+}

--- a/plugins/gs/src/apis/installations/useInstallations.ts
+++ b/plugins/gs/src/apis/installations/useInstallations.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from 'react';
+import {
+  getInstallationsConfigSnapshot,
+  InstallationConfig,
+  subscribeInstallationsConfig,
+} from './installationsConfig';
+
+export type UseInstallationsResult = {
+  /** Configured installations, or an empty array until the fetch resolves. */
+  installations: InstallationConfig[];
+  /** True until the post-sign-in `/api/gs/installations` fetch has resolved. */
+  isLoading: boolean;
+};
+
+/**
+ * React access to the installations config loaded from the authenticated
+ * backend endpoint. Backed by the module-level source
+ * (`installationsConfig.ts`) via `useSyncExternalStore`, so it works anywhere
+ * in the tree without a wrapping context provider and re-renders once the data
+ * arrives.
+ */
+export function useInstallations(): UseInstallationsResult {
+  const installations = useSyncExternalStore(
+    subscribeInstallationsConfig,
+    getInstallationsConfigSnapshot,
+  );
+
+  return {
+    installations: installations ?? [],
+    isLoading: installations === undefined,
+  };
+}

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
@@ -243,4 +243,29 @@ describe('KubernetesClient.getClusters', () => {
       { name: 'golem', authProvider: 'oidc', oidcTokenProvider: undefined },
     ]);
   });
+
+  it('does not cache an empty result and recovers once installations become non-empty', async () => {
+    const client = createClient(jest.fn());
+    (client as unknown as { clusters: unknown }).clusters = undefined;
+
+    // The loader exhausted its retries and published an empty set (a transient
+    // backend blip). getClusters must return [] without caching it.
+    setInstallationsConfig([]);
+    await expect(client.getClusters()).resolves.toEqual([]);
+    expect(
+      (client as unknown as { clusters: unknown }).clusters,
+    ).toBeUndefined();
+
+    // A later re-publish with entries recovers -- getClusters recomputes rather
+    // than serving the stale empty cache.
+    setInstallationsConfig([{ name: 'golem', authProvider: 'oidc' }]);
+    await expect(client.getClusters()).resolves.toEqual([
+      { name: 'golem', authProvider: 'oidc', oidcTokenProvider: undefined },
+    ]);
+
+    // Non-empty results ARE cached.
+    expect((client as unknown as { clusters: unknown }).clusters).toEqual([
+      { name: 'golem', authProvider: 'oidc', oidcTokenProvider: undefined },
+    ]);
+  });
 });

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.test.ts
@@ -2,6 +2,10 @@ import { ConfigApi, FetchApi } from '@backstage/core-plugin-api';
 import { KubernetesAuthProvidersApi } from '@backstage/plugin-kubernetes-react';
 import { KubernetesClient } from './KubernetesClient';
 import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
+import {
+  __resetInstallationsConfigForTests,
+  setInstallationsConfig,
+} from '../installations';
 
 function abortError(): Error {
   const error = new Error('The operation was aborted');
@@ -199,5 +203,44 @@ describe('KubernetesClient.proxy', () => {
       client.proxy({ clusterName: 'golem', path: '/api/v1/namespaces' }),
     ).resolves.toBe(response);
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('KubernetesClient.getClusters', () => {
+  beforeEach(() => {
+    __resetInstallationsConfigForTests();
+  });
+
+  afterEach(() => {
+    __resetInstallationsConfigForTests();
+  });
+
+  it('derives clusters from the async installations source', async () => {
+    const client = createClient(jest.fn());
+    // createClient stubs `clusters` to isolate proxy tests; clear it so
+    // getClusters reads from the installations source instead.
+    (client as unknown as { clusters: unknown }).clusters = undefined;
+
+    setInstallationsConfig([
+      { name: 'golem', authProvider: 'oidc', oidcTokenProvider: 'oidc-golem' },
+      { name: 'gaggle', authProvider: 'oidc' },
+    ]);
+
+    await expect(client.getClusters()).resolves.toEqual([
+      { name: 'golem', authProvider: 'oidc', oidcTokenProvider: 'oidc-golem' },
+      { name: 'gaggle', authProvider: 'oidc', oidcTokenProvider: undefined },
+    ]);
+  });
+
+  it('waits for the source when installations load after the call', async () => {
+    const client = createClient(jest.fn());
+    (client as unknown as { clusters: unknown }).clusters = undefined;
+
+    const pending = client.getClusters();
+    setInstallationsConfig([{ name: 'golem', authProvider: 'oidc' }]);
+
+    await expect(pending).resolves.toEqual([
+      { name: 'golem', authProvider: 'oidc', oidcTokenProvider: undefined },
+    ]);
   });
 });

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
@@ -140,7 +140,7 @@ export class KubernetesClient implements KubernetesApi {
     // only ever called post-sign-in (the clusters/deployments pages), so
     // awaiting the source here does not stall app boot.
     const installations = await getInstallationsConfig();
-    this.clusters = installations.map(installation => {
+    const clusters = installations.map(installation => {
       if (!installation.authProvider) {
         throw new Error(
           `Missing authProvider for installation "${installation.name}"`,
@@ -153,6 +153,18 @@ export class KubernetesClient implements KubernetesApi {
       };
     });
 
+    // Do NOT cache an empty result. When the installations loader exhausts its
+    // retries it publishes `[]` (a transient backend blip), and caching that
+    // would degrade the whole session to "no clusters". Leaving `this.clusters`
+    // unset means the next `getClusters()` recomputes and recovers once the
+    // snapshot becomes non-empty. (Residual limitation: this only recovers if
+    // the installations snapshot itself is later republished with entries; a
+    // full periodic background re-fetch of the config is out of scope here.)
+    if (clusters.length === 0) {
+      return clusters;
+    }
+
+    this.clusters = clusters;
     return this.clusters;
   }
 

--- a/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
+++ b/plugins/gs/src/apis/kubernetes/KubernetesClient.ts
@@ -12,6 +12,7 @@ import {
   WorkloadsByEntityRequest,
 } from '@backstage/plugin-kubernetes-common';
 import { DiscoveryApiClient } from '../discovery/DiscoveryApiClient';
+import { getInstallationsConfig } from '../installations';
 
 /**
  * Default per-request timeout for the k8s proxy. An unreachable management
@@ -35,7 +36,6 @@ const DEFAULT_PROXY_MAX_CONCURRENCY = 6;
 
 export class KubernetesClient implements KubernetesApi {
   private readonly backendClient: KubernetesBackendClient;
-  private readonly configApi: ConfigApi;
   private readonly discoveryApi: DiscoveryApiClient;
   private readonly fetchApi: FetchApi;
   private readonly kubernetesAuthProvidersApi: KubernetesAuthProvidersApi;
@@ -60,7 +60,6 @@ export class KubernetesClient implements KubernetesApi {
       kubernetesAuthProvidersApi: options.kubernetesAuthProvidersApi,
     });
 
-    this.configApi = options.configApi;
     this.discoveryApi = options.discoveryApi;
     this.fetchApi = options.fetchApi;
     this.kubernetesAuthProvidersApi = options.kubernetesAuthProvidersApi;
@@ -131,29 +130,30 @@ export class KubernetesClient implements KubernetesApi {
     return clusters.find(cluster => cluster.name === clusterName);
   }
 
-  getClusters(): Promise<ClusterConfiguration[]> {
+  async getClusters(): Promise<ClusterConfiguration[]> {
     if (this.clusters) {
-      return Promise.resolve(this.clusters);
+      return this.clusters;
     }
 
-    const installationsConfig =
-      this.configApi.getOptionalConfig('gs.installations');
-    if (!installationsConfig) {
-      throw new Error(`Missing gs.installations configuration`);
-    }
-
-    const installations = this.configApi.getConfig('gs.installations').keys();
+    // Installations are loaded from the authenticated backend endpoint after
+    // sign-in (they are no longer in the frontend config). `getClusters` is
+    // only ever called post-sign-in (the clusters/deployments pages), so
+    // awaiting the source here does not stall app boot.
+    const installations = await getInstallationsConfig();
     this.clusters = installations.map(installation => {
-      const installationConfig = installationsConfig.getConfig(installation);
+      if (!installation.authProvider) {
+        throw new Error(
+          `Missing authProvider for installation "${installation.name}"`,
+        );
+      }
       return {
-        name: installation,
-        authProvider: installationConfig.getString('authProvider'),
-        oidcTokenProvider:
-          installationConfig.getOptionalString('oidcTokenProvider'),
+        name: installation.name,
+        authProvider: installation.authProvider,
+        oidcTokenProvider: installation.oidcTokenProvider,
       };
     });
 
-    return Promise.resolve(this.clusters);
+    return this.clusters;
   }
 
   private async getCredentials(

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.reseed.test.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.reseed.test.tsx
@@ -3,6 +3,7 @@ import {
   renderInTestApp,
   TestApiProvider,
 } from '@backstage/frontend-test-utils';
+import { errorApiRef } from '@backstage/core-plugin-api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
 import {
@@ -17,6 +18,7 @@ import { ClusterAccessConnector } from './ClusterAccessConnector';
 
 function fakeAuthProviders(broker: string[]) {
   return {
+    ensureInitialized: () => Promise.resolve(),
     getBrokerCoveredInstallations: () => broker,
     getKubernetesAuthApis: () => ({}),
     getProviders: () => [],
@@ -43,6 +45,7 @@ describe('ClusterAccessConnector', () => {
     await renderInTestApp(
       <TestApiProvider
         apis={[
+          [errorApiRef, { post: jest.fn(), error$: jest.fn() }],
           [kubernetesApiRef, kubernetesApi],
           [gsAuthProvidersApiRef, fakeAuthProviders(['alpha', 'beta'])],
           [clusterAccessStatusApiRef, statusApi],

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useApi, SessionState } from '@backstage/core-plugin-api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
@@ -132,7 +132,30 @@ export function ClusterAccessConnector() {
   // doesn't spuriously re-run these effects and restart the fleet probe.
   const muted = useMutedInstallations();
 
+  // The broker-covered set and per-installation auth APIs are only known once
+  // the installations config has loaded (post sign-in) and the lazy auth-
+  // provider init has run. Gate the probe effects on that so they read a
+  // populated set rather than an empty one at boot.
+  const [authProvidersReady, setAuthProvidersReady] = useState(false);
   useEffect(() => {
+    let cancelled = false;
+    authProvidersApi.ensureInitialized().then(
+      () => {
+        if (!cancelled) {
+          setAuthProvidersReady(true);
+        }
+      },
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [authProvidersApi]);
+
+  useEffect(() => {
+    if (!authProvidersReady) {
+      return undefined;
+    }
     const mutedSet = new Set(muted);
     // Drop any muted installation from the status set — it may have been probed
     // and recorded before being muted, and it must not linger in the widget as
@@ -238,7 +261,7 @@ export function ClusterAccessConnector() {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [kubernetesApi, authProvidersApi, statusApi, muted]);
+  }, [kubernetesApi, authProvidersApi, statusApi, muted, authProvidersReady]);
 
   // Non-broker installations can't be probed proactively: a proxy call on one
   // without a live session would pop up a per-cluster login. So instead of
@@ -247,6 +270,9 @@ export function ClusterAccessConnector() {
   // the widget when signed out. This is the "different logic" from the broker
   // path above, which probes real apiserver health.
   useEffect(() => {
+    if (!authProvidersReady) {
+      return undefined;
+    }
     const mutedSet = new Set(muted);
     // A muted non-broker installation must also drop off the status set.
     for (const installation of muted) {
@@ -286,7 +312,7 @@ export function ClusterAccessConnector() {
     return () => {
       subscriptions.forEach(subscription => subscription.unsubscribe());
     };
-  }, [authProvidersApi, statusApi, muted]);
+  }, [authProvidersApi, statusApi, muted, authProvidersReady]);
 
   return null;
 }

--- a/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
+++ b/plugins/gs/src/components/ClusterAccessStatus/ClusterAccessConnector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useApi, SessionState } from '@backstage/core-plugin-api';
+import { errorApiRef, useApi, SessionState } from '@backstage/core-plugin-api';
 import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
 import { ClusterTokenError } from '../../apis/auth/DefaultAuthConnector';
@@ -124,6 +124,7 @@ export function ClusterAccessConnector() {
   const kubernetesApi = useApi(kubernetesApiRef);
   const authProvidersApi = useApi(gsAuthProvidersApiRef);
   const statusApi = useApi(clusterAccessStatusApiRef);
+  const errorApi = useApi(errorApiRef);
 
   // Track the user's muted set reactively so muting/unmuting re-runs the probe
   // effects (a muted installation must stop being probed and drop off the status
@@ -145,12 +146,17 @@ export function ClusterAccessConnector() {
           setAuthProvidersReady(true);
         }
       },
-      () => {},
+      error => {
+        // Do not swallow the failure: `authProvidersReady` stays false and the
+        // widget renders empty, which is indistinguishable from "no clusters"
+        // unless we report why the readiness gate never opened.
+        errorApi.post(error as Error);
+      },
     );
     return () => {
       cancelled = true;
     };
-  }, [authProvidersApi]);
+  }, [authProvidersApi, errorApi]);
 
   useEffect(() => {
     if (!authProvidersReady) {

--- a/plugins/gs/src/components/InstallationsConfigLoader/InstallationsConfigLoader.test.tsx
+++ b/plugins/gs/src/components/InstallationsConfigLoader/InstallationsConfigLoader.test.tsx
@@ -1,0 +1,96 @@
+import {
+  discoveryApiRef,
+  errorApiRef,
+  fetchApiRef,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import {
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+import { InstallationsConfigLoader } from './InstallationsConfigLoader';
+import {
+  __resetInstallationsConfigForTests,
+  getInstallationsConfig,
+} from '../../apis/installations';
+
+function fakeApis({
+  getCredentials = jest.fn().mockResolvedValue({ token: 'id-token' }),
+  getBaseUrl = jest.fn().mockResolvedValue('http://backend/api/gs'),
+  fetch = jest.fn(),
+}: {
+  getCredentials?: jest.Mock;
+  getBaseUrl?: jest.Mock;
+  fetch?: jest.Mock;
+}) {
+  const errorApi = { post: jest.fn(), error$: jest.fn() };
+  const apis = [
+    [identityApiRef, { getCredentials }],
+    [discoveryApiRef, { getBaseUrl }],
+    [fetchApiRef, { fetch }],
+    [errorApiRef, errorApi],
+  ] as const;
+  return { apis: apis as any, errorApi };
+}
+
+describe('InstallationsConfigLoader', () => {
+  beforeEach(() => {
+    __resetInstallationsConfigForTests();
+  });
+
+  afterEach(() => {
+    __resetInstallationsConfigForTests();
+  });
+
+  it('publishes an empty set (unblocking awaiters) and reports when getCredentials rejects', async () => {
+    const { apis, errorApi } = fakeApis({
+      getCredentials: jest.fn().mockRejectedValue(new Error('not signed in')),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider apis={apis}>
+        <InstallationsConfigLoader />
+      </TestApiProvider>,
+    );
+
+    // A boot-time API awaiting the source must unblock rather than deadlock.
+    await expect(getInstallationsConfig()).resolves.toEqual([]);
+    expect(errorApi.post).toHaveBeenCalled();
+  });
+
+  it('publishes an empty set and reports when getBaseUrl rejects', async () => {
+    const { apis, errorApi } = fakeApis({
+      getBaseUrl: jest.fn().mockRejectedValue(new Error('discovery failed')),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider apis={apis}>
+        <InstallationsConfigLoader />
+      </TestApiProvider>,
+    );
+
+    await expect(getInstallationsConfig()).resolves.toEqual([]);
+    expect(errorApi.post).toHaveBeenCalled();
+  });
+
+  it('publishes the normalized config on a successful fetch', async () => {
+    const { apis, errorApi } = fakeApis({
+      fetch: jest.fn().mockResolvedValue(
+        new Response(JSON.stringify({ golem: { authProvider: 'oidc' } }), {
+          status: 200,
+        }),
+      ),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider apis={apis}>
+        <InstallationsConfigLoader />
+      </TestApiProvider>,
+    );
+
+    await expect(getInstallationsConfig()).resolves.toEqual([
+      { name: 'golem', authProvider: 'oidc' },
+    ]);
+    expect(errorApi.post).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/gs/src/components/InstallationsConfigLoader/InstallationsConfigLoader.tsx
+++ b/plugins/gs/src/components/InstallationsConfigLoader/InstallationsConfigLoader.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react';
+import {
+  discoveryApiRef,
+  errorApiRef,
+  fetchApiRef,
+  identityApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import {
+  InstallationsConfigResponse,
+  normalizeInstallationsConfig,
+  setInstallationsConfig,
+} from '../../apis/installations';
+
+const MAX_ATTEMPTS = 5;
+const RETRY_BASE_DELAY_MS = 1000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Headless loader that fetches the installations config once, after the user
+ * signs in, from the authenticated `GET /api/gs/installations` endpoint and
+ * publishes it into the module-level source (`installationsConfig.ts`).
+ *
+ * `identityApi.getCredentials()` blocks until the app-wide sign-in completes
+ * (the `AppIdentityProxy` resolves its target only once `SignInPage` calls
+ * `onSignInSuccess`), so awaiting it is what defers the fetch until after the
+ * main Dex sign-in -- no per-installation OIDC/config is needed to sign in, and
+ * `backend.baseUrl` (used to reach this endpoint) does not depend on
+ * installations, so there is no chicken-and-egg problem.
+ *
+ * Renders nothing. Mounted once, high in the app tree.
+ */
+export function InstallationsConfigLoader() {
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const identityApi = useApi(identityApiRef);
+  const errorApi = useApi(errorApiRef);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      // Blocks until the app is signed in, so the authenticated endpoint does
+      // not 401.
+      await identityApi.getCredentials();
+      if (cancelled) {
+        return;
+      }
+
+      const baseUrl = await discoveryApi.getBaseUrl('gs');
+
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        if (cancelled) {
+          return;
+        }
+        try {
+          const response = await fetchApi.fetch(`${baseUrl}/installations`);
+          if (!response.ok) {
+            throw new Error(
+              `Failed to load installations config: HTTP ${response.status}`,
+            );
+          }
+          const data = (await response.json()) as InstallationsConfigResponse;
+          if (!cancelled) {
+            setInstallationsConfig(normalizeInstallationsConfig(data));
+          }
+          return;
+        } catch (error) {
+          if (attempt < MAX_ATTEMPTS - 1) {
+            await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
+            continue;
+          }
+          // Give up after exhausting retries. Report the failure and publish an
+          // empty set so awaiting boot-time APIs unblock (the app degrades to
+          // "no installations" rather than hanging forever).
+          errorApi.post(error as Error);
+          if (!cancelled) {
+            setInstallationsConfig([]);
+          }
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [discoveryApi, fetchApi, identityApi, errorApi]);
+
+  return null;
+}

--- a/plugins/gs/src/components/InstallationsConfigLoader/InstallationsConfigLoader.tsx
+++ b/plugins/gs/src/components/InstallationsConfigLoader/InstallationsConfigLoader.tsx
@@ -43,48 +43,64 @@ export function InstallationsConfigLoader() {
     let cancelled = false;
 
     const load = async () => {
-      // Blocks until the app is signed in, so the authenticated endpoint does
-      // not 401.
-      await identityApi.getCredentials();
-      if (cancelled) {
-        return;
-      }
-
-      const baseUrl = await discoveryApi.getBaseUrl('gs');
-
-      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      try {
+        // Blocks until the app is signed in, so the authenticated endpoint does
+        // not 401. Kept inside the try/catch alongside base-URL discovery so a
+        // rejection here can never leave the installations promise unresolved
+        // (every awaiting boot-time API would otherwise deadlock).
+        await identityApi.getCredentials();
         if (cancelled) {
           return;
         }
-        try {
-          const response = await fetchApi.fetch(`${baseUrl}/installations`);
-          if (!response.ok) {
-            throw new Error(
-              `Failed to load installations config: HTTP ${response.status}`,
-            );
+
+        const baseUrl = await discoveryApi.getBaseUrl('gs');
+
+        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+          if (cancelled) {
+            return;
           }
-          const data = (await response.json()) as InstallationsConfigResponse;
-          if (!cancelled) {
-            setInstallationsConfig(normalizeInstallationsConfig(data));
-          }
-          return;
-        } catch (error) {
-          if (attempt < MAX_ATTEMPTS - 1) {
-            await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
-            continue;
-          }
-          // Give up after exhausting retries. Report the failure and publish an
-          // empty set so awaiting boot-time APIs unblock (the app degrades to
-          // "no installations" rather than hanging forever).
-          errorApi.post(error as Error);
-          if (!cancelled) {
-            setInstallationsConfig([]);
+          try {
+            const response = await fetchApi.fetch(`${baseUrl}/installations`);
+            if (!response.ok) {
+              throw new Error(
+                `Failed to load installations config: HTTP ${response.status}`,
+              );
+            }
+            const data = (await response.json()) as InstallationsConfigResponse;
+            if (!cancelled) {
+              setInstallationsConfig(normalizeInstallationsConfig(data));
+            }
+            return;
+          } catch (error) {
+            if (attempt < MAX_ATTEMPTS - 1) {
+              await delay(RETRY_BASE_DELAY_MS * 2 ** attempt);
+              continue;
+            }
+            // Retries exhausted -- hand off to the outer catch, which publishes
+            // an empty set and reports the failure.
+            throw error;
           }
         }
+      } catch (error) {
+        // Any failure (sign-in credentials, base-URL discovery, or exhausted
+        // fetch retries) degrades to "no installations". Publish first, before
+        // anything that might throw (errorApi.post), so awaiting boot-time APIs
+        // always unblock rather than hanging forever.
+        if (!cancelled) {
+          setInstallationsConfig([]);
+        }
+        errorApi.post(error as Error);
       }
     };
 
-    load();
+    // load() handles its own failures, but guard the invocation too so an
+    // unexpected rejection (e.g. errorApi.post itself throwing) can never become
+    // an unhandled rejection that leaves the installations promise unresolved.
+    load().catch(() => {
+      if (!cancelled) {
+        setInstallationsConfig([]);
+      }
+    });
 
     return () => {
       cancelled = true;

--- a/plugins/gs/src/components/InstallationsConfigLoader/index.ts
+++ b/plugins/gs/src/components/InstallationsConfigLoader/index.ts
@@ -1,0 +1,1 @@
+export { InstallationsConfigLoader } from './InstallationsConfigLoader';

--- a/plugins/gs/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/plugins/gs/src/components/ProviderSettings/ProviderSettings.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import { GiantSwarmIcon } from '../../assets/icons/CustomIcons';
 import { ProviderSettingsItem } from './ProviderSettingsItem';
@@ -5,6 +6,29 @@ import { gsAuthProvidersApiRef } from '../../apis/auth';
 
 export const ProviderSettings = () => {
   const gsAuthProvidersApi = useApi(gsAuthProvidersApiRef);
+
+  // The per-installation providers are built lazily once the installations
+  // config has loaded (post sign-in). Wait for that so the settings list is
+  // populated rather than empty on first render.
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    gsAuthProvidersApi.ensureInitialized().then(
+      () => {
+        if (!cancelled) {
+          setReady(true);
+        }
+      },
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [gsAuthProvidersApi]);
+
+  if (!ready) {
+    return null;
+  }
 
   return (
     <>

--- a/plugins/gs/src/components/ProviderSettings/ProviderSettings.tsx
+++ b/plugins/gs/src/components/ProviderSettings/ProviderSettings.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useApi } from '@backstage/core-plugin-api';
+import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { GiantSwarmIcon } from '../../assets/icons/CustomIcons';
 import { ProviderSettingsItem } from './ProviderSettingsItem';
 import { gsAuthProvidersApiRef } from '../../apis/auth';
 
 export const ProviderSettings = () => {
   const gsAuthProvidersApi = useApi(gsAuthProvidersApiRef);
+  const errorApi = useApi(errorApiRef);
 
   // The per-installation providers are built lazily once the installations
   // config has loaded (post sign-in). Wait for that so the settings list is
@@ -19,12 +20,17 @@ export const ProviderSettings = () => {
           setReady(true);
         }
       },
-      () => {},
+      error => {
+        // Do not swallow the failure: `ready` stays false and the list renders
+        // empty, which is indistinguishable from "no providers" unless we report
+        // why initialization never completed.
+        errorApi.post(error as Error);
+      },
     );
     return () => {
       cancelled = true;
     };
-  }, [gsAuthProvidersApi]);
+  }, [gsAuthProvidersApi, errorApi]);
 
   if (!ready) {
     return null;

--- a/plugins/gs/src/components/hooks/useDisabledInstallations.ts
+++ b/plugins/gs/src/components/hooks/useDisabledInstallations.ts
@@ -1,19 +1,35 @@
 import { fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import { useIsRestoring, useQuery } from '@tanstack/react-query';
-import { DiscoveryApiClient } from '../../apis/discovery/DiscoveryApiClient';
 import { useMemo } from 'react';
+import { useInstallations } from '../../apis/installations';
 
 const STATUS_CHECK_TIMEOUT = 5000;
 const STATUS_CHECK_INTERVAL = 20000;
 export const useDisabledInstallations = () => {
   const isRestoring = useIsRestoring();
   const fetchApi = useApi(fetchApiRef);
-  const baseUrlOverrides = DiscoveryApiClient.getBaseUrlOverrides();
-  const uniqueEndpoints = Array.from(new Set(Object.values(baseUrlOverrides)));
+  const { installations } = useInstallations();
+
+  // Installation name -> `backendUrl` override, derived reactively from the
+  // loaded installations so this updates once they arrive after sign-in.
+  const baseUrlOverrides = useMemo(() => {
+    const overrides: Record<string, string> = {};
+    for (const installation of installations) {
+      if (installation.backendUrl) {
+        overrides[installation.name] = installation.backendUrl;
+      }
+    }
+    return overrides;
+  }, [installations]);
+
+  const uniqueEndpoints = useMemo(
+    () => Array.from(new Set(Object.values(baseUrlOverrides))),
+    [baseUrlOverrides],
+  );
 
   const { data: endpointStatuses, isLoading: isLoadingEndpointStatuses } =
     useQuery({
-      queryKey: ['installations', 'status'],
+      queryKey: ['installations', 'status', ...uniqueEndpoints],
       queryFn: async () => {
         const requestPromises = uniqueEndpoints.map(endpoint => {
           const statusEndpoint = `${endpoint}/.backstage/health/v1/readiness`;

--- a/plugins/gs/src/components/hooks/useGrafanaDashboardLink.ts
+++ b/plugins/gs/src/components/hooks/useGrafanaDashboardLink.ts
@@ -1,4 +1,4 @@
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { useInstallations } from '../../apis/installations';
 
 const typedUrl = (
   baseDomain: string,
@@ -25,10 +25,10 @@ export const useGrafanaDashboardLink = (
   namespace: string,
   applicationName: string,
 ): string | undefined => {
-  const config = useApi(configApiRef);
-  const baseDomain = config.getOptionalString(
-    `gs.installations.${installationName}.baseDomain`,
-  );
+  const { installations } = useInstallations();
+  const baseDomain = installations.find(
+    installation => installation.name === installationName,
+  )?.baseDomain;
 
   if (!baseDomain) {
     return undefined;

--- a/plugins/gs/src/components/hooks/useInstallationsInfo.ts
+++ b/plugins/gs/src/components/hooks/useInstallationsInfo.ts
@@ -1,4 +1,4 @@
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { useInstallations } from '../../apis/installations';
 
 export type InstallationInfo = {
   name: string;
@@ -8,29 +8,26 @@ export type InstallationInfo = {
   region?: string;
 };
 
+/**
+ * Installation metadata for UI consumers. Sourced from the installations config
+ * loaded from the authenticated backend endpoint after sign-in (no longer from
+ * the frontend config), so `isLoading` is true until that fetch resolves.
+ */
 export function useInstallationsInfo() {
-  const configApi = useApi(configApiRef);
-  const installationsConfig = configApi.getOptionalConfig('gs.installations');
-  if (!installationsConfig) {
-    throw new Error(`Missing gs.installations configuration`);
-  }
-
-  const installations = configApi.getConfig('gs.installations').keys();
+  const { installations, isLoading } = useInstallations();
 
   const installationsInfo: InstallationInfo[] = installations.map(
-    installation => {
-      const installationConfig = installationsConfig.getConfig(installation);
-      return {
-        name: installation,
-        pipeline: installationConfig.getString('pipeline'),
-        providers: installationConfig.getOptionalStringArray('providers') ?? [],
-        baseDomain: installationConfig.getOptionalString('baseDomain'),
-        region: installationConfig.getOptionalString('region'),
-      };
-    },
+    installation => ({
+      name: installation.name,
+      pipeline: installation.pipeline ?? '',
+      providers: installation.providers ?? [],
+      baseDomain: installation.baseDomain,
+      region: installation.region,
+    }),
   );
 
   return {
     installationsInfo,
+    isLoading,
   };
 }

--- a/plugins/gs/src/index.ts
+++ b/plugins/gs/src/index.ts
@@ -8,7 +8,17 @@ export { ReviewStep } from './components/scaffolder/ReviewStep';
 
 export { DiscoveryApiClient as GSDiscoveryApiClient } from './apis/discovery/DiscoveryApiClient';
 export { ScaffolderApiClient as GSScaffolderApiClient } from './apis/scaffolder/ScaffolderApiClient';
-export { gsAuthApiRef, gsAuthProvidersApiRef } from './apis/auth/types';
+export {
+  gsAuthApiRef,
+  gsAuthProvidersApiRef,
+  type GSAuthProvidersApi,
+} from './apis/auth/types';
+export {
+  useInstallations,
+  type InstallationConfig,
+  type UseInstallationsResult,
+} from './apis/installations';
+export { InstallationsConfigLoader } from './components/InstallationsConfigLoader';
 export {
   clusterAccessStatusApiRef,
   type ClusterAccessStatusApi,


### PR DESCRIPTION
### What does this PR do?

Changes how the frontend obtains the `gs.installations` configuration. Instead of reading it from the frontend app-config, the `gs-backend` plugin now exposes it through an authenticated endpoint (`GET /api/gs/installations`), and the frontend loads it once, after sign-in, via a small async provider.

To support this, the boot-time frontend APIs that previously read `gs.installations` synchronously from config (`DiscoveryApiClient`, `KubernetesClient`, `GSAuthProviders`) were refactored to obtain the data asynchronously from a shared source, and the per-installation auth providers are now initialized lazily once the main sign-in completes. The `gs.installations` config schema is changed to backend visibility.

Also includes a fix for a pre-sign-in deadlock found during local testing: auth base-URL resolution no longer blocks on the not-yet-loaded installations data, and the main sign-in provider is no longer treated as installation-scoped.

### What is the effect of this change to users?

No user-facing behaviour change. Installation configuration is loaded transparently after authentication.

### Any background context you can provide?

Context is tracked in the internal issue giantswarm/giantswarm#37213 (private).

This is one of two alternative implementations under consideration; it is opened as a **draft** for review and manual verification. It has been smoke-tested locally (sign-in and app load).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

> Note: this branch changes public plugin exports, so a changeset is still to be added before the `@giantswarm/backstage-plugin-*` packages are published.
