### PR TITLE
refactor(muster): migrate Tool Explorer to bui

### DIFF
--- a/.changeset/muster-tools-bui.md
+++ b/.changeset/muster-tools-bui.md
@@ -1,0 +1,9 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Migrate the muster Tool Explorer (`/agent-platform/muster/tools`) to the bui design system (`@backstage/ui`).
+
+- Rebuild the tool browser, detail panel, argument form, and result viewer on bui primitives (`AccordionGroup`, `SearchField`, `Table`, `ToggleButtonGroup`, `Select`/`NumberField`/`TextAreaField`/`Switch`, `Alert`, `Button`/`ButtonIcon`, `Flex`/`Box`/`Text`), removing most per-component `makeStyles` styling in favour of bui layout props.
+- Also migrate the shared muster `SectionHeader` (used by all four muster screens) to bui.
+- Add render/smoke tests for the migrated Tool Explorer components.

--- a/plugins/muster/src/components/ToolExplorerPage/ExplorerError.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ExplorerError.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@material-ui/core';
-import { Alert, AlertTitle } from '@material-ui/lab';
+import { Alert, Button } from '@backstage/ui';
 import { ResponseErrorPanel } from '@backstage/core-components';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -48,24 +47,27 @@ export function ExplorerError({ error, installation }: ExplorerErrorProps) {
     return <ResponseErrorPanel error={error as Error} />;
   }
 
+  const description = `Sign in to muster${
+    installation ? ` (${installation})` : ''
+  } to browse and run its tools.${
+    signIn.isError ? ' Sign-in failed — check the muster auth provider.' : ''
+  }`;
+
   return (
     <Alert
-      severity="info"
-      action={
+      status="info"
+      title="Authentication required"
+      description={description}
+      customActions={
         <Button
-          color="inherit"
+          variant="secondary"
           size="small"
-          disabled={signIn.isPending}
+          isPending={signIn.isPending}
           onClick={() => signIn.mutate()}
         >
           {signIn.isPending ? 'Signing in…' : 'Sign in'}
         </Button>
       }
-    >
-      <AlertTitle>Authentication required</AlertTitle>
-      Sign in to muster
-      {installation ? ` (${installation})` : ''} to browse and run its tools.
-      {signIn.isError && ' Sign-in failed — check the muster auth provider.'}
-    </Alert>
+    />
   );
 }

