### PR TITLE
feat(agent-platform-backend): proxy kagent session detail and tasks

### DIFF
--- a/.changeset/agent-platform-session-detail-proxy.md
+++ b/.changeset/agent-platform-session-detail-proxy.md
@@ -1,0 +1,36 @@
+---
+'@giantswarm/backstage-plugin-agent-platform-backend': minor
+---
+
+Proxy kagent's session detail and session tasks, the transport the upcoming
+Agent Platform session detail page needs.
+
+- `GET /kagent/sessions/:id` — one session plus its stored events.
+- `GET /kagent/sessions/:id/tasks` — the session's A2A tasks, which carry the
+  conversation (`history`), its state (`status.state`) and per-message token
+  usage.
+
+Both require `?installation=` and a forwarded user token, and both pass kagent's
+JSON through verbatim, as the existing routes do.
+
+Two details worth knowing:
+
+- **The conversation comes from `…/tasks`, not from `…/sessions/:id`'s `events`.**
+  That is what kagent's own UI renders from, and the two payloads carry different
+  things: an event's `data` is a JSON _string_ holding an A2A message (doubly
+  encoded) and carries no state or token usage, while task history is already
+  structured and carries both. Events are still useful for one thing — A2A
+  messages have no timestamp of their own, so per-message times come from the
+  events' `created_at`.
+- **No `A2A-Version` header is sent.** kagent's `NegotiateA2AWireVersion` treats a
+  missing header as the legacy v0 wire on both v0.9.9 and v0.10, which is the
+  shape kagent's UI consumes and therefore the best-tested one. Opting into the
+  v1 wire is a deliberate future migration.
+
+Session ids stay opaque — real responses mix 64-character hex strings and UUIDs,
+so nothing validates a format; ids are URL-encoded before being interpolated.
+
+A session belonging to another user answers **404**, exactly as a deleted one
+does, because kagent scopes the lookup by the token's user id. Both are expected
+outcomes for a stale deep link, so neither returns a 5xx — which
+`MiddlewareFactory.error()` would log at `error` and forward to Sentry.

--- a/.changeset/agent-platform-session-detail-proxy.md
+++ b/.changeset/agent-platform-session-detail-proxy.md
@@ -28,9 +28,29 @@ Two details worth knowing:
   v1 wire is a deliberate future migration.
 
 Session ids stay opaque — real responses mix 64-character hex strings and UUIDs,
-so nothing validates a format; ids are URL-encoded before being interpolated.
+so nothing validates or normalizes one. In particular they are not trimmed:
+Express hands over the decoded segment, so trimming would re-encode a _different_
+id and 404 in a way indistinguishable from a missing session.
 
 A session belonging to another user answers **404**, exactly as a deleted one
 does, because kagent scopes the lookup by the token's user id. Both are expected
 outcomes for a stale deep link, so neither returns a 5xx — which
 `MiddlewareFactory.error()` would log at `error` and forward to Sentry.
+
+404 messages are now per-endpoint, because three different things arrive as one:
+
+- Nothing listening at the host (`fetch` rejects) — "kagent is not available
+  here", the fleet-wide wording the frontend's silent classification relies on.
+- kagent answering "no such resource" (404 with a JSON body, since its error
+  middleware always answers JSON) — "that session does not exist". Previously
+  this read "The kagent API is not available for installation X", i.e. a
+  bookmarked link to a deleted session reported an outage on a healthy
+  installation.
+- The endpoint not existing (404 with a non-JSON body, because kagent registers
+  no custom `NotFoundHandler` and net/http answers `text/plain`) — "this kagent
+  predates that endpoint". Without this, an installation on an older kagent would
+  report "session not found" for every session forever, and with no version probe
+  there would be nothing else to go on.
+
+kagent's own 404 message is not forwarded: its middleware appends the underlying
+error, so a session 404 reads `Session not found: no rows in result set`.

--- a/.changeset/agent-platform-session-detail-proxy.md
+++ b/.changeset/agent-platform-session-detail-proxy.md
@@ -5,7 +5,7 @@
 Proxy kagent's session detail and session tasks, the transport the upcoming
 Agent Platform session detail page needs.
 
-- `GET /kagent/sessions/:id` — one session plus its stored events.
+- `GET /kagent/sessions/:id` — the session object.
 - `GET /kagent/sessions/:id/tasks` — the session's A2A tasks, which carry the
   conversation (`history`), its state (`status.state`) and per-message token
   usage.
@@ -13,16 +13,18 @@ Agent Platform session detail page needs.
 Both require `?installation=` and a forwarded user token, and both pass kagent's
 JSON through verbatim, as the existing routes do.
 
-Two details worth knowing:
+Three details worth knowing:
 
-`GET /kagent/sessions/:id` asks kagent for `limit=1`, because the caller wants the
-session object and nothing else. kagent bundles the session's stored events into
-that response and they dominate it — on a real 4-turn session, 591 KB of events
-against 261 bytes of session metadata. Nothing reads them (see below), so this
-trims the request by ~99%. Both v0.9.9 and v0.10 parse `limit` with the same
-handler code, and a version that ignored it would simply return everything, which
-is the previous behaviour.
-
+- **`GET /kagent/sessions/:id` asks kagent for `limit=1`.** The caller wants the
+  session object and nothing else, but kagent bundles the session's stored events
+  into that response and they dominate it — on a real 4-turn session, 591 KB of
+  events against 261 bytes of session metadata. Nothing reads them (see below), so
+  this trims the response by ~99%. It has to be `1`, not `0`: kagent's DB layer
+  gates the LIMIT clause on `opts.Limit > 0`, so `limit=0` means _unlimited_ and
+  would quietly restore the full payload. Both v0.9.9 and v0.10 honour the param —
+  v0.9.9 parses it inline in `HandleGetSession`, v0.10 in
+  `eventQueryOptionsFromRequest` — and a version that ignored it would simply
+  return everything, which is the previous behaviour.
 - **The conversation comes from `…/tasks`, not from `…/sessions/:id`'s `events`.**
   That is what kagent's own UI renders from, and only task history is structured
   as A2A messages carrying the session's state and token usage. The `events` array

--- a/.changeset/agent-platform-session-detail-proxy.md
+++ b/.changeset/agent-platform-session-detail-proxy.md
@@ -15,13 +15,22 @@ JSON through verbatim, as the existing routes do.
 
 Two details worth knowing:
 
