### PR TITLE
feat(plans): revamp the Plans page with bui components and shared markdown rendering

### DIFF
--- a/.changeset/plans-bui-migration.md
+++ b/.changeset/plans-bui-migration.md
@@ -1,0 +1,25 @@
+---
+'@giantswarm/backstage-plugin-ui-react': minor
+'@giantswarm/backstage-plugin-plans': minor
+'@giantswarm/backstage-plugin-gs': minor
+---
+
+Migrate the Plans page to the bui design system and share markdown rendering.
+
+- `ui-react`: add a shared `GSMarkdownContent` component wrapping
+  `@backstage/core-components`' `MarkdownContent` with a GFM default and
+  consistent typography — matched `<p>`/`<li>` line-height, spacing between
+  list items, and padded non-highlighted code blocks (language-tagged blocks
+  keep their `CodeSnippet` styling).
+- `plans`: move the Proposed/Merged tabs to bui `Tabs`, relocate the repository
+  picker to a bui `Select` in the plugin header (via the shared page-header
+  actions slot), and rebuild the proposed/merged/review lists on bui
+  `List`/`ListRow`. The Merged tab now renders each plan document in a bui
+  `Accordion` (expanded by default), hides dot files/folders and loose
+  repository-root documents, strips the redundant folder prefix from document
+  titles, and shows friendly labels for well-known files (e.g. `PRD.md` →
+  "Product Requirements Document"). Comments, chips (→ `Badge`), alerts and the
+  Rendered/Diff toggle move to bui equivalents, and plan/comment markdown now
+  renders through `GSMarkdownContent`.
+- `gs`: render the app/chart component README and SOUL cards
+  (`CollapsibleMarkdownCard`) through the shared `GSMarkdownContent`.

