### PR TITLE
docs: document git worktree setup for local dev

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,6 +99,25 @@ yarn clean
 - **HTTPS**: Configure via `certificate.yaml` (see `certificate.yaml.example`)
 - **Ports**: Frontend on 3000, Backend on 7007
 
+### Git worktrees
+
+A fresh `git worktree` contains only git-tracked files, so the app will not run
+in it until the gitignored local config is copied over from the main checkout.
+Symptom: the frontend loads but shows `Error: You do not appear to be signed
+in.` (missing `.env`/credentials). Copy these from the main checkout into the
+worktree root (they are all gitignored, so they won't show up in the worktree's
+diff):
+
+- `.env` — secrets (main cause of the "not signed in" error)
+- `github-app-credentials.yaml` — GitHub OAuth credentials
+- `app-config.local.yaml` — local config
+- `certificate.yaml` — HTTPS cert (`$include`d by `app-config.local.yaml`)
+- `catalog/` — local stub files + `templates/` that `app-config.local.yaml`
+  points at via `../../catalog/*.yaml`
+
+Also **do not symlink `node_modules`** — run a real `yarn install` per worktree
+(a shared/symlinked tree lets an install corrupt the main checkout's tree).
+
 ## Architecture Overview
 
 ### Monorepo Structure


### PR DESCRIPTION
### What does this PR do?

Adds a **Git worktrees** subsection to `.claude/CLAUDE.md` (under Development Setup). A fresh `git worktree` contains only git-tracked files, so the app won't run in it until the gitignored local config is copied over from the main checkout.

### What is the effect of this change to users?

Documentation only — no code or runtime change.

### How does it look like?

New subsection documents:
- The symptom (`Error: You do not appear to be signed in.`) and its cause (missing `.env`).
- The files to copy into the worktree root: `.env`, `github-app-credentials.yaml`, `app-config.local.yaml`, `certificate.yaml`, `catalog/` (all gitignored, so they don't show up in the worktree diff).
- A reminder not to symlink `node_modules` — run a real `yarn install` per worktree.

### Any background context you can provide?

Came up while working the Flux Tree view migration (#1988) in a worktree — the missing local config was non-obvious and cost some debugging time.

### Do the docs need to be updated?

This is the docs update.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))