+`GET /kagent/sessions/:id` asks kagent for `limit=1`, because the caller wants the
+session object and nothing else. kagent bundles the session's stored events into
+that response and they dominate it — on a real 4-turn session, 591 KB of events
+against 261 bytes of session metadata. Nothing reads them (see below), so this
+trims the request by ~99%. Both v0.9.9 and v0.10 parse `limit` with the same
+handler code, and a version that ignored it would simply return everything, which
+is the previous behaviour.
+
 - **The conversation comes from `…/tasks`, not from `…/sessions/:id`'s `events`.**
-  That is what kagent's own UI renders from, and the two payloads carry different
-  things: an event's `data` is a JSON _string_ holding an A2A message (doubly
-  encoded) and carries no state or token usage, while task history is already
-  structured and carries both. Events are still useful for one thing — A2A
-  messages have no timestamp of their own, so per-message times come from the
-  events' `created_at`.
+  That is what kagent's own UI renders from, and only task history is structured
+  as A2A messages carrying the session's state and token usage. The `events` array
+  is not a second view of the same thing: kagent's Go type calls each event's
+  `data` a `JSON-serialized protocol.Message`, but a real gazelle payload decodes
+  to an **ADK event** (`author`, `content`, `invocation_id`, `partial`,
+  `timestamp`, …) with no `messageId` at all — so it cannot be correlated with
+  task history, and it is ignored entirely. Hence `limit=1` above.
 - **No `A2A-Version` header is sent.** kagent's `NegotiateA2AWireVersion` treats a
   missing header as the legacy v0 wire on both v0.9.9 and v0.10, which is the
   shape kagent's UI consumes and therefore the best-tested one. Opting into the

--- a/plugins/agent-platform-backend/README.md
+++ b/plugins/agent-platform-backend/README.md
@@ -28,7 +28,7 @@ All routes are under `/api/agent-platform` and require `?installation=<name>`.
 | `GET /health`                    | —        | `{ status, configured }` — how many installations resolved |
 | `GET /kagent/installations`      | —        | Names of installations kagent can be proxied for           |
 | `GET /kagent/sessions`           | required | The user's sessions, kagent's JSON verbatim                |
-| `GET /kagent/sessions/:id`       | required | One session plus its stored events                         |
+| `GET /kagent/sessions/:id`       | required | One session object (asks kagent for `limit=1`, see below)  |
 | `GET /kagent/sessions/:id/tasks` | required | The session's A2A tasks — conversation, state, token usage |
 | `GET /kagent/me`                 | optional | Identity probe (see Diagnosing below)                      |
 
@@ -44,19 +44,36 @@ are URL-encoded before being interpolated into the kagent URL.
 
 ### Why the session detail is two routes
 
-The conversation comes from `…/tasks`, not from the `events` on `…/sessions/:id`.
-That is what kagent's own UI does (`ui/src/components/chat/ChatInterface.tsx` →
-`extractMessagesFromTasks`), and the two payloads carry different things:
+Two routes, two different jobs — **not** two views of the same data:
 
-|                    | `…/sessions/:id` → `events[]`                      | `…/sessions/:id/tasks` → `Task[]`         |
-| ------------------ | -------------------------------------------------- | ----------------------------------------- |
-| Message content    | `data` is a **JSON string** holding an A2A message | `history` is already structured           |
-| Session state      | —                                                  | `status.state`                            |
-| Token usage        | —                                                  | per-message `{adk,kagent}_usage_metadata` |
-| Per-item timestamp | `created_at`                                       | only one per task                         |
+| Route                  | What it is for                                                  |
+| ---------------------- | --------------------------------------------------------------- |
+| `…/sessions/:id`       | the session object: title, agent, timestamps, and does it exist |
+| `…/sessions/:id/tasks` | the conversation, its state (`status.state`) and token usage    |
 
-So the frontend fetches both: tasks for the timeline, events only to recover
-per-message timestamps (A2A messages carry none of their own).
+The conversation comes from `…/tasks`, which is what kagent's own UI renders from
+(`ui/src/components/chat/ChatInterface.tsx` → `extractMessagesFromTasks`). Its
+`history` is already structured as A2A messages and carries the per-message
+`{adk,kagent}_usage_metadata` the token totals are built from.
+
+**The `events` array on `…/sessions/:id` is ignored entirely,** and the request
+asks for `limit=1` to avoid transferring it. kagent's Go type calls each event's
+`data` a `JSON-serialized protocol.Message`, which suggested events could supply
+the per-message timestamps A2A messages lack. A real gazelle session disproved it:
+the decoded value is an **ADK event** (`author`, `content`, `invocation_id`,
+`partial`, `timestamp`, `usage_metadata`, …) with no `messageId` anywhere, so
+there is nothing to correlate with task history — 36 events, zero usable ids. Its
+`invocation_id` does correlate, but only per turn, which the task's own timestamp
+already provides.
+
+That matters for payload size: on that session the events were **591 KB against
+261 bytes** of session metadata. Timeline items therefore share one timestamp per
+turn, which the UI should present per turn rather than implying per-message
+precision.
+
+If a finer timeline is ever wanted, events are where it would come from — but that
+means parsing ADK `Content`, whose function calls are shaped differently from A2A
+data parts, not reusing the task parsers.
 
 Neither route sends an `A2A-Version` header. kagent's `NegotiateA2AWireVersion`
 treats a missing header as the legacy v0 wire on both v0.9.9 and v0.10 — the

--- a/plugins/agent-platform-backend/README.md
+++ b/plugins/agent-platform-backend/README.md
@@ -118,6 +118,31 @@ all mean kagent answered and failed, so they must not share an error with
 "unreachable" — otherwise a degraded installation's sessions vanish from the
 fleet-merged list with no alert and nothing logged.
 
