### PR TITLE
feat(agent-platform): set agent icon URL from technical name at creation

### DIFF
--- a/.changeset/happy-oasis-explore.md
+++ b/.changeset/happy-oasis-explore.md
@@ -1,0 +1,14 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+---
+
+Populate `agent.iconUrl` in the composed agent manifest at creation time, so the
+created Agent's `spec.iconUrl` (surfaced on the A2A AgentCard) matches the avatar
+Backstage renders.
+
+- The review/deploy page now sets `agent.iconUrl` in the HelmRelease values to
+  the size-agnostic canonical avatar URL
+  (`https://avatars.<baseDomain>/v1/<name>.png`), derived from the agent's
+  technical name via the same `useAgentAvatarUrl` builder used for display.
+- The field is omitted when the installation has no configured base domain, so
+  the chart keeps its default rather than persisting an empty URL.

--- a/plugins/agent-platform/src/components/NewAgentReviewPage/NewAgentReviewPage.tsx
+++ b/plugins/agent-platform/src/components/NewAgentReviewPage/NewAgentReviewPage.tsx
@@ -9,6 +9,7 @@ import { useProvidePageHeaderActions } from '@giantswarm/backstage-plugin-ui-rea
 
 import { CHART_DEFAULTS } from '../../lib/agentDefaults';
 import { CHART_NAME, composeManifests } from '../../lib/composeManifests';
+import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
 import { useAgentChart } from '../../hooks/useAgentChart';
 import { useDeployAgent } from '../../hooks/useDeployAgent';
 import { newAgentRouteRef } from '../../routes';
@@ -110,6 +111,12 @@ export function NewAgentReviewPage() {
   // with the create form.
   const { version: chartVersion } = useAgentChart();
 
+  // Persist the same deterministic avatar the UI renders onto the resource, as
+  // the size-agnostic canonical URL. Seeded by the technical name (= agent.name)
+  // so it matches the created agent; undefined when the installation has no
+  // configured base domain (then the chart keeps its default).
+  const buildAvatarUrl = useAgentAvatarUrl();
+
   // The agent's resources are applied alongside the ModelConfig it uses — that
   // namespace already exists and is where kagent watches.
   const namespace = state.modelConfigNamespace ?? '';
@@ -127,6 +134,7 @@ export function NewAgentReviewPage() {
           description: state.description,
           modelConfigName: state.modelConfigName ?? '',
           systemMessage: state.systemMessage,
+          iconUrl: buildAvatarUrl(state.installation, state.slug) ?? '',
           skills: state.selectedSkills.map(skill => ({
             url: skill.repoUrl,
             path: skill.path,
@@ -150,6 +158,7 @@ export function NewAgentReviewPage() {
       state.systemMessage,
       state.selectedSkills,
       state.installation,
+      buildAvatarUrl,
       namespace,
       chartOciUrl,
       chartVersion,

--- a/plugins/agent-platform/src/lib/composeManifests.test.ts
+++ b/plugins/agent-platform/src/lib/composeManifests.test.ts
@@ -7,6 +7,7 @@ const model = {
   description: "Reviews pull requests on the platform team's Go services.",
   modelConfigName: 'opus-4-7',
   systemMessage: 'You review pull requests.\nRead for intent first.',
+  iconUrl: 'https://avatars.gazelle.example.io/v1/go-service-reviewer.png',
   skills: [] as {
     url: string;
     path: string;
@@ -79,6 +80,27 @@ describe('composeManifests', () => {
     expect(values.agent.modelConfig).toBeUndefined();
     // No skills selected → the skills block is omitted (gitRefs requires ≥1).
     expect(values.skills).toBeUndefined();
+  });
+
+  it('sets agent.iconUrl from the model (also in the standalone values)', () => {
+    const { files, valuesYaml } = composeManifests(model, ctx);
+
+    const hr = parse(files[0].content);
+    expect(hr.spec.values.agent.iconUrl).toBe(
+      'https://avatars.gazelle.example.io/v1/go-service-reviewer.png',
+    );
+    // The manual `helm install --values` path carries it too.
+    expect(parse(valuesYaml).agent.iconUrl).toBe(
+      'https://avatars.gazelle.example.io/v1/go-service-reviewer.png',
+    );
+  });
+
+  it('omits agent.iconUrl when it is empty (chart default applies)', () => {
+    const hr = parse(
+      composeManifests({ ...model, iconUrl: '' }, ctx).files[0].content,
+    );
+    expect(hr.spec.values.agent.iconUrl).toBeUndefined();
+    expect(hr.spec.values.agent.name).toBe('go-service-reviewer');
   });
 
   it('omits agent.systemMessage when the prompt is empty (chart default applies)', () => {

--- a/plugins/agent-platform/src/lib/composeManifests.ts
+++ b/plugins/agent-platform/src/lib/composeManifests.ts
@@ -36,6 +36,11 @@ export type AgentModel = {
   modelConfigName: string;
   /** System message (agent.systemMessage). */
   systemMessage: string;
+  /**
+   * Canonical avatar URL (chart `agent.iconUrl`), derived from the technical
+   * name — see agentAvatar. Empty → the field is omitted (chart default).
+   */
+  iconUrl: string;
   /** Selected skills → agent.skills.gitRefs. Empty → the block is omitted. */
   skills: AgentSkillRef[];
 };
@@ -126,6 +131,12 @@ function buildValues(model: AgentModel): Record<string, unknown> {
   };
   if (model.description.trim()) {
     agent.description = model.description;
+  }
+  // Deterministic avatar URL for the agent's technical name; omitted when it
+  // can't be resolved so the chart keeps its default (empty) rather than us
+  // writing an empty string.
+  if (model.iconUrl.trim()) {
+    agent.iconUrl = model.iconUrl;
   }
   // Only override the prompt when the user provided one; an empty field means
   // "use the chart's default agent.systemMessage" (and the chart requires a


### PR DESCRIPTION
### What does this PR do?

Populates `agent.iconUrl` in the composed agent manifest at creation time, so the created Agent's `spec.iconUrl` (surfaced on the A2A AgentCard) matches the avatar Backstage already renders.

The review/deploy page now sets `agent.iconUrl` in the HelmRelease values to the **size-agnostic** canonical avatar URL (`https://avatars.<baseDomain>/v1/<name>.png`), derived from the agent's technical name via the same `useAgentAvatarUrl` builder used for display (added in #1971). The field is omitted when the installation has no configured base domain, so the chart keeps its default rather than persisting an empty URL.

### What is the effect of this change to users?

Agents created through the Agent Platform now carry a stable avatar icon on the Agent resource / A2A AgentCard, consistent with the icon shown in the Backstage agent list and creation preview — and reusable by other consumers (e.g. Slack) that read `spec.iconUrl`.

### Any background context you can provide?

Follows giantswarm/agent#8 (which added the `agent.iconUrl` chart value → `spec.iconUrl`) and giantswarm/giantswarm#37211 (comment 5035146327). This is the Backstage side of populating that field.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))