### PR TITLE
refactor: render muster and roadmap markdown with shared GSMarkdownContent

### DIFF
--- a/.changeset/muster-roadmap-shared-markdown.md
+++ b/.changeset/muster-roadmap-shared-markdown.md
@@ -1,0 +1,11 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+'@giantswarm/backstage-plugin-roadmap': patch
+---
+
+Render authored Markdown in the muster and roadmap pages with the shared
+`GSMarkdownContent` component from `@giantswarm/backstage-plugin-ui-react`
+instead of calling `MarkdownContent` directly. This gives the muster workflow
+description and the roadmap item body/comments the same consistent paragraph,
+list, and code-block typography as the Plans page, and drops muster's
+now-redundant local paragraph-styling workaround.

--- a/plugins/muster/src/components/WorkflowDetailPage/WorkflowDetailPage.tsx
+++ b/plugins/muster/src/components/WorkflowDetailPage/WorkflowDetailPage.tsx
@@ -5,7 +5,6 @@ import {
   Content,
   EmptyState,
   Link,
-  MarkdownContent,
   Progress,
   ResponseErrorPanel,
 } from '@backstage/core-components';
@@ -26,7 +25,10 @@ import Share from '@material-ui/icons/Share';
 import History from '@material-ui/icons/History';
 import AccountTree from '@material-ui/icons/AccountTree';
 import { Alert } from '@material-ui/lab';
-import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
+import {
+  DateComponent,
+  GSMarkdownContent,
+} from '@giantswarm/backstage-plugin-ui-react';
 import { useQuery } from '@tanstack/react-query';
 import { musterApiRef } from '../../apis';
 import { findReferencedBy } from '../../lib/workflowReferences';
@@ -80,16 +82,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(1.5),
     maxWidth: '80ch',
     color: theme.palette.text.secondary,
-    // MarkdownContent emits bare <p> tags without MUI Typography classes, so
-    // they fall back to the document line-height. Match the body1 variant other
-    // paragraphs use so spacing reads consistently.
-    '& p': {
-      ...theme.typography.body1,
-      margin: 0,
-    },
-    '& p + p': {
-      marginTop: theme.spacing(1),
-    },
   },
   metaRow: {
     marginTop: theme.spacing(2),
@@ -322,12 +314,10 @@ function WorkflowDetailContent() {
           </Box>
 
           {workflow.getDescription() && (
-            <Box className={classes.description}>
-              <MarkdownContent
-                content={workflow.getDescription()!}
-                dialect="gfm"
-              />
-            </Box>
+            <GSMarkdownContent
+              content={workflow.getDescription()!}
+              className={classes.description}
+            />
           )}
 
           <Box className={classes.metaRow}>

--- a/plugins/roadmap/package.json
+++ b/plugins/roadmap/package.json
@@ -28,6 +28,7 @@
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
+    "@giantswarm/backstage-plugin-ui-react": "workspace:^",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",

--- a/plugins/roadmap/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/plugins/roadmap/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -14,9 +14,9 @@ import {
   Content,
   EmptyState,
   Link,
-  MarkdownContent,
   Progress,
 } from '@backstage/core-components';
+import { GSMarkdownContent } from '@giantswarm/backstage-plugin-ui-react';
 import { useApi, useRouteRef } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
 import { roadmapApiRef } from '../../apis';
@@ -198,7 +198,7 @@ export function ItemDetailPage() {
         <Box className={classes.main}>
           <Paper className={classes.panel} variant="outlined">
             {item.body ? (
-              <MarkdownContent content={item.body} dialect="gfm" />
+              <GSMarkdownContent content={item.body} />
             ) : (
               <Typography variant="body2" color="textSecondary">
                 This item has no description.
@@ -218,7 +218,7 @@ export function ItemDetailPage() {
                     {formatDate(comment.createdAt, { time: true }) &&
                       ` · ${formatDate(comment.createdAt, { time: true })}`}
                   </Typography>
-                  <MarkdownContent content={comment.body} dialect="gfm" />
+                  <GSMarkdownContent content={comment.body} />
                 </Box>
               ))}
             </Paper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11038,6 +11038,7 @@ __metadata:
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/frontend-plugin-api": "backstage:^"
     "@backstage/test-utils": "backstage:^"
+    "@giantswarm/backstage-plugin-ui-react": "workspace:^"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"


### PR DESCRIPTION
### What does this PR do?

Swaps the raw `MarkdownContent` (from `@backstage/core-components`) usages in the muster and roadmap pages for the shared `GSMarkdownContent` renderer from `@giantswarm/backstage-plugin-ui-react` (introduced in #1969 and already used by the Plans page).

- **muster** — `WorkflowDetailPage`: workflow description now renders via `GSMarkdownContent`; the local `& p` / `& p + p` typography workaround in the `description` style is removed (the shared component handles it).
- **roadmap** — `ItemDetailPage`: item body and comment bodies now render via `GSMarkdownContent`. Adds `@giantswarm/backstage-plugin-ui-react` as a roadmap dependency.

### What is the effect of this change to users?

The muster workflow description and roadmap item body/comments now render Markdown with the same consistent paragraph, list, and code-block typography as the Plans page.

### How does it look like?

No layout change intended — paragraph/list/code-block spacing is normalized to match the rest of the app. Visual parity with the Plans page markdown.

### Any background context you can provide?

Follow-up to #1969, which introduced `GSMarkdownContent` as the shared markdown renderer for Giant Swarm plugins.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))