--- a/plugins/muster/src/components/ToolExplorerPage/ToolArgField.test.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolArgField.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SchemaField } from '../../lib/schemaForm';
+import { ToolArgField } from './ToolArgField';
+
+function renderField(field: SchemaField, overrides = {}) {
+  const onChange = jest.fn();
+  const onToggleJson = jest.fn();
+  render(
+    <ToolArgField
+      field={field}
+      value={undefined}
+      jsonMode={false}
+      onChange={onChange}
+      onToggleJson={onToggleJson}
+      {...overrides}
+    />,
+  );
+  return { onChange, onToggleJson };
+}
+
+describe('ToolArgField', () => {
+  it('renders a boolean field as a switch and reports changes', async () => {
+    const { onChange } = renderField({
+      name: 'verbose',
+      type: 'boolean',
+      required: false,
+    });
+
+    const toggle = screen.getByRole('switch');
+    await userEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders an enum field as a select', () => {
+    renderField({
+      name: 'level',
+      type: 'string',
+      required: true,
+      enumValues: ['low', 'high'],
+    });
+
+    // The bui Select renders a labelled trigger button.
+    expect(screen.getByText('level (string)')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /level/i })).toBeInTheDocument();
+  });
+
+  it('renders a number field', () => {
+    renderField({ name: 'count', type: 'integer', required: false });
+
+    expect(screen.getByText('count (integer)')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /count/i })).toBeInTheDocument();
+  });
+
+  it('renders a text field and reports typed input', async () => {
+    const { onChange } = renderField({
+      name: 'name',
+      type: 'string',
+      required: true,
+    });
+
+    const input = screen.getByRole('textbox', { name: /name/i });
+    await userEvent.type(input, 'a');
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+
+  it('renders array rows with add and JSON-mode toggle affordances', async () => {
+    const { onChange, onToggleJson } = renderField(
+      {
+        name: 'tags',
+        type: 'array',
+        required: false,
+        itemType: 'string',
+      },
+      { value: ['one'] },
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add item' }));
+    expect(onChange).toHaveBeenCalledWith(['one', '']);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit as JSON' }));
+    expect(onToggleJson).toHaveBeenCalled();
+  });
+});

--- a/plugins/muster/src/components/ToolExplorerPage/ToolArgField.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolArgField.tsx
@@ -1,49 +1,20 @@
 import {
   Box,
   Button,
-  FormControlLabel,
-  IconButton,
-  Link,
-  MenuItem,
+  ButtonIcon,
+  Flex,
+  NumberField,
+  Select,
   Switch,
+  Text,
+  TextAreaField,
   TextField,
   Tooltip,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
+  TooltipTrigger,
+} from '@backstage/ui';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import { fieldKind, FormValue, SchemaField } from '../../lib/schemaForm';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  field: {
-    marginBottom: theme.spacing(2),
-  },
-  argType: {
-    color: theme.palette.text.secondary,
-    fontSize: '0.75rem',
-  },
-  arrayHeader: {
-    display: 'flex',
-    alignItems: 'baseline',
-    justifyContent: 'space-between',
-    marginBottom: theme.spacing(0.5),
-  },
-  arrayRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-  helper: {
-    marginTop: theme.spacing(0.5),
-    display: 'block',
-  },
-  error: {
-    color: theme.palette.error.main,
-  },
-}));
 
 function helperFor(field: SchemaField, error?: string): string | undefined {
   if (error) {
@@ -56,6 +27,44 @@ function helperFor(field: SchemaField, error?: string): string | undefined {
     return `Default: ${JSON.stringify(field.default)}`;
   }
   return undefined;
+}
+
+/** The per-row editor inside an array field, chosen from the item type. */
+function ArrayItemInput({
+  label,
+  itemType,
+  enumOptions,
+  value,
+  onChange,
+}: {
+  label: string;
+  itemType?: string;
+  enumOptions: { id: string; label: string }[];
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  if (enumOptions.length > 0) {
+    return (
+      <Select
+        aria-label={label}
+        options={enumOptions}
+        selectedKey={value || null}
+        onSelectionChange={key => onChange(key === null ? '' : String(key))}
+      />
+    );
+  }
+  if (itemType === 'number') {
+    return (
+      <NumberField
+        aria-label={label}
+        value={value === '' ? NaN : Number(value)}
+        onChange={n => onChange(Number.isNaN(n) ? '' : String(n))}
+      />
+    );
+  }
+  return (
+    <TextField aria-label={label} value={value} onChange={v => onChange(v)} />
+  );
 }
 
 function ArrayField({
@@ -73,7 +82,6 @@ function ArrayField({
   onChange: (value: FormValue) => void;
   onToggleJson: () => void;
 }) {
-  const classes = useStyles();
   const rows = Array.isArray(value) ? value : [];
 
   const setRow = (index: number, next: string) => {
@@ -85,96 +93,79 @@ function ArrayField({
   const removeRow = (index: number) =>
     onChange(rows.filter((_, i) => i !== index));
 
+  const enumOptions = (field.itemEnumValues ?? []).map(option => {
+    const v = String(option);
+    return { id: v, label: v };
+  });
+
   return (
-    <Box className={classes.field}>
-      <Box className={classes.arrayHeader}>
-        <Typography variant="body2">
+    <Box mb="4">
+      <Flex align="baseline" justify="between" mb="1">
+        <Text variant="body-medium">
           {field.name}
           {field.required ? ' *' : ''}{' '}
-          <span className={classes.argType}>
+          <Text variant="body-small" color="secondary">
             (array of {field.itemType ?? 'string'})
-          </span>
-        </Typography>
-        <Link
-          component="button"
-          type="button"
-          variant="caption"
-          onClick={onToggleJson}
-        >
+          </Text>
+        </Text>
+        <Button variant="tertiary" size="small" onClick={onToggleJson}>
           {jsonMode ? 'Edit as rows' : 'Edit as JSON'}
-        </Link>
-      </Box>
+        </Button>
+      </Flex>
 
       {jsonMode ? (
-        <TextField
-          fullWidth
-          multiline
-          minRows={3}
-          variant="outlined"
-          size="small"
+        <TextAreaField
+          rows={3}
           placeholder='["a", "b"]'
-          error={Boolean(error)}
+          isInvalid={Boolean(error)}
           value={typeof value === 'string' ? value : ''}
-          onChange={e => onChange(e.target.value)}
+          onChange={v => onChange(v)}
         />
       ) : (
-        <>
+        <Flex direction="column" gap="2">
           {rows.map((row, index) => (
-            <Box key={index} className={classes.arrayRow}>
-              {field.itemEnumValues && field.itemEnumValues.length > 0 ? (
-                <TextField
-                  select
-                  fullWidth
-                  size="small"
-                  variant="outlined"
+            <Flex key={index} align="center" gap="2">
+              <Box style={{ flexGrow: 1 }}>
+                <ArrayItemInput
+                  label={`${field.name} item ${index + 1}`}
+                  itemType={field.itemType}
+                  enumOptions={enumOptions}
                   value={row}
-                  onChange={e => setRow(index, e.target.value)}
-                >
-                  {field.itemEnumValues.map(option => {
-                    const v = String(option);
-                    return (
-                      <MenuItem key={v} value={v}>
-                        {v}
-                      </MenuItem>
-                    );
-                  })}
-                </TextField>
-              ) : (
-                <TextField
-                  fullWidth
-                  size="small"
-                  variant="outlined"
-                  type={field.itemType === 'number' ? 'number' : 'text'}
-                  value={row}
-                  onChange={e => setRow(index, e.target.value)}
+                  onChange={next => setRow(index, next)}
                 />
-              )}
-              <Tooltip title="Remove">
-                <IconButton size="small" onClick={() => removeRow(index)}>
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            </Box>
+              </Box>
+              <TooltipTrigger>
+                <ButtonIcon
+                  variant="tertiary"
+                  size="small"
+                  icon={<DeleteOutlineIcon fontSize="small" />}
+                  onClick={() => removeRow(index)}
+                />
+                <Tooltip>Remove</Tooltip>
+              </TooltipTrigger>
+            </Flex>
           ))}
-          <Button
-            size="small"
-            startIcon={<AddIcon />}
-            onClick={addRow}
-            variant="outlined"
-          >
-            Add item
-          </Button>
-        </>
+          <Box>
+            <Button
+              variant="secondary"
+              size="small"
+              iconStart={<AddIcon fontSize="inherit" />}
+              onClick={addRow}
+            >
+              Add item
+            </Button>
+          </Box>
+        </Flex>
       )}
 
       {(error || field.description) && (
-        <Typography
-          variant="caption"
-          className={`${classes.helper} ${error ? classes.error : ''}`}
-          color={error ? 'error' : 'textSecondary'}
+        <Text
+          variant="body-small"
+          color={error ? 'danger' : 'secondary'}
+          style={{ display: 'block', marginTop: 4 }}
         >
           {error ?? field.description}
-        </Typography>
+        </Text>
       )}
     </Box>
   );
@@ -203,30 +194,19 @@ export function ToolArgField({
   onChange,
   onToggleJson,
 }: ToolArgFieldProps) {
-  const classes = useStyles();
   const kind = fieldKind(field);
 
   if (kind === 'boolean') {
     return (
-      <FormControlLabel
-        className={classes.field}
-        control={
-          <Switch
-            color="primary"
-            checked={Boolean(value ?? field.default ?? false)}
-            onChange={e => onChange(e.target.checked)}
-          />
-        }
-        label={
-          <>
-            {field.name}
-            {field.required ? ' *' : ''}{' '}
-            <span className={classes.argType}>
-              {field.description ?? 'boolean'}
-            </span>
-          </>
-        }
-      />
+      <Box mb="4">
+        <Switch
+          label={`${field.name}${field.required ? ' *' : ''} · ${
+            field.description ?? 'boolean'
+          }`}
+          isSelected={Boolean(value ?? field.default ?? false)}
+          onChange={checked => onChange(checked)}
+        />
+      </Box>
     );
   }
 
@@ -244,54 +224,69 @@ export function ToolArgField({
   }
 
   const helperText = helperFor(field, error);
+  const label = `${field.name} (${field.type})`;
 
   if (kind === 'enum') {
     return (
-      <TextField
-        select
-        className={classes.field}
-        fullWidth
-        variant="outlined"
-        size="small"
-        required={field.required}
-        label={`${field.name} (${field.type})`}
-        helperText={helperText}
-        error={Boolean(error)}
-        value={(value as string | undefined) ?? ''}
-        onChange={e => onChange(e.target.value)}
-      >
-        <MenuItem value="">
-          <em>unset</em>
-        </MenuItem>
-        {(field.enumValues ?? []).map(option => {
-          const v = String(option);
-          return (
-            <MenuItem key={v} value={v}>
-              {v}
-            </MenuItem>
-          );
-        })}
-      </TextField>
+      <Box mb="4">
+        <Select
+          label={label}
+          description={helperText}
+          isRequired={field.required}
+          placeholder="Select a value"
+          options={(field.enumValues ?? []).map(option => {
+            const v = String(option);
+            return { id: v, label: v };
+          })}
+          selectedKey={(value as string | undefined) || null}
+          onSelectionChange={key => onChange(key === null ? '' : String(key))}
+        />
+      </Box>
     );
   }
 
-  const isJson = kind === 'json';
+  if (kind === 'number') {
+    return (
+      <Box mb="4">
+        <NumberField
+          label={label}
+          description={helperText}
+          isRequired={field.required}
+          isInvalid={Boolean(error)}
+          value={value === undefined || value === '' ? NaN : Number(value)}
+          onChange={n => onChange(Number.isNaN(n) ? '' : String(n))}
+        />
+      </Box>
+    );
+  }
+
+  if (kind === 'json') {
+    return (
+      <Box mb="4">
+        <TextAreaField
+          label={label}
+          description={helperText}
+          isRequired={field.required}
+          isInvalid={Boolean(error)}
+          rows={3}
+          placeholder="{ }"
+          value={(value as string | undefined) ?? ''}
+          onChange={v => onChange(v)}
+        />
+      </Box>
+    );
+  }
+
   return (
-    <TextField
-      className={classes.field}
-      fullWidth
-      variant="outlined"
-      size="small"
-      type={kind === 'number' ? 'number' : 'text'}
-      multiline={isJson}
-      minRows={isJson ? 3 : undefined}
-      required={field.required}
-      label={`${field.name} (${field.type})`}
-      placeholder={isJson ? '{ }' : undefined}
-      helperText={helperText}
-      error={Boolean(error)}
-      value={(value as string | undefined) ?? ''}
-      onChange={e => onChange(e.target.value)}
-    />
+    <Box mb="4">
+      <TextField
+        label={label}
+        description={helperText}
+        isRequired={field.required}
+        isInvalid={Boolean(error)}
+        value={(value as string | undefined) ?? ''}
+        onChange={v => onChange(v)}
+      />
+    </Box>
   );
 }

--- a/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.test.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.test.tsx
@@ -1,0 +1,89 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import {
+  FilterToolsOptions,
+  FilterToolsResponse,
+  MusterApi,
+  musterApiRef,
+} from '../../apis';
+import { ToolBrowser } from './ToolBrowser';
+import { ToolPrefs } from './useToolPrefs';
+
+const browseResponse: FilterToolsResponse = {
+  total: 2,
+  filtered_count: 2,
+  truncated: false,
+  tools: [
+    { name: 'core_list_installations', summary: 'List installations' },
+    { name: 'workflow_deploy', summary: 'Deploy something' },
+  ],
+};
+
+const searchResponse: FilterToolsResponse = {
+  total: 1,
+  filtered_count: 1,
+  truncated: false,
+  tools: [{ name: 'core_search_hit', summary: 'A match', score: 7 }],
+};
+
+function makeApi(): jest.Mocked<Pick<MusterApi, 'filterTools'>> {
+  return {
+    filterTools: jest.fn((options?: FilterToolsOptions) =>
+      Promise.resolve(options?.query ? searchResponse : browseResponse),
+    ),
+  };
+}
+
+const prefs: ToolPrefs = {
+  favourites: [],
+  recents: [],
+  isFavourite: () => false,
+  toggleFavourite: jest.fn(),
+  pushRecent: jest.fn(),
+};
+
+async function renderBrowser(
+  api: Pick<MusterApi, 'filterTools'>,
+  onSelect = jest.fn(),
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  await renderInTestApp(
+    <TestApiProvider apis={[[musterApiRef, api]]}>
+      <QueryClientProvider client={queryClient}>
+        <ToolBrowser onSelect={onSelect} servers={[]} prefs={prefs} />
+      </QueryClientProvider>
+    </TestApiProvider>,
+  );
+  return { onSelect };
+}
+
+describe('ToolBrowser', () => {
+  it('renders browse groups and selects a tool on click', async () => {
+    const api = makeApi();
+    const { onSelect } = await renderBrowser(api);
+
+    // The Core group is expanded by default, so its tool row is visible.
+    const row = await screen.findByText('core_list_installations');
+    await userEvent.click(row);
+    expect(onSelect).toHaveBeenCalledWith('core_list_installations');
+  });
+
+  it('switches to ranked search results when the query is non-empty', async () => {
+    const api = makeApi();
+    await renderBrowser(api);
+
+    await screen.findByText('core_list_installations');
+    await userEvent.type(screen.getByRole('searchbox'), 'match');
+
+    expect(await screen.findByText('core_search_hit')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(api.filterTools).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'match' }),
+      ),
+    );
+  });
+});

--- a/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
@@ -1,26 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Button,
-  Chip,
-  IconButton,
-  InputAdornment,
-  List,
-  ListItem,
-  ListItemSecondaryAction,
-  ListItemText,
-  TextField,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import SearchIcon from '@material-ui/icons/Search';
+import { makeStyles, Theme } from '@material-ui/core';
 import StarIcon from '@material-ui/icons/Star';
 import StarBorderIcon from '@material-ui/icons/StarBorder';
+import {
+  Accordion,
+  AccordionGroup,
+  AccordionPanel,
+  AccordionTrigger,
+  Badge,
+  Box,
+  Button,
+  ButtonIcon,
+  Flex,
+  SearchField,
+  Text,
+} from '@backstage/ui';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useQuery } from '@tanstack/react-query';
 import { musterApiRef, ToolSummary } from '../../apis';
@@ -40,36 +34,22 @@ const BROWSE_LIMIT = 2000;
 const SEARCH_LIMIT = 50;
 
 const useStyles = makeStyles((theme: Theme) => ({
-  search: {
-    marginBottom: theme.spacing(2),
+  // The clickable tool row: a reset <button> so the whole row selects the tool
+  // while the favourite star stays a separate, non-nested button.
+  row: {
+    flexGrow: 1,
+    minWidth: 0,
+    appearance: 'none',
+    background: 'none',
+    border: 'none',
+    textAlign: 'left',
+    cursor: 'pointer',
+    padding: theme.spacing(0.75, 1),
+    borderRadius: theme.shape.borderRadius,
+    '&:hover': { backgroundColor: theme.palette.action.hover },
   },
-  toolName: {
-    fontFamily: 'monospace',
-    fontSize: '0.8rem',
-  },
-  group: {
-    boxShadow: 'none',
-    '&:before': { display: 'none' },
-  },
-  groupSummary: {
-    minHeight: 40,
-  },
-  groupTitle: {
-    fontWeight: 600,
-    display: 'flex',
-    alignItems: 'baseline',
-    gap: theme.spacing(1),
-  },
-  groupSub: {
-    color: theme.palette.text.secondary,
-    fontWeight: 400,
-    fontSize: '0.75rem',
-  },
-  details: {
-    padding: 0,
-    display: 'block',
-    maxHeight: 360,
-    overflow: 'auto',
+  rowContainer: {
+    borderBottom: `1px solid ${theme.palette.divider}`,
   },
   selected: {
     backgroundColor: theme.palette.action.selected,
@@ -77,24 +57,18 @@ const useStyles = makeStyles((theme: Theme) => ({
   active: {
     outline: `2px solid ${theme.palette.primary.main}`,
     outlineOffset: -2,
+    borderRadius: theme.shape.borderRadius,
   },
-  quickHeader: {
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    fontSize: '0.7rem',
-    color: theme.palette.text.secondary,
-    margin: theme.spacing(1, 0, 0.5),
+  toolName: {
+    fontFamily: 'monospace',
+    fontSize: '0.8rem',
   },
-  scopeBanner: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    marginBottom: theme.spacing(1),
+  panel: {
+    maxHeight: 360,
+    overflow: 'auto',
   },
   kbd: {
     fontFamily: 'monospace',
-    fontSize: '0.7rem',
-    color: theme.palette.text.secondary,
   },
 }));
 
@@ -114,41 +88,47 @@ function ToolRow({
   onToggleFavourite: (name: string) => void;
 }) {
   const classes = useStyles();
+  const subtitle = tool.summary ?? tool.description;
   return (
-    <ListItem
-      button
-      dense
-      divider
-      className={`${selected ? classes.selected : ''} ${
+    <Flex
+      align="center"
+      gap="1"
+      px="1"
+      className={`${classes.rowContainer} ${selected ? classes.selected : ''} ${
         active ? classes.active : ''
       }`}
-      onClick={() => onSelect(tool.name)}
     >
-      <ListItemText
-        primary={
-          <Box display="flex" alignItems="center" style={{ gap: 8 }}>
-            <span className={classes.toolName}>{tool.name}</span>
-            {tool.score !== undefined && (
-              <Chip size="small" label={`score ${tool.score}`} />
-            )}
-          </Box>
-        }
-        secondary={tool.summary ?? tool.description}
-      />
-      <ListItemSecondaryAction>
-        <IconButton
-          edge="end"
-          size="small"
-          onClick={() => onToggleFavourite(tool.name)}
-        >
-          {favourite ? (
+      <button
+        type="button"
+        className={classes.row}
+        onClick={() => onSelect(tool.name)}
+      >
+        <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+          <span className={classes.toolName}>{tool.name}</span>
+          {tool.score !== undefined && (
+            <Badge size="small">score {tool.score}</Badge>
+          )}
+        </Flex>
+        {subtitle && (
+          <Text as="p" variant="body-small" color="secondary" truncate>
+            {subtitle}
+          </Text>
+        )}
+      </button>
+      <ButtonIcon
+        variant="tertiary"
+        size="small"
+        aria-label={favourite ? 'Remove favourite' : 'Add favourite'}
+        icon={
+          favourite ? (
             <StarIcon fontSize="small" color="primary" />
           ) : (
             <StarBorderIcon fontSize="small" />
-          )}
-        </IconButton>
-      </ListItemSecondaryAction>
-    </ListItem>
+          )
+        }
+        onClick={() => onToggleFavourite(tool.name)}
+      />
+    </Flex>
   );
 }
 
@@ -187,13 +167,12 @@ export function ToolBrowser({
   serverScope,
   serversLoading = false,
 }: ToolBrowserProps) {
-  const classes = useStyles();
   const musterApi = useApi(musterApiRef);
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(-1);
   // A `?server=` deep link scopes the browse until the user clears it.
   const [scopeCleared, setScopeCleared] = useState(false);
-  const searchRef = useRef<HTMLInputElement>(null);
+  const searchRef = useRef<HTMLDivElement>(null);
   const trimmed = query.trim();
 
   // ⌘K / Ctrl-K focuses the search field from anywhere on the page.
@@ -201,7 +180,7 @@ export function ToolBrowser({
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
-        searchRef.current?.focus();
+        searchRef.current?.querySelector('input')?.focus();
       }
     };
     window.addEventListener('keydown', onKey);
@@ -280,25 +259,15 @@ export function ToolBrowser({
 
   return (
     <Box>
-      <TextField
-        className={classes.search}
-        fullWidth
-        variant="outlined"
-        size="small"
-        label="Search tools"
-        placeholder="e.g. list pods, prometheus query  (⌘K)"
-        value={query}
-        inputRef={searchRef}
-        onChange={e => setQuery(e.target.value)}
-        onKeyDown={onSearchKeyDown}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <SearchIcon fontSize="small" />
-            </InputAdornment>
-          ),
-        }}
-      />
+      <Box mb="3" ref={searchRef}>
+        <SearchField
+          aria-label="Search tools"
+          placeholder="e.g. list pods, prometheus query  (⌘K)"
+          value={query}
+          onChange={setQuery}
+          onKeyDown={onSearchKeyDown}
+        />
+      </Box>
 
       {trimmed !== '' ? (
         <SearchResults
@@ -316,21 +285,22 @@ export function ToolBrowser({
       ) : (
         <>
           {scoped ? (
-            <Box className={classes.scopeBanner}>
-              <Chip
+            <Flex align="center" justify="between" gap="2" mb="2">
+              <Flex align="center" gap="2">
+                <Badge>Server: {serverScope}</Badge>
+                <Text variant="body-small" color="secondary">
+                  {scoped.tools.length} tool
+                  {scoped.tools.length === 1 ? '' : 's'}
+                </Text>
+              </Flex>
+              <Button
+                variant="tertiary"
                 size="small"
-                color="primary"
-                label={`Server: ${serverScope}`}
-              />
-              <Typography variant="caption" color="textSecondary">
-                {scoped.tools.length} tool
-                {scoped.tools.length === 1 ? '' : 's'}
-              </Typography>
-              <Box flexGrow={1} />
-              <Button size="small" onClick={() => setScopeCleared(true)}>
+                onClick={() => setScopeCleared(true)}
+              >
                 Show all tools
               </Button>
-            </Box>
+            </Flex>
           ) : (
             (favouriteTools.length > 0 || recentTools.length > 0) && (
               <QuickAccess
@@ -357,6 +327,22 @@ export function ToolBrowser({
   );
 }
 
+function QuickHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <Box mt="2" mb="1">
+      <Text
+        as="p"
+        variant="body-x-small"
+        color="secondary"
+        weight="bold"
+        style={{ textTransform: 'uppercase', letterSpacing: 0.5 }}
+      >
+        {children}
+      </Text>
+    </Box>
+  );
+}
+
 function QuickAccess({
   favourites,
   recents,
@@ -370,36 +356,28 @@ function QuickAccess({
   prefs: ToolPrefs;
   onSelect: (name: string) => void;
 }) {
-  const classes = useStyles();
-  const renderList = (tools: ToolSummary[]) => (
-    <List dense disablePadding>
-      {tools.map(tool => (
-        <ToolRow
-          key={tool.name}
-          tool={tool}
-          selected={tool.name === selected}
-          favourite={prefs.isFavourite(tool.name)}
-          onSelect={onSelect}
-          onToggleFavourite={prefs.toggleFavourite}
-        />
-      ))}
-    </List>
-  );
+  const renderList = (tools: ToolSummary[]) =>
+    tools.map(tool => (
+      <ToolRow
+        key={tool.name}
+        tool={tool}
+        selected={tool.name === selected}
+        favourite={prefs.isFavourite(tool.name)}
+        onSelect={onSelect}
+        onToggleFavourite={prefs.toggleFavourite}
+      />
+    ));
   return (
     <Box>
       {favourites.length > 0 && (
         <>
-          <Typography className={classes.quickHeader}>
-            Favourites ({favourites.length})
-          </Typography>
+          <QuickHeader>Favourites ({favourites.length})</QuickHeader>
           {renderList(favourites)}
         </>
       )}
       {recents.length > 0 && (
         <>
-          <Typography className={classes.quickHeader}>
-            Recent ({recents.length})
-          </Typography>
+          <QuickHeader>Recent ({recents.length})</QuickHeader>
           {renderList(recents)}
         </>
       )}
@@ -433,33 +411,28 @@ function BrowseGroups({
   }
   if (groups.length === 0) {
     return (
-      <Typography variant="body2" color="textSecondary">
+      <Text variant="body-medium" color="secondary">
         No tools available from this installation.
-      </Typography>
+      </Text>
     );
   }
+  const coreKeys = groups.filter(g => g.kind === 'core').map(g => g.key);
+  // `defaultExpandedKeys` applies on mount only, so key the group by its
+  // contents to re-expand Core when the installation/scope changes.
+  const groupSignature = groups.map(g => g.key).join('|');
   return (
-    <>
+    <AccordionGroup
+      key={groupSignature}
+      allowsMultiple
+      defaultExpandedKeys={coreKeys}
+    >
       {groups.map(group => (
-        <Accordion
-          key={group.key}
-          className={classes.group}
-          defaultExpanded={group.kind === 'core'}
-          TransitionProps={{ unmountOnExit: true }}
-        >
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            className={classes.groupSummary}
-          >
-            <Typography className={classes.groupTitle}>
-              {group.key} ({group.tools.length})
-              {group.subtitle && (
-                <span className={classes.groupSub}>· {group.subtitle}</span>
-              )}
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails className={classes.details}>
-            <List dense disablePadding style={{ width: '100%' }}>
+        <Accordion id={group.key} key={group.key}>
+          <AccordionTrigger subtitle={group.subtitle}>
+            {group.key} ({group.tools.length})
+          </AccordionTrigger>
+          <AccordionPanel>
+            <Box className={classes.panel}>
               {group.tools.map(tool => (
                 <ToolRow
                   key={tool.name}
@@ -470,11 +443,11 @@ function BrowseGroups({
                   onToggleFavourite={prefs.toggleFavourite}
                 />
               ))}
-            </List>
-          </AccordionDetails>
+            </Box>
+          </AccordionPanel>
         </Accordion>
       ))}
-    </>
+    </AccordionGroup>
   );
 }
 
@@ -510,36 +483,33 @@ function SearchResults({
   }
   if (tools.length === 0) {
     return (
-      <Typography variant="body2" color="textSecondary">
+      <Text variant="body-medium" color="secondary">
         No tools match this search.
-      </Typography>
+      </Text>
     );
   }
   return (
     <>
-      <Box display="flex" alignItems="center" style={{ gap: 8 }}>
-        <Typography variant="caption" color="textSecondary">
+      <Flex align="center" justify="between" gap="2" mb="1">
+        <Text variant="body-small" color="secondary">
           {total} match{total === 1 ? '' : 'es'}
           {truncated ? ` (showing top ${tools.length})` : ''}
-        </Typography>
-        <Box flexGrow={1} />
-        <Typography variant="caption" className={classes.kbd}>
+        </Text>
+        <Text variant="body-small" color="secondary" className={classes.kbd}>
           ↑↓ navigate · ↵ open
-        </Typography>
-      </Box>
-      <List dense disablePadding>
-        {tools.map((tool, index) => (
-          <ToolRow
-            key={tool.name}
-            tool={tool}
-            selected={tool.name === selected}
-            active={index === activeIndex}
-            favourite={prefs.isFavourite(tool.name)}
-            onSelect={onSelect}
-            onToggleFavourite={prefs.toggleFavourite}
-          />
-        ))}
-      </List>
+        </Text>
+      </Flex>
+      {tools.map((tool, index) => (
+        <ToolRow
+          key={tool.name}
+          tool={tool}
+          selected={tool.name === selected}
+          active={index === activeIndex}
+          favourite={prefs.isFavourite(tool.name)}
+          onSelect={onSelect}
+          onToggleFavourite={prefs.toggleFavourite}
+        />
+      ))}
     </>
   );
 }

--- a/plugins/muster/src/components/ToolExplorerPage/ToolDetailPanel.test.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolDetailPanel.test.tsx
@@ -1,0 +1,76 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { MusterApi, musterApiRef, ToolDetail } from '../../apis';
+import { ToolDetailPanel } from './ToolDetailPanel';
+
+const detail: ToolDetail = {
+  name: 'core_echo',
+  description: 'Echoes a message back.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', description: 'What to echo' },
+    },
+  },
+};
+
+function makeApi(): Pick<MusterApi, 'describeTool' | 'callTool'> {
+  return {
+    describeTool: jest.fn(() => Promise.resolve(detail)),
+    callTool: jest.fn(() => Promise.resolve({ echoed: 'hi' })),
+  };
+}
+
+async function renderPanel(api: Pick<MusterApi, 'describeTool' | 'callTool'>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  await renderInTestApp(
+    <TestApiProvider apis={[[musterApiRef, api]]}>
+      <QueryClientProvider client={queryClient}>
+        <ToolDetailPanel
+          name="core_echo"
+          isFavourite={false}
+          onToggleFavourite={jest.fn()}
+        />
+      </QueryClientProvider>
+    </TestApiProvider>,
+  );
+}
+
+describe('ToolDetailPanel', () => {
+  it('renders the described tool and its argument form', async () => {
+    const api = makeApi();
+    await renderPanel(api);
+
+    expect(await screen.findByText('core_echo')).toBeInTheDocument();
+    expect(screen.getByText('Echoes a message back.')).toBeInTheDocument();
+    expect(screen.getByText('Arguments')).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /message/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('executes the tool and shows the result', async () => {
+    const api = makeApi();
+    await renderPanel(api);
+
+    await screen.findByText('core_echo');
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /message/i }),
+      'hi',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Execute' }));
+
+    await waitFor(() =>
+      expect(api.callTool).toHaveBeenCalledWith(
+        'core_echo',
+        expect.objectContaining({ message: 'hi' }),
+        undefined,
+      ),
+    );
+    expect(await screen.findByText('Result')).toBeInTheDocument();
+  });
+});

--- a/plugins/muster/src/components/ToolExplorerPage/ToolDetailPanel.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolDetailPanel.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
-import {
-  Box,
-  Button,
-  IconButton,
-  Tooltip,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
 import StarIcon from '@material-ui/icons/Star';
 import StarBorderIcon from '@material-ui/icons/StarBorder';
-import { Alert } from '@material-ui/lab';
+import {
+  Alert,
+  Box,
+  Button,
+  ButtonIcon,
+  Flex,
+  Text,
+  Tooltip,
+  TooltipTrigger,
+} from '@backstage/ui';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { musterApiRef } from '../../apis';
@@ -25,35 +25,6 @@ import { ToolArgField } from './ToolArgField';
 import { ToolResultViewer } from './ToolResultViewer';
 import { ExplorerError } from './ExplorerError';
 import { DetailSkeleton } from './states';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  header: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    flexWrap: 'wrap',
-  },
-  toolName: {
-    fontFamily: 'monospace',
-    fontWeight: 600,
-  },
-  spacer: {
-    marginLeft: 'auto',
-  },
-  description: {
-    marginTop: theme.spacing(1),
-    whiteSpace: 'pre-wrap',
-  },
-  section: {
-    marginTop: theme.spacing(2),
-  },
-  actions: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(2),
-    marginTop: theme.spacing(1),
-  },
-}));
 
 /** localStorage key for a tool's last-used arguments, scoped per installation. */
 function argsKey(installation: string | undefined, name: string): string {
@@ -97,7 +68,6 @@ export function ToolDetailPanel({
   isFavourite,
   onToggleFavourite,
 }: ToolDetailPanelProps) {
-  const classes = useStyles();
   const musterApi = useApi(musterApiRef);
 
   const storageKey = argsKey(installation, name);
@@ -207,39 +177,59 @@ export function ToolDetailPanel({
 
   return (
     <Box>
-      <Box className={classes.header}>
-        <Typography variant="h6" className={classes.toolName}>
-          {name}
-        </Typography>
-        <Box className={classes.spacer} />
-        <Tooltip title={isFavourite ? 'Remove favourite' : 'Add to favourites'}>
-          <IconButton size="small" onClick={onToggleFavourite}>
-            {isFavourite ? (
-              <StarIcon fontSize="small" color="primary" />
-            ) : (
-              <StarBorderIcon fontSize="small" />
-            )}
-          </IconButton>
-        </Tooltip>
-      </Box>
-      {data?.description && (
-        <Typography
-          variant="body2"
-          color="textSecondary"
-          className={classes.description}
+      <Flex align="center" justify="between" gap="2">
+        <Text
+          as="p"
+          variant="title-small"
+          weight="bold"
+          style={{ fontFamily: 'monospace', minWidth: 0 }}
+          truncate
         >
-          {data.description}
-        </Typography>
+          {name}
+        </Text>
+        <TooltipTrigger>
+          <ButtonIcon
+            variant="tertiary"
+            size="small"
+            aria-label={isFavourite ? 'Remove favourite' : 'Add to favourites'}
+            icon={
+              isFavourite ? (
+                <StarIcon fontSize="small" color="primary" />
+              ) : (
+                <StarBorderIcon fontSize="small" />
+              )
+            }
+            onClick={onToggleFavourite}
+          />
+          <Tooltip>
+            {isFavourite ? 'Remove favourite' : 'Add to favourites'}
+          </Tooltip>
+        </TooltipTrigger>
+      </Flex>
+
+      {data?.description && (
+        <Box mt="1">
+          <Text
+            as="p"
+            variant="body-medium"
+            color="secondary"
+            style={{ whiteSpace: 'pre-wrap' }}
+          >
+            {data.description}
+          </Text>
+        </Box>
       )}
 
-      <Box className={classes.section}>
-        <Typography variant="subtitle2" gutterBottom>
-          Arguments
-        </Typography>
+      <Box mt="3">
+        <Box mb="1">
+          <Text as="p" variant="body-large" weight="bold">
+            Arguments
+          </Text>
+        </Box>
         {fields.length === 0 ? (
-          <Typography variant="body2" color="textSecondary">
+          <Text variant="body-medium" color="secondary">
             This tool takes no arguments.
-          </Typography>
+          </Text>
         ) : (
           fields.map(field => (
             <ToolArgField
@@ -257,27 +247,28 @@ export function ToolDetailPanel({
         )}
       </Box>
 
-      <Box className={classes.actions}>
-        <Button
-          color="primary"
-          variant="contained"
-          disabled={mutation.isPending}
-          onClick={run}
-        >
+      <Box mt="2">
+        <Button variant="primary" isPending={mutation.isPending} onClick={run}>
           {mutation.isPending ? 'Running…' : 'Execute'}
         </Button>
       </Box>
 
       {mutation.isError && (
-        <Alert severity="error" className={classes.section}>
-          {(mutation.error as Error).message}
-        </Alert>
+        <Box mt="3">
+          <Alert
+            status="danger"
+            title="Execution failed"
+            description={(mutation.error as Error).message}
+          />
+        </Box>
       )}
       {mutation.isSuccess && (
-        <Box className={classes.section}>
-          <Typography variant="subtitle2" gutterBottom>
-            Result
-          </Typography>
+        <Box mt="3">
+          <Box mb="1">
+            <Text as="p" variant="body-large" weight="bold">
+              Result
+            </Text>
+          </Box>
           <ToolResultViewer
             result={mutation.data.result}
             durationMs={mutation.data.durationMs}

--- a/plugins/muster/src/components/ToolExplorerPage/ToolExplorerPage.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolExplorerPage.tsx
@@ -1,17 +1,9 @@
 import { useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import {
-  Box,
-  Button,
-  Grid,
-  Paper,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core';
 import BuildIcon from '@material-ui/icons/Build';
-import { Alert } from '@material-ui/lab';
 import { Content, EmptyState } from '@backstage/core-components';
+import { Alert, Box, Button, Text } from '@backstage/ui';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { musterApiRef } from '../../apis';
@@ -24,14 +16,25 @@ import { ToolDetailPanel } from './ToolDetailPanel';
 import { useToolPrefs } from './useToolPrefs';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  // A responsive two-panel split (browser | detail); stacks on small screens.
+  layout: {
+    display: 'grid',
+    gap: theme.spacing(2),
+    gridTemplateColumns: '1fr',
+    alignItems: 'start',
+    [theme.breakpoints.up('md')]: {
+      gridTemplateColumns: '5fr 7fr',
+    },
+  },
   panel: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(2),
     height: '100%',
   },
   placeholder: {
     padding: theme.spacing(4),
     textAlign: 'center',
-    color: theme.palette.text.secondary,
   },
 }));
 
@@ -56,25 +59,32 @@ function AuthAffordance({ installation }: { installation: string }) {
     return null;
   }
 
+  const description = `${servers.length} server${
+    servers.length === 1 ? '' : 's'
+  } require authentication and their tools are hidden until you sign in: ${servers
+    .map(s => s.name)
+    .join(', ')}.${
+    signIn.isError ? ' Sign-in failed — check the muster auth provider.' : ''
+  }`;
+
   return (
-    <Alert
-      severity="warning"
-      action={
-        <Button
-          color="inherit"
-          size="small"
-          disabled={signIn.isPending}
-          onClick={() => signIn.mutate()}
-        >
-          {signIn.isPending ? 'Signing in…' : 'Sign in'}
-        </Button>
-      }
-    >
-      {servers.length} server{servers.length === 1 ? '' : 's'} require
-      authentication and their tools are hidden until you sign in:{' '}
-      {servers.map(s => s.name).join(', ')}.
-      {signIn.isError && ' Sign-in failed — check the muster auth provider.'}
-    </Alert>
+    <Box mb="3">
+      <Alert
+        status="warning"
+        title="Authentication required"
+        description={description}
+        customActions={
+          <Button
+            variant="secondary"
+            size="small"
+            isPending={signIn.isPending}
+            onClick={() => signIn.mutate()}
+          >
+            {signIn.isPending ? 'Signing in…' : 'Sign in'}
+          </Button>
+        }
+      />
+    </Box>
   );
 }
 
@@ -116,44 +126,39 @@ function ExplorerBody({ installation }: { installation: string }) {
   return (
     <>
       <AuthAffordance installation={installation} />
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={5}>
-          <Paper className={classes.panel} variant="outlined">
-            <ToolBrowser
+      <Box className={classes.layout}>
+        <Box className={classes.panel}>
+          <ToolBrowser
+            installation={installation}
+            selected={selected}
+            onSelect={handleSelect}
+            servers={servers}
+            prefs={prefs}
+            serverScope={serverScope}
+            serversLoading={isLoading}
+          />
+        </Box>
+        <Box className={classes.panel}>
+          {selected ? (
+            <ToolDetailPanel
+              key={`${installation}/${selected}`}
+              name={selected}
               installation={installation}
-              selected={selected}
-              onSelect={handleSelect}
-              servers={servers}
-              prefs={prefs}
-              serverScope={serverScope}
-              serversLoading={isLoading}
+              isFavourite={prefs.isFavourite(selected)}
+              onToggleFavourite={() => prefs.toggleFavourite(selected)}
             />
-          </Paper>
-        </Grid>
-        <Grid item xs={12} md={7}>
-          <Paper className={classes.panel} variant="outlined">
-            {selected ? (
-              <ToolDetailPanel
-                key={`${installation}/${selected}`}
-                name={selected}
-                installation={installation}
-                isFavourite={prefs.isFavourite(selected)}
-                onToggleFavourite={() => prefs.toggleFavourite(selected)}
-              />
-            ) : (
-              <Box className={classes.placeholder}>
-                <Typography variant="body1">
-                  Select a tool to view its schema and run it.
-                </Typography>
-                <Typography variant="body2" color="textSecondary">
-                  Press <strong>⌘K</strong> to search, ↑/↓ to navigate, ↵ to
-                  open.
-                </Typography>
-              </Box>
-            )}
-          </Paper>
-        </Grid>
-      </Grid>
+          ) : (
+            <Box className={classes.placeholder}>
+              <Text as="p" variant="body-medium">
+                Select a tool to view its schema and run it.
+              </Text>
+              <Text as="p" variant="body-small" color="secondary">
+                Press ⌘K to search, ↑/↓ to navigate, ↵ to open.
+              </Text>
+            </Box>
+          )}
+        </Box>
+      </Box>
     </>
   );
 }

--- a/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.test.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderInTestApp } from '@backstage/test-utils';
+import { ToolResultViewer } from './ToolResultViewer';
+
+const listResult = [
+  { metadata: { name: 'alpha', namespace: 'default' }, status: 'Ready' },
+  { metadata: { name: 'beta', namespace: 'kube-system' }, status: 'Pending' },
+];
+
+describe('ToolResultViewer', () => {
+  it('defaults to the table view for a list-of-objects result', async () => {
+    await renderInTestApp(<ToolResultViewer result={listResult} />);
+
+    // Column headers derived from the flattened rows.
+    expect(screen.getByText('name')).toBeInTheDocument();
+    expect(screen.getByText('namespace')).toBeInTheDocument();
+    // Cell values render.
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('switches to the Raw view', async () => {
+    await renderInTestApp(<ToolResultViewer result={listResult} />);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Raw' }));
+    // Raw view renders compact JSON, so a quoted key is present verbatim.
+    expect(screen.getByText(/"status":"Ready"/)).toBeInTheDocument();
+  });
+
+  it('shows the duration and size meta', async () => {
+    await renderInTestApp(
+      <ToolResultViewer result={{ ok: true }} durationMs={42} />,
+    );
+
+    expect(screen.getByText('42 ms')).toBeInTheDocument();
+    // Size of the compact JSON `{"ok":true}` is well under 1 KiB.
+    expect(screen.getByText(/\bB$/)).toBeInTheDocument();
+  });
+
+  it('offers a re-run affordance when a handler is given', async () => {
+    const onRerun = jest.fn();
+    await renderInTestApp(
+      <ToolResultViewer result={{ ok: true }} onRerun={onRerun} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /run again/i }));
+    expect(onRerun).toHaveBeenCalled();
+  });
+});

--- a/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.tsx
@@ -1,19 +1,18 @@
 import { useMemo, useState } from 'react';
+import type { Key } from 'react-aria-components';
 import {
   Box,
-  Button,
-  ButtonGroup,
-  IconButton,
+  ButtonIcon,
+  CellText,
+  ColumnConfig,
+  Flex,
   Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
+  Text,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
-  Typography,
-  makeStyles,
-  Theme,
-} from '@material-ui/core';
+  TooltipTrigger,
+} from '@backstage/ui';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import ReplayIcon from '@material-ui/icons/Replay';
 import UnfoldLessIcon from '@material-ui/icons/UnfoldLess';
@@ -22,53 +21,10 @@ import { CopyTextButton } from '@backstage/core-components';
 import { JsonHighlight } from '@giantswarm/backstage-plugin-ui-react';
 import { detectTable } from '../../lib/resultShape';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-    flexWrap: 'wrap',
-  },
-  meta: {
-    marginLeft: 'auto',
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1.5),
-    color: theme.palette.text.secondary,
-  },
-  metaValue: {
-    fontVariantNumeric: 'tabular-nums',
-  },
-  raw: {
-    margin: 0,
-    fontFamily: 'monospace',
-    fontSize: '0.75rem',
-    whiteSpace: 'pre-wrap',
-    wordBreak: 'break-word',
-    maxHeight: 480,
-    overflow: 'auto',
-  },
-  cell: {
-    fontFamily: 'monospace',
-    fontSize: '0.75rem',
-    maxWidth: 280,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  headerCell: {
-    whiteSpace: 'nowrap',
-  },
-  tableWrap: {
-    maxHeight: 480,
-    overflow: 'auto',
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.shape.borderRadius,
-  },
-}));
-
 type ViewMode = 'parsed' | 'raw' | 'table';
+
+/** One table row: a stable id plus the raw record `detectTable` produced. */
+type ResultRow = { id: string; values: Record<string, unknown> };
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -107,7 +63,6 @@ export function ToolResultViewer({
   onRerun,
   rerunDisabled,
 }: ToolResultViewerProps) {
-  const classes = useStyles();
   const table = useMemo(() => detectTable(result), [result]);
   const [mode, setMode] = useState<ViewMode>(table ? 'table' : 'parsed');
   const [collapsed, setCollapsed] = useState(false);
@@ -122,6 +77,20 @@ export function ToolResultViewer({
   const approxTokens = Math.max(1, Math.ceil(sizeBytes / 4));
   const copyText = mode === 'raw' ? raw : pretty;
 
+  const columnConfig = useMemo<ColumnConfig<ResultRow>[]>(
+    () =>
+      (table?.columns ?? []).map(col => ({
+        id: col,
+        label: col,
+        cell: row => <CellText title={cellText(row.values[col])} />,
+      })),
+    [table],
+  );
+  const rows = useMemo<ResultRow[]>(
+    () => (table?.rows ?? []).map((values, i) => ({ id: String(i), values })),
+    [table],
+  );
+
   const download = () => {
     const blob = new Blob([pretty], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -132,120 +101,142 @@ export function ToolResultViewer({
     URL.revokeObjectURL(url);
   };
 
+  const onModeChange = (keys: Set<Key>) => {
+    const next = [...keys][0];
+    if (next) {
+      setMode(String(next) as ViewMode);
+    }
+  };
+
   return (
     <Box>
-      <Box className={classes.toolbar}>
-        <ButtonGroup size="small">
-          {table && (
-            <Button
-              variant={mode === 'table' ? 'contained' : 'outlined'}
-              onClick={() => setMode('table')}
-            >
-              Table
-            </Button>
-          )}
-          <Button
-            variant={mode === 'parsed' ? 'contained' : 'outlined'}
-            onClick={() => setMode('parsed')}
+      <Flex
+        align="center"
+        justify="between"
+        gap="2"
+        style={{ flexWrap: 'wrap' }}
+      >
+        <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
+          <ToggleButtonGroup
+            selectionMode="single"
+            disallowEmptySelection
+            selectedKeys={[mode]}
+            onSelectionChange={onModeChange}
           >
-            Parsed
-          </Button>
-          <Button
-            variant={mode === 'raw' ? 'contained' : 'outlined'}
-            onClick={() => setMode('raw')}
-          >
-            Raw
-          </Button>
-        </ButtonGroup>
-        <CopyTextButton text={copyText} tooltipText="Copied result" />
-        <Tooltip title="Download as JSON">
-          <IconButton size="small" onClick={download}>
-            <GetAppIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-        {mode === 'parsed' && (
-          <Tooltip title={collapsed ? 'Expand' : 'Collapse'}>
-            <IconButton size="small" onClick={() => setCollapsed(c => !c)}>
-              {collapsed ? (
-                <UnfoldMoreIcon fontSize="small" />
-              ) : (
-                <UnfoldLessIcon fontSize="small" />
-              )}
-            </IconButton>
-          </Tooltip>
-        )}
-        {onRerun && (
-          <Tooltip title="Run again with the same arguments">
-            <span>
-              <IconButton
+            {table ? <ToggleButton id="table">Table</ToggleButton> : <></>}
+            <ToggleButton id="parsed">Parsed</ToggleButton>
+            <ToggleButton id="raw">Raw</ToggleButton>
+          </ToggleButtonGroup>
+          <CopyTextButton text={copyText} tooltipText="Copied result" />
+          <TooltipTrigger>
+            <ButtonIcon
+              variant="tertiary"
+              size="small"
+              aria-label="Download as JSON"
+              icon={<GetAppIcon fontSize="small" />}
+              onClick={download}
+            />
+            <Tooltip>Download as JSON</Tooltip>
+          </TooltipTrigger>
+          {mode === 'parsed' && (
+            <TooltipTrigger>
+              <ButtonIcon
+                variant="tertiary"
                 size="small"
-                onClick={onRerun}
-                disabled={rerunDisabled}
-              >
-                <ReplayIcon fontSize="small" />
-              </IconButton>
-            </span>
-          </Tooltip>
-        )}
-        <Box className={classes.meta}>
-          {durationMs !== undefined && (
-            <Typography variant="caption" className={classes.metaValue}>
-              {durationMs} ms
-            </Typography>
+                aria-label={collapsed ? 'Expand' : 'Collapse'}
+                icon={
+                  collapsed ? (
+                    <UnfoldMoreIcon fontSize="small" />
+                  ) : (
+                    <UnfoldLessIcon fontSize="small" />
+                  )
+                }
+                onClick={() => setCollapsed(c => !c)}
+              />
+              <Tooltip>{collapsed ? 'Expand' : 'Collapse'}</Tooltip>
+            </TooltipTrigger>
           )}
-          <Typography variant="caption" className={classes.metaValue}>
-            {formatBytes(sizeBytes)}
-          </Typography>
-          <Typography variant="caption" className={classes.metaValue}>
-            ~{approxTokens.toLocaleString()} tok
-          </Typography>
-        </Box>
-      </Box>
-
-      {mode === 'table' && table && (
-        <Box className={classes.tableWrap}>
-          <Table size="small" stickyHeader>
-            <TableHead>
-              <TableRow>
-                {table.columns.map(col => (
-                  <TableCell key={col} className={classes.headerCell}>
-                    {col}
-                  </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {table.rows.map((row, i) => (
-                <TableRow key={i}>
-                  {table.columns.map(col => (
-                    <TableCell key={col} className={classes.cell}>
-                      <Tooltip title={cellText(row[col])}>
-                        <span>{cellText(row[col])}</span>
-                      </Tooltip>
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </Box>
-      )}
-
-      {mode === 'parsed' &&
-        (collapsed ? (
-          <Typography variant="caption" color="textSecondary">
-            Result collapsed ({table ? `${table.rows.length} rows, ` : ''}
-            {formatBytes(sizeBytes)}). Use the expand button to show it.
-          </Typography>
-        ) : (
-          <JsonHighlight
-            customStyle={{ margin: 0, fontSize: '0.75rem', maxHeight: 480 }}
+          {onRerun && (
+            <TooltipTrigger>
+              <ButtonIcon
+                variant="tertiary"
+                size="small"
+                aria-label="Run again with the same arguments"
+                icon={<ReplayIcon fontSize="small" />}
+                isDisabled={rerunDisabled}
+                onClick={onRerun}
+              />
+              <Tooltip>Run again with the same arguments</Tooltip>
+            </TooltipTrigger>
+          )}
+        </Flex>
+        <Flex align="center" gap="3">
+          {durationMs !== undefined && (
+            <Text
+              variant="body-small"
+              color="secondary"
+              style={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              {durationMs} ms
+            </Text>
+          )}
+          <Text
+            variant="body-small"
+            color="secondary"
+            style={{ fontVariantNumeric: 'tabular-nums' }}
           >
-            {pretty}
-          </JsonHighlight>
-        ))}
+            {formatBytes(sizeBytes)}
+          </Text>
+          <Text
+            variant="body-small"
+            color="secondary"
+            style={{ fontVariantNumeric: 'tabular-nums' }}
+          >
+            ~{approxTokens.toLocaleString()} tok
+          </Text>
+        </Flex>
+      </Flex>
 
-      {mode === 'raw' && <pre className={classes.raw}>{raw}</pre>}
+      <Box mt="2">
+        {mode === 'table' && table && (
+          <Table<ResultRow>
+            columnConfig={columnConfig}
+            data={rows}
+            pagination={{ type: 'none' }}
+          />
+        )}
+
+        {mode === 'parsed' &&
+          (collapsed ? (
+            <Text variant="body-small" color="secondary">
+              Result collapsed ({table ? `${table.rows.length} rows, ` : ''}
+              {formatBytes(sizeBytes)}). Use the expand button to show it.
+            </Text>
+          ) : (
+            <JsonHighlight
+              customStyle={{ margin: 0, fontSize: '0.75rem', maxHeight: 480 }}
+            >
+              {pretty}
+            </JsonHighlight>
+          ))}
+
+        {mode === 'raw' && (
+          <Box
+            as="pre"
+            style={{
+              margin: 0,
+              fontFamily: 'monospace',
+              fontSize: '0.75rem',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              maxHeight: 480,
+              overflow: 'auto',
+            }}
+          >
+            {raw}
+          </Box>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/plugins/muster/src/components/ToolExplorerPage/states.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/states.tsx
@@ -1,77 +1,31 @@
-import { Box, Divider, Typography, makeStyles, Theme } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  row: {
-    marginBottom: theme.spacing(1),
-  },
-  empty: {
-    padding: theme.spacing(4),
-    textAlign: 'center',
-    color: theme.palette.text.secondary,
-  },
-}));
+import { Flex, Skeleton } from '@backstage/ui';
 
 /** Placeholder rows for the browse/search list while tools load. */
 export function BrowserSkeleton({ rows = 6 }: { rows?: number }) {
-  const classes = useStyles();
   return (
-    <Box>
+    <Flex direction="column" gap="3">
       {Array.from({ length: rows }).map((_, i) => (
-        <Box key={i} className={classes.row}>
-          <Skeleton variant="text" width="60%" height={20} />
-          <Skeleton variant="text" width="85%" height={16} />
-        </Box>
+        <Flex key={i} direction="column" gap="1">
+          <Skeleton width="60%" height={20} />
+          <Skeleton width="85%" height={16} />
+        </Flex>
       ))}
-    </Box>
+    </Flex>
   );
 }
 
 /** Placeholder for the tool detail panel while `describe_tool` loads. */
 export function DetailSkeleton() {
   return (
-    <Box>
-      <Skeleton variant="text" width="40%" height={32} />
-      <Skeleton variant="text" width="90%" height={18} />
-      <Box mt={2}>
-        <Skeleton variant="text" width="25%" height={20} />
-        <Skeleton variant="rect" width="100%" height={44} />
-        <Box mt={2} />
-        <Skeleton variant="rect" width="100%" height={44} />
-      </Box>
-      <Box mt={2}>
-        <Skeleton variant="rect" width={120} height={36} />
-      </Box>
-    </Box>
-  );
-}
-
-/** A friendly, centred zero-result / empty message. */
-export function ExplorerEmpty({
-  title,
-  description,
-}: {
-  title: string;
-  description?: string;
-}) {
-  const classes = useStyles();
-  return (
-    <Box className={classes.empty}>
-      <Typography variant="body1">{title}</Typography>
-      {description && (
-        <>
-          <Box mt={1}>
-            <Divider />
-          </Box>
-          <Typography
-            variant="body2"
-            color="textSecondary"
-            style={{ marginTop: 8 }}
-          >
-            {description}
-          </Typography>
-        </>
-      )}
-    </Box>
+    <Flex direction="column" gap="2">
+      <Skeleton width="40%" height={32} />
+      <Skeleton width="90%" height={18} />
+      <Flex direction="column" gap="2" mt="2">
+        <Skeleton width="25%" height={20} />
+        <Skeleton width="100%" height={44} />
+        <Skeleton width="100%" height={44} />
+      </Flex>
+      <Skeleton width={120} height={36} />
+    </Flex>
   );
 }

--- a/plugins/muster/src/components/shared/SectionHeader.test.tsx
+++ b/plugins/muster/src/components/shared/SectionHeader.test.tsx
@@ -1,0 +1,30 @@
+import { screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { SectionHeader } from './SectionHeader';
+
+describe('SectionHeader', () => {
+  it('renders the title, description, icon, and action', async () => {
+    await renderInTestApp(
+      <SectionHeader
+        icon={<svg data-testid="section-icon" />}
+        title="Tool explorer"
+        description="Browse and run tools."
+        action={<button type="button">Do thing</button>}
+      />,
+    );
+
+    expect(screen.getByText('Tool explorer')).toBeInTheDocument();
+    expect(screen.getByText('Browse and run tools.')).toBeInTheDocument();
+    expect(screen.getByTestId('section-icon')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Do thing' }),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the description and action when not provided', async () => {
+    await renderInTestApp(<SectionHeader icon={<svg />} title="Servers" />);
+
+    expect(screen.getByText('Servers')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/muster/src/components/shared/SectionHeader.tsx
+++ b/plugins/muster/src/components/shared/SectionHeader.tsx
@@ -1,13 +1,11 @@
 import { ReactNode } from 'react';
-import { Box, Typography, makeStyles, Theme } from '@material-ui/core';
+import { Box, Flex, Text } from '@backstage/ui';
+import { makeStyles, Theme } from '@material-ui/core';
 
+// The muted rounded icon square has no bui primitive (Box exposes no
+// background/border-radius props), so keep a tiny makeStyles block for just
+// that surface. Everything else is expressed with bui layout/typography props.
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    gap: theme.spacing(1.5),
-    marginBottom: theme.spacing(2.5),
-  },
   iconSquare: {
     flexShrink: 0,
     width: 32,
@@ -22,22 +20,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& svg': {
       fontSize: 18,
     },
-  },
-  body: {
-    minWidth: 0,
-  },
-  title: {
-    fontWeight: 600,
-    lineHeight: 1.3,
-  },
-  description: {
-    marginTop: theme.spacing(0.5),
-    maxWidth: '70ch',
-    color: theme.palette.text.secondary,
-  },
-  action: {
-    marginLeft: 'auto',
-    flexShrink: 0,
   },
 }));
 
@@ -63,19 +45,24 @@ export function SectionHeader({
 }: SectionHeaderProps) {
   const classes = useStyles();
   return (
-    <Box className={classes.root}>
+    <Flex align="start" gap="2" mb="5">
       <span className={classes.iconSquare}>{icon}</span>
-      <Box className={classes.body}>
-        <Typography variant="subtitle1" className={classes.title}>
+      <Flex direction="column" gap="1" style={{ minWidth: 0, flexGrow: 1 }}>
+        <Text as="p" variant="body-large" weight="bold">
           {title}
-        </Typography>
+        </Text>
         {description && (
-          <Typography variant="body2" className={classes.description}>
+          <Text
+            as="p"
+            variant="body-medium"
+            color="secondary"
+            style={{ maxWidth: '70ch' }}
+          >
             {description}
-          </Typography>
+          </Text>
         )}
-      </Box>
-      {action && <Box className={classes.action}>{action}</Box>}
-    </Box>
+      </Flex>
+      {action && <Box style={{ flexShrink: 0 }}>{action}</Box>}
+    </Flex>
   );
 }


### PR DESCRIPTION
### What does this PR do?

Migrates the muster **Tool Explorer** page (`/agent-platform/muster/tools`) from classic MUI v4 (`@material-ui/core`, `@material-ui/lab`) + `@backstage/core-components` to **bui** (`@backstage/ui`), the new Backstage design system this repo is migrating toward.

- Rebuild the tool browser, detail panel, argument form, and result viewer on bui primitives (`AccordionGroup`, `SearchField`, `Table`, `ToggleButtonGroup`, `Select`/`NumberField`/`TextAreaField`/`Switch`, `Alert`, `Button`/`ButtonIcon`, `Flex`/`Box`/`Text`), removing most per-component `makeStyles` styling in favour of bui layout props.
- Also migrate the shared muster `SectionHeader` (used by all four muster screens — Dashboard, Servers, Workflows, Tools).
- Add render/smoke tests for the migrated Tool Explorer components (none existed before).
- Kept components with no bui equivalent: core-components `Content`/`EmptyState`/`ResponseErrorPanel`/`CopyTextButton` and ui-react `JsonHighlight`.

### What is the effect of this change to users?

The Tool Explorer now matches the rest of the design system visually; behaviour is unchanged — browse/search (⌘K, ↑/↓/↵ nav), favourites, `?tool=`/`?server=` deep links, the typed argument form, Execute, and the Table/Parsed/Raw result viewer all work as before.

### Any background context you can provide?

Part of the ongoing bui migration. Relates to https://github.com/giantswarm/giantswarm/issues/37055.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))