### PR TITLE
feat(agent-platform): add Sessions tab

### DIFF
--- a/.changeset/agent-platform-sessions-tab.md
+++ b/.changeset/agent-platform-sessions-tab.md
@@ -1,0 +1,42 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+---
+
+Add a "Sessions" tab to the Agent Platform section
+(`/agent-platform/sessions`), listing the signed-in user's kagent chat sessions
+across the fleet.
+
+- Read-only bui table — Session, Agent (display name + avatar), Installation,
+  Started, Last activity — with client-side search across title, agent and
+  installation, sortable columns, and pagination. Timestamps render as relative
+  dates via `ui-react`'s `DateComponent`, with a dash where kagent reports none.
+- Agent names and avatars are resolved by matching kagent's `agent_id` against the
+  `Agent` CRs the plugin already loads. The match is done on the **encode** side
+  (`ns/name` → `ns__NS__name` with `-` → `_`), because kagent's encoding is
+  lossless while decoding is not; a decoded label is only a display fallback, and
+  a genuine encode collision resolves deterministically.
+- **Fleet-aware**, like the Agents tab: reachable installations are narrowed
+  first, then intersected with the backend's kagent allowlist — and the session
+  queries **wait** for that allowlist, since kagent runs on only a couple of
+  installations and querying the rest would fire a doomed request per
+  installation, each minting that installation's Dex token first. One cached call
+  is cheaper than N wasted ones. If the allowlist itself fails we fall back to the
+  reachable set, so a backend hiccup doesn't look like an empty list.
+- Each installation loads independently: rows appear as soon as the first
+  installation answers, further loading shows as a thin bar rather than blanking
+  the table, and `404`/`503` ("kagent isn't deployed here" — the common case
+  fleet-wide) stays silent while anything else is surfaced.
+- Warns when an installation's kagent is **not scoped to the signed-in user**
+  (`unsecure` auth mode resolves every caller to a shared built-in user, so the
+  list would silently not be the user's own). Only an explicit negative triggers
+  the warning: an unresolved or subject-less probe means "unknown" and stays
+  quiet, so a healthy installation whose IdP omits `sub` isn't flagged.
+- Reports as its own page in telemetry, ahead of the generic `/agent-platform`
+  cases which would otherwise label it "Agents".
+
+Scope is deliberately reduced against the prototype: a kagent `Session` has 7
+fields, so status, trigger, duration, cost, tokens, team, linked task, results and
+evaluation — plus the summary stat band derived from them — have no backing data.
+kagent also lists sessions with `WHERE user_id = <sub>` and exposes no cross-user
+endpoint, so the prototype's Mine/Watched/All scopes reduce to one implicit scope.
+Session detail, delete and rename are deferred.

--- a/.claude/skills/tables/SKILL.md
+++ b/.claude/skills/tables/SKILL.md
@@ -11,16 +11,26 @@ we're moving. But it is not yet a full replacement for the older component.
 
 | Need | Use |
 | --- | --- |
-| Simple listing, no built-in search/filter/column-toggle | **bui `Table`** from `@backstage/ui` |
-| Built-in quick-search, per-column filtering, column-visibility toggle, CSV export | **`Table`** from `@backstage/core-components` (material-table based) |
+| Listing, incl. search, sorting, pagination, row selection | **bui `Table`** from `@backstage/ui` |
+| Column-visibility toggle, CSV export, faceted-sidebar filtering | **`Table`** from `@backstage/core-components` (material-table based) |
+
+As of `@backstage/ui` **0.17.0** the bui `Table` does support sorting
+(`isSortable` per column + `initialSort`), row selection, pagination,
+`isPending`/`error`/`emptyState` — and its `useTable` hook provides client-side
+search and filtering via `searchFn`/`filterFn` (with `searchDebounceMs`). Pair it
+with a bui `SearchField`. Reference:
+`plugins/agent-platform/src/components/SessionsTable/` (search + sort + pagination
+via `useTable`), `plugins/agent-platform/src/components/AgentsTable/` (plain
+listing), and `plugins/ai-chat/src/components/ConversationHistoryTable/`.
 
 The `@backstage/core-components` `Table` (documented in the bulk of this skill)
-wraps `@material-table/core` and is still the only option when you need its
-search box, `columnsButton`, `customFilterAndSearch`, or the faceted-sidebar
-pattern. The bui `Table` has **none** of those yet — no search, no filtering, no
-column visibility — so don't reach for it when those are required. Reference for
-bui usage: `plugins/ai-chat/src/components/ConversationHistoryTable/` and
-`plugins/gs/src/components/deployments/deployment-details/DeploymentGateway/DeploymentHttpRoutesCard/`.
+wraps `@material-table/core` and remains the option when you need its
+`columnsButton` column-visibility toggle (with `useTableColumns` persistence),
+CSV export, or the faceted `FiltersLayout` sidebar pattern.
+
+> Two gotchas when using `useTable` in `'complete'` mode: pass `data: undefined`
+> (not `[]`) while loading, or the empty state flashes instead of the skeleton;
+> and column `id`s must match the row field names your `sortFn` reads.
 
 ## bui Table (`@backstage/ui`)
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -185,9 +185,118 @@ covered.) The generated `HelmRelease` sets it from
 `agentPlatform.fluxServiceAccountName`. This is currently a **placeholder** — see
 the open TODOs.
 
+## The Sessions tab
+
+`/agent-platform/sessions` lists the signed-in user's kagent chat sessions across
+the fleet. Read-only: no create, delete, rename, or detail view.
+
+### Why it needs a backend proxy
+
+Unlike agents and model configs, kagent **sessions are not Kubernetes
+resources** — they live in kagent's Postgres and are served over the controller's
+HTTP API, so the Kubernetes proxy the rest of the plugin uses cannot reach them.
+Two things then force a backend hop, which `agent-platform-backend` provides:
+
+- The browser cannot call `kagent.<baseDomain>` cross-origin.
+- kagent runs `controller.auth.mode: trusted-proxy` and derives the user from the
+  `sub` claim of an `Authorization: Bearer` JWT — but inbound, that header carries
+  the Backstage identity. So the user's per-installation Dex ID token travels in a
+  separate `backstage-kagent-authorization` header and is promoted to
+  `Authorization` by the proxy. Same approach as `muster-backend`.
+
+The URL is derived per installation as `https://kagent.<baseDomain>/api` (the
+oauth2-proxy-fronted host whose nginx sidecar proxies `/api/` to
+`kagent-controller:8083`), overridable via `agentPlatform.kagent.installations`.
+Everything stays under `/api`: that is the only prefix either ingress routes to
+the controller, which is also why there is **no version probe** — kagent serves
+`/version` at its server root, where the derived door's nginx answers from the UI
+and the agentgateway override's `/kagent` prefix does not match.
+
+### What the list can and cannot show
+
+A kagent `Session` carries only `id`, `name?`, `user_id`, `created_at`,
+`updated_at`, `deleted_at?`, `agent_id?` and `source?`. So the columns are
+Session, Agent, Installation, Started, and Last activity — and the prototype's
+status, trigger, duration, cost, tokens, team, linked task, results and evaluation
+columns have no backing data at all. The nine-stat summary band derives from those
+same absent fields, so it is out too.
+
+Two consequences worth knowing:
+
+- **Only "your" sessions exist as a concept.** kagent lists with
+  `WHERE user_id = <sub>` and exposes no cross-user endpoint, so the prototype's
+  Mine/Watched/All scope tabs reduce to a single implicit scope.
+- **Titles are short and lossy.** kagent derives them from the first message and
+  truncates to 20 characters (`"What issues are assi..."`), and the full text is
+  unrecoverable — so the Agent column carries much of a row's meaning.
+
+### Fleet behaviour
+
+Each installation is an independent kagent deployment, so reachability, auth mode,
+and availability all vary per installation:
+
+1. `useReachableInstallations` narrows to installations the app considers
+   reachable, so the fan-out doesn't hang on unreachable clusters.
+2. `GET /kagent/installations` says which of those the backend can reach kagent
+   on. **The session queries wait for this**, deliberately: kagent runs on only a
+   couple of installations, and querying the rest would fire a doomed request each
+   — every one of which mints that installation's Dex token first. One cached call
+   up front is much cheaper than N wasted ones per cold load. If the allowlist
+   itself fails, we fall back to the reachable set so a backend hiccup doesn't look
+   like an empty session list.
+3. One react-query per installation, so each loads, caches and fails
+   independently. Rows are merged and re-sorted across the fleet, each tagged with
+   its installation.
+4. `isLoading` is true only while _no_ rows exist; once any installation answers,
+   further loading shows as a thin progress bar so a slow cluster never blanks the
+   table.
+
+Failures are classified per installation: `404`/`503` mean "kagent isn't deployed
+here" — the common case fleet-wide and not actionable — so they contribute nothing
+and stay silent. Anything else lands in the `UnreachableInstallationsAlert`. (The
+backend also maps an unknown-installation `400` to `404`, so a not-configured
+installation takes the silent path.)
+
+### User scoping
+
+kagent's `unsecure` auth mode ignores the forwarded token and resolves every
+caller to a shared built-in user, which would silently present a shared list as
+the user's own. A `/kagent/me` probe detects this per installation and the UI warns
+about the affected installations.
+
+The flag is **tri-state**, and the distinction matters: `undefined` means "we don't
+know" — the probe hasn't resolved, or kagent reported no subject, which is
+reachable on a healthy deployment since `/api/me` returns the token's claims
+verbatim and an IdP need not emit `sub`. The UI warns **only** on an explicit
+`false`, so an odd-but-working installation isn't flagged.
+
+### Version tolerance
+
+kagent ships no OpenAPI spec, GS pins v0.9.9 while upstream is on v0.10.x, and the
+fleet can run a mix. Tolerance therefore lives in the parsing layer
+(`lib/kagentSchema.ts`, `lib/kagentSessions.ts`) rather than in version detection:
+
+- Permissive zod schemas — unknown fields pass through, every field may be absent
+  or retyped, and rows are validated one at a time so a single bad entry is
+  skipped rather than costing the list.
+- Envelope tolerance: `data` absent (Go's `omitempty` on an empty slice — this is
+  what "no sessions" looks like on the wire), `data: null`, or a bare array. An
+  in-band `{error: true}` on a 200 is reported rather than becoming a silent empty
+  list.
+- Go zero time (`0001-01-01T00:00:00Z`, which browsers render as "Dec 31, 0000")
+  and unparseable timestamps are dropped so the UI shows a dash.
+
+Backed by version-matrix fixtures in `lib/__fixtures__/`, including a captured
+live v0.9.9 response, asserting v0.9.9 and v0.10 payloads normalise identically.
+
+`source === 'agent'` (A2A subagent) sessions are excluded — though note live
+v0.9.9 responses omit `source` entirely, so this is forward-compatibility rather
+than active filtering today.
+
 ## Configuration
 
-All under `agentPlatform` (see `plugins/agent-platform/config.d.ts`):
+All under `agentPlatform` (see `plugins/agent-platform/config.d.ts` and
+`plugins/agent-platform-backend/config.d.ts`):
 
 | Key                      | Purpose                                                                                                                           |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -196,6 +305,13 @@ All under `agentPlatform` (see `plugins/agent-platform/config.d.ts`):
 | `fluxServiceAccountName` | ServiceAccount the HelmRelease runs as. Required for direct apply in tenant namespaces. Provisional.                              |
 | `deployTemplateRef`      | Entity ref of the deploy template. Defaults to `template:default/agent-deployment`.                                               |
 | `skills.repositories`    | GitHub repo URLs to discover skills from (each `SKILL.md` is a skill).                                                            |
+| `kagent.timeoutMs`       | Per-request timeout toward a kagent API (default 10000). Backend-only.                                                            |
+| `kagent.installations`   | Which installations to proxy kagent for, keyed by name; also the allowlist. `apiBaseUrl` overrides the derived URL. Backend-only. |
+
+The `kagent` keys keep the default **backend** visibility and are never served to
+the frontend: `apiBaseUrl` embeds `baseDomain`, which deanonymises customers (the
+same reason `gs.installations` is backend-only). The frontend learns installation
+_names_ from the authenticated `GET /kagent/installations` instead.
 
 The plugin's page and nav item are enabled via `app.extensions` in
 `app-config.yaml`.
