### PR TITLE
refactor(ui-react): migrate AsyncValue to bui

### DIFF
--- a/.changeset/async-value-bui-skeleton.md
+++ b/.changeset/async-value-bui-skeleton.md
@@ -1,0 +1,8 @@
+---
+'@giantswarm/backstage-plugin-ui-react': patch
+---
+
+Migrate `AsyncValue` from MUI v4 to bui (`@backstage/ui`). The loading state now
+renders a bui `Skeleton` instead of a MUI `Box` wrapping a
+`@backstage/core-components` `Progress` bar. The public props are unchanged; the
+`height` prop now sets the skeleton's height (default `24`).

--- a/plugins/ui-react/src/components/AsyncValue/AsyncValue.stories.tsx
+++ b/plugins/ui-react/src/components/AsyncValue/AsyncValue.stories.tsx
@@ -14,18 +14,18 @@ const meta = {
         component: componentDocs({
           summary:
             'Renders the three states of an asynchronously-loaded value from one ' +
-            'set of props: a loading `Progress` bar, an inline `ErrorStatus` (when ' +
-            '`errorMessage` is set), a `NotAvailable` marker (when the value is ' +
-            '`null`/`undefined`), or the value itself.',
+            'set of props: a loading `Skeleton` placeholder, an inline ' +
+            '`ErrorStatus` (when `errorMessage` is set), a `NotAvailable` marker ' +
+            '(when the value is `null`/`undefined`), or the value itself.',
           whenToUse:
             'Anywhere you render a single value fetched from an API and want ' +
             'consistent loading/error/empty handling without repeating the ' +
             'if/else in every cell. Pass a `children` render function to format ' +
             'the loaded value.',
-          migration: 'mixed',
+          migration: 'bui',
           extra:
-            'Built on MUI v4 `Box` for layout and `@backstage/core-components` ' +
-            '`Progress` for the loading bar.',
+            'The loading state renders a bui (`@backstage/ui`) `Skeleton`; the ' +
+            '`height` prop sets its height (default `24`).',
         }),
       },
     },
@@ -55,7 +55,9 @@ export const Loading: Story = {
   render: () => <AsyncValue value={undefined} isLoading />,
   parameters: {
     docs: {
-      description: { story: 'While loading, a slim `Progress` bar is shown.' },
+      description: {
+        story: 'While loading, a `Skeleton` placeholder is shown.',
+      },
     },
   },
 };

--- a/plugins/ui-react/src/components/AsyncValue/AsyncValue.tsx
+++ b/plugins/ui-react/src/components/AsyncValue/AsyncValue.tsx
@@ -1,10 +1,7 @@
 import { ReactNode } from 'react';
-import { Progress } from '@backstage/core-components';
-import { Box } from '@material-ui/core';
+import { Skeleton } from '@backstage/ui';
 import { ErrorStatus } from '../ErrorStatus';
 import { NotAvailable } from '../NotAvailable';
-
-const progressHeight = 4;
 
 const defaultRenderErrorFn = (errorMessage: string) => (
   <ErrorStatus errorMessage={errorMessage} />
@@ -38,14 +35,7 @@ export const AsyncValue = <T extends ReactNode>({
 
   return (
     <>
-      {isLoading && (
-        <Box
-          paddingTop={`${(height - progressHeight) / 2}px`}
-          height={`${height}px`}
-        >
-          <Progress />
-        </Box>
-      )}
+      {isLoading && <Skeleton height={height} />}
 
       {!isLoading && !errorMessage && renderValue()}
 


### PR DESCRIPTION
### What does this PR do?

Migrates the shared `AsyncValue` component (`@giantswarm/backstage-plugin-ui-react`) from MUI v4 to bui (`@backstage/ui`) — the next component flagged for migration in the `ui-react` Storybook.

The loading state previously used a MUI v4 `Box` wrapping a `@backstage/core-components` `Progress` bar. It now renders a bui `Skeleton`. This removes the component's last MUI v4 / core-components dependencies, moving its Storybook migration status from `mixed` → `bui`.

The public props are unchanged (`value`, `isLoading`, `errorMessage`, `children`, `renderError`, `renderNotAvailable`, `height`); `height` now sets the skeleton's height (default `24`). No caller passes `height`, so every existing use is behavior-preserving in layout.

### What is the effect of this change to users?

While an async value is loading, the placeholder is now a bui `Skeleton` shimmer instead of a thin progress bar. Same vertical footprint, so no layout shift. Visible in the Cluster/Deployment **About** cards and the Flux **GitOps** card.

### How does it look like?

Verified in the `ui-react` Storybook (`Components/AsyncValue`) and in the running app on the Cluster detail → Overview **About** card (loading skeleton renders per field before values resolve).

### Any background context you can provide?

Part of the ongoing MUI v4 → bui migration of the shared `ui-react` library; migration status is tracked per component in Storybook.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))