### PR TITLE
fix(agent-platform): remove muster gateway configuration warning from agent creation review

### DIFF
--- a/plugins/agent-platform/src/components/NewAgentReviewPage/NewAgentReviewPage.tsx
+++ b/plugins/agent-platform/src/components/NewAgentReviewPage/NewAgentReviewPage.tsx
@@ -349,14 +349,6 @@ export function NewAgentReviewPage() {
               <CodeBlock content={helmInstallCommand} />
             </div>
           </details>
-
-          <Box mt="3">
-            <Alert
-              status="warning"
-              title="The muster gateway isn't fully configured yet"
-              description="The chart wires the shared muster gateway by default, but the create flow doesn't set the per-installation muster.stsWellKnownUri, so a freshly deployed agent may not reach its tools until that's provided."
-            />
-          </Box>
         </div>
       </div>
     </Content>


### PR DESCRIPTION
### What does this PR do?

Removes the "The muster gateway isn't fully configured yet" warning card from the agent creation review page (`NewAgentReviewPage`). The muster gateway configuration concern this warning described is no longer relevant, so the warning is now removed.

### What is the effect of this change to users?

Users no longer see the muster gateway warning when reviewing a new agent before deploying.

### Any background context you can provide?

The warning was a temporary note about `muster.stsWellKnownUri` not being set by the create flow. This is no longer applicable.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.