@@ -271,9 +387,14 @@ above). What remains is a separate, deeper concern:
   `spec.skills.gitAuthSecretRef` wired (the field exists in the CRD/chart but the
   create flow doesn't set it); (2) discovery reads a repo's **default branch** and
   doesn't expose per-skill version/`ref` selection in the UI.
-- **Agent list / management view.** Only the create flow exists so far. A delete
-  action must respect the shared `OCIRepository/agent` (see "Shared OCIRepository
-  per namespace") — delete only the agent's `HelmRelease`, not the shared source.
+- **Agent management actions.** The agent list exists; management does not. A
+  delete action must respect the shared `OCIRepository/agent` (see "Shared
+  OCIRepository per namespace") — delete only the agent's `HelmRelease`, not the
+  shared source.
+- **Session management + detail.** The Sessions tab is read-only. kagent supports
+  deleting (soft) and renaming sessions, and exposes a session's events and A2A
+  tasks — enough for a detail view. Deliberately deferred: rename in particular
+  deviates from the prototype, where sessions are never user-named.
 - **Main menu entry + landing page.** The plugin is not yet surfaced in the main
   sidebar menu. Adding it requires deciding **what page the entry leads to** —
   there is no landing page yet (only the create flow and a minimal index). The

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -288,11 +288,42 @@ and availability all vary per installation:
    further loading shows as a thin progress bar so a slow cluster never blanks the
    table.
 
-Failures are classified per installation: `404`/`503` mean "kagent isn't deployed
-here" — the common case fleet-wide and not actionable — so they contribute nothing
-and stay silent. Anything else lands in the `UnreachableInstallationsAlert`. (The
-backend also maps an unknown-installation `400` to `404`, so a not-configured
-installation takes the silent path.)
+Failures are classified per installation, and the line is drawn between **absent**
+and **unwell** rather than by status code alone:
+
+- **Silent** — `404` (no kagent API at that host; the backend also maps an
+  unknown-installation `400` here) and `503`, which the backend now raises _only_
+  for connection-level failures: DNS, TLS, connection refused. These mean nothing
+  is deployed there, which is the common case fleet-wide and not actionable.
+- **Reported** via `UnreachableInstallationsAlert` — everything else, including a
+  `5xx`/`429` from kagent, a request that times out, and a response whose body
+  can't be read. kagent answered and failed in all of those, so it is deployed and
+  unwell. Sharing an error with "unreachable" would let a degraded installation's
+  sessions disappear from the merged list with no alert and nothing logged —
+  indistinguishable from "you have no sessions there".
+
+The same applies to responses that are nominally successful: an in-band
+`{error: true}` on a `200`, or a `data` that is no longer an array, both throw so
+the installation is reported rather than contributing an innocuous empty list. A
+partial read (some rows unparseable) does _not_ throw — the rows we could read are
+still shown, with a console warning recording what was dropped.
+
+### Caching: user-scoped data is never persisted
+
+The plugin's `QueryClientProvider` persists its cache to `localStorage` for an
+hour, which is right for the Agents and ModelConfig lists — that is installation
+state, identical for every user, and caching it across reloads is the point.
+
+Sessions are different: the rows are one user's chat titles, and the identity probe
+caches their subject (an email). Those two query keys are therefore excluded from
+persistence via `dehydrateOptions.shouldDehydrateQuery`, so they live in memory
+only. Without that, on a shared workstation the data would outlive sign-out on
+disk, and `PersistQueryClientProvider` would rehydrate the previous user's sessions
+for the next one — under the same origin and key, and with `staleTime: 60_000` an
+entry under a minute old would not even be refetched.
+
+The filter composes with `defaultShouldDehydrateQuery` rather than replacing it, so
+the library's "only persist successful queries" rule still applies.
 
 ### User scoping
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -291,10 +291,10 @@ and availability all vary per installation:
 Failures are classified per installation, and the line is drawn between **absent**
 and **unwell** rather than by status code alone:
 
-- **Silent** — `404` (no kagent API at that host; the backend also maps an
-  unknown-installation `400` here) and `503`, which the backend now raises _only_
-  for connection-level failures: DNS, TLS, connection refused. These mean nothing
-  is deployed there, which is the common case fleet-wide and not actionable.
+- **Silent** — `404`, which the backend uses for everything meaning "no kagent API
+  here": kagent's own 404, an unknown-installation `400`, and connection-level
+  failures (DNS, TLS, connection refused). Nothing is deployed there, which is the
+  common case fleet-wide and not actionable.
 - **Reported** via `UnreachableInstallationsAlert` — everything else, including a
   `5xx`/`429` from kagent, a request that times out, and a response whose body
   can't be read. kagent answered and failed in all of those, so it is deployed and
@@ -307,6 +307,16 @@ The same applies to responses that are nominally successful: an in-band
 the installation is reported rather than contributing an innocuous empty list. A
 partial read (some rows unparseable) does _not_ throw — the rows we could read are
 still shown, with a console warning recording what was dropped.
+
+**Why the status codes matter beyond classification.**
+`MiddlewareFactory.error()` logs at `error` for any status `>= 500`, and the root
+logger forwards `warn`/`error` to Sentry. The Sessions tab queries every reachable
+installation, so on a fleet where kagent runs on two of fifteen, thirteen answer
+"no kagent here" on every page view — twice over with the identity probe. Returning
+a `5xx` for that would raise ~26 Sentry events per page view per user, split into
+one issue per installation name. Hence `404` for the expected case, and `500`
+reserved for the rare, actionable one. Logging the cause at `debug` in the client
+does not help: the throw is what the middleware logs.
 
 ### Caching: user-scoped data is never persisted
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -212,6 +212,43 @@ the controller, which is also why there is **no version probe** — kagent serve
 `/version` at its server root, where the derived door's nginx answers from the UI
 and the agentgateway override's `/kagent` prefix does not match.
 
+### ⚠️ Prerequisite: kagent's oauth2-proxy must accept Backstage's audience
+
+kagent's oauth2-proxy runs with `skip-jwt-bearer-tokens: true`, which accepts a
+bearer JWT **only when its audience matches oauth2-proxy's own `--client-id`**.
+Backstage mints per-installation tokens for its _own_ Dex client
+(`aud: [dex-k8s-authenticator, <backstage client>]`), while kagent's oauth2-proxy
+uses a separate Dex client. Unless the two are reconciled, every session read
+returns **401** and the tab shows "Couldn't read N installations".
+
+The fix is platform-side: add Backstage's Dex client id as an
+`--oidc-extra-audience` on kagent's oauth2-proxy (neither the charts nor the
+install configs set one today).
+
+For **local development** before that lands, point an installation at the
+agentgateway door instead, which enforces no auth of its own and passes the bearer
+through to kagent's `trusted-proxy` mode:
+
+```yaml
+agentPlatform:
+  kagent:
+    installations:
+      <installation>:
+        apiBaseUrl: https://agentgateway.<baseDomain>/kagent/api
+```
+
+Local dev only — that door is unauthenticated on GS installations and must never
+be the default. (Worth reporting separately: it exposes kagent's whole REST + A2A
+surface with no enforcement, because the `AgentgatewayPolicy` JWT check only
+renders under `oauthMode: validate` and only targets `/mcp`, while GS runs
+`passthrough`.)
+
+**Related open question.** kagent scopes with `WHERE user_id = <userIdClaim>` and
+GS sets `userIdClaim: sub`, but existing sessions have been observed keyed by
+email. If the `sub` Backstage sends doesn't match what kagent recorded, the list
+will be correct-but-empty rather than erroring. `GET /kagent/me` reports the
+identity kagent resolved and is the way to tell the two apart.
+
 ### What the list can and cannot show
 
 A kagent `Session` carries only `id`, `name?`, `user_id`, `created_at`,

--- a/packages/app/src/utils/telemetry.test.ts
+++ b/packages/app/src/utils/telemetry.test.ts
@@ -277,6 +277,16 @@ describe('getTelemetryPageViewPayload', () => {
     });
   });
 