+#### Three things arrive as a 404
+
+The status is the same for all three; the **message** is what tells them apart,
+and the session routes need that because two of the three are routine there:
+
+| Actually happened                  | How we know                               | Message says                       |
+| ---------------------------------- | ----------------------------------------- | ---------------------------------- |
+| Nothing is listening at that host  | `fetch` rejected (DNS/TLS/refused)        | kagent is not available here       |
+| kagent answered "no such resource" | 404 with `Content-Type: application/json` | that session does not exist        |
+| The endpoint does not exist        | 404 with a non-JSON body                  | this kagent predates that endpoint |
+
+The content-type check works because kagent's error middleware always answers
+JSON (`go/core/internal/httpserver/middleware_error.go`), while an unrouted path
+falls through to net/http's `http.NotFound` — kagent registers no custom
+`NotFoundHandler` — which answers `text/plain`.
+
+Without the second and third being distinguished, an installation running a
+kagent that predates an endpoint would tell every user "session not found" for
+every session, on every page load, and with no version probe there would be
+nothing else to go on.
+
+kagent's own 404 message is deliberately **not** forwarded: its middleware appends
+the underlying error, so a session 404 reads `Session not found: no rows in result
+set`. Database internals do not belong in front of a user.
+
 ### Never return a 5xx for an expected outcome
 
 These status codes are not only about frontend classification — they decide what

--- a/plugins/agent-platform-backend/README.md
+++ b/plugins/agent-platform-backend/README.md
@@ -71,6 +71,10 @@ That matters for payload size: on that session the events were **591 KB against
 turn, which the UI should present per turn rather than implying per-message
 precision.
 
+The limit must be **`1`, not `0`** — kagent's DB layer gates the LIMIT clause on
+`opts.Limit > 0`, so `limit=0` reads as _unlimited_ and would quietly restore the
+full payload. `1` is the smallest value that limits anything.
+
 If a finer timeline is ever wanted, events are where it would come from — but that
 means parsing ADK `Content`, whose function calls are shaped differently from A2A
 data parts, not reusing the task parsers.

--- a/plugins/agent-platform-backend/README.md
+++ b/plugins/agent-platform-backend/README.md
@@ -23,18 +23,49 @@ Two things then force a backend hop:
 
 All routes are under `/api/agent-platform` and require `?installation=<name>`.
 
-| Route                       | Token    | Purpose                                                    |
-| --------------------------- | -------- | ---------------------------------------------------------- |
-| `GET /health`               | —        | `{ status, configured }` — how many installations resolved |
-| `GET /kagent/installations` | —        | Names of installations kagent can be proxied for           |
-| `GET /kagent/sessions`      | required | The user's sessions, kagent's JSON verbatim                |
-| `GET /kagent/me`            | optional | Identity probe (see Diagnosing below)                      |
+| Route                            | Token    | Purpose                                                    |
+| -------------------------------- | -------- | ---------------------------------------------------------- |
+| `GET /health`                    | —        | `{ status, configured }` — how many installations resolved |
+| `GET /kagent/installations`      | —        | Names of installations kagent can be proxied for           |
+| `GET /kagent/sessions`           | required | The user's sessions, kagent's JSON verbatim                |
+| `GET /kagent/sessions/:id`       | required | One session plus its stored events                         |
+| `GET /kagent/sessions/:id/tasks` | required | The session's A2A tasks — conversation, state, token usage |
+| `GET /kagent/me`                 | optional | Identity probe (see Diagnosing below)                      |
 
 The user token is read from the `backstage-kagent-authorization` header, which
 must match `KAGENT_AUTH_HEADER` in `plugins/agent-platform`.
 
 Every kagent-side path stays under `/api`, because that is the only prefix either
 door proxies to the controller.
