### PR TITLE
fix(muster): address Tool Explorer bui migration review

### DIFF
--- a/.changeset/muster-tools-bui-review-fixes.md
+++ b/.changeset/muster-tools-bui-review-fixes.md
@@ -1,0 +1,9 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Fix regressions from the muster Tool Explorer bui migration:
+
+- Restore the result table's scroll cap (max-height with overflow) so large tabular results scroll inside the panel instead of overflowing it.
+- Keep the clickable tool row's contents as phrasing content so no block-level elements nest inside the native `<button>`.
+- Restore the ability to clear an optional enum argument back to unset (a leading "unset" option), so a previously chosen value can be removed from the call payload.

--- a/plugins/muster/src/components/ToolExplorerPage/ToolArgField.test.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolArgField.test.tsx
@@ -45,6 +45,22 @@ describe('ToolArgField', () => {
     expect(screen.getByRole('button', { name: /level/i })).toBeInTheDocument();
   });
 
+  it('lets an enum value be cleared via the "unset" option', async () => {
+    const { onChange } = renderField(
+      {
+        name: 'level',
+        type: 'string',
+        required: false,
+        enumValues: ['low', 'high'],
+      },
+      { value: 'high' },
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /level/i }));
+    await userEvent.click(screen.getByRole('option', { name: 'unset' }));
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
   it('renders a number field', () => {
     renderField({ name: 'count', type: 'integer', required: false });
 

--- a/plugins/muster/src/components/ToolExplorerPage/ToolArgField.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolArgField.tsx
@@ -227,6 +227,10 @@ export function ToolArgField({
   const label = `${field.name} (${field.type})`;
 
   if (kind === 'enum') {
+    // A leading "unset" entry lets an optional enum be cleared back to empty
+    // (react-aria Select has no built-in clear); the sentinel maps to '' so it
+    // is dropped from the call payload.
+    const UNSET = '__unset__';
     return (
       <Box mb="4">
         <Select
@@ -234,12 +238,17 @@ export function ToolArgField({
           description={helperText}
           isRequired={field.required}
           placeholder="Select a value"
-          options={(field.enumValues ?? []).map(option => {
-            const v = String(option);
-            return { id: v, label: v };
-          })}
+          options={[
+            { id: UNSET, label: 'unset' },
+            ...(field.enumValues ?? []).map(option => {
+              const v = String(option);
+              return { id: v, label: v };
+            }),
+          ]}
           selectedKey={(value as string | undefined) || null}
-          onSelectionChange={key => onChange(key === null ? '' : String(key))}
+          onSelectionChange={key =>
+            onChange(key === null || key === UNSET ? '' : String(key))
+          }
         />
       </Box>
     );

--- a/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolBrowser.tsx
@@ -103,14 +103,24 @@ function ToolRow({
         className={classes.row}
         onClick={() => onSelect(tool.name)}
       >
-        <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+        {/* Children are phrasing content (spans) so nothing block-level nests
+            inside the native <button>. */}
+        <span
+          style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}
+        >
           <span className={classes.toolName}>{tool.name}</span>
           {tool.score !== undefined && (
             <Badge size="small">score {tool.score}</Badge>
           )}
-        </Flex>
+        </span>
         {subtitle && (
-          <Text as="p" variant="body-small" color="secondary" truncate>
+          <Text
+            as="span"
+            variant="body-small"
+            color="secondary"
+            truncate
+            style={{ display: 'block' }}
+          >
             {subtitle}
           </Text>
         )}

--- a/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.tsx
+++ b/plugins/muster/src/components/ToolExplorerPage/ToolResultViewer.tsx
@@ -199,11 +199,20 @@ export function ToolResultViewer({
 
       <Box mt="2">
         {mode === 'table' && table && (
-          <Table<ResultRow>
-            columnConfig={columnConfig}
-            data={rows}
-            pagination={{ type: 'none' }}
-          />
+          <Box
+            style={{
+              maxHeight: 480,
+              overflow: 'auto',
+              border: '1px solid var(--bui-border-1)',
+              borderRadius: 'var(--bui-radius-2)',
+            }}
+          >
+            <Table<ResultRow>
+              columnConfig={columnConfig}
+              data={rows}
+              pagination={{ type: 'none' }}
+            />
+          </Box>
         )}
 
         {mode === 'parsed' &&


### PR DESCRIPTION
### What does this PR do?

Follow-up to #1979 (muster Tool Explorer bui migration), addressing regressions found in review:

- **Result table scroll cap** — the migrated bui `Table` lost the old wrapper's max-height + overflow, so large tabular results overflowed the panel. Wrapped it back in a bordered, scrollable container.
- **Invalid DOM nesting** — the clickable tool row nested a `<div>` (`Flex`) and `<p>` (`Text`) inside a native `<button>`. Its contents are now phrasing-level (`span`), so nothing block-level nests inside the button.
- **Optional enum couldn't be cleared** — the classic select had an explicit "unset" entry; the bui `Select` offered no way back to empty, so a chosen value stayed in the `call_tool` payload. Restored a leading "unset" option (main enum fields only, matching the previous behaviour).

Also adds a test covering the enum "unset" path.

### What is the effect of this change to users?

Large table results scroll within the panel again, and an optional enum argument can be reset to unset. No other behaviour change.

### Any background context you can provide?

Follows #1979. Relates to https://github.com/giantswarm/giantswarm/issues/37055.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))