+  it('should return correct payload for the sessions tab', () => {
+    // Reported as its own page rather than falling through to the generic
+    // agent-platform case, which would label it `page: 'Agents'`.
+    const result = getTelemetryPageViewPayload('/agent-platform/sessions');
+    expect(result).toEqual({
+      page: 'Sessions index',
+      path: '/agent-platform/sessions',
+    });
+  });
+
   it('should return correct payload for metrics page', () => {
     const result = getTelemetryPageViewPayload('/metrics');
     expect(result).toEqual({
@@ -337,6 +347,7 @@ describe('getTelemetryPageViewPayload', () => {
       '/agent-platform',
       '/agent-platform/agents/new',
       '/agent-platform/agents/new/review',
+      '/agent-platform/sessions',
       '/metrics',
       '/search',
     ];

--- a/packages/app/src/utils/telemetry.ts
+++ b/packages/app/src/utils/telemetry.ts
@@ -139,6 +139,13 @@ export function getTelemetryPageViewPayload(pathname: string): {
       break;
     }
 
+    // Must stay above the generic '/agent-platform' cases below: `switch (true)`
+    // takes the first match, so after them this would be dead and the Sessions
+    // tab would report as `page: 'Agents', view: 'sessions'`.
+    case pathname === '/agent-platform/sessions':
+      payload = { page: 'Sessions index' };
+      break;
+
     case pathname === '/agent-platform':
       payload = { page: 'Agents index' };
       break;

--- a/plugins/agent-platform-backend/README.md
+++ b/plugins/agent-platform-backend/README.md
@@ -66,6 +66,24 @@ The one transport detail worth knowing: `redirect: 'manual'` is set so an
 oauth2-proxy redirect into Dex surfaces as a 401 instead of being followed into
 a 200 HTML sign-in page.
 
+### Error mapping: "absent" vs "unwell"
+
+The distinction matters because the frontend **silences** one and **surfaces** the
+other, and getting it wrong makes a broken kagent look like an empty account.
+
+| Upstream outcome                            | Error                     | HTTP | Frontend treats as             |
+| ------------------------------------------- | ------------------------- | ---- | ------------------------------ |
+| DNS failure, TLS error, connection refused  | `ServiceUnavailableError` | 503  | not deployed here — **silent** |
+| 404 (and an unknown-installation 400)       | `NotFoundError`           | 404  | not deployed here — **silent** |
+| 3xx, 401, or a 2xx non-JSON body            | `AuthenticationError`     | 401  | read failure — reported        |
+| 403                                         | `NotAllowedError`         | 403  | read failure — reported        |
+| 5xx / 429, a timeout, or an unreadable body | `UpstreamError`           | 500  | read failure — reported        |
+
+Only the first two mean _nothing is there_. A timeout, a 500, or a truncated body
+all mean kagent answered and failed, so they must not share an error with
+"unreachable" — otherwise a degraded installation's sessions vanish from the
+fleet-merged list with no alert and nothing logged.
+
 ## URL resolution
 
 The base URL is **derived**, not configured per installation:

--- a/plugins/agent-platform-backend/README.md
+++ b/plugins/agent-platform-backend/README.md
@@ -71,18 +71,41 @@ a 200 HTML sign-in page.
 The distinction matters because the frontend **silences** one and **surfaces** the
 other, and getting it wrong makes a broken kagent look like an empty account.
 
-| Upstream outcome                            | Error                     | HTTP | Frontend treats as             |
-| ------------------------------------------- | ------------------------- | ---- | ------------------------------ |
-| DNS failure, TLS error, connection refused  | `ServiceUnavailableError` | 503  | not deployed here — **silent** |
-| 404 (and an unknown-installation 400)       | `NotFoundError`           | 404  | not deployed here — **silent** |
-| 3xx, 401, or a 2xx non-JSON body            | `AuthenticationError`     | 401  | read failure — reported        |
-| 403                                         | `NotAllowedError`         | 403  | read failure — reported        |
-| 5xx / 429, a timeout, or an unreadable body | `UpstreamError`           | 500  | read failure — reported        |
+| Upstream outcome                               | Error                 | HTTP | Frontend treats as             |
+| ---------------------------------------------- | --------------------- | ---- | ------------------------------ |
+| DNS failure, TLS error, connection refused     | `NotFoundError`       | 404  | not deployed here — **silent** |
+| kagent's own 404 (or unknown-installation 400) | `NotFoundError`       | 404  | not deployed here — **silent** |
+| 3xx, 401, or a 2xx non-JSON body               | `AuthenticationError` | 401  | read failure — reported        |
+| 403                                            | `NotAllowedError`     | 403  | read failure — reported        |
+| 5xx / 429, a timeout, or an unreadable body    | `UpstreamError`       | 500  | read failure — reported        |
+
+Plus `ServiceUnavailableError` (503) when _no_ installation is configured at all —
+a real misconfiguration, unlike the per-installation cases above.
 
 Only the first two mean _nothing is there_. A timeout, a 500, or a truncated body
 all mean kagent answered and failed, so they must not share an error with
 "unreachable" — otherwise a degraded installation's sessions vanish from the
 fleet-merged list with no alert and nothing logged.
+
+### Never return a 5xx for an expected outcome
+
+These status codes are not only about frontend classification — they decide what
+reaches Sentry. `MiddlewareFactory.error()` logs at `error` for any status `>= 500`,
+and the root logger forwards `warn`/`error` to Sentry
+(`packages/backend-common/src/rootLogger.ts`).
+
+On a fleet where kagent runs on two of fifteen installations, the Sessions tab
+queries every reachable one and thirteen answer "no kagent here" — twice over,
+counting the identity probe. As a 503 that would have raised ~26 Sentry events per
+page view per user, fanned out into a separate issue per installation name. Hence
+404: below the logging threshold, and semantically right.
+
+Logging the cause at `debug` in the client does **not** avoid this — the throw is
+what gets logged, by the middleware, after the client is done. The only fix is not
+to raise a 5xx for something expected.
+
+The inverse holds too: `UpstreamError` is deliberately a 500, because a
+deployed-but-degraded kagent is rare and genuinely worth an alert.
 
 ## URL resolution
 

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -240,8 +240,15 @@ describe('KagentClient', () => {
       [401, 'AuthenticationError'],
       [403, 'NotAllowedError'],
       [404, 'NotFoundError'],
-      [500, 'ServiceUnavailableError'],
-      [503, 'ServiceUnavailableError'],
+      // A kagent that answers and fails is deployed but unwell. It must NOT share
+      // ServiceUnavailableError with "host unreachable", which the frontend
+      // silences as "no kagent here" — that would make a degraded kagent look
+      // like an empty account.
+      [429, 'UpstreamError'],
+      [500, 'UpstreamError'],
+      [502, 'UpstreamError'],
+      [503, 'UpstreamError'],
+      [504, 'UpstreamError'],
     ])('maps status %s to %s', async (status, expectedName) => {
       const fetchFn = jest
         .fn()
@@ -265,22 +272,35 @@ describe('KagentClient', () => {
       ).rejects.toMatchObject({ name: 'AuthenticationError' });
     });
 
-    it('maps a transport failure to ServiceUnavailableError', async () => {
-      const fetchFn = jest.fn().mockRejectedValue(new Error('ENOTFOUND'));
+    it.each([
+      ['DNS failure', 'ENOTFOUND'],
+      ['connection refused', 'ECONNREFUSED'],
+    ])(
+      'maps %s to ServiceUnavailableError (nothing is deployed there)',
+      async (_label, message) => {
+        // Genuinely "no kagent at that host" — the normal outcome across a fleet
+        // where only a couple of installations run kagent, so the frontend
+        // silences it.
+        const fetchFn = jest.fn().mockRejectedValue(new Error(message));
+
+        await expect(
+          build(fetchFn).listSessions({ userToken: 't' }),
+        ).rejects.toMatchObject({ name: 'ServiceUnavailableError' });
+      },
+    );
+
+    it('maps a timeout to UpstreamError, not "not deployed"', async () => {
+      // Something answered slowly, so kagent exists and is unwell. Silencing this
+      // would drop a slow installation's sessions without a word.
+      const timeoutError = new Error(
+        'The operation was aborted due to timeout',
+      );
+      timeoutError.name = 'TimeoutError';
+      const fetchFn = jest.fn().mockRejectedValue(timeoutError);
 
       await expect(
         build(fetchFn).listSessions({ userToken: 't' }),
-      ).rejects.toMatchObject({ name: 'ServiceUnavailableError' });
-    });
-
-    it('maps an abort/timeout to ServiceUnavailableError', async () => {
-      const abortError = new Error('The operation was aborted');
-      abortError.name = 'AbortError';
-      const fetchFn = jest.fn().mockRejectedValue(abortError);
-
-      await expect(
-        build(fetchFn).listSessions({ userToken: 't' }),
-      ).rejects.toMatchObject({ name: 'ServiceUnavailableError' });
+      ).rejects.toMatchObject({ name: 'UpstreamError' });
     });
 
     it('names the installation in the error message', async () => {
@@ -293,8 +313,9 @@ describe('KagentClient', () => {
 
     describe('failures while reading the body', () => {
       // The abort signal stays armed after the headers arrive, so the body read
-      // is a second chance to fail. These must map to the same 503 the frontend
-      // keys off, not escape as an unmapped 500.
+      // is a second chance to fail. kagent answered in all of these cases, so
+      // they are upstream failures the frontend surfaces — not the silent
+      // "kagent isn't deployed here" path.
       function respondWithBodyError(error: Error) {
         return jest.fn().mockResolvedValue({
           ok: true,
@@ -306,7 +327,7 @@ describe('KagentClient', () => {
         } as unknown as Response);
       }
 
-      it('maps a mid-stream abort to ServiceUnavailableError', async () => {
+      it('maps a mid-stream abort to UpstreamError', async () => {
         const abortError = new Error('The operation was aborted');
         abortError.name = 'AbortError';
 
@@ -314,25 +335,25 @@ describe('KagentClient', () => {
           build(respondWithBodyError(abortError)).listSessions({
             userToken: 't',
           }),
-        ).rejects.toMatchObject({ name: 'ServiceUnavailableError' });
+        ).rejects.toMatchObject({ name: 'UpstreamError' });
       });
 
-      it('maps invalid or truncated JSON to ServiceUnavailableError', async () => {
+      it('maps invalid or truncated JSON to UpstreamError', async () => {
         const syntaxError = new SyntaxError('Unexpected end of JSON input');
 
         await expect(
           build(respondWithBodyError(syntaxError)).listSessions({
             userToken: 't',
           }),
-        ).rejects.toMatchObject({ name: 'ServiceUnavailableError' });
+        ).rejects.toMatchObject({ name: 'UpstreamError' });
       });
 
-      it('maps a connection reset mid-body to ServiceUnavailableError', async () => {
+      it('maps a connection reset mid-body to UpstreamError', async () => {
         await expect(
           build(respondWithBodyError(new Error('ECONNRESET'))).listSessions({
             userToken: 't',
           }),
-        ).rejects.toMatchObject({ name: 'ServiceUnavailableError' });
+        ).rejects.toMatchObject({ name: 'UpstreamError' });
       });
     });
   });

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -276,16 +276,22 @@ describe('KagentClient', () => {
       ['DNS failure', 'ENOTFOUND'],
       ['connection refused', 'ECONNREFUSED'],
     ])(
-      'maps %s to ServiceUnavailableError (nothing is deployed there)',
+      'maps %s to NotFoundError (nothing is deployed there)',
       async (_label, message) => {
         // Genuinely "no kagent at that host" — the normal outcome across a fleet
         // where only a couple of installations run kagent, so the frontend
         // silences it.
+        //
+        // A 404 rather than a 503 is load-bearing beyond semantics:
+        // MiddlewareFactory.error() logs at `error` for any status >= 500 and the
+        // root logger forwards that to Sentry, so a 5xx here would raise an event
+        // per kagent-less installation per page view. Never return a 5xx for an
+        // expected outcome.
         const fetchFn = jest.fn().mockRejectedValue(new Error(message));
 
         await expect(
           build(fetchFn).listSessions({ userToken: 't' }),
-        ).rejects.toMatchObject({ name: 'ServiceUnavailableError' });
+        ).rejects.toMatchObject({ name: 'NotFoundError' });
       },
     );
 

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -67,6 +67,23 @@ function stripTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
+/**
+ * kagent answered (or was reachable) and then failed: a 5xx, a 429, a timeout, or
+ * a body that could not be read.
+ *
+ * Deliberately **not** `ServiceUnavailableError`. That maps to HTTP 503, which the
+ * frontend treats as "kagent isn't deployed on this installation" and silences —
+ * correct for a host that doesn't resolve, badly wrong for a deployed-but-degraded
+ * kagent, whose sessions would then vanish from the fleet-merged list with no
+ * alert and nothing logged. An unrecognised error surfaces as a 500, which the
+ * frontend classifies as a genuine read failure and reports.
+ */
+function upstreamError(message: string): Error {
+  const error = new Error(message);
+  error.name = 'UpstreamError';
+  return error;
+}
+
 /** Whether a configured URL is absolute and http(s), so `fetch` can use it. */
 function isAbsoluteHttpUrl(url: string): boolean {
   try {
@@ -213,10 +230,25 @@ export class KagentClient {
         signal: AbortSignal.timeout(this.timeoutMs),
       });
     } catch (error) {
-      // DNS failure, TLS error, connection refused or timeout. On a fleet where
-      // most installations do not run kagent this is the normal, expected
-      // outcome, so it is logged at debug rather than warn (the root logger
-      // forwards warn/error to Sentry).
+      // A timeout means something *is* listening but did not answer in time —
+      // kagent is deployed and unwell, not absent. That must not be swallowed as
+      // "no kagent here", so it becomes an upstream failure the frontend
+      // surfaces. `AbortSignal.timeout` rejects with a TimeoutError.
+      if ((error as Error)?.name === 'TimeoutError') {
+        this.logger.debug(
+          `kagent request timed out for installation '${this.installation.name}'`,
+          { timeoutMs: this.timeoutMs },
+        );
+        throw upstreamError(
+          `The kagent API for installation '${this.installation.name}' did not respond within ${this.timeoutMs}ms.`,
+        );
+      }
+
+      // DNS failure, TLS error or connection refused: nothing is reachable at
+      // that host. On a fleet where most installations do not run kagent this is
+      // the normal, expected outcome, so it is logged at debug rather than warn
+      // (the root logger forwards warn/error to Sentry) and the frontend treats
+      // it as "not deployed here".
       this.logger.debug(
         `kagent request failed for installation '${this.installation.name}'`,
         { error: String(error) },
@@ -251,11 +283,15 @@ export class KagentClient {
     }
 
     if (!response.ok) {
+      // Anything else non-ok (5xx, 429, …) means kagent or its ingress answered
+      // and failed. It is deployed but unwell, so this must NOT share
+      // ServiceUnavailableError with "host unreachable" — the frontend silences
+      // that one, which would make a degraded kagent look like an empty account.
       this.logger.debug(
         `kagent API returned an error status for installation '${this.installation.name}'`,
         { status: response.status },
       );
-      throw new ServiceUnavailableError(
+      throw upstreamError(
         `The kagent API for installation '${this.installation.name}' returned status ${response.status}.`,
       );
     }
@@ -272,8 +308,8 @@ export class KagentClient {
     // Reading the body is a second chance to fail: the abort signal is still
     // armed after the headers arrive, so a slow or large response can abort
     // mid-stream, the connection can reset, or the body can be truncated /
-    // invalid JSON. All of those are transport failures and must map to the
-    // same 503 the frontend keys off — not escape as an unmapped 500.
+    // invalid JSON. kagent answered in all of those cases, so they are upstream
+    // failures worth surfacing — not "kagent isn't deployed here".
     try {
       return await response.json();
     } catch (error) {
@@ -281,7 +317,7 @@ export class KagentClient {
         `Failed to read the kagent API response body for installation '${this.installation.name}'`,
         { error: String(error) },
       );
-      throw new ServiceUnavailableError(
+      throw upstreamError(
         `Could not read the response from the kagent API for installation '${this.installation.name}'.`,
       );
     }

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -4,7 +4,6 @@ import {
   AuthenticationError,
   NotAllowedError,
   NotFoundError,
-  ServiceUnavailableError,
 } from '@backstage/errors';
 
 /**
@@ -71,12 +70,15 @@ function stripTrailingSlash(url: string): string {
  * kagent answered (or was reachable) and then failed: a 5xx, a 429, a timeout, or
  * a body that could not be read.
  *
- * Deliberately **not** `ServiceUnavailableError`. That maps to HTTP 503, which the
- * frontend treats as "kagent isn't deployed on this installation" and silences —
- * correct for a host that doesn't resolve, badly wrong for a deployed-but-degraded
- * kagent, whose sessions would then vanish from the fleet-merged list with no
- * alert and nothing logged. An unrecognised error surfaces as a 500, which the
- * frontend classifies as a genuine read failure and reports.
+ * Deliberately **not** the same error as "kagent is absent". That case is a 404
+ * (see the catch block in `request`): silenced by the frontend, and below the
+ * `>= 500` threshold at which `MiddlewareFactory.error()` logs to Sentry, which
+ * matters because it is the expected outcome on most installations.
+ *
+ * This one surfaces as a 500, so the frontend reports it *and* it reaches Sentry —
+ * both correct here. A deployed-but-degraded kagent is rare and genuinely
+ * actionable, and its sessions silently vanishing from the fleet-merged list would
+ * be the worse failure.
  */
 function upstreamError(message: string): Error {
   const error = new Error(message);
@@ -245,16 +247,26 @@ export class KagentClient {
       }
 
       // DNS failure, TLS error or connection refused: nothing is reachable at
-      // that host. On a fleet where most installations do not run kagent this is
-      // the normal, expected outcome, so it is logged at debug rather than warn
-      // (the root logger forwards warn/error to Sentry) and the frontend treats
-      // it as "not deployed here".
+      // that host, i.e. kagent is not deployed on this installation. On a fleet
+      // where only a couple of installations run kagent, this is the *normal,
+      // expected* outcome for most of them on every page view.
+      //
+      // It must therefore be a 404 and not a 503. `MiddlewareFactory.error()`
+      // logs `logger.error` for any status >= 500, and the root logger forwards
+      // warn/error to Sentry — so a 503 here would raise one Sentry event per
+      // kagent-less installation per page view, per user, fanned out into a
+      // separate issue per installation name. Logging the cause at debug does
+      // not prevent that; only not throwing a 5xx does.
+      //
+      // 404 also matches what the frontend already does with kagent's own 404:
+      // treat it as "no kagent API here" and stay silent. The two cases carried
+      // no distinguishable meaning, so collapsing them loses nothing.
       this.logger.debug(
-        `kagent request failed for installation '${this.installation.name}'`,
+        `kagent is not reachable for installation '${this.installation.name}'`,
         { error: String(error) },
       );
-      throw new ServiceUnavailableError(
-        `Could not reach the kagent API for installation '${this.installation.name}'.`,
+      throw new NotFoundError(
+        `The kagent API is not available for installation '${this.installation.name}'.`,
       );
     }
 

--- a/plugins/agent-platform-backend/src/router.test.ts
+++ b/plugins/agent-platform-backend/src/router.test.ts
@@ -110,12 +110,52 @@ describe('createRouter', () => {
     });
 
     it('returns 503 for reads', async () => {
+      // Nothing configured at all is a real misconfiguration, so a 5xx (and the
+      // Sentry event that follows) is wanted here — unlike the per-installation
+      // "kagent isn't deployed" case below.
       const response = await request(await buildUnconfiguredApp())
         .get('/kagent/sessions')
         .query({ installation: 'gazelle' })
         .set(KAGENT_AUTH_HEADER, 'user-token');
 
       expect(response.status).toBe(503);
+    });
+  });
+
+  describe('Sentry noise', () => {
+    // MiddlewareFactory.error() logs at `error` for any status >= 500, and the
+    // root logger forwards warn/error to Sentry. So the expected outcome on a
+    // fleet — most installations simply not running kagent — must never come back
+    // as a 5xx, or every page view raises an event per kagent-less installation.
+    it('reports an unreachable kagent as 404, not a 5xx', async () => {
+      const notFound = new Error(
+        'The kagent API is not available for installation gazelle.',
+      );
+      notFound.name = 'NotFoundError';
+      listSessions.mockRejectedValue(notFound);
+
+      const response = await request(app)
+        .get('/kagent/sessions')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(404);
+      expect(response.status).toBeLessThan(500);
+    });
+
+    it('still reports a degraded kagent as a 5xx', async () => {
+      // The counterpart: deployed-but-unwell is rare and actionable, so it should
+      // reach Sentry.
+      const upstream = new Error('kagent returned status 500');
+      upstream.name = 'UpstreamError';
+      listSessions.mockRejectedValue(upstream);
+
+      const response = await request(app)
+        .get('/kagent/sessions')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBeGreaterThanOrEqual(500);
     });
   });
 

--- a/plugins/agent-platform-backend/src/router.ts
+++ b/plugins/agent-platform-backend/src/router.ts
@@ -104,6 +104,11 @@ export async function createRouter(
     req: express.Request,
   ): { config: KagentInstallationConfig; client: KagentClient } => {
     if (clients.size === 0) {
+      // Kept as a 503 — unlike "kagent is absent on this installation", nothing
+      // configured at all is a genuine misconfiguration worth a Sentry event. It
+      // also cannot spam: with no installations resolved, `/kagent/installations`
+      // returns an empty list and the frontend queries nothing, so this is only
+      // ever reached by a hand-made request.
       throw new ServiceUnavailableError(
         'No kagent installation is configured. Add gs.installations entries with a baseDomain, or set agentPlatform.kagent.installations.',
       );

--- a/plugins/agent-platform/src/apis/KagentApiClient.test.ts
+++ b/plugins/agent-platform/src/apis/KagentApiClient.test.ts
@@ -83,6 +83,48 @@ describe('KagentApiClient', () => {
       expect(sessions.map(session => session.source)).toContain('agent');
     });
 
+    it('throws on an in-band error rather than resolving empty', async () => {
+      // kagent can fail on a 200. Resolving with [] would put the installation
+      // on the success path and show "no sessions" with nothing but a console
+      // line — so this must reach the provider's failure path instead.
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          error: true,
+          data: null,
+          message: 'failed to list sessions: database connection lost',
+        }),
+      );
+
+      await expect(buildClient().listSessions('gazelle')).rejects.toThrow(
+        'failed to list sessions: database connection lost',
+      );
+    });
+
+    it('throws when the contract moved and dropped every row', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ error: false, data: { unexpected: 'object' } }),
+      );
+
+      await expect(buildClient().listSessions('gazelle')).rejects.toThrow(
+        /not an array/,
+      );
+    });
+
+    it('still resolves when only some rows were unreadable', async () => {
+      // Partial data is worth showing; the warning records what was dropped.
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          error: false,
+          data: [{ id: 'good', name: 'Kept' }, {}, null],
+        }),
+      );
+
+      const sessions = await buildClient().listSessions('gazelle');
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].sessionId).toBe('good');
+    });
+
     it('returns an empty list when kagent omits the data key', async () => {
       fetchMock.mockResolvedValue(
         jsonResponse({ error: false, message: 'Successfully listed sessions' }),

--- a/plugins/agent-platform/src/apis/KagentApiClient.ts
+++ b/plugins/agent-platform/src/apis/KagentApiClient.ts
@@ -86,9 +86,30 @@ export class KagentApiClient implements KagentApi {
   async listSessions(installation: string): Promise<KagentSession[]> {
     const body = await this.get<unknown>('/kagent/sessions', installation);
     const { sessions, drift } = normalizeSessionList(body, installation);
+
     if (drift) {
       reportDrift(installation, drift);
     }
+
+    // Two drift kinds mean we cannot claim to have read this installation's
+    // sessions, so they must reach the caller's failure path rather than
+    // resolving as an empty list:
+    //
+    // - `error-envelope`: kagent reported a failure in-band on a 200. Resolving
+    //   with [] would be indistinguishable from "this user has no sessions".
+    // - `data-not-array`: the contract moved and we dropped every row.
+    //
+    // A console warning alone is not enough — nobody is watching it. Throwing
+    // puts the installation into `unreachableInstallations`, which is visible.
+    //
+    // `skipped-rows` deliberately does *not* throw: partial data is still worth
+    // showing, and the warning records what was dropped.
+    if (drift?.kind === 'error-envelope' || drift?.kind === 'data-not-array') {
+      const error = new Error(drift.message);
+      error.name = 'UpstreamError';
+      throw error;
+    }
+
     return sessions;
   }
 

--- a/plugins/agent-platform/src/components/QueryClientProvider.test.ts
+++ b/plugins/agent-platform/src/components/QueryClientProvider.test.ts
@@ -1,0 +1,49 @@
+import { shouldDehydrateAgentPlatformQuery } from './QueryClientProvider';
+
+describe('shouldDehydrateAgentPlatformQuery', () => {
+  it.each([
+    ['sessions', ['agent-platform', 'kagent', 'sessions', 'gazelle']],
+    ['identity', ['agent-platform', 'kagent', 'me', 'gazelle']],
+  ])('never persists user-scoped %s data', (_label, queryKey) => {
+    // These hold one user's chat titles and their email. Persisting them would
+    // leave them on disk after sign-out and let PersistQueryClientProvider
+    // rehydrate them for the next user on a shared workstation.
+    expect(shouldDehydrateAgentPlatformQuery(queryKey)).toBe(false);
+  });
+
+  it.each([
+    [
+      'the kagent installation allowlist',
+      ['agent-platform', 'kagent', 'installations'],
+    ],
+    [
+      'fleet agents',
+      ['cluster', 'gazelle', 'list', 'kagent.dev', 'v1alpha2', 'agents'],
+    ],
+    [
+      'fleet model configs',
+      ['cluster', 'gazelle', 'list', 'kagent.dev', 'v1alpha2', 'modelconfigs'],
+    ],
+  ])('still persists installation-wide %s', (_label, queryKey) => {
+    // Identical for every user, so caching across reloads is the whole point.
+    expect(shouldDehydrateAgentPlatformQuery(queryKey)).toBe(true);
+  });
+
+  it('does not over-match a similarly shaped key from elsewhere', () => {
+    expect(
+      shouldDehydrateAgentPlatformQuery(['other-plugin', 'kagent', 'sessions']),
+    ).toBe(true);
+    expect(
+      shouldDehydrateAgentPlatformQuery([
+        'agent-platform',
+        'other',
+        'sessions',
+      ]),
+    ).toBe(true);
+  });
+
+  it('tolerates short and empty keys', () => {
+    expect(shouldDehydrateAgentPlatformQuery([])).toBe(true);
+    expect(shouldDehydrateAgentPlatformQuery(['agent-platform'])).toBe(true);
+  });
+});

--- a/plugins/agent-platform/src/components/QueryClientProvider.tsx
+++ b/plugins/agent-platform/src/components/QueryClientProvider.tsx
@@ -1,5 +1,10 @@
 import { ReactNode, useMemo } from 'react';
-import { QueryClient, QueryClientConfig } from '@tanstack/react-query';
+import type { QueryKey } from '@tanstack/react-query';
+import {
+  defaultShouldDehydrateQuery,
+  QueryClient,
+  QueryClientConfig,
+} from '@tanstack/react-query';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
 
@@ -12,6 +17,34 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 // triggered and one cluster transiently failed.
 const gcTime = 1000 * 60 * 60;
 const maxAge = gcTime;
+
+/**
+ * Query keys whose data belongs to one *user* rather than to the fleet, and which
+ * must therefore never be written to localStorage.
+ *
+ * Everything else cached here (Agents, ModelConfigs, the kagent installation
+ * list) is installation state: identical for every user, and safe to persist.
+ * kagent sessions are not — the rows are one user's chat titles, and the identity
+ * probe caches their subject (an email address).
+ *
+ * Persisting them would be wrong twice over on a shared workstation: the data
+ * outlives sign-out on disk, and `PersistQueryClientProvider` would rehydrate the
+ * previous user's sessions for the next one under the same origin and key — which
+ * `staleTime` would not even refetch if the entry is under a minute old.
+ */
+function isUserScopedQueryKey(queryKey: QueryKey): boolean {
+  const [scope, subsystem, resource] = queryKey as unknown[];
+  return (
+    scope === 'agent-platform' &&
+    subsystem === 'kagent' &&
+    (resource === 'sessions' || resource === 'me')
+  );
+}
+
+/** Exported for testing: the persistence filter applied below. */
+export function shouldDehydrateAgentPlatformQuery(queryKey: QueryKey): boolean {
+  return !isUserScopedQueryKey(queryKey);
+}
 
 export const QueryClientProvider = ({ children }: { children: ReactNode }) => {
   const queryClient = useMemo(() => {
@@ -56,7 +89,18 @@ export const QueryClientProvider = ({ children }: { children: ReactNode }) => {
   return (
     <PersistQueryClientProvider
       client={queryClient}
-      persistOptions={{ persister, maxAge }}
+      persistOptions={{
+        persister,
+        maxAge,
+        // User-scoped queries stay in memory only — see isUserScopedQueryKey
+        // above. Composed with the library default rather than replacing it, so
+        // its "only persist successful queries" rule still applies.
+        dehydrateOptions: {
+          shouldDehydrateQuery: query =>
+            defaultShouldDehydrateQuery(query) &&
+            shouldDehydrateAgentPlatformQuery(query.queryKey),
+        },
+      }}
     >
       {children}
     </PersistQueryClientProvider>

--- a/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.test.tsx
@@ -215,24 +215,30 @@ describe('SessionsDataProvider', () => {
       expect(result.current.unreachableInstallations).toEqual([]);
     });
 
-    it.each(['ForbiddenError', 'UnauthorizedError', 'Error'])(
-      'surfaces %s',
-      async errorName => {
-        listSessions.mockImplementation((installation: string) =>
-          installation === 'gazelle'
-            ? Promise.resolve([session()])
-            : Promise.reject(namedError(errorName)),
-        );
+    it.each([
+      'ForbiddenError',
+      'UnauthorizedError',
+      // Raised by the backend for a 5xx/429, a timeout, or an unreadable body —
+      // kagent answered and failed, so it is deployed and unwell. Must not share
+      // the silent path with "unreachable", or a degraded installation's sessions
+      // would vanish with no alert.
+      'UpstreamError',
+      'Error',
+    ])('surfaces %s', async errorName => {
+      listSessions.mockImplementation((installation: string) =>
+        installation === 'gazelle'
+          ? Promise.resolve([session()])
+          : Promise.reject(namedError(errorName)),
+      );
 
-        const { result } = renderProvider();
+      const { result } = renderProvider();
 
-        await waitFor(() =>
-          expect(result.current.unreachableInstallations).toEqual(['golem']),
-        );
-        // The healthy installation's rows still render.
-        expect(result.current.rows).toHaveLength(1);
-      },
-    );
+      await waitFor(() =>
+        expect(result.current.unreachableInstallations).toEqual(['golem']),
+      );
+      // The healthy installation's rows still render.
+      expect(result.current.rows).toHaveLength(1);
+    });
 
     it('does not let one failing installation empty the table', async () => {
       listSessions.mockImplementation((installation: string) =>

--- a/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.test.tsx
@@ -1,0 +1,365 @@
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { kagentApiRef } from '../../apis';
+import { KagentApi } from '../../apis/types';
+import { KagentSession } from '../../lib/kagentSessions';
+import { SessionsDataProvider, useSessions } from './SessionsDataProvider';
+
+// Mock the fleet plumbing so the test drives the fan-out, classification and
+// loading logic directly. `mock`-prefixed names are the only out-of-scope
+// references jest allows inside a mock factory.
+let mockConfigInstallations: string[] = ['gazelle', 'golem'];
+let mockReachable: { installations: string[]; isProbing: boolean } = {
+  installations: ['gazelle', 'golem'],
+  isProbing: false,
+};
+let mockAgentRows: unknown[] = [];
+let mockCapabilities: Record<string, { isUserScoped?: boolean }> = {};
+
+jest.mock('@giantswarm/backstage-plugin-gs', () => ({
+  useInstallations: () => ({
+    installations: mockConfigInstallations.map(name => ({ name })),
+    isLoading: false,
+  }),
+}));
+
+jest.mock('../../hooks/useReachableInstallations', () => ({
+  useReachableInstallations: () => mockReachable,
+}));
+
+jest.mock('../AgentsDataProvider', () => ({
+  useAgents: () => ({ rows: mockAgentRows }),
+}));
+
+jest.mock('../../hooks/useKagentCapabilities', () => ({
+  useKagentCapabilitiesMap: () => (installation: string) =>
+    mockCapabilities[installation] ?? {},
+}));
+
+const listSessions = jest.fn();
+const listInstallations = jest.fn();
+
+const kagentApi = {
+  listSessions,
+  listInstallations,
+  getIdentity: jest.fn(),
+} as unknown as KagentApi;
+
+function session(overrides: Partial<KagentSession> = {}): KagentSession {
+  return {
+    id: 'gazelle/abc',
+    sessionId: 'abc',
+    installation: 'gazelle',
+    title: 'A session',
+    updatedAt: '2026-07-23T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function namedError(name: string): Error {
+  const error = new Error(name);
+  error.name = name;
+  return error;
+}
+
+function renderProvider() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <TestApiProvider apis={[[kagentApiRef, kagentApi]]}>
+      <QueryClientProvider client={queryClient}>
+        <SessionsDataProvider>{children}</SessionsDataProvider>
+      </QueryClientProvider>
+    </TestApiProvider>
+  );
+  return renderHook(() => useSessions(), { wrapper });
+}
+
+beforeEach(() => {
+  listSessions.mockReset();
+  listInstallations.mockReset();
+  listInstallations.mockResolvedValue(['gazelle', 'golem']);
+  mockConfigInstallations = ['gazelle', 'golem'];
+  mockReachable = { installations: ['gazelle', 'golem'], isProbing: false };
+  mockAgentRows = [];
+  mockCapabilities = {};
+});
+
+describe('SessionsDataProvider', () => {
+  it('aggregates rows across installations, most recent first', async () => {
+    listSessions.mockImplementation((installation: string) =>
+      Promise.resolve(
+        installation === 'gazelle'
+          ? [
+              session({
+                id: 'gazelle/old',
+                updatedAt: '2026-07-20T10:00:00Z',
+                title: 'older',
+              }),
+            ]
+          : [
+              session({
+                id: 'golem/new',
+                installation: 'golem',
+                updatedAt: '2026-07-23T10:00:00Z',
+                title: 'newer',
+              }),
+            ],
+      ),
+    );
+
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(2));
+    expect(result.current.rows.map(row => row.title)).toEqual([
+      'newer',
+      'older',
+    ]);
+    // Every row carries its origin, since the list is fleet-wide.
+    expect(result.current.rows.map(row => row.installation)).toEqual([
+      'golem',
+      'gazelle',
+    ]);
+  });
+
+  it('queries one installation per reachable, allowlisted installation', async () => {
+    listSessions.mockResolvedValue([]);
+
+    renderProvider();
+
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(2));
+    expect(listSessions).toHaveBeenCalledWith('gazelle');
+    expect(listSessions).toHaveBeenCalledWith('golem');
+  });
+
+  it('trims the fan-out to the backend’s kagent allowlist', async () => {
+    // kagent runs on only some installations; querying the rest is wasted work —
+    // and each wasted request mints that installation's Dex token before it can
+    // fail.
+    listInstallations.mockResolvedValue(['gazelle']);
+    listSessions.mockResolvedValue([]);
+
+    renderProvider();
+
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(1));
+    expect(listSessions).toHaveBeenCalledWith('gazelle');
+    expect(listSessions).not.toHaveBeenCalledWith('golem');
+  });
+
+  it('queries nothing until the allowlist resolves', async () => {
+    // The whole point of waiting: no request may go out before we know which
+    // installations actually have kagent, or the fan-out is doomed-by-default.
+    let resolveAllowlist: (value: string[]) => void = () => {};
+    listInstallations.mockReturnValue(
+      new Promise<string[]>(resolve => {
+        resolveAllowlist = resolve;
+      }),
+    );
+    listSessions.mockResolvedValue([]);
+
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(listSessions).not.toHaveBeenCalled();
+
+    resolveAllowlist(['gazelle']);
+
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(1));
+  });
+
+  it('falls back to the reachable set when the allowlist itself fails', async () => {
+    // A backend hiccup must not look like "you have no sessions".
+    listInstallations.mockRejectedValue(new Error('backend down'));
+    listSessions.mockResolvedValue([session()]);
+
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(listSessions).toHaveBeenCalledTimes(2));
+    expect(result.current.rows.length).toBeGreaterThan(0);
+  });
+
+  it('excludes A2A subagent sessions', async () => {
+    listSessions.mockImplementation((installation: string) =>
+      Promise.resolve(
+        installation === 'gazelle'
+          ? [session({ id: 'gazelle/sub', source: 'agent' }), session()]
+          : [],
+      ),
+    );
+
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+    expect(result.current.rows[0].id).toBe('gazelle/abc');
+  });
+
+  describe('per-installation failure classification', () => {
+    it.each([
+      ['NotFoundError', 'kagent is not deployed there'],
+      ['ServiceUnavailableError', 'the host does not resolve'],
+    ])('stays silent for %s (%s)', async errorName => {
+      // The common case across a fleet where kagent runs on a couple of
+      // installations, and not something a user can act on.
+      listSessions.mockImplementation((installation: string) =>
+        installation === 'gazelle'
+          ? Promise.resolve([session()])
+          : Promise.reject(namedError(errorName)),
+      );
+
+      const { result } = renderProvider();
+
+      await waitFor(() => expect(result.current.rows).toHaveLength(1));
+      expect(result.current.unreachableInstallations).toEqual([]);
+    });
+
+    it.each(['ForbiddenError', 'UnauthorizedError', 'Error'])(
+      'surfaces %s',
+      async errorName => {
+        listSessions.mockImplementation((installation: string) =>
+          installation === 'gazelle'
+            ? Promise.resolve([session()])
+            : Promise.reject(namedError(errorName)),
+        );
+
+        const { result } = renderProvider();
+
+        await waitFor(() =>
+          expect(result.current.unreachableInstallations).toEqual(['golem']),
+        );
+        // The healthy installation's rows still render.
+        expect(result.current.rows).toHaveLength(1);
+      },
+    );
+
+    it('does not let one failing installation empty the table', async () => {
+      listSessions.mockImplementation((installation: string) =>
+        installation === 'gazelle'
+          ? Promise.resolve([session()])
+          : Promise.reject(namedError('ForbiddenError')),
+      );
+
+      const { result } = renderProvider();
+
+      await waitFor(() => expect(result.current.rows).toHaveLength(1));
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('loading states', () => {
+    it('reports isLoadingMore, not isLoading, once some rows are in', async () => {
+      // One installation answers, the other never settles: the table must show
+      // what it has rather than a blocking skeleton.
+      listSessions.mockImplementation((installation: string) =>
+        installation === 'gazelle'
+          ? Promise.resolve([session()])
+          : new Promise(() => {}),
+      );
+
+      const { result } = renderProvider();
+
+      await waitFor(() => expect(result.current.rows).toHaveLength(1));
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isLoadingMore).toBe(true);
+    });
+
+    it('is not loading when no installations are configured', async () => {
+      // useReachableInstallations reports isProbing forever on an empty fleet, so
+      // without the hasInstallations gate this would pin isLoading true and hide
+      // the "no installations configured" empty state.
+      mockConfigInstallations = [];
+      mockReachable = { installations: [], isProbing: true };
+
+      const { result } = renderProvider();
+
+      await waitFor(() => expect(result.current.hasInstallations).toBe(false));
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('user scoping', () => {
+    it('flags an installation whose kagent is not user-scoped', async () => {
+      mockCapabilities = { golem: { isUserScoped: false } };
+      listSessions.mockImplementation((installation: string) =>
+        Promise.resolve([session({ id: `${installation}/x`, installation })]),
+      );
+
+      const { result } = renderProvider();
+
+      await waitFor(() => expect(result.current.rows).toHaveLength(2));
+      expect(result.current.notUserScopedInstallations).toEqual(['golem']);
+    });
+
+    it.each([
+      ['unknown', undefined],
+      ['confirmed scoped', true],
+    ])('stays silent when scoping is %s', async (_label, isUserScoped) => {
+      // `undefined` means the probe hasn't resolved or kagent reported no subject
+      // — warning there would flag a healthy installation for no reason.
+      mockCapabilities = { golem: { isUserScoped } };
+      listSessions.mockImplementation((installation: string) =>
+        Promise.resolve([session({ id: `${installation}/x`, installation })]),
+      );
+
+      const { result } = renderProvider();
+
+      await waitFor(() => expect(result.current.rows).toHaveLength(2));
+      expect(result.current.notUserScopedInstallations).toEqual([]);
+    });
+
+    it('does not flag an installation contributing no rows', async () => {
+      // Warning that a list "isn't yours" is meaningless when it's empty.
+      mockCapabilities = { golem: { isUserScoped: false } };
+      listSessions.mockImplementation((installation: string) =>
+        Promise.resolve(installation === 'gazelle' ? [session()] : []),
+      );
+
+      const { result } = renderProvider();
+
+      await waitFor(() => expect(result.current.rows).toHaveLength(1));
+      expect(result.current.notUserScopedInstallations).toEqual([]);
+    });
+  });
+
+  it('resolves agent display names from the loaded Agent CRs', async () => {
+    mockAgentRows = [
+      {
+        id: 'gazelle/kagent/sre-agent',
+        installation: 'gazelle',
+        namespace: 'kagent',
+        name: 'SRE agent',
+        technicalName: 'sre-agent',
+        description: '',
+        skillCount: 0,
+      },
+    ];
+    listSessions.mockImplementation((installation: string) =>
+      Promise.resolve(
+        installation === 'gazelle'
+          ? [session({ agentId: 'kagent__NS__sre_agent' })]
+          : [],
+      ),
+    );
+
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+    expect(result.current.rows[0].agentName).toBe('SRE agent');
+    expect(result.current.rows[0].agentTechnicalName).toBe('sre-agent');
+  });
+
+  it('throws when used outside the provider', () => {
+    // React logs the render error itself; silence it so the suite output stays
+    // readable.
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => renderHook(() => useSessions())).toThrow(
+        /must be used within a SessionsDataProvider/,
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.tsx
@@ -1,0 +1,243 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useInstallations } from '@giantswarm/backstage-plugin-gs';
+import { kagentApiRef } from '../../apis';
+import { useKagentCapabilitiesMap } from '../../hooks/useKagentCapabilities';
+import { useReachableInstallations } from '../../hooks/useReachableInstallations';
+import { useAgents } from '../AgentsDataProvider';
+import {
+  buildAgentIndex,
+  isListableSession,
+  SessionRow,
+  sortSessionRows,
+  toSessionRow,
+} from './helpers';
+
+/** The backend's kagent allowlist changes with config, not with navigation. */
+const INSTALLATIONS_STALE_TIME_MS = 60 * 60 * 1000;
+
+export type SessionsContextValue = {
+  /** Sessions flattened into plain rows, most recent activity first. */
+  rows: SessionRow[];
+  /**
+   * Initial load: no rows yet and the fleet is still being queried. Only true
+   * until the first installation responds — one slow installation must not keep
+   * the whole table in a skeleton.
+   */
+  isLoading: boolean;
+  /** Rows are shown, but more installations are still resolving. */
+  isLoadingMore: boolean;
+  /** Whether any installation is configured at all. */
+  hasInstallations: boolean;
+  /**
+   * Installations we queried but couldn't read. Surfaced instead of silently
+   * dropped, so an empty list is distinguishable from a partial one.
+   *
+   * Excludes installations where kagent simply isn't deployed — that is the
+   * common case across the fleet and not something a user can act on.
+   */
+  unreachableInstallations: string[];
+  /**
+   * Installations that reported a session list which is **not** scoped to the
+   * signed-in user, because their kagent runs in `unsecure` mode. Rows are still
+   * shown; the UI must stop describing them as the user's own.
+   */
+  notUserScopedInstallations: string[];
+};
+
+const SessionsContext = createContext<SessionsContextValue | undefined>(
+  undefined,
+);
+
+/**
+ * Lists the signed-in user's kagent sessions across every reachable installation
+ * that has kagent configured, and exposes them as plain rows.
+ *
+ * Agent names and avatars are resolved against the `Agent` CRs loaded by
+ * {@link AgentsDataProvider}, so this must be mounted inside one.
+ *
+ * Unlike {@link AgentsDataProvider} this keeps **no sticky per-installation
+ * cache**. That machinery exists there because `useResources` returns fresh
+ * arrays every render and a transient error blanks them; react-query already
+ * retains the last successful `data` per installation across failed refetches,
+ * and an installation genuinely dropping out of the queried set *should* prune
+ * its rows. Please don't "restore parity" — it would add state with nothing to
+ * fix.
+ */
+export function SessionsDataProvider({ children }: { children: ReactNode }) {
+  const kagentApi = useApi(kagentApiRef);
+  const { installations } = useInstallations();
+  const allInstallations = installations.map(installation => installation.name);
+
+  // Only query reachable installations, for the same reason as the other
+  // providers: an unreachable cluster otherwise hangs for the full proxy timeout
+  // and retries, dominating the tail.
+  const { installations: reachableInstallations, isProbing } =
+    useReachableInstallations(allInstallations);
+
+  // Which installations the backend can actually reach kagent on.
+  //
+  // We deliberately *wait* for this before querying anything. kagent runs on only
+  // a couple of installations, so fanning out to the whole reachable set first
+  // would fire a doomed request per remaining installation — and each one mints
+  // that installation's Dex token before it can fail, which may involve a broker
+  // exchange. This is one cheap backend call, cached for an hour and persisted, so
+  // paying a single round-trip up front is far cheaper than N wasted ones on every
+  // cold load.
+  const {
+    data: proxiedInstallations,
+    isLoading: isLoadingAllowlist,
+    isError: allowlistFailed,
+  } = useQuery({
+    queryKey: ['agent-platform', 'kagent', 'installations'],
+    queryFn: () => kagentApi.listInstallations(),
+    staleTime: INSTALLATIONS_STALE_TIME_MS,
+  });
+
+  // Key memos on contents, not identity: both arrays are derived fresh each
+  // render. Extracted to variables so the deps can be statically checked.
+  const reachableKey = reachableInstallations.join(',');
+  const proxiedKey = proxiedInstallations?.join(',');
+
+  const targets = useMemo(() => {
+    // If the allowlist itself is unavailable, fall back to the reachable set
+    // rather than showing an empty page: a backend hiccup shouldn't look like
+    // "you have no sessions".
+    if (allowlistFailed) {
+      return reachableInstallations;
+    }
+    if (!proxiedInstallations) {
+      return [];
+    }
+    const allowed = new Set(proxiedInstallations);
+    return reachableInstallations.filter(installation =>
+      allowed.has(installation),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reachableKey, proxiedKey, allowlistFailed]);
+
+  const sessionQueries = useQueries({
+    queries: targets.map(installation => ({
+      queryKey: ['agent-platform', 'kagent', 'sessions', installation],
+      queryFn: () => kagentApi.listSessions(installation),
+      // No `retry` override: the QueryClientProvider predicate already declines
+      // to retry NotFoundError/ServiceUnavailableError, which is the normal
+      // outcome for the installations without kagent.
+    })),
+  });
+
+  const capabilitiesFor = useKagentCapabilitiesMap(targets);
+
+  const { rows: agentRows } = useAgents();
+  const agentRowsKey = agentRows.map(agent => agent.id).join('|');
+  const agentIndex = useMemo(
+    () => buildAgentIndex(agentRows),
+    // Rebuild only when the agents actually change, not on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [agentRowsKey],
+  );
+
+  // useQueries returns fresh arrays every render, so key the memo on a stable
+  // signature of the per-installation outcomes.
+  const readSignature = targets
+    .map((installation, index) => {
+      const query = sessionQueries[index];
+      return `${installation}:${query?.status}:${query?.dataUpdatedAt}:${
+        (query?.error as Error | null)?.name ?? ''
+      }`;
+    })
+    .join('|');
+
+  const value = useMemo<SessionsContextValue>(() => {
+    const rows: SessionRow[] = [];
+    const unreachable: string[] = [];
+
+    targets.forEach((installation, index) => {
+      const query = sessionQueries[index];
+      if (!query) {
+        return;
+      }
+
+      if (query.data) {
+        rows.push(
+          ...query.data
+            .filter(isListableSession)
+            .map(session => toSessionRow(session, agentIndex)),
+        );
+        return;
+      }
+
+      if (query.status !== 'error') {
+        return;
+      }
+
+      // "kagent isn't deployed here" is the common case across the fleet and
+      // isn't actionable, so it contributes nothing and stays silent:
+      //   404 — the backend reached kagent's host but there is no API there
+      //   503 — the host didn't resolve, or no kagent endpoint is configured
+      //         (the backend also maps an unknown-installation 400 to 404)
+      // Anything else means we genuinely couldn't read it, which is worth saying.
+      const errorName = (query.error as Error | null)?.name;
+      const notDeployed =
+        errorName === 'NotFoundError' ||
+        errorName === 'ServiceUnavailableError';
+      if (!notDeployed) {
+        unreachable.push(installation);
+      }
+    });
+
+    // Only flag installations we are actually showing rows from: warning that a
+    // list "isn't yours" is meaningless when the list is empty.
+    const installationsWithRows = new Set(rows.map(row => row.installation));
+    const notUserScopedInstallations = targets.filter(
+      installation =>
+        installationsWithRows.has(installation) &&
+        // Strictly `false`. `undefined` means the probe hasn't resolved or kagent
+        // reported no subject at all, and claiming either answer there would show
+        // a healthy installation a warning it hasn't earned.
+        capabilitiesFor(installation).isUserScoped === false,
+    );
+
+    const hasInstallations = allInstallations.length > 0;
+    // Includes the allowlist query: without it there is a window where nothing is
+    // loading yet and the table would flash "No sessions found." before the first
+    // installation is even queried.
+    const isBusy =
+      hasInstallations &&
+      (isProbing ||
+        isLoadingAllowlist ||
+        sessionQueries.some(query => query.isLoading));
+
+    return {
+      rows: sortSessionRows(rows),
+      isLoading: isBusy && rows.length === 0,
+      isLoadingMore: isBusy && rows.length > 0,
+      hasInstallations,
+      unreachableInstallations: unreachable,
+      notUserScopedInstallations,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    readSignature,
+    agentIndex,
+    capabilitiesFor,
+    isProbing,
+    isLoadingAllowlist,
+    allInstallations.length,
+  ]);
+
+  return (
+    <SessionsContext.Provider value={value}>
+      {children}
+    </SessionsContext.Provider>
+  );
+}
+
+export function useSessions(): SessionsContextValue {
+  const ctx = useContext(SessionsContext);
+  if (!ctx) {
+    throw new Error('useSessions must be used within a SessionsDataProvider');
+  }
+  return ctx;
+}

--- a/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.tsx
@@ -181,11 +181,19 @@ export function SessionsDataProvider({ children }: { children: ReactNode }) {
       }
 
       // "kagent isn't deployed here" is the common case across the fleet and
-      // isn't actionable, so it contributes nothing and stays silent:
-      //   404 — the backend reached kagent's host but there is no API there
-      //   503 — the host didn't resolve, or no kagent endpoint is configured
-      //         (the backend also maps an unknown-installation 400 to 404)
-      // Anything else means we genuinely couldn't read it, which is worth saying.
+      // isn't actionable, so it contributes nothing and stays silent. The backend
+      // funnels every such outcome into a 404 → NotFoundError: kagent's own 404,
+      // an unknown-installation 400, and connection-level failures (DNS, TLS,
+      // refused). It deliberately does not use a 5xx for these, because anything
+      // >= 500 is logged at `error` and forwarded to Sentry — once per
+      // kagent-less installation per page view.
+      //
+      // ServiceUnavailableError is still treated as silent for safety, though the
+      // backend now only raises it when *no* installation is configured at all, in
+      // which case no session query runs.
+      //
+      // Anything else — including UpstreamError for a 5xx, a timeout or an
+      // unreadable body — means kagent answered and failed, which is worth saying.
       const errorName = (query.error as Error | null)?.name;
       const notDeployed =
         errorName === 'NotFoundError' ||

--- a/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/SessionsDataProvider.tsx
@@ -130,7 +130,15 @@ export function SessionsDataProvider({ children }: { children: ReactNode }) {
   const capabilitiesFor = useKagentCapabilitiesMap(targets);
 
   const { rows: agentRows } = useAgents();
-  const agentRowsKey = agentRows.map(agent => agent.id).join('|');
+  // Keyed on id *and* display name: `AgentRow.id` is
+  // `installation/namespace/name`, which does not change when an agent's
+  // display-name annotation does. AgentsDataProvider picks such an edit up (its
+  // signature includes resourceVersion) and emits fresh rows, so keying on ids
+  // alone would leave this index holding the previous objects and the table
+  // showing the old name until an agent is added or removed.
+  const agentRowsKey = agentRows
+    .map(agent => `${agent.id}@${agent.name}`)
+    .join('|');
   const agentIndex = useMemo(
     () => buildAgentIndex(agentRows),
     // Rebuild only when the agents actually change, not on every render.

--- a/plugins/agent-platform/src/components/SessionsDataProvider/helpers.test.ts
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/helpers.test.ts
@@ -1,0 +1,299 @@
+import { KagentSession } from '../../lib/kagentSessions';
+import { AgentRow } from '../AgentsDataProvider';
+import {
+  buildAgentIndex,
+  decodeAgentIdLabel,
+  isListableSession,
+  SESSION_TITLE_FALLBACK,
+  sessionSearchFn,
+  SessionRow,
+  sortSessionRows,
+  sortSessionsBy,
+  toAgentIdentifier,
+  toSessionRow,
+} from './helpers';
+
+function agent(overrides: Partial<AgentRow> = {}): AgentRow {
+  return {
+    id: 'gazelle/kagent/sre-agent',
+    installation: 'gazelle',
+    namespace: 'kagent',
+    name: 'SRE agent',
+    technicalName: 'sre-agent',
+    description: '',
+    skillCount: 0,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<KagentSession> = {}): KagentSession {
+  return {
+    id: 'gazelle/abc',
+    sessionId: 'abc',
+    installation: 'gazelle',
+    ...overrides,
+  };
+}
+
+describe('toAgentIdentifier', () => {
+  it('encodes namespace and name the way kagent does', () => {
+    // ConvertToPythonIdentifier: every `-` → `_`, then `/` → `__NS__`.
+    expect(toAgentIdentifier('kagent', 'k8s-agent')).toBe(
+      'kagent__NS__k8s_agent',
+    );
+  });
+
+  it('leaves a name without dashes alone', () => {
+    expect(toAgentIdentifier('kagent', 'k8s')).toBe('kagent__NS__k8s');
+  });
+
+  it('encodes dashes in the namespace too', () => {
+    expect(toAgentIdentifier('my-ns', 'my-agent')).toBe('my_ns__NS__my_agent');
+  });
+});
+
+describe('toSessionRow — the agent join', () => {
+  it('resolves the agent display name and avatar seed', () => {
+    const index = buildAgentIndex([agent()]);
+
+    const row = toSessionRow(
+      session({ agentId: 'kagent__NS__sre_agent' }),
+      index,
+    );
+
+    expect(row.agentName).toBe('SRE agent');
+    expect(row.agentTechnicalName).toBe('sre-agent');
+  });
+
+  it('scopes the join per installation', () => {
+    // The same agent_id exists on many installations, so a golem session must
+    // not pick up gazelle's agent.
+    const index = buildAgentIndex([agent()]);
+
+    const row = toSessionRow(
+      session({ installation: 'golem', agentId: 'kagent__NS__sre_agent' }),
+      index,
+    );
+
+    expect(row.agentName).toBe('kagent/sre-agent'); // lossy decode fallback
+    expect(row.agentTechnicalName).toBeUndefined();
+  });
+
+  it('falls back to a decoded label when no agent matched', () => {
+    const row = toSessionRow(
+      session({ agentId: 'kagent__NS__issue_tracker' }),
+      new Map(),
+    );
+
+    expect(row.agentName).toBe('kagent/issue-tracker');
+    expect(row.agentTechnicalName).toBeUndefined();
+  });
+
+  it('leaves the agent blank when the session references none', () => {
+    const row = toSessionRow(session({ agentId: undefined }), new Map());
+
+    expect(row.agentName).toBe('');
+  });
+
+  it('resolves an encode-collision deterministically', () => {
+    // `sre-agent` and `sre_agent` both encode to kagent__NS__sre_agent, so the
+    // join genuinely cannot tell them apart. The invariant that matters is that
+    // the winner does not depend on the order the agents arrived in — which one
+    // wins is down to locale collation and not worth pinning.
+    const dash = agent({ technicalName: 'sre-agent', name: 'Dash agent' });
+    const underscore = agent({
+      technicalName: 'sre_agent',
+      name: 'Underscore agent',
+    });
+    const target = session({ agentId: 'kagent__NS__sre_agent' });
+
+    const oneOrder = toSessionRow(target, buildAgentIndex([dash, underscore]));
+    const otherOrder = toSessionRow(
+      target,
+      buildAgentIndex([underscore, dash]),
+    );
+
+    expect(oneOrder.agentName).toBe(otherOrder.agentName);
+    expect(['Dash agent', 'Underscore agent']).toContain(oneOrder.agentName);
+  });
+});
+
+describe('toSessionRow — title', () => {
+  it.each([
+    ['undefined', undefined],
+    ['an empty string', ''],
+  ])('falls back for %s', (_label, title) => {
+    expect(
+      toSessionRow(session({ title: title || undefined }), new Map()).title,
+    ).toBe(SESSION_TITLE_FALLBACK);
+  });
+
+  it('keeps kagent’s truncated title verbatim', () => {
+    // kagent derives titles from the first message and truncates to 20 chars, so
+    // the ellipsis is real data.
+    const row = toSessionRow(
+      session({ title: 'What issues are assi...' }),
+      new Map(),
+    );
+
+    expect(row.title).toBe('What issues are assi...');
+  });
+});
+
+describe('decodeAgentIdLabel', () => {
+  it('splits the namespace marker and restores dashes', () => {
+    expect(decodeAgentIdLabel('kagent__NS__mega_k8s_sre')).toBe(
+      'kagent/mega-k8s-sre',
+    );
+  });
+
+  it('handles an id without the namespace marker', () => {
+    expect(decodeAgentIdLabel('lonely_agent')).toBe('lonely-agent');
+  });
+});
+
+describe('isListableSession', () => {
+  it('excludes A2A subagent sessions', () => {
+    expect(isListableSession(session({ source: 'agent' }))).toBe(false);
+  });
+
+  it.each([
+    ['user', 'user'],
+    ['an unknown future value', 'scheduled'],
+    ['absent', undefined],
+  ])('includes a session whose source is %s', (_label, source) => {
+    // Absent is the real-world case: live v0.9.9 responses omit `source`, so this
+    // filter hides nothing today and must not start hiding rows.
+    expect(isListableSession(session({ source }))).toBe(true);
+  });
+});
+
+describe('sortSessionRows', () => {
+  function row(overrides: Partial<SessionRow>): SessionRow {
+    return {
+      id: 'gazelle/x',
+      installation: 'gazelle',
+      title: 'x',
+      agentName: '',
+      ...overrides,
+    };
+  }
+
+  it('orders most recent activity first', () => {
+    const sorted = sortSessionRows([
+      row({ id: 'a', updatedAt: '2026-07-20T10:00:00Z' }),
+      row({ id: 'b', updatedAt: '2026-07-23T10:00:00Z' }),
+    ]);
+
+    expect(sorted.map(r => r.id)).toEqual(['b', 'a']);
+  });
+
+  it('puts rows with no timestamp last', () => {
+    const sorted = sortSessionRows([
+      row({ id: 'none' }),
+      row({ id: 'dated', updatedAt: '2026-07-20T10:00:00Z' }),
+    ]);
+
+    expect(sorted.map(r => r.id)).toEqual(['dated', 'none']);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [
+      row({ id: 'a', updatedAt: '2026-07-20T10:00:00Z' }),
+      row({ id: 'b', updatedAt: '2026-07-23T10:00:00Z' }),
+    ];
+    sortSessionRows(input);
+
+    expect(input.map(r => r.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('sortSessionsBy', () => {
+  function row(overrides: Partial<SessionRow>): SessionRow {
+    return {
+      id: 'gazelle/x',
+      installation: 'gazelle',
+      title: 'x',
+      agentName: '',
+      ...overrides,
+    };
+  }
+
+  const rows = [
+    row({ id: 'old', createdAt: '2026-07-20T10:00:00Z', title: 'b' }),
+    row({ id: 'new', createdAt: '2026-07-23T10:00:00Z', title: 'a' }),
+    row({ id: 'unknown', title: 'c' }),
+  ];
+
+  it('sorts a timestamp column ascending', () => {
+    const sorted = sortSessionsBy(rows, {
+      column: 'createdAt',
+      direction: 'ascending',
+    });
+
+    expect(sorted.map(r => r.id)).toEqual(['old', 'new', 'unknown']);
+  });
+
+  it('sorts a timestamp column descending', () => {
+    const sorted = sortSessionsBy(rows, {
+      column: 'createdAt',
+      direction: 'descending',
+    });
+
+    expect(sorted.map(r => r.id)).toEqual(['new', 'old', 'unknown']);
+  });
+
+  it('keeps unknown timestamps last in both directions', () => {
+    // "Unknown" is not "oldest", so it must not lead the ascending sort.
+    for (const direction of ['ascending', 'descending'] as const) {
+      const sorted = sortSessionsBy(rows, { column: 'createdAt', direction });
+      expect(sorted[sorted.length - 1].id).toBe('unknown');
+    }
+  });
+
+  it('sorts a text column', () => {
+    const sorted = sortSessionsBy(rows, {
+      column: 'title',
+      direction: 'ascending',
+    });
+
+    expect(sorted.map(r => r.title)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('sessionSearchFn', () => {
+  const rows: SessionRow[] = [
+    {
+      id: '1',
+      installation: 'gazelle',
+      title: 'Redis OOM triage',
+      agentName: 'SRE agent',
+    },
+    {
+      id: '2',
+      installation: 'golem',
+      title: 'Ingress question',
+      agentName: 'Issue tracker',
+    },
+  ];
+
+  it('matches on the title', () => {
+    expect(sessionSearchFn(rows, 'redis').map(r => r.id)).toEqual(['1']);
+  });
+
+  it('matches on the agent name', () => {
+    expect(sessionSearchFn(rows, 'tracker').map(r => r.id)).toEqual(['2']);
+  });
+
+  it('matches on the installation', () => {
+    expect(sessionSearchFn(rows, 'golem').map(r => r.id)).toEqual(['2']);
+  });
+
+  it('is case-insensitive and trims', () => {
+    expect(sessionSearchFn(rows, '  OOM  ').map(r => r.id)).toEqual(['1']);
+  });
+
+  it('returns everything for an empty query', () => {
+    expect(sessionSearchFn(rows, '   ')).toHaveLength(2);
+  });
+});

--- a/plugins/agent-platform/src/components/SessionsDataProvider/helpers.ts
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/helpers.ts
@@ -1,0 +1,203 @@
+import { KagentSession } from '../../lib/kagentSessions';
+import { AgentRow } from '../AgentsDataProvider';
+
+/**
+ * Shown when kagent has no title for a session. Matches the placeholder kagent's
+ * own UI uses, so the two surfaces agree.
+ */
+export const SESSION_TITLE_FALLBACK = 'Chat';
+
+/**
+ * A single session flattened for the table. Plain objects (not domain instances)
+ * so sorting and rendering stay trivial and the table layer stays decoupled.
+ */
+export type SessionRow = {
+  /** Stable unique key: `${installation}/${sessionId}`. */
+  id: string;
+  installation: string;
+  /**
+   * Display title. kagent derives these from the first message and truncates
+   * them to 20 characters, so they are short and lossy by nature — the agent
+   * column carries much of a row's meaning.
+   */
+  title: string;
+  /** Resolved agent display name, else a lossy decode of the id, else ''. */
+  agentName: string;
+  /**
+   * Matched `Agent` CR's technical name, which seeds the deterministic avatar.
+   * Undefined when no CR matched — callers fall back to initials.
+   */
+  agentTechnicalName?: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+/**
+ * Encode a namespace/name pair the way kagent does.
+ *
+ * kagent's `ConvertToPythonIdentifier` replaces every `-` with `_` and then `/`
+ * with `__NS__` (`go/core/internal/utils/common.go`), so `kagent/k8s-agent`
+ * becomes `kagent__NS__k8s_agent`.
+ *
+ * We match on this *encode* side rather than decoding kagent's `agent_id`,
+ * because encoding is lossless and decoding is not.
+ */
+export function toAgentIdentifier(namespace: string, name: string): string {
+  return `${namespace}/${name}`.replace(/-/g, '_').replace('/', '__NS__');
+}
+
+/**
+ * Index the already-loaded `Agent` CRs by `${installation}|${encodedAgentId}`.
+ *
+ * Scoped per installation because the same `agent_id` exists on many
+ * installations. Ties — two agents in one namespace differing only by `-` vs `_`,
+ * which encode identically — resolve to the first by sorted technical name so the
+ * result is at least deterministic.
+ */
+export function buildAgentIndex(agents: AgentRow[]): Map<string, AgentRow> {
+  const index = new Map<string, AgentRow>();
+
+  const sorted = [...agents].sort((a, b) =>
+    a.technicalName.localeCompare(b.technicalName),
+  );
+
+  for (const agent of sorted) {
+    const key = `${agent.installation}|${toAgentIdentifier(
+      agent.namespace,
+      agent.technicalName,
+    )}`;
+    if (!index.has(key)) {
+      index.set(key, agent);
+    }
+  }
+
+  return index;
+}
+
+/**
+ * Best-effort display label when no `Agent` CR matched.
+ *
+ * Lossy by construction: every `_` becomes `-`, so an agent whose name genuinely
+ * contains an underscore is rendered wrongly. Only ever a fallback.
+ */
+export function decodeAgentIdLabel(agentId: string): string {
+  const [namespace, name] = agentId.split('__NS__');
+  if (name === undefined) {
+    return agentId.replace(/_/g, '-');
+  }
+  return `${namespace.replace(/_/g, '-')}/${name.replace(/_/g, '-')}`;
+}
+
+/** Flatten a {@link KagentSession} into a plain {@link SessionRow}. */
+export function toSessionRow(
+  session: KagentSession,
+  agentIndex: Map<string, AgentRow>,
+): SessionRow {
+  const match = session.agentId
+    ? agentIndex.get(`${session.installation}|${session.agentId}`)
+    : undefined;
+
+  let agentName = '';
+  if (match) {
+    agentName = match.name;
+  } else if (session.agentId) {
+    agentName = decodeAgentIdLabel(session.agentId);
+  }
+
+  return {
+    id: session.id,
+    installation: session.installation,
+    title: session.title ?? SESSION_TITLE_FALLBACK,
+    agentName,
+    agentTechnicalName: match?.technicalName,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+  };
+}
+
+/**
+ * Whether a session belongs in the list.
+ *
+ * A2A subagent sessions (`source === 'agent'`) are child threads spawned by a
+ * parent agent, not work the user started, so they are excluded.
+ *
+ * Note this is forward-compatibility rather than active filtering: live kagent
+ * v0.9.9 responses omit `source` entirely, so nothing is hidden today. An absent
+ * or unrecognised value is listable — only an explicit `'agent'` is not.
+ */
+export function isListableSession(session: KagentSession): boolean {
+  return session.source !== 'agent';
+}
+
+/** Sort key for a timestamp, placing unknown values last in either direction. */
+function timestampValue(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** Default ordering: most recent activity first, then title. */
+export function sortSessionRows(rows: SessionRow[]): SessionRow[] {
+  return [...rows].sort((a, b) => {
+    const aTime = timestampValue(a.updatedAt);
+    const bTime = timestampValue(b.updatedAt);
+    if (aTime !== bTime) {
+      // Rows with no timestamp sort last regardless of direction.
+      if (aTime === undefined) return 1;
+      if (bTime === undefined) return -1;
+      return bTime - aTime;
+    }
+    return a.title.localeCompare(b.title);
+  });
+}
+
+/**
+ * Sort rows for the table, by column id and direction.
+ *
+ * Timestamp columns compare parsed times so string ordering can't mislead, and
+ * rows with an unknown timestamp always sort last — in *both* directions, since
+ * "unknown" is not "oldest".
+ */
+export function sortSessionsBy(
+  rows: SessionRow[],
+  sort: { column: unknown; direction: 'ascending' | 'descending' },
+): SessionRow[] {
+  const column = String(sort.column);
+  const factor = sort.direction === 'ascending' ? 1 : -1;
+
+  return [...rows].sort((a, b) => {
+    if (column === 'createdAt' || column === 'updatedAt') {
+      const aTime = timestampValue(a[column]);
+      const bTime = timestampValue(b[column]);
+      if (aTime === bTime) {
+        return a.title.localeCompare(b.title);
+      }
+      if (aTime === undefined) return 1;
+      if (bTime === undefined) return -1;
+      return (aTime - bTime) * factor;
+    }
+
+    const aValue = String(a[column as keyof SessionRow] ?? '');
+    const bValue = String(b[column as keyof SessionRow] ?? '');
+    return aValue.localeCompare(bValue) * factor;
+  });
+}
+
+/** Free-text search over the title and the agent name. */
+export function sessionSearchFn(
+  rows: SessionRow[],
+  search: string,
+): SessionRow[] {
+  const needle = search.trim().toLowerCase();
+  if (!needle) {
+    return rows;
+  }
+  return rows.filter(
+    row =>
+      row.title.toLowerCase().includes(needle) ||
+      row.agentName.toLowerCase().includes(needle) ||
+      row.installation.toLowerCase().includes(needle),
+  );
+}

--- a/plugins/agent-platform/src/components/SessionsDataProvider/index.ts
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/index.ts
@@ -1,0 +1,4 @@
+export { SessionsDataProvider, useSessions } from './SessionsDataProvider';
+export type { SessionsContextValue } from './SessionsDataProvider';
+export { SESSION_TITLE_FALLBACK, sessionSearchFn } from './helpers';
+export type { SessionRow } from './helpers';

--- a/plugins/agent-platform/src/components/SessionsIndexPage/SessionsIndexPage.tsx
+++ b/plugins/agent-platform/src/components/SessionsIndexPage/SessionsIndexPage.tsx
@@ -37,9 +37,15 @@ function SessionsIndexPageContent() {
   return (
     <Content>
       <Flex direction="column" gap="3">
+        {/* The "only your own" reassurance is dropped when any installation
+            reports that its kagent does not identify individual users —
+            otherwise the page would promise it at the top and contradict itself
+            in the warning below the table, and the reassuring claim is the one
+            read first. */}
         <Text color="secondary">
-          Your agent chat sessions across the management clusters. kagent scopes
-          sessions to the signed-in user, so only your own are listed.
+          {notUserScopedInstallations.length > 0
+            ? 'Agent chat sessions across the management clusters.'
+            : 'Your agent chat sessions across the management clusters. kagent scopes sessions to the signed-in user, so only your own are listed.'}
         </Text>
 
         {isLoading ? (

--- a/plugins/agent-platform/src/components/SessionsIndexPage/SessionsIndexPage.tsx
+++ b/plugins/agent-platform/src/components/SessionsIndexPage/SessionsIndexPage.tsx
@@ -1,0 +1,106 @@
+import { Content, EmptyState, Progress } from '@backstage/core-components';
+import { Alert, Box, Flex, Text } from '@backstage/ui';
+import { LinearProgress } from '@material-ui/core';
+
+import { QueryClientProvider } from '../QueryClientProvider';
+import { ModelConfigsProvider } from '../ModelConfigsProvider';
+import { AgentsDataProvider } from '../AgentsDataProvider';
+import { SessionsDataProvider, useSessions } from '../SessionsDataProvider';
+import { SessionsTable } from '../SessionsTable';
+import { UnreachableInstallationsAlert } from '../UnreachableInstallationsAlert';
+
+// Content of the "Sessions" tab. The section header + tabs come from the Agent
+// Platform page (GSPageLayout), so this renders content only. Read-only, so
+// there are no header actions to provide.
+function SessionsIndexPageContent() {
+  const {
+    rows,
+    isLoading,
+    isLoadingMore,
+    hasInstallations,
+    unreachableInstallations,
+    notUserScopedInstallations,
+  } = useSessions();
+
+  if (!isLoading && !hasInstallations) {
+    return (
+      <Content>
+        <EmptyState
+          missing="data"
+          title="No installations configured"
+          description="Sessions are read from kagent on your management clusters, but no installations are configured for this instance."
+        />
+      </Content>
+    );
+  }
+
+  return (
+    <Content>
+      <Flex direction="column" gap="3">
+        <Text color="secondary">
+          Your agent chat sessions across the management clusters. kagent scopes
+          sessions to the signed-in user, so only your own are listed.
+        </Text>
+
+        {isLoading ? (
+          // No rows yet — show activity instead of an empty table skeleton.
+          <Progress aria-label="Loading sessions" />
+        ) : (
+          <>
+            {/* Rows are in, but more installations are still resolving. */}
+            {isLoadingMore && (
+              <LinearProgress aria-label="Loading more sessions" />
+            )}
+
+            <Box>
+              <SessionsTable rows={rows} />
+            </Box>
+          </>
+        )}
+
+        {/* Only ever shown for an explicit `false` from the identity probe: an
+            installation whose kagent runs in `unsecure` mode ignores the
+            forwarded token and answers for a shared built-in user, so the rows
+            above are not this user's. An unresolved or subject-less probe is
+            "unknown" and stays silent — warning there would flag a healthy
+            installation for no reason. */}
+        {notUserScopedInstallations.length > 0 && (
+          <Alert
+            status="warning"
+            title="Some sessions are not scoped to you"
+            description={`kagent on ${notUserScopedInstallations.join(
+              ', ',
+            )} is not configured to identify individual users, so sessions from those installations are shared rather than yours alone.`}
+          />
+        )}
+
+        {/* Rendered regardless of the loading branch so a fleet whose only
+            reachable installations all error still surfaces the failure instead
+            of an indefinite progress bar. */}
+        <UnreachableInstallationsAlert
+          installations={unreachableInstallations}
+          resourceName="Sessions"
+        />
+      </Flex>
+    </Content>
+  );
+}
+
+export function SessionsIndexPage() {
+  return (
+    <QueryClientProvider>
+      <ModelConfigsProvider>
+        {/* AgentsDataProvider supplies the Agent CRs the session rows join
+            against for agent display names and avatars. It requires
+            ModelConfigsProvider above it, so the Sessions tab pays for a
+            fleet-wide ModelConfig list it doesn't itself use — cached,
+            persisted, and shared with the Agents tab, so effectively free. */}
+        <AgentsDataProvider>
+          <SessionsDataProvider>
+            <SessionsIndexPageContent />
+          </SessionsDataProvider>
+        </AgentsDataProvider>
+      </ModelConfigsProvider>
+    </QueryClientProvider>
+  );
+}

--- a/plugins/agent-platform/src/components/SessionsIndexPage/index.ts
+++ b/plugins/agent-platform/src/components/SessionsIndexPage/index.ts
@@ -1,0 +1,1 @@
+export { SessionsIndexPage } from './SessionsIndexPage';

--- a/plugins/agent-platform/src/components/SessionsTable/SessionsTable.test.tsx
+++ b/plugins/agent-platform/src/components/SessionsTable/SessionsTable.test.tsx
@@ -1,0 +1,135 @@
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SessionRow } from '../SessionsDataProvider/helpers';
+import { SessionsTable } from './SessionsTable';
+
+const mockBuildAvatarUrl = jest.fn(
+  (installation: string, name: string) =>
+    `https://avatars.${installation}.example/v1/48/${name}.png`,
+);
+
+jest.mock('../../hooks/useAgentAvatarUrl', () => ({
+  useAgentAvatarUrl: () => mockBuildAvatarUrl,
+}));
+
+const rows: SessionRow[] = [
+  {
+    id: 'gazelle/abc',
+    installation: 'gazelle',
+    title: 'What issues are assi...',
+    agentName: 'Issue tracker',
+    agentTechnicalName: 'issue-tracker',
+    createdAt: '2026-07-23T16:04:28.586641Z',
+    updatedAt: '2026-07-23T16:09:58.162014Z',
+  },
+  {
+    id: 'golem/def',
+    installation: 'golem',
+    title: 'Chat',
+    agentName: '',
+    createdAt: undefined,
+    updatedAt: undefined,
+  },
+];
+
+describe('SessionsTable', () => {
+  beforeEach(() => {
+    mockBuildAvatarUrl.mockClear();
+  });
+
+  it('renders every column header', async () => {
+    await renderInTestApp(<SessionsTable rows={rows} />);
+
+    for (const header of [
+      'Session',
+      'Agent',
+      'Installation',
+      'Started',
+      'Last activity',
+    ]) {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    }
+  });
+
+  it('renders session titles as kagent supplied them', async () => {
+    await renderInTestApp(<SessionsTable rows={rows} />);
+
+    // kagent truncates to 20 chars, so the ellipsis is real data, not ours.
+    expect(screen.getByText('What issues are assi...')).toBeInTheDocument();
+    // The fallback for a session kagent never titled.
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+  });
+
+  it('seeds the avatar from the resolved agent’s technical name', async () => {
+    await renderInTestApp(<SessionsTable rows={rows} />);
+
+    expect(mockBuildAvatarUrl).toHaveBeenCalledWith(
+      'gazelle',
+      'issue-tracker',
+      {
+        size: 48,
+      },
+    );
+  });
+
+  it('shows a dash where a value is unknown', async () => {
+    await renderInTestApp(<SessionsTable rows={[rows[1]]} />);
+
+    // Missing agent, missing created/updated timestamps: three dashes. Explicit
+    // because DateComponent renders null for a falsy value, which would leave the
+    // cell blank.
+    expect(screen.getAllByText('—')).toHaveLength(3);
+  });
+
+  it('renders the empty state when there are no rows', async () => {
+    await renderInTestApp(<SessionsTable rows={[]} />);
+
+    expect(screen.getByText('No sessions found.')).toBeInTheDocument();
+  });
+
+  it('shows a skeleton rather than the empty state while loading', async () => {
+    // The `data={undefined}` gotcha: passing `[]` would render "No sessions
+    // found." before the first rows arrive.
+    await renderInTestApp(<SessionsTable rows={[]} isLoading />);
+
+    expect(screen.queryByText('No sessions found.')).not.toBeInTheDocument();
+  });
+
+  describe('search', () => {
+    it('filters by session title', async () => {
+      await renderInTestApp(<SessionsTable rows={rows} searchDebounceMs={0} />);
+
+      await userEvent.type(
+        screen.getByRole('searchbox', { name: 'Search sessions' }),
+        'issues',
+      );
+
+      expect(screen.getByText('What issues are assi...')).toBeInTheDocument();
+      expect(screen.queryByText('Chat')).not.toBeInTheDocument();
+    });
+
+    it('filters by agent name', async () => {
+      await renderInTestApp(<SessionsTable rows={rows} searchDebounceMs={0} />);
+
+      await userEvent.type(
+        screen.getByRole('searchbox', { name: 'Search sessions' }),
+        'tracker',
+      );
+
+      expect(screen.getByText('What issues are assi...')).toBeInTheDocument();
+      expect(screen.queryByText('Chat')).not.toBeInTheDocument();
+    });
+
+    it('shows the empty state when nothing matches', async () => {
+      await renderInTestApp(<SessionsTable rows={rows} searchDebounceMs={0} />);
+
+      await userEvent.type(
+        screen.getByRole('searchbox', { name: 'Search sessions' }),
+        'nothing matches this',
+      );
+
+      expect(screen.getByText('No sessions found.')).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
+++ b/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
@@ -1,0 +1,180 @@
+import { useMemo } from 'react';
+import {
+  Avatar,
+  Cell,
+  CellText,
+  ColumnConfig,
+  Flex,
+  SearchField,
+  Table,
+  Text,
+  useTable,
+} from '@backstage/ui';
+import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
+import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
+import { AvatarSize } from '../../lib/agentAvatar';
+import {
+  SessionRow,
+  sessionSearchFn,
+  sortSessionsBy,
+} from '../SessionsDataProvider/helpers';
+
+/** The avatar is one line of text tall; request 2× for hi-dpi crispness. */
+const ROW_AVATAR_SIZE: AvatarSize = 48;
+
+/** Dash shown where a value is genuinely unknown. */
+function Unknown() {
+  return (
+    <Text variant="body-medium" color="secondary">
+      —
+    </Text>
+  );
+}
+
+function getColumnConfig(
+  buildAvatarUrl: ReturnType<typeof useAgentAvatarUrl>,
+): ColumnConfig<SessionRow>[] {
+  return [
+    {
+      // kagent truncates titles to 20 characters when deriving them from the
+      // first message, so these are short and lossy by nature — nothing to gain
+      // from a wide column.
+      id: 'title',
+      label: 'Session',
+      isRowHeader: true,
+      isSortable: true,
+      cell: row => <CellText title={row.title} />,
+    },
+    {
+      id: 'agentName',
+      label: 'Agent',
+      isSortable: true,
+      cell: row => (
+        <Cell>
+          {row.agentName ? (
+            <Flex align="center" gap="2">
+              <Avatar
+                size="small"
+                purpose="decoration"
+                name={row.agentName}
+                src={
+                  buildAvatarUrl(
+                    row.installation,
+                    row.agentTechnicalName ?? '',
+                    {
+                      size: ROW_AVATAR_SIZE,
+                    },
+                  ) ?? ''
+                }
+              />
+              <Text
+                variant="body-medium"
+                truncate
+                title={row.agentName}
+                style={{ minWidth: 0 }}
+              >
+                {row.agentName}
+              </Text>
+            </Flex>
+          ) : (
+            <Unknown />
+          )}
+        </Cell>
+      ),
+    },
+    {
+      id: 'installation',
+      label: 'Installation',
+      isSortable: true,
+      cell: row => <CellText title={row.installation} />,
+    },
+    {
+      id: 'createdAt',
+      label: 'Started',
+      isSortable: true,
+      cell: row => (
+        <Cell>
+          {row.createdAt ? (
+            <DateComponent value={row.createdAt} relative />
+          ) : (
+            <Unknown />
+          )}
+        </Cell>
+      ),
+    },
+    {
+      id: 'updatedAt',
+      label: 'Last activity',
+      isSortable: true,
+      cell: row => (
+        <Cell>
+          {row.updatedAt ? (
+            <DateComponent value={row.updatedAt} relative />
+          ) : (
+            <Unknown />
+          )}
+        </Cell>
+      ),
+    },
+  ];
+}
+
+export type SessionsTableProps = {
+  rows: SessionRow[];
+  /** True only while no rows exist yet, so the skeleton replaces the table. */
+  isLoading?: boolean;
+  /** Search debounce; set to 0 in tests so typing takes effect immediately. */
+  searchDebounceMs?: number;
+};
+
+/**
+ * Presentational table of sessions, with client-side search and sorting.
+ *
+ * The page owns the loading indicator for incremental fleet loading and the
+ * per-installation notices; this renders rows, the search field, and the empty
+ * state.
+ */
+export function SessionsTable({
+  rows,
+  isLoading,
+  searchDebounceMs = 150,
+}: SessionsTableProps) {
+  const buildAvatarUrl = useAgentAvatarUrl();
+  const columnConfig = useMemo(
+    () => getColumnConfig(buildAvatarUrl),
+    [buildAvatarUrl],
+  );
+
+  const { tableProps, search } = useTable<SessionRow>({
+    mode: 'complete',
+    // `undefined` rather than `[]` while loading: an empty array renders the
+    // empty state, so the skeleton would never show and "No sessions found."
+    // would flash before the first rows arrive.
+    data: isLoading ? undefined : rows,
+    searchFn: sessionSearchFn,
+    searchDebounceMs,
+    sortFn: sortSessionsBy,
+    initialSort: { column: 'updatedAt', direction: 'descending' },
+    paginationOptions: { pageSize: 25, pageSizeOptions: [25, 50, 100] },
+  });
+
+  return (
+    <Flex direction="column" gap="3">
+      <SearchField
+        aria-label="Search sessions"
+        placeholder="Search by session, agent, or installation"
+        value={search.value}
+        onChange={search.onChange}
+      />
+      <Table<SessionRow>
+        {...tableProps}
+        columnConfig={columnConfig}
+        emptyState={
+          <Text variant="body-medium" color="secondary">
+            No sessions found.
+          </Text>
+        }
+      />
+    </Flex>
+  );
+}

--- a/plugins/agent-platform/src/components/SessionsTable/index.ts
+++ b/plugins/agent-platform/src/components/SessionsTable/index.ts
@@ -1,0 +1,2 @@
+export { SessionsTable } from './SessionsTable';
+export type { SessionsTableProps } from './SessionsTable';

--- a/plugins/agent-platform/src/plugin.tsx
+++ b/plugins/agent-platform/src/plugin.tsx
@@ -18,6 +18,7 @@ import {
   newAgentReviewRouteRef,
   newAgentRouteRef,
   rootRouteRef,
+  sessionsRouteRef,
 } from './routes';
 
 // The Agent Platform section is a tabbed page: with no loader of its own,
@@ -55,6 +56,23 @@ const agentsSubPage = SubPageBlueprint.make({
   },
 });
 
+// The "Sessions" tab. Read-only list of the signed-in user's kagent chat
+// sessions across the fleet, via the agent-platform-backend kagent proxy.
+// Declared after the Agents tab because tab order follows the `extensions` array.
+const sessionsSubPage = SubPageBlueprint.make({
+  name: 'sessions',
+  params: {
+    path: 'sessions',
+    title: 'Sessions',
+    routeRef: sessionsRouteRef,
+    loader: async () => {
+      const { SessionsIndexPage } =
+        await import('./components/SessionsIndexPage');
+      return <SessionsIndexPage />;
+    },
+  },
+});
+
 // Client for the kagent REST API, via the agent-platform-backend proxy. The
 // kubernetes APIs are dependencies because each installation's Dex ID token is
 // minted through them (kubernetesApi.getCluster →
@@ -77,11 +95,12 @@ const kagentApi = ApiBlueprint.make({
 
 export const agentPlatformPlugin = createFrontendPlugin({
   pluginId: 'agent-platform',
-  extensions: [agentPlatformPage, agentsSubPage, kagentApi],
+  extensions: [agentPlatformPage, agentsSubPage, sessionsSubPage, kagentApi],
   routes: {
     root: rootRouteRef,
     agents: agentsRouteRef,
     newAgent: newAgentRouteRef,
     newAgentReview: newAgentReviewRouteRef,
+    sessions: sessionsRouteRef,
   },
 });

--- a/plugins/agent-platform/src/routes.ts
+++ b/plugins/agent-platform/src/routes.ts
@@ -21,3 +21,6 @@ export const newAgentReviewRouteRef = createSubRouteRef({
   path: '/new/review',
   parent: agentsRouteRef,
 });
+
+// The "Sessions" tab (`/agent-platform/sessions`).
+export const sessionsRouteRef = createRouteRef();


### PR DESCRIPTION
### What does this PR do?

Adds the **Sessions** tab at `/agent-platform/sessions` — a read-only list of the
signed-in user's kagent chat sessions across the fleet, built on the client from
#1998.

> **Stacked on #1998.** Base is `agent-platform-kagent-client`; it will retarget to
> `main` automatically when that merges.

Columns: Session, Agent (display name + avatar), Installation, Started, Last
activity. Client-side search across title/agent/installation, sortable columns,
pagination.

Three decisions worth a reviewer's attention:

**The session queries wait for the kagent allowlist.** My first cut fanned out to
every reachable installation immediately and narrowed once
`GET /kagent/installations` resolved. A test caught the cost: kagent runs on only a
couple of installations, so that fires a doomed request for every *other* one — and
each mints that installation's Dex token (potentially a broker exchange) before it
can fail. The allowlist is a single cheap backend call, cached for an hour and
persisted, so paying one round-trip up front beats N wasted ones on every cold
load. If the allowlist itself fails we fall back to the reachable set, so a backend
hiccup doesn't look like "you have no sessions".

**The agent join matches on the encode side.** kagent's `agent_id` is a "python
identifier" (`ns/name` → `ns__NS__name`, every `-` → `_`), so decoding is lossy —
`sre_agent` and `sre-agent` are indistinguishable. Instead of decoding, the already
loaded `Agent` CRs are indexed by their *encoded* id, scoped per installation. A
decoded label is only a display fallback, and a genuine encode collision resolves
deterministically (asserted by reordering the inputs rather than by pinning which
one wins, since that's down to locale collation).

**The not-user-scoped warning fires only on an explicit negative.** kagent's
`unsecure` mode resolves every caller to a shared built-in user, which would
silently present a shared list as the user's own. But `isUserScoped` is tri-state:
`undefined` means the probe hasn't resolved *or* kagent reported no subject — which
is reachable on a healthy deployment, since `/api/me` returns claims verbatim and
an IdP need not emit `sub`. Warning there would flag a working installation, so the
UI stays silent unless the answer is definitively "no".

### What is the effect of this change to users?

A new "Sessions" tab in the Agent Platform section, listing your own kagent
sessions across all management clusters that run kagent. Installations without
kagent are silently skipped; ones that genuinely fail to read are reported.

### How does it look like?

Fleet-merged table sorted by last activity, each row tagged with its installation.
Timestamps render as relative dates (`ui-react`'s `DateComponent`), with a dash
where kagent reports none.

Two things about the data that shape the design, both from the live payload:

- **Titles are short and lossy.** kagent derives them from the first message and
  truncates to 20 characters — `"What issues are assi..."` — and the full text is
  unrecoverable. So the Session column is weak by nature and the Agent column
  carries much of a row's meaning. Worth knowing before judging the layout.
- **`source` is absent on every real row**, so the "exclude A2A subagent sessions"
  filter hides nothing today. Kept as forward-compatibility, not load-bearing.

### Any background context you can provide?

Re-implementation of the Sessions view from the
[agent-platform-ui prototype](https://github.com/giantswarm/agent-platform-ui),
deliberately reduced. A kagent `Session` has 7 fields, so the prototype's status,
trigger, duration, cost, tokens, team, linked task, results and evaluation columns
— plus the nine-stat summary band derived from them — have **no backing data at
all**. kagent also lists with `WHERE user_id = <sub>` and exposes no cross-user
endpoint, so Mine/Watched/All collapses to one implicit scope. Session detail,
delete and rename are deferred (rename in particular deviates from the prototype,
where sessions are never user-named).

Full rationale is in `docs/agent-platform.md` under "The Sessions tab".

Drive-by: **the `tables` skill was stale.** It claimed the bui `Table` has no
search, filtering or sorting. As of `@backstage/ui` 0.17.0 it has all three, plus
row selection, pagination and loading/error states via `useTable` — corrected, with
the two gotchas I hit (`data: undefined` while loading, and column `id`s having to
match the fields `sortFn` reads).

### Do the docs need to be updated?

Done in this PR: a "Sessions tab" section in `docs/agent-platform.md` covering the
proxy rationale, what the list can and cannot show, fleet behaviour, user scoping,
and version tolerance; new config keys with a note on their backend-only
visibility; and the Open TODOs updated.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