+
+Session ids are **opaque**: real responses mix 64-character hex strings and
+UUIDs, so nothing validates a format — only that a path segment is present. They
+are URL-encoded before being interpolated into the kagent URL.
+
+### Why the session detail is two routes
+
+The conversation comes from `…/tasks`, not from the `events` on `…/sessions/:id`.
+That is what kagent's own UI does (`ui/src/components/chat/ChatInterface.tsx` →
+`extractMessagesFromTasks`), and the two payloads carry different things:
+
+|                    | `…/sessions/:id` → `events[]`                      | `…/sessions/:id/tasks` → `Task[]`         |
+| ------------------ | -------------------------------------------------- | ----------------------------------------- |
+| Message content    | `data` is a **JSON string** holding an A2A message | `history` is already structured           |
+| Session state      | —                                                  | `status.state`                            |
+| Token usage        | —                                                  | per-message `{adk,kagent}_usage_metadata` |
+| Per-item timestamp | `created_at`                                       | only one per task                         |
+
+So the frontend fetches both: tasks for the timeline, events only to recover
+per-message timestamps (A2A messages carry none of their own).
+
+Neither route sends an `A2A-Version` header. kagent's `NegotiateA2AWireVersion`
+treats a missing header as the legacy v0 wire on both v0.9.9 and v0.10 — the
+shape its own UI consumes, and therefore the best-tested one. Opting into the v1
+wire would be a deliberate future migration.
+
+A session belonging to another user answers **404**, exactly as a deleted one
+does: kagent scopes the lookup by the token's user id. Both are expected outcomes
+for a stale deep link, which is why neither becomes a 5xx (see below).
 
 ### Why there is no version endpoint
 

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -205,10 +205,87 @@ describe('KagentClient', () => {
 
     await client.listSessions({ userToken: 't' });
     await client.getMe({ userToken: 't' });
+    await client.getSession('abc', { userToken: 't' });
+    await client.listSessionTasks('abc', { userToken: 't' });
 
     for (const [url] of fetchFn.mock.calls) {
       expect(url).toMatch(/^https:\/\/kagent\.gazelle\.example\.io\/api\//);
     }
+  });
+
+  describe('session detail', () => {
+    it('requests one session under the sessions path', async () => {
+      const fetchFn = jest.fn().mockResolvedValue(jsonResponse({}));
+
+      await build(fetchFn).getSession('abc123', { userToken: 't' });
+
+      expect(fetchFn.mock.calls[0][0]).toBe(
+        'https://kagent.gazelle.example.io/api/sessions/abc123',
+      );
+    });
+
+    it('requests the session tasks path', async () => {
+      const fetchFn = jest.fn().mockResolvedValue(jsonResponse({}));
+
+      await build(fetchFn).listSessionTasks('abc123', { userToken: 't' });
+
+      expect(fetchFn.mock.calls[0][0]).toBe(
+        'https://kagent.gazelle.example.io/api/sessions/abc123/tasks',
+      );
+    });
+
+    it('sends no A2A-Version header, so kagent answers on the legacy wire', async () => {
+      // kagent's NegotiateA2AWireVersion treats a missing header as the legacy v0
+      // wire on both v0.9.9 and v0.10 — the shape kagent's own UI consumes, and so
+      // the best-tested one. Asserted so a header is not added casually.
+      const fetchFn = jest.fn().mockResolvedValue(jsonResponse({}));
+
+      await build(fetchFn).listSessionTasks('abc123', { userToken: 't' });
+
+      expect(fetchFn.mock.calls[0][1].headers).toEqual({
+        Accept: 'application/json',
+        Authorization: 'Bearer t',
+      });
+    });
+
+    it('escapes a session id that is not URL-safe', async () => {
+      // Session ids are opaque. Real ones are hex or UUIDs, but nothing in kagent
+      // guarantees that, so the id must never be interpolated raw — a `/` or `?`
+      // would otherwise retarget the request.
+      const fetchFn = jest.fn().mockResolvedValue(jsonResponse({}));
+
+      await build(fetchFn).getSession('a/b?c=d', { userToken: 't' });
+
+      expect(fetchFn.mock.calls[0][0]).toBe(
+        'https://kagent.gazelle.example.io/api/sessions/a%2Fb%3Fc%3Dd',
+      );
+    });
+
+    it('returns the tasks body verbatim, including unknown fields', async () => {
+      const body = {
+        error: false,
+        data: [
+          {
+            id: 'task-1',
+            contextId: 'ctx-1',
+            kind: 'task',
+            status: { state: 'completed', timestamp: '2026-07-23T16:09:58Z' },
+            history: [
+              { kind: 'message', messageId: 'm1', role: 'user', parts: [] },
+            ],
+            some_future_field: 'kept',
+          },
+        ],
+        message: 'Successfully retrieved session tasks',
+      };
+      const fetchFn = jest.fn().mockResolvedValue(jsonResponse(body));
+
+      const result = await build(fetchFn).listSessionTasks('abc123', {
+        userToken: 't',
+      });
+
+      expect(result).toEqual(body);
+    });
   });
 
   it('requests /me under the API base URL', async () => {

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -217,9 +217,14 @@ describe('KagentClient', () => {
     it('requests one session under the sessions path, asking for no events', async () => {
       // kagent bundles the session's stored events into this response and they
       // dominate it — 591 KB of events against 261 bytes of session metadata on a
-      // real 4-turn session. Nothing reads them, so `limit=1` trims the request by
+      // real 4-turn session. Nothing reads them, so `limit=1` trims the response by
       // ~99%. A version that ignored `limit` would just return everything, which
       // is today's behaviour, so this can only help.
+      //
+      // If this assertion fails because someone changed the value: `limit=0` does
+      // NOT mean "no events". kagent gates its LIMIT clause on `opts.Limit > 0`, so
+      // zero reads as *unlimited* and restores the full payload. `1` is the
+      // smallest value that limits anything.
       const fetchFn = jest.fn().mockResolvedValue(jsonResponse({}));
 
       await build(fetchFn).getSession('abc123', { userToken: 't' });

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -214,13 +214,18 @@ describe('KagentClient', () => {
   });
 
   describe('session detail', () => {
-    it('requests one session under the sessions path', async () => {
+    it('requests one session under the sessions path, asking for no events', async () => {
+      // kagent bundles the session's stored events into this response and they
+      // dominate it — 591 KB of events against 261 bytes of session metadata on a
+      // real 4-turn session. Nothing reads them, so `limit=1` trims the request by
+      // ~99%. A version that ignored `limit` would just return everything, which
+      // is today's behaviour, so this can only help.
       const fetchFn = jest.fn().mockResolvedValue(jsonResponse({}));
 
       await build(fetchFn).getSession('abc123', { userToken: 't' });
 
       expect(fetchFn.mock.calls[0][0]).toBe(
-        'https://kagent.gazelle.example.io/api/sessions/abc123',
+        'https://kagent.gazelle.example.io/api/sessions/abc123?limit=1',
       );
     });
 
@@ -257,7 +262,7 @@ describe('KagentClient', () => {
       await build(fetchFn).getSession('a/b?c=d', { userToken: 't' });
 
       expect(fetchFn.mock.calls[0][0]).toBe(
-        'https://kagent.gazelle.example.io/api/sessions/a%2Fb%3Fc%3Dd',
+        'https://kagent.gazelle.example.io/api/sessions/a%2Fb%3Fc%3Dd?limit=1',
       );
     });
 

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -336,6 +336,109 @@ describe('KagentClient', () => {
       ).rejects.toMatchObject({ name: expectedName });
     });
 
+    describe('what a 404 actually means', () => {
+      /** kagent's error middleware always answers JSON. */
+      function kagentNotFound() {
+        return new Response(JSON.stringify({ error: 'Session not found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      /** An unrouted path falls through to net/http's plain-text handler. */
+      function routeNotFound() {
+        return new Response('404 page not found', {
+          status: 404,
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+        });
+      }
+
+      it('reports a session that does not exist, not an outage', async () => {
+        // The message a user reads when they follow a bookmark to a deleted
+        // session. "The kagent API is not available" would claim an outage on a
+        // perfectly healthy installation.
+        const fetchFn = jest.fn().mockResolvedValue(kagentNotFound());
+
+        await expect(
+          build(fetchFn).getSession('abc', { userToken: 't' }),
+        ).rejects.toMatchObject({
+          name: 'NotFoundError',
+          message: expect.stringContaining('That session does not exist'),
+        });
+      });
+
+      it('reports an absent route as a version problem, not a missing session', async () => {
+        // Otherwise an installation running a kagent without this endpoint tells
+        // every user "session not found" for every session, forever — and with no
+        // version probe there is nothing else to go on.
+        const fetchFn = jest.fn().mockResolvedValue(routeNotFound());
+
+        await expect(
+          build(fetchFn).listSessionTasks('abc', { userToken: 't' }),
+        ).rejects.toMatchObject({
+          name: 'NotFoundError',
+          message: expect.stringContaining('has no session tasks endpoint'),
+        });
+      });
+
+      it('does not forward kagent’s own message', async () => {
+        // kagent's middleware appends the underlying error, so its session 404
+        // reads "Session not found: no rows in result set". Database internals are
+        // not something to put in front of a user.
+        const fetchFn = jest.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              error: 'Session not found: no rows in result set',
+            }),
+            { status: 404, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+
+        await expect(
+          build(fetchFn).getSession('abc', { userToken: 't' }),
+        ).rejects.toMatchObject({
+          message: expect.not.stringContaining('no rows in result set'),
+        });
+      });
+
+      it('keeps the "not available" wording for the fleet-wide routes', async () => {
+        // `/sessions` and `/me` are probed across the whole fleet, where a 404
+        // genuinely does mean "no kagent here" — the wording the frontend's silent
+        // classification is built around.
+        const fetchFn = jest
+          .fn()
+          .mockImplementation(async () => kagentNotFound());
+        const client = build(fetchFn);
+
+        await expect(
+          client.listSessions({ userToken: 't' }),
+        ).rejects.toMatchObject({
+          message: expect.stringContaining('is not available for installation'),
+        });
+        await expect(client.getMe({ userToken: 't' })).rejects.toMatchObject({
+          message: expect.stringContaining('is not available for installation'),
+        });
+      });
+
+      it('still maps every 404 to NotFoundError, whatever the wording', async () => {
+        // The status is what keeps this out of Sentry; only the message varies.
+        const fetchFn = jest
+          .fn()
+          .mockImplementation(async () => routeNotFound());
+        const client = build(fetchFn);
+
+        for (const call of [
+          () => client.getSession('abc', { userToken: 't' }),
+          () => client.listSessionTasks('abc', { userToken: 't' }),
+          () => client.listSessions({ userToken: 't' }),
+        ]) {
+          await expect(call()).rejects.toMatchObject({
+            name: 'NotFoundError',
+          });
+        }
+      });
+    });
+
     it('treats a 200 HTML body as a sign-in page', async () => {
       const fetchFn = jest.fn().mockResolvedValue(
         new Response('<html>Sign in</html>', {

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -184,6 +184,52 @@ export class KagentClient {
     return this.request(`${this.installation.apiBaseUrl}/sessions`, options);
   }
 
+  /**
+   * `GET <apiBaseUrl>/sessions/<id>` — one session plus its stored events.
+   *
+   * kagent scopes this by the forwarded token's user id, so a session belonging
+   * to somebody else is indistinguishable from one that does not exist: both
+   * answer 404. That is an expected outcome for a stale or shared deep link, and
+   * `request` already maps it to `NotFoundError` (404) rather than a 5xx.
+   *
+   * The frontend reads the `events` array only to recover per-message
+   * timestamps; the conversation itself comes from {@link listSessionTasks},
+   * because A2A messages carry no timestamp of their own.
+   */
+  async getSession(
+    sessionId: string,
+    options: KagentRequestOptions,
+  ): Promise<unknown> {
+    return this.request(
+      `${this.installation.apiBaseUrl}/sessions/${encodeURIComponent(
+        sessionId,
+      )}`,
+      options,
+    );
+  }
+
+  /**
+   * `GET <apiBaseUrl>/sessions/<id>/tasks` — the session's A2A tasks, which
+   * carry the conversation (`history`), its state (`status.state`) and per-message
+   * token usage. This is the same endpoint kagent's own UI renders its chat from.
+   *
+   * Deliberately sends no `A2A-Version` header: kagent's `NegotiateA2AWireVersion`
+   * treats a missing header as the legacy v0 wire on both v0.9.9 and v0.10, which
+   * is the shape kagent's UI consumes and therefore the best-tested one. Opting
+   * into the v1 wire is a future, deliberate migration.
+   */
+  async listSessionTasks(
+    sessionId: string,
+    options: KagentRequestOptions,
+  ): Promise<unknown> {
+    return this.request(
+      `${this.installation.apiBaseUrl}/sessions/${encodeURIComponent(
+        sessionId,
+      )}/tasks`,
+      options,
+    );
+  }
+
   // There is deliberately no version probe. kagent serves `/version` at the
   // server root (`APIPathVersion`), not under `/api`, and neither door we
   // support routes the root to the controller:

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -221,16 +221,24 @@ export class KagentClient {
     options: KagentRequestOptions,
   ): Promise<unknown> {
     return this.request(
-      // `limit=1` because the caller wants the session object and nothing else.
-      // kagent bundles the session's stored events into this response and they
-      // dominate it — on a real 4-turn session, 591 KB of events against 261
-      // bytes of session metadata. They are not the conversation (that comes from
-      // `/tasks`) and, despite kagent's Go doc comment, not A2A messages either,
-      // so there is nothing in them we can use.
+      // `limit=1` — **not** `limit=0`, which kagent reads as *unlimited*: its DB
+      // layer gates the LIMIT clause on `opts.Limit > 0`
+      // (`go/core/internal/database/client_postgres.go`), and an absent param
+      // leaves `Limit` at its zero value. So `1` is the smallest value that limits
+      // anything, and "ask for zero events, we don't read them" — the
+      // obvious-looking simplification — silently restores the full payload.
       //
-      // Both v0.9.9 and v0.10 parse `limit` with the same handler code. A version
-      // that ignored it would simply return everything, which is exactly today's
-      // behaviour — so this can only help.
+      // The caller wants the session object and nothing else. kagent bundles the
+      // session's stored events into this response and they dominate it — on a real
+      // 4-turn session, 591 KB of events against 261 bytes of session metadata.
+      // They are not the conversation (that comes from `/tasks`) and, despite
+      // kagent's Go doc comment, not A2A messages either, so there is nothing in
+      // them we can use.
+      //
+      // Both v0.9.9 and v0.10 honour `limit` on this endpoint — v0.9.9 parses it
+      // inline in `HandleGetSession`, v0.10 in `eventQueryOptionsFromRequest`. A
+      // version that ignored it would simply return everything, which is exactly
+      // today's behaviour — so this can only help.
       `${this.installation.apiBaseUrl}/sessions/${encodeURIComponent(
         sessionId,
       )}?limit=1`,

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -206,25 +206,34 @@ export class KagentClient {
   }
 
   /**
-   * `GET <apiBaseUrl>/sessions/<id>` — one session plus its stored events.
+   * `GET <apiBaseUrl>/sessions/<id>` — the session object.
    *
    * kagent scopes this by the forwarded token's user id, so a session belonging
    * to somebody else is indistinguishable from one that does not exist: both
    * answer 404. That is an expected outcome for a stale or shared deep link, and
    * `request` already maps it to `NotFoundError` (404) rather than a 5xx.
    *
-   * The frontend reads the `events` array only to recover per-message
-   * timestamps; the conversation itself comes from {@link listSessionTasks},
-   * because A2A messages carry no timestamp of their own.
+   * The conversation comes from {@link listSessionTasks}, not from this response's
+   * `events` array — which is ignored entirely, hence the `limit=1` below.
    */
   async getSession(
     sessionId: string,
     options: KagentRequestOptions,
   ): Promise<unknown> {
     return this.request(
+      // `limit=1` because the caller wants the session object and nothing else.
+      // kagent bundles the session's stored events into this response and they
+      // dominate it — on a real 4-turn session, 591 KB of events against 261
+      // bytes of session metadata. They are not the conversation (that comes from
+      // `/tasks`) and, despite kagent's Go doc comment, not A2A messages either,
+      // so there is nothing in them we can use.
+      //
+      // Both v0.9.9 and v0.10 parse `limit` with the same handler code. A version
+      // that ignored it would simply return everything, which is exactly today's
+      // behaviour — so this can only help.
       `${this.installation.apiBaseUrl}/sessions/${encodeURIComponent(
         sessionId,
-      )}`,
+      )}?limit=1`,
       options,
       {
         // The id is left out on purpose: it is opaque and high-cardinality, and

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -42,6 +42,27 @@ export interface KagentRequestOptions {
 }
 
 /**
+ * Per-endpoint wording for a 404, so the message a user reads matches what
+ * actually went wrong.
+ *
+ * Without this every 404 reports "The kagent API is not available for
+ * installation X", which is an outage claim — badly wrong for the common case of
+ * a bookmarked link to a session that has since been deleted.
+ */
+interface NotFoundContext {
+  /**
+   * What a 404 means when **kagent's own handler** answered it: the endpoint
+   * exists, the resource does not.
+   */
+  missingResource: string;
+  /**
+   * Short name of the endpoint, used when the **route itself** is absent — an
+   * older kagent that predates it.
+   */
+  endpoint: string;
+}
+
+/**
  * Derive the kagent API base URL for an installation from its base domain.
  *
  * The hostname pattern matches the `agentic-platform-connectivity` chart's
@@ -205,6 +226,12 @@ export class KagentClient {
         sessionId,
       )}`,
       options,
+      {
+        // The id is left out on purpose: it is opaque and high-cardinality, and
+        // the user already has it in the URL they followed.
+        missingResource: `That session does not exist on installation '${this.installation.name}'. It may have been deleted, or it may belong to another user.`,
+        endpoint: 'session detail',
+      },
     );
   }
 
@@ -227,6 +254,10 @@ export class KagentClient {
         sessionId,
       )}/tasks`,
       options,
+      {
+        missingResource: `That session does not exist on installation '${this.installation.name}'. It may have been deleted, or it may belong to another user.`,
+        endpoint: 'session tasks',
+      },
     );
   }
 
@@ -261,6 +292,7 @@ export class KagentClient {
   private async request(
     url: string,
     options: KagentRequestOptions,
+    notFound?: NotFoundContext,
   ): Promise<unknown> {
     let response: Response;
     try {
@@ -335,8 +367,38 @@ export class KagentClient {
     }
 
     if (response.status === 404) {
+      // Two very different things arrive here, and conflating them shows users a
+      // message about the wrong problem:
+      //
+      // - **kagent's handler said "no such resource".** Its error middleware
+      //   always answers `Content-Type: application/json`
+      //   (`go/core/internal/httpserver/middleware_error.go`), so a JSON 404 means
+      //   the endpoint exists and the thing we asked for does not — a deleted
+      //   session, or one belonging to another user.
+      // - **The route does not exist.** kagent registers no custom
+      //   `NotFoundHandler`, so an unrouted path falls through to net/http's
+      //   `http.NotFound`, which answers `text/plain`. That is what an
+      //   installation running a kagent older than an endpoint looks like.
+      //
+      // The second case matters most for the session routes: without the
+      // distinction, "this kagent is too old" would read as "session not found" on
+      // every session, on every page load, with no way to tell from the UI.
+      //
+      // kagent's own message is deliberately *not* forwarded: its middleware
+      // appends the underlying error, so a session 404 reads
+      // "Session not found: no rows in result set" — database internals are not
+      // something to put in front of a user.
+      const contentType = response.headers.get('content-type') ?? '';
+      const kagentAnswered = contentType.includes('application/json');
+
+      if (!kagentAnswered && notFound) {
+        throw new NotFoundError(
+          `The kagent API for installation '${this.installation.name}' has no ${notFound.endpoint} endpoint; it is probably running a version that predates it.`,
+        );
+      }
       throw new NotFoundError(
-        `The kagent API is not available for installation '${this.installation.name}'.`,
+        notFound?.missingResource ??
+          `The kagent API is not available for installation '${this.installation.name}'.`,
       );
     }
 

--- a/plugins/agent-platform-backend/src/router.test.ts
+++ b/plugins/agent-platform-backend/src/router.test.ts
@@ -18,10 +18,14 @@ const twoInstallations = {
 describe('createRouter', () => {
   const listSessions = jest.fn();
   const getMe = jest.fn();
+  const getSession = jest.fn();
+  const listSessionTasks = jest.fn();
 
   const mockClient = {
     listSessions,
     getMe,
+    getSession,
+    listSessionTasks,
   } as unknown as KagentClient;
 
   // Mirror the production setup: the backend's root HTTP router applies
@@ -50,6 +54,8 @@ describe('createRouter', () => {
   beforeEach(async () => {
     listSessions.mockReset();
     getMe.mockReset();
+    getSession.mockReset();
+    listSessionTasks.mockReset();
     app = await buildApp();
   });
 
@@ -253,6 +259,222 @@ describe('createRouter', () => {
 
       expect(response.body).toEqual(body);
       expect(response.body.data).toBeUndefined();
+    });
+  });
+
+  describe('GET /kagent/sessions/:sessionId', () => {
+    const sessionBody = {
+      error: false,
+      data: {
+        session: {
+          id: 'abc',
+          name: 'What issues are assi...',
+          user_id: 'marian@giantswarm.io',
+          created_at: '2026-07-23T16:04:28.586641Z',
+          updated_at: '2026-07-23T16:09:58.162014Z',
+          agent_id: 'kagent__NS__issue_tracker',
+        },
+        events: [
+          {
+            id: 'e1',
+            session_id: 'abc',
+            created_at: '2026-07-23T16:04:29Z',
+            data: '{"kind":"message","messageId":"m1","role":"user","parts":[]}',
+          },
+        ],
+        some_future_field: 'kept',
+      },
+      message: 'Successfully retrieved session',
+    };
+
+    it('does not shadow the list route', async () => {
+      listSessions.mockResolvedValue({ error: false, data: [] });
+
+      await request(app)
+        .get('/kagent/sessions')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(listSessions).toHaveBeenCalledTimes(1);
+      expect(getSession).not.toHaveBeenCalled();
+    });
+
+    it('forwards the id and token and echoes the body verbatim', async () => {
+      getSession.mockResolvedValue(sessionBody);
+
+      const response = await request(app)
+        .get('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(sessionBody);
+      expect(getSession).toHaveBeenCalledWith('abc', {
+        userToken: 'user-token',
+      });
+    });
+
+    it('passes an id through decoded, whatever shape it has', async () => {
+      // Both 64-char hex and UUIDs occur in real responses, so the router must not
+      // validate a format — only that a segment is present.
+      getSession.mockResolvedValue(sessionBody);
+
+      await request(app)
+        .get('/kagent/sessions/019f8a13-c6c2-73af-a1d9-ab0abeeb6734')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(getSession).toHaveBeenCalledWith(
+        '019f8a13-c6c2-73af-a1d9-ab0abeeb6734',
+        { userToken: 'user-token' },
+      );
+    });
+
+    it('requires the installation query parameter', async () => {
+      const response = await request(app)
+        .get('/kagent/sessions/abc')
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(400);
+      expect(getSession).not.toHaveBeenCalled();
+    });
+
+    it('requires a forwarded user token', async () => {
+      const response = await request(app)
+        .get('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' });
+
+      expect(response.status).toBe(401);
+      expect(getSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown installation', async () => {
+      const response = await request(app)
+        .get('/kagent/sessions/abc')
+        .query({ installation: 'nope' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(400);
+      expect(getSession).not.toHaveBeenCalled();
+    });
+
+    it('reports someone else’s or a deleted session as 404, not a 5xx', async () => {
+      // kagent scopes the lookup by user id, so "not yours" and "gone" are the
+      // same 404. Both are expected outcomes for a stale deep link, and anything
+      // >= 500 would be logged at error and forwarded to Sentry.
+      const notFound = new Error('Session not found');
+      notFound.name = 'NotFoundError';
+      getSession.mockRejectedValue(notFound);
+
+      const response = await request(app)
+        .get('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(404);
+      expect(response.status).toBeLessThan(500);
+    });
+
+    it('still reports a degraded kagent as a 5xx', async () => {
+      const upstream = new Error('kagent returned status 500');
+      upstream.name = 'UpstreamError';
+      getSession.mockRejectedValue(upstream);
+
+      const response = await request(app)
+        .get('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBeGreaterThanOrEqual(500);
+    });
+  });
+
+  describe('GET /kagent/sessions/:sessionId/tasks', () => {
+    const tasksBody = {
+      error: false,
+      data: [
+        {
+          id: 'task-1',
+          contextId: 'abc',
+          kind: 'task',
+          status: { state: 'completed', timestamp: '2026-07-23T16:09:58Z' },
+          history: [
+            {
+              kind: 'message',
+              messageId: 'm1',
+              role: 'user',
+              parts: [{ kind: 'text', text: 'hello' }],
+            },
+          ],
+          some_future_field: 'kept',
+        },
+      ],
+      message: 'Successfully retrieved session tasks',
+    };
+
+    it('forwards the id and token and echoes the body verbatim', async () => {
+      listSessionTasks.mockResolvedValue(tasksBody);
+
+      const response = await request(app)
+        .get('/kagent/sessions/abc/tasks')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(tasksBody);
+      expect(listSessionTasks).toHaveBeenCalledWith('abc', {
+        userToken: 'user-token',
+      });
+      expect(getSession).not.toHaveBeenCalled();
+    });
+
+    it('requires the installation query parameter', async () => {
+      const response = await request(app)
+        .get('/kagent/sessions/abc/tasks')
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(400);
+      expect(listSessionTasks).not.toHaveBeenCalled();
+    });
+
+    it('requires a forwarded user token', async () => {
+      const response = await request(app)
+        .get('/kagent/sessions/abc/tasks')
+        .query({ installation: 'gazelle' });
+
+      expect(response.status).toBe(401);
+      expect(listSessionTasks).not.toHaveBeenCalled();
+    });
+
+    it('reports a session with no tasks as an empty list, not an error', async () => {
+      // Go's `omitempty` drops a zero-length slice, so an untouched session comes
+      // back with no `data` key at all.
+      const body = {
+        error: false,
+        message: 'Successfully retrieved session tasks',
+      };
+      listSessionTasks.mockResolvedValue(body);
+
+      const response = await request(app)
+        .get('/kagent/sessions/abc/tasks')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(body);
+    });
+
+    it('reports an unreadable session as 404, not a 5xx', async () => {
+      const notFound = new Error('Session not found for given ID');
+      notFound.name = 'NotFoundError';
+      listSessionTasks.mockRejectedValue(notFound);
+
+      const response = await request(app)
+        .get('/kagent/sessions/abc/tasks')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(404);
     });
   });
 

--- a/plugins/agent-platform-backend/src/router.test.ts
+++ b/plugins/agent-platform-backend/src/router.test.ts
@@ -314,6 +314,39 @@ describe('createRouter', () => {
       });
     });
 
+    it('leaves the list route to handle a trailing slash', async () => {
+      // `:sessionId` cannot match an empty segment, so `/kagent/sessions/` reaches
+      // the list route. Pinned because the detail handler's id helper is written
+      // as a typing shim on that basis — it has no empty-id branch.
+      listSessions.mockResolvedValue({ error: false, data: [] });
+
+      const response = await request(app)
+        .get('/kagent/sessions/')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(200);
+      expect(listSessions).toHaveBeenCalledTimes(1);
+      expect(getSession).not.toHaveBeenCalled();
+    });
+
+    it('does not trim an id, so the id sent upstream is the id received', async () => {
+      // Trimming is a format assumption about a value documented as opaque. If
+      // kagent ever issues an id with surrounding whitespace, trimming it here
+      // would send a *different* id upstream and 404 in a way that looks exactly
+      // like a missing session.
+      getSession.mockResolvedValue(sessionBody);
+
+      await request(app)
+        .get('/kagent/sessions/%20abc%20')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(getSession).toHaveBeenCalledWith(' abc ', {
+        userToken: 'user-token',
+      });
+    });
+
     it('passes an id through decoded, whatever shape it has', async () => {
       // Both 64-char hex and UUIDs occur in real responses, so the router must not
       // validate a format — only that a segment is present.

--- a/plugins/agent-platform-backend/src/router.ts
+++ b/plugins/agent-platform-backend/src/router.ts
@@ -154,9 +154,52 @@ export async function createRouter(
     return token;
   };
 
+  /**
+   * Read the session id from the path.
+   *
+   * Session ids are **opaque**: real kagent responses mix 64-character hex
+   * strings and UUIDs, so nothing may validate a format. Express has already
+   * decoded the segment and cannot match across `/`, so "non-empty" is the only
+   * check left worth making.
+   */
+  const readSessionId = (req: express.Request): string => {
+    const raw = req.params.sessionId;
+    const sessionId = typeof raw === 'string' ? raw.trim() : '';
+    if (!sessionId) {
+      throw new InputError('A session id is required.');
+    }
+    return sessionId;
+  };
+
   router.get('/kagent/sessions', async (req, res) => {
     const { client } = resolveInstallation(req);
     const result = await client.listSessions({
+      userToken: readUserToken(req, { required: true }),
+    });
+    res.json(result);
+  });
+
+  /**
+   * One session's metadata and stored events. Express matches these paths
+   * exactly, so this and the list route above do not shadow each other.
+   *
+   * A session that belongs to someone else answers 404 exactly as a deleted one
+   * does — kagent scopes the lookup by user id. That is an expected outcome for a
+   * stale deep link, so it stays a 404 and never becomes a 5xx (which
+   * `MiddlewareFactory.error()` would forward to Sentry).
+   */
+  router.get('/kagent/sessions/:sessionId', async (req, res) => {
+    const { client } = resolveInstallation(req);
+    const result = await client.getSession(readSessionId(req), {
+      userToken: readUserToken(req, { required: true }),
+    });
+    res.json(result);
+  });
+
+  /** The session's A2A tasks — the conversation, its state and token usage. */
+  router.get('/kagent/sessions/:sessionId/tasks', async (req, res) => {
+    const { client } = resolveInstallation(req);
+    const result = await client.listSessionTasks(readSessionId(req), {
       userToken: readUserToken(req, { required: true }),
     });
     res.json(result);

--- a/plugins/agent-platform-backend/src/router.ts
+++ b/plugins/agent-platform-backend/src/router.ts
@@ -158,17 +158,19 @@ export async function createRouter(
    * Read the session id from the path.
    *
    * Session ids are **opaque**: real kagent responses mix 64-character hex
-   * strings and UUIDs, so nothing may validate a format. Express has already
-   * decoded the segment and cannot match across `/`, so "non-empty" is the only
-   * check left worth making.
+   * strings and UUIDs, so nothing here validates or normalizes one. In
+   * particular there is deliberately no `trim()` — Express hands us the decoded
+   * segment, so an id with surrounding whitespace would be trimmed here,
+   * re-encoded on the way out, and a *different* id sent upstream, producing a
+   * 404 indistinguishable from a missing session.
+   *
+   * This is purely a typing shim: `req.params` is loosely typed, but `:sessionId`
+   * cannot match an empty segment, so `/kagent/sessions/` reaches the list route
+   * above rather than arriving here empty (pinned by a test).
    */
   const readSessionId = (req: express.Request): string => {
     const raw = req.params.sessionId;
-    const sessionId = typeof raw === 'string' ? raw.trim() : '';
-    if (!sessionId) {
-      throw new InputError('A session id is required.');
-    }
-    return sessionId;
+    return typeof raw === 'string' ? raw : '';
   };
 
   router.get('/kagent/sessions', async (req, res) => {


### PR DESCRIPTION
### What does this PR do?

Adds the transport the upcoming Agent Platform **session detail page** needs. Two new proxy routes, both requiring `?installation=` and a forwarded user token, both passing kagent's JSON through verbatim like the existing ones:

| Route | Purpose |
| --- | --- |
| `GET /kagent/sessions/:id` | One session plus its stored events |
| `GET /kagent/sessions/:id/tasks` | The session's A2A tasks — conversation, state, token usage |

Nothing calls them yet; the frontend lands in follow-up PRs.

### What is the effect of this change to users?

None yet — no UI consumes these routes in this PR.

### Any background context you can provide?

Three decisions worth reviewing:

**1. The conversation comes from `…/tasks`, not from `…/sessions/:id`'s `events`.** This is what kagent's own UI renders from (`ui/src/components/chat/ChatInterface.tsx` → `extractMessagesFromTasks`), and the two payloads carry genuinely different things:

| | `events[]` | `Task[]` |
| --- | --- | --- |
| Message content | `data` is a JSON **string** holding an A2A message (doubly encoded) | `history` already structured |
| Session state | — | `status.state` |
| Token usage | — | per-message `{adk,kagent}_usage_metadata` |
| Per-item timestamp | `created_at` | only one per task |

So the frontend will fetch both: tasks for the timeline and state, events only to recover per-message timestamps — A2A messages carry none of their own. Hence two routes rather than one.

**2. No `A2A-Version` header is sent.** kagent's `NegotiateA2AWireVersion` treats a missing header as the legacy v0 wire on both v0.9.9 (our pin) and v0.10, which is the shape kagent's UI consumes and therefore the best-tested one. There's a test asserting the header stays absent so it isn't added casually; opting into the v1 wire should be a deliberate migration.

**3. Session ids stay opaque.** Real responses mix 64-character hex strings and UUIDs, so nothing validates a format — only that a path segment is present. Ids are `encodeURIComponent`-ed before interpolation, with a test that a `/` or `?` in an id can't retarget the request.

One consequence to be aware of: a session belonging to **another user** answers 404 exactly as a deleted one does, because kagent scopes the lookup by the token's user id. Both are expected outcomes for a stale deep link, so neither returns a 5xx — anything `>= 500` is logged at `error` by `MiddlewareFactory.error()` and forwarded to Sentry. Both cases are covered by tests asserting `< 500`.

Backend tests: 54 → 72.

### Do the docs need to be updated?

Yes, done in this PR — the plugin README gains the two routes, the events-vs-tasks comparison, the wire-version rationale, and the id-opacity note.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.