### PR TITLE
chore: regenerate helm values schema

### DIFF
--- a/helm/backstage/values.schema.json
+++ b/helm/backstage/values.schema.json
@@ -3053,6 +3053,13 @@
                         "mountPath"
                     ],
                     "properties": {
+                        "bindMountOptions": {
+                            "description": "bindMountOptions is the list of additional bind mount options to apply when mounting this volume into the container. Allowed values are noexec, nodev, and nosuid. These are Linux mount options and have no effect on Windows nodes. This field is not supported with image volumes. This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "mountPath": {
                             "description": "Path within the container at which the volume should be mounted.",
                             "type": "string"


### PR DESCRIPTION
### What does this PR do?

Regenerates `helm/backstage/values.schema.json`.

The `helm-schema` pre-commit hook resolves the upstream Kubernetes JSON schema at
run time, and that schema gained a new alpha field — `bindMountOptions` on volume
mounts. The hook therefore regenerates the file and **fails the `pre-commit` check
on every PR opened since the drift appeared**. `main` last passed on 2026-07-25.

Regenerated with `pre-commit run -a`; no hand edits (the file is generated from
`values.yaml` annotations plus the upstream k8s definitions).

### What is the effect of this change to users?

None. Generated-artifact refresh only.

### How does it look like?

A 7-line addition, entirely the new upstream field:

```
+ "bindMountOptions": {
+     "description": "bindMountOptions is the list of additional bind mount options ...",
+     "type": "array",
+     "items": { "type": "string" }
+ },
```

After this, `pre-commit run -a` is fully green.

### Any background context you can provide?

Found while opening #1997 — its `pre-commit` check failed for this reason alone.
Splitting it out so the fix is reviewable on its own and unblocks every other open
PR, rather than riding along in an unrelated feature branch.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

No changeset — no published package changes.