--- a/plugins/gs/src/components/UI/CollapsibleMarkdownCard/CollapsibleMarkdownCard.tsx
+++ b/plugins/gs/src/components/UI/CollapsibleMarkdownCard/CollapsibleMarkdownCard.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useEffect, useCallback, ReactNode } from 'react';
-import { MarkdownContent, Progress } from '@backstage/core-components';
-import { InfoCard } from '@giantswarm/backstage-plugin-ui-react';
+import { Progress } from '@backstage/core-components';
+import {
+  GSMarkdownContent,
+  InfoCard,
+} from '@giantswarm/backstage-plugin-ui-react';
 import {
   Box,
   Button,
@@ -153,7 +156,7 @@ export const CollapsibleMarkdownCard = ({
             collapsedSize={collapsedSize}
           >
             <div ref={contentRef}>
-              <MarkdownContent content={content} />
+              <GSMarkdownContent content={content} />
             </div>
           </Collapse>
           {needsExpansion && !expanded && (

--- a/plugins/plans/package.json
+++ b/plugins/plans/package.json
@@ -28,6 +28,8 @@
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
+    "@backstage/ui": "backstage:^",
+    "@giantswarm/backstage-plugin-ui-react": "workspace:^",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",

--- a/plugins/plans/src/components/Comments/Comments.tsx
+++ b/plugins/plans/src/components/Comments/Comments.tsx
@@ -1,14 +1,7 @@
 import { FormEvent, useState } from 'react';
-import {
-  Box,
-  Button,
-  TextField,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import { MarkdownContent } from '@backstage/core-components';
+import { Alert, Button, Flex, Text, TextAreaField } from '@backstage/ui';
+import { makeStyles, Theme } from '@material-ui/core';
+import { GSMarkdownContent } from '@giantswarm/backstage-plugin-ui-react';
 import { NewReviewComment, PlanComment } from '../../apis';
 import { ReviewThread } from '../../lib/annotations';
 import { formatDate } from '../../lib/dates';
@@ -20,16 +13,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       borderTop: `1px solid ${theme.palette.divider}`,
     },
   },
-  meta: {
-    color: theme.palette.text.secondary,
-    fontSize: 12,
-  },
   form: {
-    marginTop: theme.spacing(1),
-  },
-  actions: {
-    display: 'flex',
-    gap: theme.spacing(1),
     marginTop: theme.spacing(1),
   },
 }));
@@ -44,13 +28,13 @@ export function CommentItem({ comment }: { comment: PlanComment }) {
   const created = formatDate(comment.createdAt, { time: true });
 
   return (
-    <Box className={classes.comment}>
-      <Typography className={classes.meta}>
+    <div className={classes.comment}>
+      <Text variant="body-small" color="secondary">
         {comment.author ?? 'unknown'}
         {created && ` · ${created}`}
-      </Typography>
-      <MarkdownContent content={comment.body} dialect="gfm" />
-    </Box>
+      </Text>
+      <GSMarkdownContent content={comment.body} />
+    </div>
   );
 }
 
@@ -92,6 +76,8 @@ export function CommentForm(props: {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
 
+  const label = placeholder ?? 'Leave a comment (markdown supported)';
+
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     if (body.trim() === '' || pending) {
@@ -111,34 +97,39 @@ export function CommentForm(props: {
 
   return (
     <form className={classes.form} onSubmit={submit}>
-      <TextField
-        fullWidth
-        multiline
-        minRows={2}
-        variant="outlined"
-        size="small"
-        placeholder={placeholder ?? 'Leave a comment (markdown supported)'}
-        value={body}
-        onChange={event => setBody(event.target.value)}
-        disabled={pending}
-      />
-      {error && <Alert severity="error">{error}</Alert>}
-      <Box className={classes.actions}>
-        <Button
-          type="submit"
-          size="small"
-          variant="contained"
-          color="primary"
-          disabled={pending || body.trim() === ''}
-        >
-          Comment
-        </Button>
-        {onCancel && (
-          <Button size="small" onClick={onCancel} disabled={pending}>
-            Cancel
-          </Button>
+      <Flex direction="column" gap="2">
+        <TextAreaField
+          aria-label={label}
+          placeholder={label}
+          rows={2}
+          value={body}
+          onChange={setBody}
+          isDisabled={pending}
+        />
+        {error && (
+          <Alert status="danger" title="Comment failed" description={error} />
         )}
-      </Box>
+        <Flex gap="2">
+          <Button
+            type="submit"
+            variant="primary"
+            size="small"
+            isDisabled={pending || body.trim() === ''}
+          >
+            Comment
+          </Button>
+          {onCancel && (
+            <Button
+              variant="tertiary"
+              size="small"
+              onClick={onCancel}
+              isDisabled={pending}
+            >
+              Cancel
+            </Button>
+          )}
+        </Flex>
+      </Flex>
     </form>
   );
 }

--- a/plugins/plans/src/components/EpicChip/EpicChip.tsx
+++ b/plugins/plans/src/components/EpicChip/EpicChip.tsx
@@ -1,4 +1,5 @@
-import { Chip, Tooltip } from '@material-ui/core';
+import { Tooltip } from '@material-ui/core';
+import { Badge } from '@backstage/ui';
 import { Link } from '@backstage/core-components';
 import {
   discoveryApiRef,
@@ -52,12 +53,9 @@ export function EpicChip({ epic }: { epic: EpicRef }) {
   return (
     <Tooltip title={item?.title ?? `${epic.owner}/${epic.repo}#${epic.number}`}>
       <Link to={to} underline="none">
-        <Chip
-          size="small"
-          variant="outlined"
-          clickable
-          label={status ? `Epic · ${status}` : `Epic #${epic.number}`}
-        />
+        <Badge size="small">
+          {status ? `Epic · ${status}` : `Epic #${epic.number}`}
+        </Badge>
       </Link>
     </Tooltip>
   );

--- a/plugins/plans/src/components/MergedTab/MergedTab.tsx
+++ b/plugins/plans/src/components/MergedTab/MergedTab.tsx
@@ -1,46 +1,53 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import type { Selection } from 'react-aria-components';
 import {
-  Box,
-  Grid,
+  Accordion,
+  AccordionGroup,
+  AccordionPanel,
+  AccordionTrigger,
+  Alert,
+  Flex,
   List,
-  ListItem,
-  ListItemSecondaryAction,
-  ListItemText,
-  Paper,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
+  ListRow,
+} from '@backstage/ui';
+import { makeStyles, Theme } from '@material-ui/core';
 import { EmptyState, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
 import { plansApiRef } from '../../apis';
-import { compareDisplayPaths, isRenderableFile } from '../../lib/files';
+import {
+  compareDisplayPaths,
+  friendlyFileName,
+  isDotPath,
+  isRenderableFile,
+  stripFolderPrefix,
+} from '../../lib/files';
 import { EpicChip } from '../EpicChip';
 import { PlanFileContent } from '../PlanFileContent';
 
-const ROOT_GROUP = '(repository root)';
-
 const useStyles = makeStyles((theme: Theme) => ({
-  listPanel: {
-    padding: 0,
-  },
-  detailPanel: {
-    padding: theme.spacing(2),
-  },
-  fileSection: {
-    marginTop: theme.spacing(2),
-    '&:first-child': {
-      marginTop: 0,
+  layout: {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: theme.spacing(2),
+    alignItems: 'start',
+    [theme.breakpoints.up('md')]: {
+      gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 2fr)',
     },
   },
+  // The file path in each accordion trigger, so a long plan reads as a
+  // navigable stack of documents rather than one wall of text.
   fileName: {
     fontFamily: 'monospace',
-    fontSize: 14,
-    fontWeight: 600,
-    marginBottom: theme.spacing(1),
+  },
+  // bui's accordion trigger has no bottom padding, so an expanded header sits
+  // flush against the document below it. Add breathing room only when
+  // expanded — a collapsed header would otherwise look top-heavy.
+  accordionGroup: {
+    '& .bui-AccordionTriggerButton[aria-expanded="true"]': {
+      paddingBottom: theme.spacing(1),
+    },
   },
 }));
 
@@ -94,8 +101,16 @@ export function MergedTab({ repo }: { repo: string }) {
       if (!isRenderableFile(entry.path)) {
         continue;
       }
+      // Hide dot files/folders (e.g. `.agents/…`) and loose repository-root
+      // documents — a plan is a top-level folder of documents.
+      if (isDotPath(entry.path)) {
+        continue;
+      }
       const slash = entry.path.indexOf('/');
-      const folder = slash === -1 ? ROOT_GROUP : entry.path.slice(0, slash);
+      if (slash === -1) {
+        continue;
+      }
+      const folder = entry.path.slice(0, slash);
       byFolder.set(folder, [...(byFolder.get(folder) ?? []), entry.path]);
     }
     return [...byFolder.entries()]
@@ -103,18 +118,20 @@ export function MergedTab({ repo }: { repo: string }) {
         name,
         files: [...files].sort(compareDisplayPaths),
       }))
-      .sort((a, b) => {
-        if (a.name === ROOT_GROUP) return 1;
-        if (b.name === ROOT_GROUP) return -1;
-        return a.name.localeCompare(b.name);
-      });
+      .sort((a, b) => a.name.localeCompare(b.name));
   }, [data]);
 
   if (isLoading) {
     return <Progress />;
   }
   if (error) {
-    return <Alert severity="error">{(error as Error).message}</Alert>;
+    return (
+      <Alert
+        status="danger"
+        title="Failed to load merged plans"
+        description={(error as Error).message}
+      />
+    );
   }
   if (groups.length === 0) {
     return (
@@ -129,53 +146,82 @@ export function MergedTab({ repo }: { repo: string }) {
   const selectedGroup =
     groups.find(group => group.name === selected) ?? groups[0];
 
+  const onSelectionChange = (selection: Selection) => {
+    if (selection === 'all' || selection.size === 0) {
+      return;
+    }
+    selectPlan(String(selection.values().next().value));
+  };
+
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} md={4}>
-        <Paper className={classes.listPanel} variant="outlined">
-          <List disablePadding>
-            {groups.map(group => (
-              <ListItem
-                key={group.name}
-                button
-                divider
-                selected={group.name === selectedGroup.name}
-                onClick={() => selectPlan(group.name)}
-              >
-                <ListItemText
-                  primary={group.name}
-                  secondary={`${group.files.length} document${
-                    group.files.length === 1 ? '' : 's'
-                  }`}
-                />
-                {epicByFolder.has(group.name) && (
-                  <ListItemSecondaryAction>
-                    <EpicChip epic={epicByFolder.get(group.name)!.epic} />
-                  </ListItemSecondaryAction>
-                )}
-              </ListItem>
-            ))}
-          </List>
-        </Paper>
-      </Grid>
-      <Grid item xs={12} md={8}>
-        <Paper className={classes.detailPanel} variant="outlined">
-          {data?.truncated && (
-            <Alert severity="warning">
-              The repository tree was truncated by GitHub; some documents may be
-              missing.
-            </Alert>
-          )}
-          {selectedGroup.files.map(path => (
-            <Box key={path} className={classes.fileSection}>
-              {selectedGroup.files.length > 1 && (
-                <Typography className={classes.fileName}>{path}</Typography>
-              )}
-              <PlanFileContent repo={repo} refName="HEAD" path={path} />
-            </Box>
-          ))}
-        </Paper>
-      </Grid>
-    </Grid>
+    <div className={classes.layout}>
+      <List
+        aria-label="Merged plans"
+        selectionMode="single"
+        disallowEmptySelection
+        selectedKeys={new Set([selectedGroup.name])}
+        onSelectionChange={onSelectionChange}
+      >
+        {groups.map(group => (
+          <ListRow
+            key={group.name}
+            id={group.name}
+            textValue={group.name}
+            description={`${group.files.length} document${
+              group.files.length === 1 ? '' : 's'
+            }`}
+            customActions={
+              epicByFolder.has(group.name) ? (
+                <EpicChip epic={epicByFolder.get(group.name)!.epic} />
+              ) : undefined
+            }
+          >
+            {group.name}
+          </ListRow>
+        ))}
+      </List>
+      <Flex direction="column" gap="3">
+        {data?.truncated && (
+          <Alert
+            status="warning"
+            title="Truncated repository tree"
+            description="The repository tree was truncated by GitHub; some documents may be missing."
+          />
+        )}
+        {/* One accordion per document, all expanded by default so the plan
+            reads top-to-bottom while still being collapsible when long. Keying
+            the group by folder remounts it on selection change, so a newly
+            selected plan's documents start expanded too (defaultExpandedKeys
+            only applies on mount). */}
+        <AccordionGroup
+          key={selectedGroup.name}
+          className={classes.accordionGroup}
+          allowsMultiple
+          defaultExpandedKeys={new Set(selectedGroup.files)}
+        >
+          {selectedGroup.files.map(path => {
+            const displayPath = stripFolderPrefix(path, selectedGroup.name);
+            const friendly = friendlyFileName(displayPath);
+            return (
+              <Accordion key={path} id={path}>
+                <AccordionTrigger>
+                  {friendly ? (
+                    <span>
+                      {friendly}{' '}
+                      <span className={classes.fileName}>({displayPath})</span>
+                    </span>
+                  ) : (
+                    <span className={classes.fileName}>{displayPath}</span>
+                  )}
+                </AccordionTrigger>
+                <AccordionPanel>
+                  <PlanFileContent repo={repo} refName="HEAD" path={path} />
+                </AccordionPanel>
+              </Accordion>
+            );
+          })}
+        </AccordionGroup>
+      </Flex>
+    </div>
   );
 }

--- a/plugins/plans/src/components/MergedTab/MergedTab.tsx
+++ b/plugins/plans/src/components/MergedTab/MergedTab.tsx
@@ -58,8 +58,8 @@ interface PlanGroup {
 
 /**
  * Merged plans: renderable documents on the default branch, grouped by their
- * top-level folder (one folder per plan by convention; loose root documents
- * are grouped under a synthetic root entry).
+ * top-level folder (one folder per plan by convention). Loose repository-root
+ * documents and dot files/folders are hidden.
  */
 export function MergedTab({ repo }: { repo: string }) {
   const classes = useStyles();

--- a/plugins/plans/src/components/PlanFileContent.tsx
+++ b/plugins/plans/src/components/PlanFileContent.tsx
@@ -1,6 +1,7 @@
 import { Box, makeStyles, Theme } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
-import { MarkdownContent, Progress } from '@backstage/core-components';
+import { Progress } from '@backstage/core-components';
+import { GSMarkdownContent } from '@giantswarm/backstage-plugin-ui-react';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
 import { plansApiRef } from '../apis';
@@ -79,7 +80,7 @@ export function PlanFileContent(props: {
   return (
     <Box className={classes.markdown}>
       {frontmatter && <Box className={classes.frontmatter}>{frontmatter}</Box>}
-      <MarkdownContent content={body} dialect="gfm" />
+      <GSMarkdownContent content={body} />
     </Box>
   );
 }

--- a/plugins/plans/src/components/PlansPage/PlansPage.tsx
+++ b/plugins/plans/src/components/PlansPage/PlansPage.tsx
@@ -1,39 +1,21 @@
-import { useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import {
-  Box,
-  MenuItem,
-  Tab,
-  Tabs,
-  TextField,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
 import { Content, EmptyState, Progress } from '@backstage/core-components';
-import { Alert } from '@material-ui/lab';
+import {
+  Alert,
+  Box,
+  Select,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from '@backstage/ui';
+import { useProvidePageHeaderActions } from '@giantswarm/backstage-plugin-ui-react';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
 import { plansApiRef } from '../../apis';
 import { ProposedTab } from '../ProposedTab';
 import { MergedTab } from '../MergedTab';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-    gap: theme.spacing(2),
-    marginBottom: theme.spacing(2),
-    borderBottom: `1px solid ${theme.palette.divider}`,
-  },
-  repoPicker: {
-    marginLeft: 'auto',
-    minWidth: 280,
-  },
-  tabBody: {
-    paddingTop: theme.spacing(1),
-  },
-}));
 
 /**
  * Plans viewer: proposed plans (open PRs, rendered from their head branch)
@@ -41,7 +23,6 @@ const useStyles = makeStyles((theme: Theme) => ({
  * repositories configured in `plans.repositories`.
  */
 export function PlansPage() {
-  const classes = useStyles();
   const plansApi = useApi(plansApiRef);
   // The selected repository lives in `?repo=` (the same param the review
   // page uses), so it survives navigating into a PR and back and the list
@@ -49,21 +30,56 @@ export function PlansPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const repo = searchParams.get('repo') ?? undefined;
   // Deep links to a merged plan (`?plan=`, e.g. from the roadmap epic view)
-  // land on the merged tab directly.
-  const [tab, setTab] = useState<'proposed' | 'merged'>(
-    searchParams.has('plan') ? 'merged' : 'proposed',
-  );
+  // land on the merged tab directly; after that the tab is uncontrolled UI
+  // state that never needs to travel back to the URL.
+  const defaultTab = searchParams.has('plan') ? 'merged' : 'proposed';
 
-  const selectRepo = (next: string) => {
-    const params = new URLSearchParams(searchParams);
-    params.set('repo', next);
-    setSearchParams(params, { replace: true });
-  };
+  // Functional update so this callback never depends on the current
+  // `searchParams` identity and stays stable across renders (the repo Select
+  // is memoized on it).
+  const selectRepo = useCallback(
+    (next: string) => {
+      setSearchParams(
+        prev => {
+          const params = new URLSearchParams(prev);
+          params.set('repo', next);
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['plans', 'repos'],
     queryFn: () => plansApi.listRepos(),
   });
+
+  const repositories = useMemo(() => data?.repositories ?? [], [data]);
+  const activeRepo =
+    repo && repositories.includes(repo) ? repo : repositories[0];
+
+  // The repository picker lives in the shared "Plans" PluginHeader (rendered by
+  // the app's PageLayout), injected via the header-actions slot rather than a
+  // toolbar in the page body. The review page provides no actions, so the slot
+  // clears automatically when this page unmounts.
+  const headerActions = useMemo(
+    () =>
+      repositories.length > 0 ? (
+        <Select
+          aria-label="Repository"
+          options={repositories.map(repository => ({
+            id: repository,
+            label: repository,
+          }))}
+          selectedKey={activeRepo ?? null}
+          onSelectionChange={key => key && selectRepo(String(key))}
+        />
+      ) : null,
+    [repositories, activeRepo, selectRepo],
+  );
+  useProvidePageHeaderActions(headerActions);
 
   if (isLoading) {
     return (
@@ -75,12 +91,15 @@ export function PlansPage() {
   if (error) {
     return (
       <Content>
-        <Alert severity="error">{(error as Error).message}</Alert>
+        <Alert
+          status="danger"
+          title="Failed to load plan repositories"
+          description={(error as Error).message}
+        />
       </Content>
     );
   }
 
-  const repositories = data?.repositories ?? [];
   if (repositories.length === 0) {
     return (
       <Content>
@@ -93,45 +112,24 @@ export function PlansPage() {
     );
   }
 
-  const activeRepo =
-    repo && repositories.includes(repo) ? repo : repositories[0];
-
   return (
     <Content>
-      <Box className={classes.toolbar}>
-        <Tabs
-          value={tab}
-          onChange={(_, value) => setTab(value)}
-          indicatorColor="primary"
-        >
-          <Tab label="Proposed" value="proposed" />
-          <Tab label="Merged" value="merged" />
-        </Tabs>
-        {/* Always visible, even with a single repository: the repo name is
-            what tells the user whose plans they are looking at. */}
-        <TextField
-          className={classes.repoPicker}
-          select
-          size="small"
-          variant="outlined"
-          label="Repository"
-          value={activeRepo}
-          onChange={event => selectRepo(event.target.value)}
-        >
-          {repositories.map(repository => (
-            <MenuItem key={repository} value={repository}>
-              {repository}
-            </MenuItem>
-          ))}
-        </TextField>
-      </Box>
-      <Box className={classes.tabBody}>
-        {tab === 'proposed' ? (
-          <ProposedTab repo={activeRepo} />
-        ) : (
-          <MergedTab repo={activeRepo} />
-        )}
-      </Box>
+      <Tabs defaultSelectedKey={defaultTab}>
+        <TabList>
+          <Tab id="proposed">Proposed</Tab>
+          <Tab id="merged">Merged</Tab>
+        </TabList>
+        <TabPanel id="proposed">
+          <Box pt="4">
+            <ProposedTab repo={activeRepo} />
+          </Box>
+        </TabPanel>
+        <TabPanel id="merged">
+          <Box pt="4">
+            <MergedTab repo={activeRepo} />
+          </Box>
+        </TabPanel>
+      </Tabs>
     </Content>
   );
 }

--- a/plugins/plans/src/components/ProposedTab/ProposedTab.tsx
+++ b/plugins/plans/src/components/ProposedTab/ProposedTab.tsx
@@ -1,15 +1,7 @@
-import {
-  Chip,
-  List,
-  ListItem,
-  ListItemSecondaryAction,
-  ListItemText,
-  Paper,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
-import { Link as RouterLink } from 'react-router-dom';
-import { Alert } from '@material-ui/lab';
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Alert, Badge, Flex, List, ListRow } from '@backstage/ui';
+import { makeStyles } from '@material-ui/core';
 import { EmptyState, Progress } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/frontend-plugin-api';
 import { useQueries, useQuery } from '@tanstack/react-query';
@@ -18,14 +10,25 @@ import { formatDate } from '../../lib/dates';
 import { pullRouteRef } from '../../routes';
 import { EpicChip } from '../EpicChip';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  listPanel: {
-    padding: 0,
+// bui only applies row affordances (pointer, hover/press background, padding)
+// to selection lists. This is an action list — clicking a row navigates — so
+// re-apply the same affordances (matching bui's own selection-mode values) to
+// make the rows read as interactive.
+const useStyles = makeStyles({
+  list: {
+    '& .bui-ListRow': {
+      cursor: 'pointer',
+      paddingBlock: 'var(--bui-space-2)',
+      paddingInline: 'var(--bui-space-2)',
+      '&[data-hovered], &[data-focus-visible]': {
+        backgroundColor: 'var(--bui-bg-neutral-1-hover)',
+      },
+      '&[data-pressed]': {
+        backgroundColor: 'var(--bui-bg-neutral-1-pressed)',
+      },
+    },
   },
-  draftChip: {
-    marginLeft: theme.spacing(1),
-  },
-}));
+});
 
 /**
  * Open pull requests against the plan repository -- plans proposed for team
@@ -37,6 +40,7 @@ export function ProposedTab({ repo }: { repo: string }) {
   const classes = useStyles();
   const plansApi = useApi(plansApiRef);
   const pullLink = useRouteRef(pullRouteRef);
+  const navigate = useNavigate();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['plans', 'pulls', repo],
@@ -52,8 +56,9 @@ export function ProposedTab({ repo }: { repo: string }) {
     queryFn: () => plansApi.listEpics(repo),
     retry: false,
   });
-  const epicByPull = new Map(
-    (epicsData?.pulls ?? []).map(entry => [entry.number, entry]),
+  const epicByPull = useMemo(
+    () => new Map((epicsData?.pulls ?? []).map(entry => [entry.number, entry])),
+    [epicsData],
   );
 
   // Changed-file counts for the list. Same query keys as the review page,
@@ -69,7 +74,13 @@ export function ProposedTab({ repo }: { repo: string }) {
     return <Progress />;
   }
   if (error) {
-    return <Alert severity="error">{(error as Error).message}</Alert>;
+    return (
+      <Alert
+        status="danger"
+        title="Failed to load proposed plans"
+        description={(error as Error).message}
+      />
+    );
   }
 
   if (pulls.length === 0) {
@@ -83,55 +94,47 @@ export function ProposedTab({ repo }: { repo: string }) {
   }
 
   return (
-    <Paper className={classes.listPanel} variant="outlined">
-      <List disablePadding>
-        {pulls.map((pull, index) => {
-          const fileCount = fileQueries[index]?.data?.files.length;
-          const updated = formatDate(pull.updatedAt);
-          const secondary = [
-            `#${pull.number}`,
-            pull.author,
-            fileCount !== undefined
-              ? `${fileCount} file${fileCount === 1 ? '' : 's'} changed`
-              : undefined,
-            updated ? `updated ${updated}` : undefined,
-          ]
-            .filter(Boolean)
-            .join(' · ');
-          const to = `${pullLink?.({ number: String(pull.number) }) ?? '#'}?repo=${encodeURIComponent(repo)}`;
+    <List
+      aria-label="Proposed plans"
+      className={classes.list}
+      onAction={key => {
+        const to = `${pullLink?.({ number: String(key) }) ?? '#'}?repo=${encodeURIComponent(repo)}`;
+        navigate(to);
+      }}
+    >
+      {pulls.map((pull, index) => {
+        const fileCount = fileQueries[index]?.data?.files.length;
+        const updated = formatDate(pull.updatedAt);
+        const secondary = [
+          `#${pull.number}`,
+          pull.author,
+          fileCount !== undefined
+            ? `${fileCount} file${fileCount === 1 ? '' : 's'} changed`
+            : undefined,
+          updated ? `updated ${updated}` : undefined,
+        ]
+          .filter(Boolean)
+          .join(' · ');
 
-          return (
-            <ListItem
-              key={pull.number}
-              button
-              divider
-              component={RouterLink}
-              to={to}
-            >
-              <ListItemText
-                primary={
-                  <>
-                    {pull.title}
-                    {pull.draft && (
-                      <Chip
-                        className={classes.draftChip}
-                        size="small"
-                        label="Draft"
-                      />
-                    )}
-                  </>
-                }
-                secondary={secondary}
-              />
-              {epicByPull.has(pull.number) && (
-                <ListItemSecondaryAction>
-                  <EpicChip epic={epicByPull.get(pull.number)!.epic} />
-                </ListItemSecondaryAction>
-              )}
-            </ListItem>
-          );
-        })}
-      </List>
-    </Paper>
+        return (
+          <ListRow
+            key={pull.number}
+            id={String(pull.number)}
+            textValue={pull.title}
+            description={secondary}
+            customActions={
+              epicByPull.has(pull.number) ? (
+                <EpicChip epic={epicByPull.get(pull.number)!.epic} />
+              ) : undefined
+            }
+          >
+            <Flex align="center" gap="2">
+              {pull.title}
+              {pull.draft && <Badge size="small">Draft</Badge>}
+            </Flex>
+          </ListRow>
+        );
+      })}
+    </List>
   );
 }

--- a/plugins/plans/src/components/PullReviewPage/PullReviewPage.tsx
+++ b/plugins/plans/src/components/PullReviewPage/PullReviewPage.tsx
@@ -1,25 +1,24 @@
 import { useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
+import type { Selection } from 'react-aria-components';
+import { makeStyles, Theme } from '@material-ui/core';
 import {
-  Box,
-  Chip,
+  Alert,
+  Badge,
   List,
-  ListItem,
-  ListItemText,
-  Paper,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
-import { Alert, ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+  ListRow,
+  Text,
+  ToggleButton,
+  ToggleButtonGroup,
+} from '@backstage/ui';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import {
   Content,
   EmptyState,
   Link,
-  MarkdownContent,
   Progress,
 } from '@backstage/core-components';
+import { GSMarkdownContent } from '@giantswarm/backstage-plugin-ui-react';
 import { useApi, useRouteRef } from '@backstage/frontend-plugin-api';
 import {
   useMutation,
@@ -73,28 +72,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     position: 'sticky',
     top: theme.spacing(2),
   },
-  navItemText: {
-    '& .MuiListItemText-primary': {
-      fontSize: 14,
-    },
-    '& .MuiListItemText-secondary': {
-      fontSize: 11,
-      fontFamily: 'monospace',
-      wordBreak: 'break-all',
-    },
-  },
-  countBadge: {
-    height: 20,
-    fontSize: 11,
-    marginLeft: theme.spacing(1),
-  },
   statusDot: {
     display: 'inline-block',
     width: 8,
     height: 8,
     borderRadius: '50%',
-    marginRight: theme.spacing(1),
     flexShrink: 0,
+    marginRight: theme.spacing(1),
   },
   added: {
     backgroundColor: theme.palette.success.main,
@@ -109,6 +93,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   panel: {
     padding: theme.spacing(3),
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
   },
   toolbar: {
     display: 'flex',
@@ -184,30 +170,32 @@ function OverviewPanel(props: { repo: string; pull: PlanPull }) {
   return (
     <>
       {pull.body ? (
-        <MarkdownContent content={pull.body} dialect="gfm" />
+        <GSMarkdownContent content={pull.body} />
       ) : (
-        <Typography variant="body2" color="textSecondary">
-          This pull request has no description.
-        </Typography>
+        <Text color="secondary">This pull request has no description.</Text>
       )}
-      <Typography variant="h6" className={classes.discussionTitle}>
+      <Text as="h6" variant="title-small" className={classes.discussionTitle}>
         Discussion
-      </Typography>
+      </Text>
       {isLoading && <Progress />}
       {error ? (
-        <Alert severity="error">{(error as Error).message}</Alert>
+        <Alert
+          status="danger"
+          title="Failed to load discussion"
+          description={(error as Error).message}
+        />
       ) : null}
       {data?.comments.length === 0 && (
-        <Typography variant="body2" color="textSecondary">
+        <Text color="secondary">
           No comments yet. Start the discussion below.
-        </Typography>
+        </Text>
       )}
       {data?.comments.length ? (
-        <Box className={classes.discussion}>
+        <div className={classes.discussion}>
           {data.comments.map(comment => (
             <CommentItem key={comment.id} comment={comment} />
           ))}
-        </Box>
+        </div>
       ) : null}
       <CommentForm onSubmit={body => createComment.mutateAsync(body)} />
     </>
@@ -259,7 +247,13 @@ function DocumentPanel(props: {
     if (isLoading) {
       body = <Progress />;
     } else if (error) {
-      body = <Alert severity="error">{(error as Error).message}</Alert>;
+      body = (
+        <Alert
+          status="danger"
+          title="Failed to load document"
+          description={(error as Error).message}
+        />
+      );
     } else if (!data) {
       body = null;
     } else if (html) {
@@ -291,35 +285,36 @@ function DocumentPanel(props: {
       />
     );
   } else {
-    body = (
-      <Typography variant="body2" color="textSecondary">
-        No diff available for this file.
-      </Typography>
-    );
+    body = <Text color="secondary">No diff available for this file.</Text>;
   }
 
   return (
     <>
-      <Box className={classes.toolbar}>
+      <div className={classes.toolbar}>
         {renderable && file.patch && (
           <ToggleButtonGroup
-            size="small"
-            exclusive
-            value={view}
-            onChange={(_, value) => value && setView(value)}
+            selectionMode="single"
+            disallowEmptySelection
+            selectedKeys={[view]}
+            onSelectionChange={keys => {
+              const next = [...keys][0];
+              if (next === 'rendered' || next === 'diff') {
+                setView(next);
+              }
+            }}
           >
-            <ToggleButton value="rendered">Rendered</ToggleButton>
-            <ToggleButton value="diff">Diff</ToggleButton>
+            <ToggleButton id="rendered">Rendered</ToggleButton>
+            <ToggleButton id="diff">Diff</ToggleButton>
           </ToggleButtonGroup>
         )}
         {file.status !== 'modified' && (
-          <Chip size="small" variant="outlined" label={file.status} />
+          <Badge size="small">{file.status}</Badge>
         )}
         <span className={classes.additions}>+{file.additions}</span>
         <span className={classes.deletions}>−{file.deletions}</span>
-        <Box className={classes.toolbarSpacer} />
+        <div className={classes.toolbarSpacer} />
         <Link to={githubUrl}>View on GitHub</Link>
-      </Box>
+      </div>
       {body}
     </>
   );
@@ -440,7 +435,11 @@ export function PullReviewPage() {
   if (loadError) {
     return (
       <Content>
-        <Alert severity="error">{(loadError as Error).message}</Alert>
+        <Alert
+          status="danger"
+          title="Failed to load pull request"
+          description={(loadError as Error).message}
+        />
       </Content>
     );
   }
@@ -469,57 +468,69 @@ export function PullReviewPage() {
     setSearchParams(params);
   };
 
+  const onNavSelectionChange = (selection: Selection) => {
+    if (selection === 'all' || selection.size === 0) {
+      return;
+    }
+    selectDoc(String(selection.values().next().value));
+  };
+
   const selectedFile = files.find(file => file.filename === doc);
   const updated = formatDate(pull.updatedAt);
   const discussionCount = discussionComments?.comments.length;
 
-  const countChip = (count: number | undefined) =>
+  const countBadge = (count: number | undefined) =>
     count !== undefined && count > 0 ? (
-      <Chip className={classes.countBadge} size="small" label={count} />
+      <Badge size="small">{String(count)}</Badge>
     ) : null;
 
   return (
     <Content>
-      <Box className={classes.header}>
+      <div className={classes.header}>
         <Link className={classes.backLink} to={plansPath}>
           <ArrowBackIcon fontSize="inherit" /> All plans
         </Link>
-        <Typography variant="h4">{pull.title}</Typography>
-        <Box className={classes.headerMeta}>
-          {pull.draft && <Chip size="small" label="Draft" />}
-          <Typography variant="body2" color="textSecondary">
+        <Text as="h4" variant="title-medium">
+          {pull.title}
+        </Text>
+        <div className={classes.headerMeta}>
+          {pull.draft && <Badge size="small">Draft</Badge>}
+          <Text variant="body-small" color="secondary">
             <Link to={`https://github.com/${repo}/pull/${pull.number}`}>
               {repo}#{pull.number}
             </Link>
             {pull.author && ` by ${pull.author}`}
             {updated && ` · updated ${updated}`}
-          </Typography>
-        </Box>
-      </Box>
+          </Text>
+        </div>
+      </div>
 
-      <Box className={classes.layout}>
-        <Paper className={classes.nav} variant="outlined">
-          <List dense disablePadding>
-            <ListItem
-              button
-              divider
-              selected={doc === OVERVIEW}
-              onClick={() => selectDoc(OVERVIEW)}
+      <div className={classes.layout}>
+        <nav className={classes.nav}>
+          <List
+            aria-label="Documents in this pull request"
+            selectionMode="single"
+            disallowEmptySelection
+            selectedKeys={new Set([doc])}
+            onSelectionChange={onNavSelectionChange}
+          >
+            <ListRow
+              id={OVERVIEW}
+              textValue="Overview"
+              description="Description & discussion"
+              customActions={countBadge(discussionCount)}
             >
-              <ListItemText
-                className={classes.navItemText}
-                primary="Overview"
-                secondary="Description & discussion"
-              />
-              {countChip(discussionCount)}
-            </ListItem>
+              Overview
+            </ListRow>
             {files.map(file => (
-              <ListItem
+              <ListRow
                 key={file.filename}
-                button
-                divider
-                selected={doc === file.filename}
-                onClick={() => selectDoc(file.filename)}
+                id={file.filename}
+                textValue={titles.get(file.filename) ?? basename(file.filename)}
+                description={file.filename}
+                customActions={countBadge(
+                  commentsByFile.get(file.filename)?.length,
+                )}
               >
                 {file.status !== 'modified' && (
                   <span
@@ -531,19 +542,14 @@ export function PullReviewPage() {
                     title={file.status}
                   />
                 )}
-                <ListItemText
-                  className={classes.navItemText}
-                  primary={titles.get(file.filename) ?? basename(file.filename)}
-                  secondary={file.filename}
-                />
-                {countChip(commentsByFile.get(file.filename)?.length)}
-              </ListItem>
+                {titles.get(file.filename) ?? basename(file.filename)}
+              </ListRow>
             ))}
           </List>
-        </Paper>
+        </nav>
 
-        <Box className={classes.reading}>
-          <Paper className={classes.panel} variant="outlined">
+        <div className={classes.reading}>
+          <div className={classes.panel}>
             {selectedFile ? (
               <DocumentPanel
                 key={selectedFile.filename}
@@ -557,9 +563,9 @@ export function PullReviewPage() {
             ) : (
               <OverviewPanel repo={repo} pull={pull} />
             )}
-          </Paper>
-        </Box>
-      </Box>
+          </div>
+        </div>
+      </div>
     </Content>
   );
 }

--- a/plugins/plans/src/lib/files.test.ts
+++ b/plugins/plans/src/lib/files.test.ts
@@ -132,10 +132,8 @@ describe('stripFolderPrefix', () => {
   });
 
   it('leaves paths outside the folder unchanged', () => {
-    // Root-level documents grouped under a synthetic folder name.
-    expect(stripFolderPrefix('README.md', '(repository root)')).toBe(
-      'README.md',
-    );
+    // A path that isn't under the given folder is returned verbatim.
+    expect(stripFolderPrefix('README.md', 'my-plan')).toBe('README.md');
     // A folder name that is a prefix but not a path segment must not match.
     expect(stripFolderPrefix('my-plan-2/README.md', 'my-plan')).toBe(
       'my-plan-2/README.md',

--- a/plugins/plans/src/lib/files.test.ts
+++ b/plugins/plans/src/lib/files.test.ts
@@ -1,10 +1,13 @@
 import {
   compareDisplayPaths,
   firstHeading,
+  friendlyFileName,
   isHtmlFile,
   isMarkdownFile,
+  isDotPath,
   isRenderableFile,
   splitFrontmatter,
+  stripFolderPrefix,
 } from './files';
 
 describe('file type helpers', () => {
@@ -84,5 +87,58 @@ describe('compareDisplayPaths', () => {
       'plan/top.md',
       'plan/sub/deep.md',
     ]);
+  });
+});
+
+describe('friendlyFileName', () => {
+  it('maps well-known file names case-insensitively', () => {
+    expect(friendlyFileName('PRD.md')).toBe('Product Requirements Document');
+    expect(friendlyFileName('prd.md')).toBe('Product Requirements Document');
+    expect(friendlyFileName('index.html')).toBe('Web page');
+    // Matches on the basename, so nested paths still resolve.
+    expect(friendlyFileName('sub/PRD.md')).toBe(
+      'Product Requirements Document',
+    );
+  });
+
+  it('returns undefined for files without a known convention', () => {
+    expect(friendlyFileName('notes.md')).toBeUndefined();
+    expect(friendlyFileName('design.html')).toBeUndefined();
+  });
+});
+
+describe('isDotPath', () => {
+  it('flags dot files and folders anywhere in the path', () => {
+    expect(isDotPath('.agents/plan.md')).toBe(true);
+    expect(isDotPath('.cursor')).toBe(true);
+    expect(isDotPath('plan/.notes.md')).toBe(true);
+    expect(isDotPath('plan/.hidden/doc.md')).toBe(true);
+  });
+
+  it('leaves normal paths unflagged', () => {
+    expect(isDotPath('my-plan/README.md')).toBe(false);
+    expect(isDotPath('plan/sub/deep.md')).toBe(false);
+    // A dot inside a segment (not a prefix) is fine.
+    expect(isDotPath('plan/v1.2.3-notes.md')).toBe(false);
+  });
+});
+
+describe('stripFolderPrefix', () => {
+  it('removes the folder prefix from a path within it', () => {
+    expect(stripFolderPrefix('my-plan/README.md', 'my-plan')).toBe('README.md');
+    expect(stripFolderPrefix('my-plan/sub/deep.md', 'my-plan')).toBe(
+      'sub/deep.md',
+    );
+  });
+
+  it('leaves paths outside the folder unchanged', () => {
+    // Root-level documents grouped under a synthetic folder name.
+    expect(stripFolderPrefix('README.md', '(repository root)')).toBe(
+      'README.md',
+    );
+    // A folder name that is a prefix but not a path segment must not match.
+    expect(stripFolderPrefix('my-plan-2/README.md', 'my-plan')).toBe(
+      'my-plan-2/README.md',
+    );
   });
 });

--- a/plugins/plans/src/lib/files.ts
+++ b/plugins/plans/src/lib/files.ts
@@ -59,6 +59,42 @@ export function compareDisplayPaths(a: string, b: string): number {
   return a.localeCompare(b);
 }
 
+// Friendly, human-readable names for well-known plan file names, keyed by
+// lower-cased basename. Extend as new conventions appear.
+const FRIENDLY_FILE_NAMES: Record<string, string> = {
+  'prd.md': 'Product Requirements Document',
+  'index.html': 'Web page',
+};
+
+/**
+ * A human-friendly name for a well-known plan file (e.g. `PRD.md` →
+ * "Product Requirements Document"), matched case-insensitively on the file's
+ * basename. Returns undefined for files without a known convention.
+ */
+export function friendlyFileName(path: string): string | undefined {
+  const base = path.split('/').pop()?.toLowerCase() ?? '';
+  return FRIENDLY_FILE_NAMES[base];
+}
+
+/**
+ * Whether any segment of the path is dot-prefixed, i.e. it is (or lives under)
+ * a hidden file or folder such as `.agents/…` or `plan/.notes.md`.
+ */
+export function isDotPath(path: string): boolean {
+  return path.split('/').some(segment => segment.startsWith('.'));
+}
+
+/**
+ * The path with its plan-folder prefix removed, for display in a context that
+ * already names the folder (e.g. a per-folder accordion). Paths that don't sit
+ * under `folder` — including root-level documents grouped under a synthetic
+ * folder name — are returned unchanged.
+ */
+export function stripFolderPrefix(path: string, folder: string): string {
+  const prefix = `${folder}/`;
+  return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
 function displayRank(path: string): number {
   const base = path.split('/').pop()?.toLowerCase() ?? '';
   if (base === 'readme.md') return 0;

--- a/plugins/ui-react/src/components/GSMarkdownContent/GSMarkdownContent.test.tsx
+++ b/plugins/ui-react/src/components/GSMarkdownContent/GSMarkdownContent.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { GSMarkdownContent } from './GSMarkdownContent';
+
+describe('GSMarkdownContent', () => {
+  it('renders markdown content', () => {
+    render(<GSMarkdownContent content={'# Heading\n\nA paragraph of text.'} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Heading' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('A paragraph of text.')).toBeInTheDocument();
+  });
+
+  it('renders GFM tables by default', () => {
+    render(<GSMarkdownContent content={'| a | b |\n| - | - |\n| 1 | 2 |'} />);
+
+    // GFM table syntax produces a real <table> only when the gfm dialect is
+    // active, which is the default for this component.
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'a' })).toBeInTheDocument();
+  });
+
+  it('applies a caller-provided className to the wrapper', () => {
+    const { container } = render(
+      <GSMarkdownContent content="text" className="custom-class" />,
+    );
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});

--- a/plugins/ui-react/src/components/GSMarkdownContent/GSMarkdownContent.tsx
+++ b/plugins/ui-react/src/components/GSMarkdownContent/GSMarkdownContent.tsx
@@ -1,0 +1,71 @@
+import { MarkdownContent } from '@backstage/core-components';
+import { makeStyles } from '@material-ui/core';
+import classNames from 'classnames';
+
+type Dialect = 'gfm' | 'common-mark';
+
+type GSMarkdownContentProps = {
+  content: string;
+  /** Markdown dialect passed through to the underlying renderer. Defaults to GFM. */
+  dialect?: Dialect;
+  className?: string;
+};
+
+const useStyles = makeStyles(theme => ({
+  // `MarkdownContent` emits bare `<p>`/`<li>` tags without MUI Typography
+  // classes, so they fall back to the document line-height and read
+  // inconsistently — both next to surrounding MUI/bui text and against each
+  // other (roomy paragraphs, dense list items). Normalise both to the body1
+  // variant so every caller gets the same, correct rendering instead of
+  // re-implementing this fix locally.
+  root: {
+    '& p, & li': {
+      ...theme.typography.body1,
+    },
+    // Space consecutive list items apart so lists don't read as one dense block.
+    '& li + li': {
+      marginTop: theme.spacing(1),
+    },
+    '& p:first-child': {
+      marginTop: 0,
+    },
+    '& p:last-child': {
+      marginBottom: 0,
+    },
+    // Non-highlighted fenced blocks render as a bare `<pre><code>` with no
+    // line-height or padding. Give them the readable body1 line-height and
+    // block padding. Language-tagged blocks go through core-components'
+    // CodeSnippet, whose wrapping `<pre>` holds a `<div>` (not a direct
+    // `<code>`) and renders its own styled block — the `:has(> code)` scope
+    // keeps us off it so it isn't double-boxed.
+    '& pre:has(> code)': {
+      lineHeight: theme.typography.body1.lineHeight,
+      padding: theme.spacing(1.5),
+      borderRadius: theme.shape.borderRadius,
+      backgroundColor: theme.palette.action.hover,
+      overflowX: 'auto',
+    },
+  },
+}));
+
+/**
+ * Shared markdown renderer for Giant Swarm plugins.
+ *
+ * Wraps `@backstage/core-components`' `MarkdownContent` with a consistent
+ * default (GFM) and the paragraph-typography fix every caller otherwise had to
+ * add by hand. Use this for rendering user/authored markdown — README and SOUL
+ * of catalog entities, plan documents, PR bodies and comments, etc.
+ */
+export const GSMarkdownContent = ({
+  content,
+  dialect = 'gfm',
+  className,
+}: GSMarkdownContentProps) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classNames(classes.root, className)}>
+      <MarkdownContent content={content} dialect={dialect} />
+    </div>
+  );
+};

--- a/plugins/ui-react/src/components/GSMarkdownContent/index.ts
+++ b/plugins/ui-react/src/components/GSMarkdownContent/index.ts
@@ -1,0 +1,1 @@
+export { GSMarkdownContent } from './GSMarkdownContent';

--- a/plugins/ui-react/src/components/index.ts
+++ b/plugins/ui-react/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './DateComponent';
 export * from './DetailsPane';
 export * from './ErrorStatus';
 export * from './ExternalLink';
+export * from './GSMarkdownContent';
 export * from './InfoCard';
 export * from './JsonHighlight';
 export * from './MultiplePicker';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10990,6 +10990,8 @@ __metadata:
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/frontend-plugin-api": "backstage:^"
     "@backstage/test-utils": "backstage:^"
+    "@backstage/ui": "backstage:^"
+    "@giantswarm/backstage-plugin-ui-react": "workspace:^"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"


### PR DESCRIPTION
### What does this PR do?

Migrates the internal **Plans** page from Material-UI to the bui design system
(`@backstage/ui`), and extracts a shared markdown renderer.

- **Shared markdown** — new `GSMarkdownContent` in `ui-react` wraps
  core-components' `MarkdownContent` (GFM default) with consistent typography:
  matched `<p>`/`<li>` line-height, spacing between list items, and padded
  non-highlighted code blocks (language-tagged blocks keep their `CodeSnippet`
  styling). The `gs` README/SOUL cards (`CollapsibleMarkdownCard`) and the plans
  document/PR-body/comment rendering all route through it.
- **Header & tabs** — Proposed/Merged move to bui `Tabs`; the repository picker
  becomes a bui `Select` placed in the plugin header via the shared
  page-header-actions slot (instead of a body toolbar).
- **Lists** — proposed, merged-folder, and review-nav lists rebuilt on bui
  `List`/`ListRow`.
- **Merged tab** — each document renders in a bui `Accordion` (expanded by
  default); dot files/folders and loose repository-root documents are hidden;
  the redundant folder prefix is stripped from titles; well-known files get
  friendly labels (e.g. `PRD.md` → "Product Requirements Document (PRD.md)",
  `index.html` → "Web page (index.html)").
- Comments, chips (→ `Badge`), alerts, and the Rendered/Diff toggle move to bui
  equivalents.

### What is the effect of this change to users?

The Plans page adopts the bui look-and-feel: the repository selector sits in the
page header, tabs and lists match the rest of the modernised UI, and merged
plans are browsable as a stack of collapsible documents with friendlier titles.

### How does it look like?

Verified in the running app via the DOM (header Select, bui tabs, List rows with
hover affordances, Accordion group expanded by default, code-block styling for
bare vs. highlighted blocks).

### Any background context you can provide?

The `plans` plugin was the last Plans surface still fully on MUI v4. Markdown
rendering was previously duplicated across plugins with ad-hoc `<p>` fixes; this
consolidates the common case into `ui-react` (follow-ups: adopt
`GSMarkdownContent` in muster/roadmap and migrate EpicChip's remaining MUI
`Tooltip`).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.
