### PR TITLE
refactor(gs): migrate SimpleAccordion to bui (@backstage/ui)

### DIFF
--- a/plugins/gs/src/components/UI/SimpleAccordion/SimpleAccordion.tsx
+++ b/plugins/gs/src/components/UI/SimpleAccordion/SimpleAccordion.tsx
@@ -1,72 +1,23 @@
-import MuiAccordion from '@material-ui/core/Accordion';
-import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
-import MuiAccordionDetails from '@material-ui/core/AccordionDetails';
-import ArrowRightIcon from '@material-ui/icons/ArrowRight';
-import { Box, Typography, withStyles } from '@material-ui/core';
-
-const Accordion = withStyles({
-  root: {
-    boxShadow: 'none',
-    '&:not(:last-child)': {
-      borderBottom: 0,
-    },
-    '&:before': {
-      display: 'none',
-    },
-    '&$expanded': {
-      margin: 'auto',
-    },
-  },
-  expanded: {},
-})(MuiAccordion);
-
-const AccordionSummary = withStyles({
-  root: {
-    flexDirection: 'row-reverse',
-    padding: 0,
-    minHeight: 'auto',
-    '&$expanded': {
-      minHeight: 'auto',
-    },
-  },
-  content: {
-    margin: '0',
-    '&$expanded': {
-      margin: '0',
-    },
-  },
-  expanded: {},
-  expandIcon: {
-    padding: '6px',
-    marginLeft: '-6px',
-    marginRight: '0',
-    '&$expanded': {
-      transform: 'rotate(90deg)',
-    },
-  },
-})(MuiAccordionSummary);
-
-const AccordionDetails = withStyles(theme => ({
-  root: {
-    padding: 0,
-    marginTop: theme.spacing(1),
-  },
-}))(MuiAccordionDetails);
+import { ReactNode } from 'react';
+import {
+  Accordion,
+  AccordionGroup,
+  AccordionPanel,
+  AccordionTrigger,
+} from '@backstage/ui';
 
 type SimpleAccordionProps = {
   title: string;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export const SimpleAccordion = ({ title, children }: SimpleAccordionProps) => {
   return (
-    <Accordion>
-      <AccordionSummary expandIcon={<ArrowRightIcon />}>
-        <Box display="flex" alignItems="center">
-          <Typography variant="body2">{title}</Typography>
-        </Box>
-      </AccordionSummary>
-      <AccordionDetails>{children}</AccordionDetails>
-    </Accordion>
+    <AccordionGroup>
+      <Accordion id={title}>
+        <AccordionTrigger>{title}</AccordionTrigger>
+        <AccordionPanel>{children}</AccordionPanel>
+      </Accordion>
+    </AccordionGroup>
   );
 };


### PR DESCRIPTION
### What does this PR do?

Migrates the internal `SimpleAccordion` component in the `gs` plugin from Material-UI v4 (`@material-ui/core/Accordion` + `withStyles`) to the new Backstage UI design system (bui, `@backstage/ui`).

The component is reimplemented on the bui Accordion primitives (`AccordionGroup` / `Accordion` / `AccordionTrigger` / `AccordionPanel`), dropping all the MUI `withStyles` boilerplate (77 → 21 lines). The public `{ title, children }` API is unchanged, so both consumers — `ClusterAccessGS` ("How to set up tsh") and `WorkloadDetailsPane`'s `RawDataAccordion` ("Raw data") — work without edits.

### What is the effect of this change to users?

The two accordions now render with the bui look & feel (chevron + bui typography/spacing) instead of the old MUI styling. Behavior is otherwise unchanged (collapsed by default, single expandable section).

### How does it look like?

Verified in the running app on the cluster details page — the "How to set up tsh" accordion renders via bui (`bui-Accordion*` in the DOM).

### Any background context you can provide?

Part of the ongoing MUI → bui migration. `SimpleAccordion` is internal to the `gs` plugin (not exported from the package root).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

_Not applicable — `@giantswarm/backstage-plugin-gs` is a private package (not published to npm)._
