### PR TITLE
refactor(muster): migrate DisclosureAccordion to bui (@backstage/ui)

### DIFF
--- a/plugins/muster/src/components/shared/DisclosureAccordion.tsx
+++ b/plugins/muster/src/components/shared/DisclosureAccordion.tsx
@@ -1,49 +1,28 @@
-import { ReactNode } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { ReactNode, useState } from 'react';
+import { makeStyles, Theme } from '@material-ui/core';
+import { Accordion, AccordionPanel, AccordionTrigger } from '@backstage/ui';
 
 const useStyles = makeStyles((theme: Theme) => ({
   accordion: {
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadius,
-    boxShadow: 'none',
     backgroundColor: theme.palette.background.paper,
     '&:not(:last-child)': {
       marginBottom: theme.spacing(1),
     },
-    '&:before': {
-      display: 'none',
-    },
-    '&$expanded': {
-      margin: `0 0 ${theme.spacing(1)}px`,
-    },
   },
-  expanded: {},
-  summary: {
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    '&$expanded': {
-      minHeight: 48,
-    },
-  },
-  summaryContent: {
-    alignItems: 'center',
-    '&$expanded': {
-      margin: '12px 0',
+  trigger: {
+    // The consumer summaries are full-width flex rows that right-align their
+    // trailing badges via `marginLeft: auto`; keep the trigger content able to
+    // fill the bui trigger button so that alignment still works.
+    '& > button': {
+      width: '100%',
     },
   },
   details: {
+    display: 'flex',
     flexDirection: 'column',
     paddingTop: 0,
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
   },
 }));
 
@@ -58,6 +37,10 @@ export interface DisclosureAccordionProps {
  * A flat, outlined disclosure styled to look like the mockups' `<details>`
  * card rows: no shadow, a subtle border, rounded corners, and a summary row
  * that carries the name/meta/state on the left and content below when opened.
+ *
+ * Controlled so that the panel content only mounts while expanded, matching the
+ * previous `unmountOnExit` behaviour -- the panels run live k8s/muster queries,
+ * so collapsed rows must not fire them.
  */
 export function DisclosureAccordion({
   summary,
@@ -65,25 +48,17 @@ export function DisclosureAccordion({
   defaultExpanded,
 }: DisclosureAccordionProps) {
   const classes = useStyles();
+  const [isExpanded, setExpanded] = useState(Boolean(defaultExpanded));
   return (
     <Accordion
-      defaultExpanded={defaultExpanded}
-      classes={{ root: classes.accordion, expanded: classes.expanded }}
-      TransitionProps={{ unmountOnExit: true }}
+      className={classes.accordion}
+      isExpanded={isExpanded}
+      onExpandedChange={setExpanded}
     >
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon />}
-        classes={{
-          root: classes.summary,
-          content: classes.summaryContent,
-          expanded: classes.expanded,
-        }}
-      >
-        {summary}
-      </AccordionSummary>
-      <AccordionDetails className={classes.details}>
-        {children}
-      </AccordionDetails>
+      <AccordionTrigger className={classes.trigger}>{summary}</AccordionTrigger>
+      <AccordionPanel className={classes.details}>
+        {isExpanded ? children : null}
+      </AccordionPanel>
     </Accordion>
   );
 }


### PR DESCRIPTION
### What does this PR do?

Migrates the muster plugin's `DisclosureAccordion` from the MUI v4 `Accordion`/`AccordionSummary`/`AccordionDetails` to the bui `Accordion`/`AccordionTrigger`/`AccordionPanel` from `@backstage/ui`, continuing the ongoing bui migration (follows #1976, which did the same for `SimpleAccordion`).

The public API (`summary`, `children`, `defaultExpanded`) is unchanged, so the three call sites (`IntegrationServerDisclosure`, `StandardServerDisclosure`, and the "muster core" row in `McpServersPage`) and the plugin exports need no edits.

Two current behaviours are reconstructed on top of bui defaults:

- **Flat outlined card look** — bui provides no border/background, so a small `makeStyles` block re-applies the border, radius, `background.paper`, and inter-item spacing via `className`. bui renders its own right-side chevron, so the manual `ExpandMoreIcon` is dropped.
- **Lazy mount** — bui/react-aria keeps panel content mounted (hidden via a `hidden` attribute), but these panels run live k8s/muster queries (`RuntimeState`, `ServerTools`, `CoreFamiliesPanel`). The component is now controlled and renders children only while expanded, preserving the previous `unmountOnExit` behaviour so collapsed rows don't fire their queries.

### What is the effect of this change to users?

No functional change. The MCP Servers rows keep their flat, bordered card appearance and expand/collapse behaviour; the expand chevron is now bui's (right-aligned, rotates on expand).

### How does it look like?

Visually unchanged from the current bordered card rows on the MCP Servers tab (`/agent-platform/muster`).

### Any background context you can provide?

Part of the incremental migration to bui (`@backstage/ui`).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] N/A — the `@giantswarm/backstage-plugin-muster` package is `private` (not published), so no changeset is needed.