### PR TITLE
feat(flux-react): disable Suspend when spec.suspend is GitOps-managed

### DIFF
--- a/.changeset/flux-suspend-field-ownership.md
+++ b/.changeset/flux-suspend-field-ownership.md
@@ -1,0 +1,43 @@
+---
+'@giantswarm/backstage-plugin-kubernetes-react': minor
+'@giantswarm/backstage-plugin-flux-react': minor
+---
+
+Detect when a Flux resource's `spec.suspend` is under declarative management, and
+disable the Suspend/Resume toggle rather than offering a change that would be
+silently undone.
+
+- Server-side apply is field-level, so what matters is not whether a resource is
+  GitOps-managed but whether the _applied manifest asserts `spec.suspend`_. When it
+  does, the applying controller force-takes the field back on its next apply
+  (Flux's SSA always passes `ForceOwnership`) and an imperative suspend lasts only
+  until then. `FluxObject.isSuspendFieldManaged()` reads this off
+  `metadata.managedFields`, which the API already returns: any entry with
+  operation `Apply` that owns `f:spec.f:suspend`. The toggle is disabled with a
+  tooltip naming the owning manager(s).
+- Not restricted to `kustomize-controller`: a Flux object deployed by a
+  HelmRelease is applied by `helm-controller`, and a human
+  `kubectl apply --server-side` has the same effect. `Update`-operation owners are
+  ignored — they hold ownership but have no declared desired state to restore, so
+  they never revert anything. That includes our own merge patches.
+- **Reconcile is deliberately left enabled**, including on managed resources. The
+  `reconcile.fluxcd.io/requestedAt` annotation is never part of an applied
+  manifest, so no apply-owner asserts or prunes it, and the controller records the
+  value into `status.lastHandledReconcileAt` rather than clearing it. There is no
+  race to lose.
+- `kubernetes-react` gains a general `KubeObject.getApplyFieldOwners(path)` for
+  this, handling `fieldsV1`'s `f:`-prefixed encoding and atomic parent fields.
+- Writes now set `?fieldManager=giantswarm-backstage` explicitly
+  (`BACKSTAGE_FIELD_MANAGER`). The apiserver otherwise derives the manager name
+  from the request's User-Agent, which for a write proxied through the Backstage
+  backend is unpredictable and useless for auditing. A deliberate name makes our
+  changes attributable in `--show-managed-fields`, and gives operators a value for
+  a controller's `--override-manager`. We deliberately do not masquerade as
+  `flux`: nothing in Flux keys off that name — the CLI never sets a field manager
+  at all, and kustomize-controller's disallowed-manager list does not include it —
+  so impersonation would buy nothing and destroy attribution.
+- Corrects the `ImagePolicy` justification in the actionable-kinds list. The claim
+  that Flux offers neither operation for the kind was wrong: both `v1` and
+  `v1beta2` declare `spec.suspend` and `status.lastHandledReconcileAt`, and the
+  CLI covers it as well (`flux reconcile|suspend|resume image policy`). Including
+  the kind was right; the stated reason was not.

--- a/.changeset/flux-suspend-field-ownership.md
+++ b/.changeset/flux-suspend-field-ownership.md
@@ -15,11 +15,25 @@ silently undone.
   `metadata.managedFields`, which the API already returns: any entry with
   operation `Apply` that owns `f:spec.f:suspend`. The toggle is disabled with a
   tooltip naming the owning manager(s).
-- Not restricted to `kustomize-controller`: a Flux object deployed by a
-  HelmRelease is applied by `helm-controller`, and a human
-  `kubectl apply --server-side` has the same effect. `Update`-operation owners are
-  ignored — they hold ownership but have no declared desired state to restore, so
-  they never revert anything. That includes our own merge patches.
+- Not restricted to `kustomize-controller`: a human `kubectl apply --server-side`,
+  or helm-controller's drift correction when `spec.driftDetection` is enabled, has
+  the same effect.
+- Stale ownership is accounted for. A `managedFields` entry is only rewritten by a
+  write, so it outlives the applier: an object handed over for manual control with
+  `kustomize.toolkit.fluxcd.io/reconcile: disabled` or
+  `kustomize.toolkit.fluxcd.io/ssa: Ignore` keeps a stale `Apply` entry naming the
+  field, and `ssa: IfNotPresent` objects carry one from creation onwards despite
+  never being applied again. Those three annotations short-circuit the check, so
+  such objects keep a working toggle instead of a permanently disabled one.
+- **Detection is limited to SSA appliers**, and is a best-effort signal rather
+  than a guarantee. The two common non-SSA declarative writers are recorded as
+  `operation: Update` and so are not detected, even though both keep a stored
+  desired state and re-assert it: client-side `kubectl apply`
+  (`kubectl-client-side-apply`), and a plain `helm upgrade`, whose three-way merge
+  resets drift on chart-declared fields. A chart that ships a Kustomization with
+  `spec.suspend` declared will therefore still show an enabled toggle whose change
+  the next upgrade reverts. Documented on
+  `KubeObject.getApplyFieldOwners` rather than guessed at from manager names.
 - **Reconcile is deliberately left enabled**, including on managed resources. The
   `reconcile.fluxcd.io/requestedAt` annotation is never part of an applied
   manifest, so no apply-owner asserts or prunes it, and the controller records the

--- a/.changeset/flux-suspend-field-ownership.md
+++ b/.changeset/flux-suspend-field-ownership.md
@@ -14,7 +14,10 @@ silently undone.
   until then. `FluxObject.isSuspendFieldManaged()` reads this off
   `metadata.managedFields`, which the API already returns: any entry with
   operation `Apply` that owns `f:spec.f:suspend`. The toggle is disabled with a
-  tooltip naming the owning manager(s).
+  tooltip naming the owning manager(s) and pointing at the source that applies
+  the field — deliberately not "change it in Git", since the applier may equally
+  be a chart rendered by helm-controller or a human's
+  `kubectl apply --server-side`.
 - Not restricted to `kustomize-controller`: a human `kubectl apply --server-side`,
   or helm-controller's drift correction when `spec.driftDetection` is enabled, has
   the same effect.

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.test.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.test.tsx
@@ -409,7 +409,7 @@ describe('FluxResourceActions with a GitOps-managed spec.suspend', () => {
     // button receives no hover events.
     expect(
       screen.getByTitle(
-        'spec.suspend is applied by kustomize-controller, so a change made here would be reverted on the next reconciliation. Change it in Git instead.',
+        'spec.suspend is applied by kustomize-controller, so a change made here would be reverted on the next reconciliation. Change it at the source that applies it.',
       ),
     ).toBeInTheDocument();
   });
@@ -544,5 +544,65 @@ describe('FluxResourceActions disabled-button tooltips', () => {
     expect(
       screen.getByTitle(/applied by one, two and three,/),
     ).toBeInTheDocument();
+  });
+});
+
+describe('FluxResourceActions hint wording', () => {
+  it('does not send a suspended, managed resource to a disabled Resume button', async () => {
+    // Both buttons are disabled in this state, so Reconcile must not advise
+    // "Resume it first" — that would point at the control we just disabled.
+    await renderActions(
+      createKustomization({
+        suspend: true,
+        managedFields: [SUSPEND_APPLIED_BY_KUSTOMIZE_CONTROLLER],
+      }),
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Reconcile' }),
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeDisabled();
+
+    expect(
+      screen.getByTitle(
+        'Suspended resources are not reconciled, and spec.suspend is applied by kustomize-controller — resume it at the source that applies it.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTitle(/Resume it first/)).not.toBeInTheDocument();
+  });
+
+  it('still advises resuming first when the suspension is not managed', async () => {
+    await renderActions(createKustomization({ suspend: true }));
+
+    expect(await screen.findByRole('button', { name: 'Resume' })).toBeEnabled();
+    expect(
+      screen.getByTitle(
+        'Suspended resources are not reconciled. Resume it first.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('avoids Git-specific advice, since the applier need not be a repository', async () => {
+    // helm-controller drift correction and `kubectl apply --server-side` both
+    // count as appliers, so "change it in Git" would be wrong for them.
+    await renderActions(
+      createKustomization({
+        managedFields: [
+          {
+            manager: 'helm-controller',
+            operation: 'Apply',
+            fieldsV1: { 'f:spec': { 'f:suspend': {} } },
+          },
+        ],
+      }),
+    );
+
+    await screen.findByRole('button', { name: 'Suspend' });
+    expect(
+      screen.getByTitle(
+        /applied by helm-controller.*source that applies it\.$/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTitle(/in Git/)).not.toBeInTheDocument();
   });
 });

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.test.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.test.tsx
@@ -14,11 +14,19 @@ import { FluxResourceActions } from './FluxResourceActions';
 
 const SSAR_PATH = '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews';
 
+/** A managedFields entry showing `spec.suspend` under declarative management. */
+const SUSPEND_APPLIED_BY_KUSTOMIZE_CONTROLLER = {
+  manager: 'kustomize-controller',
+  operation: 'Apply',
+  fieldsV1: { 'f:spec': { 'f:suspend': {} } },
+};
+
 function createKustomization(
   options: {
     suspend?: boolean;
     requestedAt?: string;
     lastHandledReconcileAt?: string;
+    managedFields?: unknown[];
   } = {},
 ): Kustomization {
   const json = {
@@ -27,6 +35,7 @@ function createKustomization(
     metadata: {
       name: 'my-app',
       namespace: 'flux-system',
+      managedFields: options.managedFields,
       annotations: options.requestedAt
         ? { 'reconcile.fluxcd.io/requestedAt': options.requestedAt }
         : undefined,
@@ -232,7 +241,7 @@ describe('FluxResourceActions', () => {
         ([args]: [ProxyArgs]) => args.init?.method === 'PATCH',
       )![0].path,
     ).toBe(
-      '/apis/image.toolkit.fluxcd.io/v1beta2/namespaces/flux-system/imagepolicies/my-policy',
+      '/apis/image.toolkit.fluxcd.io/v1beta2/namespaces/flux-system/imagepolicies/my-policy?fieldManager=giantswarm-backstage',
     );
   });
 
@@ -382,5 +391,90 @@ describe('FluxResourceActions', () => {
           'You are not allowed to suspend Kustomization flux-system/my-app on cluster test-installation.',
       }),
     );
+  });
+});
+
+describe('FluxResourceActions with a GitOps-managed spec.suspend', () => {
+  it('disables the suspend toggle and explains why', async () => {
+    await renderActions(
+      createKustomization({
+        managedFields: [SUSPEND_APPLIED_BY_KUSTOMIZE_CONTROLLER],
+      }),
+    );
+
+    const toggle = await screen.findByRole('button', { name: 'Suspend' });
+    expect(toggle).toBeDisabled();
+
+    // The explanation lives on a wrapping span, since a disabled react-aria
+    // button receives no hover events.
+    expect(
+      screen.getByTitle(
+        'spec.suspend is applied by kustomize-controller, so a change made here would be reverted on the next reconciliation. Change it in Git instead.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('disables Resume too, for an already-suspended managed resource', async () => {
+    await renderActions(
+      createKustomization({
+        suspend: true,
+        managedFields: [SUSPEND_APPLIED_BY_KUSTOMIZE_CONTROLLER],
+      }),
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Resume' }),
+    ).toBeDisabled();
+  });
+
+  it('leaves Reconcile enabled — the annotation is never apply-owned', async () => {
+    await renderActions(
+      createKustomization({
+        managedFields: [SUSPEND_APPLIED_BY_KUSTOMIZE_CONTROLLER],
+      }),
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Reconcile' }),
+    ).toBeEnabled();
+  });
+
+  it('names every apply-owner in the explanation', async () => {
+    await renderActions(
+      createKustomization({
+        managedFields: [
+          SUSPEND_APPLIED_BY_KUSTOMIZE_CONTROLLER,
+          {
+            manager: 'helm-controller',
+            operation: 'Apply',
+            fieldsV1: { 'f:spec': { 'f:suspend': {} } },
+          },
+        ],
+      }),
+    );
+
+    await screen.findByRole('button', { name: 'Suspend' });
+    expect(
+      screen.getByTitle(/kustomize-controller and helm-controller/),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the toggle enabled when only an imperative writer owns the field', async () => {
+    // Our own merge patches land as operation Update — they must not lock us out.
+    await renderActions(
+      createKustomization({
+        managedFields: [
+          {
+            manager: 'giantswarm-backstage',
+            operation: 'Update',
+            fieldsV1: { 'f:spec': { 'f:suspend': {} } },
+          },
+        ],
+      }),
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Suspend' }),
+    ).toBeEnabled();
   });
 });

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.test.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.test.tsx
@@ -204,7 +204,7 @@ describe('FluxResourceActions', () => {
 
   it('offers both actions for an ImagePolicy', async () => {
     // image-reflector-controller honours the reconcile-request annotation and
-    // `spec.suspend` for ImagePolicy; only the `flux` CLI lacks a subcommand.
+    // `spec.suspend` for ImagePolicy, and the CLI covers the kind too.
     const { kubernetesApi } = await renderActions(createImagePolicy());
 
     expect(
@@ -476,5 +476,73 @@ describe('FluxResourceActions with a GitOps-managed spec.suspend', () => {
     expect(
       await screen.findByRole('button', { name: 'Suspend' }),
     ).toBeEnabled();
+  });
+});
+
+describe('FluxResourceActions disabled-button tooltips', () => {
+  it('opens the real tooltip on hover, not just the native title', async () => {
+    // bui's disabled styling sets only `cursor: not-allowed`, so without an
+    // explicit `pointer-events: none` the disabled <button> swallows the hover and
+    // MUI's handler on the wrapping span never fires — leaving only the native
+    // `title` attribute, which is what MUI renders while closed.
+    //
+    // The `toHaveStyle` assertion below is the actual regression guard. jsdom
+    // cannot model pointer-events retargeting, and `userEvent.hover(span)`
+    // dispatches straight at the span, so the hover assertions pass with or
+    // without the fix; they only prove the tooltip is wired up at all.
+    await renderActions(
+      createKustomization({
+        managedFields: [SUSPEND_APPLIED_BY_KUSTOMIZE_CONTROLLER],
+      }),
+    );
+
+    const toggle = await screen.findByRole('button', { name: 'Suspend' });
+    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveStyle({ pointerEvents: 'none' });
+
+    await userEvent.hover(toggle.parentElement!);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(
+      /spec\.suspend is applied by kustomize-controller/,
+    );
+  });
+
+  it('leaves an enabled button clickable, with no pointer-events override', async () => {
+    await renderActions(createKustomization());
+
+    const toggle = await screen.findByRole('button', { name: 'Suspend' });
+    expect(toggle).toBeEnabled();
+    expect(toggle).not.toHaveStyle({ pointerEvents: 'none' });
+  });
+
+  it('opens the tooltip for a disabled Reconcile button too', async () => {
+    await renderActions(createKustomization({ suspend: true }));
+
+    const reconcile = await screen.findByRole('button', { name: 'Reconcile' });
+    expect(reconcile).toBeDisabled();
+
+    await userEvent.hover(reconcile.parentElement!);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      /Suspended resources are not reconciled/,
+    );
+  });
+
+  it('joins three owners with commas and a final and', async () => {
+    await renderActions(
+      createKustomization({
+        managedFields: ['one', 'two', 'three'].map(manager => ({
+          manager,
+          operation: 'Apply',
+          fieldsV1: { 'f:spec': { 'f:suspend': {} } },
+        })),
+      }),
+    );
+
+    await screen.findByRole('button', { name: 'Suspend' });
+    expect(
+      screen.getByTitle(/applied by one, two and three,/),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.tsx
@@ -24,6 +24,12 @@ function describe(resource: FluxObject): string {
   return `${resource.getKind()} ${namespace ? `${namespace}/` : ''}${name}`;
 }
 
+function buildManagedSuspendHint(owners: string[]): string {
+  const by = owners.length === 1 ? owners[0] : owners.join(' and ');
+
+  return `spec.suspend is applied by ${by}, so a change made here would be reverted on the next reconciliation. Change it in Git instead.`;
+}
+
 const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
   const alertApi = useApi(alertApiRef);
   const {
@@ -50,6 +56,16 @@ const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
   } else if (isReconcileRequestPending) {
     reconcileHint = REQUEST_PENDING_HINT;
   }
+
+  // Reconcile is deliberately *not* gated on declarative management: the
+  // `reconcile.fluxcd.io/requestedAt` annotation is never part of an applied
+  // manifest, so no apply-owner ever asserts or prunes it. Only `spec.suspend`
+  // can be contested.
+  const suspendFieldApplyOwners = resource.getSuspendFieldApplyOwners();
+  const isSuspendFieldManaged = suspendFieldApplyOwners.length > 0;
+  const suspendHint = isSuspendFieldManaged
+    ? buildManagedSuspendHint(suspendFieldApplyOwners)
+    : '';
 
   const notifyFailure = (error: unknown, action: string) => {
     const forbidden = error instanceof Error && error.name === 'ForbiddenError';
@@ -127,21 +143,26 @@ const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
             </Button>
           </span>
         </Tooltip>
-        <Button
-          variant="secondary"
-          size="small"
-          iconStart={
-            isSuspended ? (
-              <PlayArrowIcon fontSize="small" />
-            ) : (
-              <PauseIcon fontSize="small" />
-            )
-          }
-          isPending={isSettingSuspended}
-          onPress={handleToggleSuspended}
-        >
-          {isSuspended ? 'Resume' : 'Suspend'}
-        </Button>
+        <Tooltip title={suspendHint}>
+          <span>
+            <Button
+              variant="secondary"
+              size="small"
+              iconStart={
+                isSuspended ? (
+                  <PlayArrowIcon fontSize="small" />
+                ) : (
+                  <PauseIcon fontSize="small" />
+                )
+              }
+              isDisabled={isSuspendFieldManaged}
+              isPending={isSettingSuspended}
+              onPress={handleToggleSuspended}
+            >
+              {isSuspended ? 'Resume' : 'Suspend'}
+            </Button>
+          </span>
+        </Tooltip>
       </Flex>
     </Box>
   );

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.tsx
@@ -32,10 +32,27 @@ function joinWithAnd(items: string[]): string {
   return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
 }
 
+/**
+ * Deliberately says "at the source that applies it" rather than "in Git": the
+ * ownership check is not Git-specific, so the applier may be a chart rendered by
+ * helm-controller or a human's `kubectl apply --server-side` just as easily as a
+ * Kustomization built from a repository.
+ */
 function buildManagedSuspendHint(owners: string[]): string {
   return `spec.suspend is applied by ${joinWithAnd(
     owners,
-  )}, so a change made here would be reverted on the next reconciliation. Change it in Git instead.`;
+  )}, so a change made here would be reverted on the next reconciliation. Change it at the source that applies it.`;
+}
+
+/**
+ * Reconcile's hint when the resource is suspended *and* its suspension is
+ * declaratively managed. Plain {@link SUSPENDED_HINT} would say "Resume it first",
+ * which is a dead end here — we have just disabled Resume for the same reason.
+ */
+function buildManagedSuspendedReconcileHint(owners: string[]): string {
+  return `Suspended resources are not reconciled, and spec.suspend is applied by ${joinWithAnd(
+    owners,
+  )} — resume it at the source that applies it.`;
 }
 
 /**
@@ -69,19 +86,23 @@ const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
 
   const isReconcileDisabled = isSuspended || isReconcileRequestPending;
 
-  let reconcileHint = '';
-  if (isSuspended) {
-    reconcileHint = SUSPENDED_HINT;
-  } else if (isReconcileRequestPending) {
-    reconcileHint = REQUEST_PENDING_HINT;
-  }
-
   // Reconcile is deliberately *not* gated on declarative management: the
   // `reconcile.fluxcd.io/requestedAt` annotation is never part of an applied
   // manifest, so no apply-owner ever asserts or prunes it. Only `spec.suspend`
   // can be contested.
   const suspendFieldApplyOwners = resource.getSuspendFieldApplyOwners();
   const isSuspendFieldManaged = suspendFieldApplyOwners.length > 0;
+
+  let reconcileHint = '';
+  if (isSuspended && isSuspendFieldManaged) {
+    // Must precede the plain suspended case: telling someone to resume first
+    // would be a dead end when Resume is disabled for being managed.
+    reconcileHint = buildManagedSuspendedReconcileHint(suspendFieldApplyOwners);
+  } else if (isSuspended) {
+    reconcileHint = SUSPENDED_HINT;
+  } else if (isReconcileRequestPending) {
+    reconcileHint = REQUEST_PENDING_HINT;
+  }
   const suspendHint = isSuspendFieldManaged
     ? buildManagedSuspendHint(suspendFieldApplyOwners)
     : '';

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/FluxResourceActions/FluxResourceActions.tsx
@@ -24,11 +24,28 @@ function describe(resource: FluxObject): string {
   return `${resource.getKind()} ${namespace ? `${namespace}/` : ''}${name}`;
 }
 
-function buildManagedSuspendHint(owners: string[]): string {
-  const by = owners.length === 1 ? owners[0] : owners.join(' and ');
+function joinWithAnd(items: string[]): string {
+  if (items.length < 2) {
+    return items.join('');
+  }
 
-  return `spec.suspend is applied by ${by}, so a change made here would be reverted on the next reconciliation. Change it in Git instead.`;
+  return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
 }
+
+function buildManagedSuspendHint(owners: string[]): string {
+  return `spec.suspend is applied by ${joinWithAnd(
+    owners,
+  )}, so a change made here would be reverted on the next reconciliation. Change it in Git instead.`;
+}
+
+/**
+ * A disabled react-aria button still receives pointer events — bui's disabled
+ * styling only sets `cursor: not-allowed` — so the native `<button>` swallows the
+ * hover and the tooltip on the wrapping span never opens. MUI's own
+ * wrap-in-a-span recipe works only because its `ButtonBase` sets
+ * `pointer-events: none` when disabled; this restores that half of it.
+ */
+const DISABLED_BUTTON_STYLE = { pointerEvents: 'none' } as const;
 
 const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
   const alertApi = useApi(alertApiRef);
@@ -49,6 +66,8 @@ const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
   // the resource's own annotation-vs-status comparison covers the gap after it,
   // and survives a reload or a request someone else made.
   const isReconcileRequestPending = resource.isReconcileRequestPending();
+
+  const isReconcileDisabled = isSuspended || isReconcileRequestPending;
 
   let reconcileHint = '';
   if (isSuspended) {
@@ -135,7 +154,8 @@ const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
               variant="secondary"
               size="small"
               iconStart={<RefreshIcon fontSize="small" />}
-              isDisabled={isSuspended || isReconcileRequestPending}
+              isDisabled={isReconcileDisabled}
+              style={isReconcileDisabled ? DISABLED_BUTTON_STYLE : undefined}
               isPending={isRequestingReconciliation}
               onPress={handleReconcile}
             >
@@ -156,6 +176,7 @@ const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
                 )
               }
               isDisabled={isSuspendFieldManaged}
+              style={isSuspendFieldManaged ? DISABLED_BUTTON_STYLE : undefined}
               isPending={isSettingSuspended}
               onPress={handleToggleSuspended}
             >
@@ -173,8 +194,8 @@ const FluxResourceActionsContent = ({ resource }: { resource: FluxObject }) => {
  * them, shown only to users whose cluster RBAC allows the write.
  */
 export const FluxResourceActions = ({ resource }: { resource: KubeObject }) => {
-  // Guard before the inner component mounts so unsupported kinds (e.g.
-  // ImagePolicy) issue no access review at all.
+  // Guard before the inner component mounts so unsupported kinds (e.g. a
+  // ConfigMap, or any non-Flux object) issue no access review at all.
   if (!supportsFluxActions(resource)) {
     return null;
   }

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/fluxActions.ts
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/fluxActions.ts
@@ -13,10 +13,12 @@ import {
  * resource class that lacks the fields does not silently get buttons that
  * cannot work.
  *
- * Note this is deliberately *not* the same set as the `flux` CLI's reconcile
- * subcommands: there is no `flux reconcile image policy`, but
- * image-reflector-controller does honour the annotation and `spec.suspend` for
- * ImagePolicy, so the UI can offer both.
+ * `ImagePolicy` belongs here like the rest: `crds.fluxcd.v1.ImagePolicy` and
+ * `v1beta2` both declare `spec.suspend` and `status.lastHandledReconcileAt`, and
+ * the CLI covers it too (`flux reconcile|suspend|resume image policy`, see
+ * `cmd/flux/reconcile_image_policy.go` and siblings in fluxcd/flux2). It was
+ * originally left out of this list on the mistaken grounds that Flux supported
+ * neither operation for the kind.
  */
 const ACTIONABLE_KINDS = [
   'Kustomization',

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/fluxActions.ts
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/fluxActions.ts
@@ -16,9 +16,9 @@ import {
  * `ImagePolicy` belongs here like the rest: `crds.fluxcd.v1.ImagePolicy` and
  * `v1beta2` both declare `spec.suspend` and `status.lastHandledReconcileAt`, and
  * the CLI covers it too (`flux reconcile|suspend|resume image policy`, see
- * `cmd/flux/reconcile_image_policy.go` and siblings in fluxcd/flux2). It was
- * originally left out of this list on the mistaken grounds that Flux supported
- * neither operation for the kind.
+ * `cmd/flux/reconcile_image_policy.go` and siblings in fluxcd/flux2). The reason
+ * previously given here — that Flux supported neither operation for the kind —
+ * was wrong.
  */
 const ACTIONABLE_KINDS = [
   'Kustomization',

--- a/plugins/kubernetes-react/src/hooks/useFluxResourceActions/useFluxResourceActions.test.tsx
+++ b/plugins/kubernetes-react/src/hooks/useFluxResourceActions/useFluxResourceActions.test.tsx
@@ -9,7 +9,7 @@ import { useFluxResourceActions } from './useFluxResourceActions';
 
 const SSAR_PATH = '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews';
 const KUSTOMIZATION_PATH =
-  '/apis/kustomize.toolkit.fluxcd.io/v1/namespaces/flux-system/kustomizations/my-app';
+  '/apis/kustomize.toolkit.fluxcd.io/v1/namespaces/flux-system/kustomizations/my-app?fieldManager=giantswarm-backstage';
 
 function createKustomization(
   options: { suspend?: boolean; apiVersion?: string } = {},
@@ -177,7 +177,7 @@ describe('useFluxResourceActions', () => {
     await result.current.setSuspended(true);
 
     expect(findPatchCall(api)!.path).toBe(
-      '/apis/kustomize.toolkit.fluxcd.io/v1beta2/namespaces/flux-system/kustomizations/my-app',
+      '/apis/kustomize.toolkit.fluxcd.io/v1beta2/namespaces/flux-system/kustomizations/my-app?fieldManager=giantswarm-backstage',
     );
   });
 

--- a/plugins/kubernetes-react/src/hooks/utils/patchResource.test.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/patchResource.test.ts
@@ -1,6 +1,6 @@
 import { KubernetesApi } from '@backstage/plugin-kubernetes-react';
 import { CustomResourceMatcher } from '../../lib/k8s/CustomResourceMatcher';
-import { patchResource } from './patchResource';
+import { BACKSTAGE_FIELD_MANAGER, patchResource } from './patchResource';
 
 const gvk: CustomResourceMatcher = {
   group: 'kustomize.toolkit.fluxcd.io',
@@ -39,7 +39,7 @@ describe('patchResource', () => {
       clusterName: 'test-installation',
       // No trailing slash: `getK8sGetPath` appends one, which we do not want to
       // rely on the apiserver tolerating for a mutating verb.
-      path: '/apis/kustomize.toolkit.fluxcd.io/v1/namespaces/flux-system/kustomizations/my-app',
+      path: '/apis/kustomize.toolkit.fluxcd.io/v1/namespaces/flux-system/kustomizations/my-app?fieldManager=giantswarm-backstage',
       init: {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/merge-patch+json' },
@@ -82,7 +82,7 @@ describe('patchResource', () => {
     });
 
     expect(proxy.mock.calls[0][0].path).toBe(
-      '/apis/kustomize.toolkit.fluxcd.io/v1/kustomizations/my-app',
+      '/apis/kustomize.toolkit.fluxcd.io/v1/kustomizations/my-app?fieldManager=giantswarm-backstage',
     );
   });
 
@@ -148,5 +148,21 @@ describe('patchResource', () => {
         patch: {},
       }),
     ).rejects.toThrow(/Internal Server Error/);
+  });
+});
+
+describe('BACKSTAGE_FIELD_MANAGER', () => {
+  it('is an honest, attributable name rather than an impersonation of flux', () => {
+    // The apiserver would otherwise derive the manager from the proxied
+    // request's User-Agent. Masquerading as `flux` would buy nothing — nothing in
+    // Flux keys off that name — and would destroy attribution.
+    expect(BACKSTAGE_FIELD_MANAGER).toBe('giantswarm-backstage');
+    expect(BACKSTAGE_FIELD_MANAGER).not.toBe('flux');
+  });
+
+  it('needs no escaping in a query string', () => {
+    expect(encodeURIComponent(BACKSTAGE_FIELD_MANAGER)).toBe(
+      BACKSTAGE_FIELD_MANAGER,
+    );
   });
 });

--- a/plugins/kubernetes-react/src/hooks/utils/patchResource.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/patchResource.ts
@@ -3,6 +3,23 @@ import { CustomResourceMatcher } from '../../lib/k8s/CustomResourceMatcher';
 import { getK8sGetPath } from './k8sPath';
 
 /**
+ * The `metadata.managedFields` manager name recorded for writes made from here.
+ *
+ * Set explicitly because the apiserver otherwise derives the manager from the
+ * request's User-Agent — which, for a write proxied through the Backstage
+ * backend, is both unpredictable and useless in an audit trail. A deliberate name
+ * makes our writes attributable in `kubectl get ... --show-managed-fields`, and
+ * gives cluster operators a value they can pass to a controller's
+ * `--override-manager` if they want these changes force-reverted.
+ *
+ * Note we deliberately do *not* masquerade as `flux`. Nothing in Flux keys off
+ * that name — the CLI never sets a field manager at all, and
+ * kustomize-controller's disallowed-manager list does not mention it — so
+ * impersonating it would buy nothing and destroy attribution.
+ */
+export const BACKSTAGE_FIELD_MANAGER = 'giantswarm-backstage';
+
+/**
  * Reads succeed with the trailing slash `k8sUrl.create` appends, but we do not
  * want to rely on the apiserver tolerating it for a mutating verb.
  */
@@ -41,7 +58,9 @@ export async function patchResource(options: {
   patch: object;
 }): Promise<void> {
   const { kubernetesApi, cluster, gvk, name, namespace, patch } = options;
-  const path = stripTrailingSlash(getK8sGetPath(gvk, name, namespace));
+  const path = `${stripTrailingSlash(
+    getK8sGetPath(gvk, name, namespace),
+  )}?fieldManager=${encodeURIComponent(BACKSTAGE_FIELD_MANAGER)}`;
 
   const response = await kubernetesApi.proxy({
     clusterName: cluster,

--- a/plugins/kubernetes-react/src/lib/k8s/FluxObject.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/FluxObject.test.ts
@@ -149,3 +149,59 @@ describe('FluxObject suspend field ownership', () => {
     expect(resource.isSuspendFieldManaged()).toBe(false);
   });
 });
+
+describe('FluxObject suspend ownership and apply opt-outs', () => {
+  const suspendFields = { 'f:spec': { 'f:suspend': {} } };
+  const applyEntry = {
+    manager: 'kustomize-controller',
+    operation: 'Apply',
+    fieldsV1: suspendFields,
+  };
+
+  function withAnnotations(annotations: Record<string, string>): Kustomization {
+    return new Kustomization(
+      {
+        apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+        kind: 'Kustomization',
+        metadata: {
+          name: 'my-app',
+          namespace: 'flux-system',
+          annotations,
+          managedFields: [applyEntry],
+        },
+        spec: {},
+        status: {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      'test-installation',
+    );
+  }
+
+  // A managedFields entry is only rewritten by a write, so it outlives the
+  // applier — an object handed over for manual control keeps a stale Apply entry.
+  it.each([
+    ['kustomize.toolkit.fluxcd.io/reconcile', 'disabled'],
+    ['kustomize.toolkit.fluxcd.io/ssa', 'Ignore'],
+    ['kustomize.toolkit.fluxcd.io/ssa', 'IfNotPresent'],
+  ])('ignores a stale Apply entry when %s is %s', (annotation, value) => {
+    const resource = withAnnotations({ [annotation]: value });
+
+    expect(resource.getSuspendFieldApplyOwners()).toEqual([]);
+    expect(resource.isSuspendFieldManaged()).toBe(false);
+  });
+
+  it('still reports ownership for an unrelated annotation value', () => {
+    const resource = withAnnotations({
+      'kustomize.toolkit.fluxcd.io/ssa': 'Merge',
+      'kustomize.toolkit.fluxcd.io/reconcile': 'enabled',
+    });
+
+    expect(resource.isSuspendFieldManaged()).toBe(true);
+  });
+
+  it('still reports ownership when there are no annotations at all', () => {
+    const resource = withAnnotations({});
+
+    expect(resource.isSuspendFieldManaged()).toBe(true);
+  });
+});

--- a/plugins/kubernetes-react/src/lib/k8s/FluxObject.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/FluxObject.test.ts
@@ -77,3 +77,75 @@ describe('FluxObject.isReconcileRequestPending', () => {
     );
   });
 });
+
+describe('FluxObject suspend field ownership', () => {
+  function withManagedFields(managedFields: unknown[]): Kustomization {
+    return new Kustomization(
+      {
+        apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+        kind: 'Kustomization',
+        metadata: { name: 'my-app', namespace: 'flux-system', managedFields },
+        spec: {},
+        status: {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      'test-installation',
+    );
+  }
+
+  const suspendFields = { 'f:spec': { 'f:suspend': {} } };
+
+  it('is unmanaged when nothing applies spec.suspend', () => {
+    const resource = withManagedFields([
+      {
+        manager: 'kustomize-controller',
+        operation: 'Apply',
+        fieldsV1: { 'f:spec': { 'f:interval': {}, 'f:path': {} } },
+      },
+    ]);
+
+    expect(resource.getSuspendFieldApplyOwners()).toEqual([]);
+    expect(resource.isSuspendFieldManaged()).toBe(false);
+  });
+
+  it('is managed when kustomize-controller applies spec.suspend', () => {
+    const resource = withManagedFields([
+      {
+        manager: 'kustomize-controller',
+        operation: 'Apply',
+        fieldsV1: suspendFields,
+      },
+    ]);
+
+    expect(resource.getSuspendFieldApplyOwners()).toEqual([
+      'kustomize-controller',
+    ]);
+    expect(resource.isSuspendFieldManaged()).toBe(true);
+  });
+
+  it('is managed for any apply-owner, not just kustomize-controller', () => {
+    // A Flux object deployed by a HelmRelease is applied by helm-controller, and
+    // a human `kubectl apply --server-side` has the same effect.
+    const resource = withManagedFields([
+      {
+        manager: 'helm-controller',
+        operation: 'Apply',
+        fieldsV1: suspendFields,
+      },
+    ]);
+
+    expect(resource.isSuspendFieldManaged()).toBe(true);
+  });
+
+  it('is unmanaged when only an imperative writer owns the field', () => {
+    const resource = withManagedFields([
+      {
+        manager: 'giantswarm-backstage',
+        operation: 'Update',
+        fieldsV1: suspendFields,
+      },
+    ]);
+
+    expect(resource.isSuspendFieldManaged()).toBe(false);
+  });
+});

--- a/plugins/kubernetes-react/src/lib/k8s/FluxObject.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/FluxObject.ts
@@ -63,6 +63,37 @@ export class FluxObject<
     return Boolean(this.jsonData.spec?.suspend);
   }
 
+  /**
+   * The managers that server-side apply `spec.suspend`, if any.
+   *
+   * When this is non-empty the field is under declarative management — typically
+   * `kustomize-controller`, when the object itself is deployed from Git by a
+   * parent Kustomization whose manifest asserts `spec.suspend`. Flux's SSA always
+   * applies with `ForceOwnership`, so that manager silently takes the field back
+   * on its next apply and an imperative suspend/resume is undone within one of
+   * *its* intervals (not this object's).
+   *
+   * Note the button a suspend toggle offers always flips away from the current
+   * value, and the current value is what the apply-owner last asserted — so
+   * whenever this is non-empty, the offered action is precisely the one that
+   * would be reverted.
+   *
+   * Deliberately not restricted to `kustomize-controller`: a HelmRelease-deployed
+   * Flux object is applied by `helm-controller`, and a `kubectl apply
+   * --server-side` by a human has the same effect. Any apply-owner will revert us.
+   */
+  getSuspendFieldApplyOwners(): string[] {
+    return this.getApplyFieldOwners(['spec', 'suspend']);
+  }
+
+  /**
+   * Whether `spec.suspend` is declaratively managed, and so cannot be changed
+   * durably from here. See {@link getSuspendFieldApplyOwners}.
+   */
+  isSuspendFieldManaged(): boolean {
+    return this.getSuspendFieldApplyOwners().length > 0;
+  }
+
   getReconcileRequestedAt(): string | undefined {
     return this.getAnnotations()?.[RECONCILE_REQUESTED_AT_ANNOTATION];
   }

--- a/plugins/kubernetes-react/src/lib/k8s/FluxObject.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/FluxObject.ts
@@ -28,6 +28,20 @@ interface FluxObjectInterface extends KubeObjectInterface {
 export const RECONCILE_REQUESTED_AT_ANNOTATION =
   'reconcile.fluxcd.io/requestedAt';
 
+/**
+ * Annotations with which a Kustomization's *own* manifest opts an object out of
+ * being applied, handing it over for manual control.
+ *
+ * Values from `kustomizev1` in fluxcd/kustomize-controller: `reconcile: disabled`
+ * and `ssa: Ignore` exclude the object from apply entirely, and
+ * `ssa: IfNotPresent` applies it on create only and never again.
+ */
+const APPLY_OPT_OUT_ANNOTATIONS: Array<[annotation: string, value: string]> = [
+  ['kustomize.toolkit.fluxcd.io/reconcile', 'disabled'],
+  ['kustomize.toolkit.fluxcd.io/ssa', 'Ignore'],
+  ['kustomize.toolkit.fluxcd.io/ssa', 'IfNotPresent'],
+];
+
 export class FluxObject<
   T extends FluxObjectInterface = any,
 > extends KubeObject<T> {
@@ -78,11 +92,32 @@ export class FluxObject<
    * whenever this is non-empty, the offered action is precisely the one that
    * would be reverted.
    *
-   * Deliberately not restricted to `kustomize-controller`: a HelmRelease-deployed
-   * Flux object is applied by `helm-controller`, and a `kubectl apply
-   * --server-side` by a human has the same effect. Any apply-owner will revert us.
+   * Deliberately not restricted to `kustomize-controller`: a `kubectl apply
+   * --server-side` by a human, or helm-controller's drift correction when
+   * `spec.driftDetection` is enabled, has the same effect. Any SSA applier of the
+   * field will revert us.
+   *
+   * Returns nothing when the object opts out of being applied (see
+   * {@link APPLY_OPT_OUT_ANNOTATIONS}). A `managedFields` entry is only ever
+   * rewritten by a write, so it outlives the applier: an object handed over for
+   * manual control keeps a stale `Apply` entry naming the field, and
+   * `ssa: IfNotPresent` objects carry one from creation onwards despite never
+   * being applied again. Without this check both would look managed forever.
+   *
+   * Inherits the SSA-only limitation of {@link KubeObject.getApplyFieldOwners} —
+   * a client-side `kubectl apply` or a plain `helm upgrade` that declares
+   * `spec.suspend` will still revert us without being detected here.
    */
   getSuspendFieldApplyOwners(): string[] {
+    const annotations = this.getAnnotations() ?? {};
+    const optedOut = APPLY_OPT_OUT_ANNOTATIONS.some(
+      ([annotation, value]) => annotations[annotation] === value,
+    );
+
+    if (optedOut) {
+      return [];
+    }
+
     return this.getApplyFieldOwners(['spec', 'suspend']);
   }
 

--- a/plugins/kubernetes-react/src/lib/k8s/KubeObject.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/KubeObject.test.ts
@@ -91,3 +91,115 @@ describe('KubeObject.getResolvedGVK', () => {
     ]);
   });
 });
+
+describe('KubeObject.getApplyFieldOwners', () => {
+  function withManagedFields(
+    managedFields: unknown[] | undefined,
+  ): Kustomization {
+    return new Kustomization(
+      {
+        apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+        kind: 'Kustomization',
+        metadata: { name: 'my-app', namespace: 'flux-system', managedFields },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      'test-installation',
+    );
+  }
+
+  const suspendFields = { 'f:spec': { 'f:suspend': {} } };
+
+  it('returns nothing when the object has no managed fields', () => {
+    expect(
+      withManagedFields(undefined).getApplyFieldOwners(['spec', 'suspend']),
+    ).toEqual([]);
+  });
+
+  it('reports an Apply-operation owner of the field', () => {
+    const resource = withManagedFields([
+      {
+        manager: 'kustomize-controller',
+        operation: 'Apply',
+        fieldsV1: suspendFields,
+      },
+    ]);
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([
+      'kustomize-controller',
+    ]);
+  });
+
+  it('ignores Update-operation owners, which never re-assert', () => {
+    // This is what our own merge patches are recorded as: ownership without a
+    // declared desired state, so nothing to revert to.
+    const resource = withManagedFields([
+      {
+        manager: 'giantswarm-backstage',
+        operation: 'Update',
+        fieldsV1: suspendFields,
+      },
+    ]);
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([]);
+  });
+
+  it('ignores an Apply owner of a different field', () => {
+    const resource = withManagedFields([
+      {
+        manager: 'kustomize-controller',
+        operation: 'Apply',
+        fieldsV1: { 'f:spec': { 'f:interval': {} } },
+      },
+    ]);
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([]);
+  });
+
+  it('reports every Apply owner of the field', () => {
+    const resource = withManagedFields([
+      {
+        manager: 'kustomize-controller',
+        operation: 'Apply',
+        fieldsV1: suspendFields,
+      },
+      { manager: 'someone-else', operation: 'Apply', fieldsV1: suspendFields },
+      {
+        manager: 'kubectl',
+        operation: 'Update',
+        fieldsV1: suspendFields,
+      },
+    ]);
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([
+      'kustomize-controller',
+      'someone-else',
+    ]);
+  });
+
+  it('treats an atomic parent field as owning the whole subtree', () => {
+    // `f:spec: {}` — the manager owns spec wholesale, suspend included.
+    const resource = withManagedFields([
+      { manager: 'owner', operation: 'Apply', fieldsV1: { 'f:spec': {} } },
+    ]);
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([
+      'owner',
+    ]);
+  });
+
+  it('does not treat an empty field set as owning everything', () => {
+    const resource = withManagedFields([
+      { manager: 'owner', operation: 'Apply', fieldsV1: {} },
+    ]);
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([]);
+  });
+
+  it('skips entries with no manager name', () => {
+    const resource = withManagedFields([
+      { operation: 'Apply', fieldsV1: suspendFields },
+    ]);
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([]);
+  });
+});

--- a/plugins/kubernetes-react/src/lib/k8s/KubeObject.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/KubeObject.test.ts
@@ -203,3 +203,41 @@ describe('KubeObject.getApplyFieldOwners', () => {
     expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([]);
   });
 });
+
+describe('KubeObject.getApplyFieldOwners deduplication', () => {
+  it('reports a manager once even when it holds several entries', () => {
+    // Entries are keyed by manager + operation + apiVersion + subresource, so the
+    // same controller legitimately appears twice after a CRD version migration.
+    const suspendFields = { 'f:spec': { 'f:suspend': {} } };
+    const resource = new Kustomization(
+      {
+        apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+        kind: 'Kustomization',
+        metadata: {
+          name: 'my-app',
+          namespace: 'flux-system',
+          managedFields: [
+            {
+              manager: 'kustomize-controller',
+              operation: 'Apply',
+              apiVersion: 'kustomize.toolkit.fluxcd.io/v1beta2',
+              fieldsV1: suspendFields,
+            },
+            {
+              manager: 'kustomize-controller',
+              operation: 'Apply',
+              apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+              fieldsV1: suspendFields,
+            },
+          ],
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      'test-installation',
+    );
+
+    expect(resource.getApplyFieldOwners(['spec', 'suspend'])).toEqual([
+      'kustomize-controller',
+    ]);
+  });
+});

--- a/plugins/kubernetes-react/src/lib/k8s/KubeObject.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/KubeObject.ts
@@ -176,21 +176,39 @@ export class KubeObject<T extends KubeObjectInterface = any> {
    * The managers that *server-side apply* the given field, and will therefore
    * re-assert it on their next apply — reverting any imperative write we make.
    *
-   * Only `Apply`-operation entries count. A manager that reached the field with
-   * an imperative `Update` (a PUT or a non-apply PATCH, which is what our own
-   * writes are) holds ownership but has no declared desired state to restore, so
-   * it will never revert anything.
+   * Only `Apply`-operation entries count, so this detects **SSA appliers only**.
+   * That is narrower than "everything that could revert us": the two common
+   * non-SSA declarative writers keep a stored desired state and re-assert it,
+   * yet are both recorded as `operation: Update` and so are missed here.
+   *
+   * - client-side `kubectl apply` (`manager: kubectl-client-side-apply`) resends
+   *   the whole manifest as a strategic-merge patch, which is why it undoes a
+   *   `kubectl edit`;
+   * - `helm upgrade` (and helm-controller's release writes) patch via a
+   *   three-way merge that resets drift on chart-declared fields. Only
+   *   helm-controller's separate drift-correction path uses SSA, i.e. when
+   *   `spec.driftDetection` is enabled.
+   *
+   * So an empty result means "no SSA applier claims this field", not "nothing
+   * will revert a write to it". Callers gating a write affordance on this should
+   * treat it as a best-effort signal.
+   *
+   * Results are deduplicated: entries are keyed by manager + operation +
+   * apiVersion + subresource, so one manager can legitimately hold several (e.g.
+   * the same controller at two apiVersions after a CRD version migration).
    *
    * @param path field path from the object root, e.g. `['spec', 'suspend']`
    */
   getApplyFieldOwners(path: string[]): string[] {
-    return (this.getManagedFields() ?? [])
+    const managers = (this.getManagedFields() ?? [])
       .filter(
         entry =>
           entry.operation === 'Apply' && ownsFieldPath(entry.fieldsV1, path),
       )
       .map(entry => entry.manager)
       .filter((manager): manager is string => Boolean(manager));
+
+    return [...new Set(managers)];
   }
 
   static getGVK(): MultiVersionResourceMatcher {

--- a/plugins/kubernetes-react/src/lib/k8s/KubeObject.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/KubeObject.ts
@@ -12,6 +12,37 @@ export interface KubeObjectInterface {
   status?: any;
 }
 
+/**
+ * Whether a `managedFields` entry's `fieldsV1` set covers the given field path.
+ *
+ * `fieldsV1` prefixes every path segment with `f:`, so ownership of
+ * `spec.suspend` is encoded as `{"f:spec":{"f:suspend":{}}}`.
+ */
+function ownsFieldPath(fieldsV1: unknown, path: string[]): boolean {
+  let node = fieldsV1;
+
+  for (let depth = 0; depth < path.length; depth++) {
+    if (!node || typeof node !== 'object') {
+      return false;
+    }
+
+    const fields = node as Record<string, unknown>;
+    const key = `f:${path[depth]}`;
+
+    if (key in fields) {
+      node = fields[key];
+      continue;
+    }
+
+    // A node we have descended into that lists no children is an atomic field:
+    // the manager owns the whole subtree, including the path being asked about.
+    // At the root, though, an empty set simply means the manager owns nothing.
+    return depth > 0 && Object.keys(fields).length === 0;
+  }
+
+  return true;
+}
+
 export class KubeObject<T extends KubeObjectInterface = any> {
   jsonData: T;
   cluster: string;
@@ -135,6 +166,31 @@ export class KubeObject<T extends KubeObjectInterface = any> {
 
   findLabel(label: string) {
     return this.jsonData.metadata.labels?.[label];
+  }
+
+  getManagedFields() {
+    return this.jsonData.metadata.managedFields;
+  }
+
+  /**
+   * The managers that *server-side apply* the given field, and will therefore
+   * re-assert it on their next apply — reverting any imperative write we make.
+   *
+   * Only `Apply`-operation entries count. A manager that reached the field with
+   * an imperative `Update` (a PUT or a non-apply PATCH, which is what our own
+   * writes are) holds ownership but has no declared desired state to restore, so
+   * it will never revert anything.
+   *
+   * @param path field path from the object root, e.g. `['spec', 'suspend']`
+   */
+  getApplyFieldOwners(path: string[]): string[] {
+    return (this.getManagedFields() ?? [])
+      .filter(
+        entry =>
+          entry.operation === 'Apply' && ownsFieldPath(entry.fieldsV1, path),
+      )
+      .map(entry => entry.manager)
+      .filter((manager): manager is string => Boolean(manager));
   }
 
   static getGVK(): MultiVersionResourceMatcher {


### PR DESCRIPTION
### What does this PR do?

Follow-up to #2001, from [Flux-team feedback](https://gigantic.slack.com/archives/C02GDJJ68Q1/p1785243811567809) about manipulating `.spec` from a UI. Three changes.

**1. Detect a contested `spec.suspend` and disable the toggle.**

The concern raised was that a manual suspend on a GitOps-managed resource gets overwritten. That is right — but the precise condition is narrower than "the resource is GitOps-managed". Server-side apply is **field-level**: kustomize-controller only touches fields present in the manifest it applies, and removes a field only if it previously owned it and has since dropped it. So what matters is whether **the applied manifest asserts `spec.suspend`**.

When it does, the applying controller force-takes the field back on its next apply — `ssa/manager_apply.go` in fluxcd/pkg always passes `client.ForceOwnership` — and the suspension undoes itself within one of *that* controller's intervals, not the resource's own. Silently: no conflict error, nothing degraded.

We can see this exactly, without guessing, from `metadata.managedFields` (already in our GET responses): any entry with operation `Apply` that owns `f:spec.f:suspend`. When present, the Suspend/Resume toggle is disabled with a tooltip naming the owning manager(s).

Two details worth reviewing:

- **Not restricted to `kustomize-controller`.** A human `kubectl apply --server-side`, or helm-controller's drift correction when `spec.driftDetection` is enabled, has the same effect. Any SSA applier of the field will revert us, so the check is generic.
- **Detection covers SSA appliers only**, and is a best-effort signal. `Update`-operation owners are skipped, which correctly excludes our own merge patches (so our writes don't lock the button out) — but also misses the two common *non-SSA* declarative writers, which do keep a stored desired state and re-assert it: client-side `kubectl apply` (`kubectl-client-side-apply`) and a plain `helm upgrade`, whose three-way merge resets drift on chart-declared fields. So a chart shipping a Kustomization with `spec.suspend` declared still shows an enabled toggle whose change the next upgrade reverts. This is documented on `getApplyFieldOwners` rather than papered over by matching manager names, which would be a guess.
- **Stale ownership is handled.** A `managedFields` entry is only rewritten by a write, so it outlives the applier — see the escape-hatch note below.

Disabling is precisely correct here rather than merely conservative: the toggle always flips *away* from the current value, and the current value is what the apply-owner last asserted — so whenever the field is apply-owned, the action on offer is exactly the one that would be reverted.

**2. Reconcile is deliberately left enabled**, including on managed resources.

`reconcile.fluxcd.io/requestedAt` is never part of an applied manifest, so no apply-owner asserts or prunes it. kustomize-controller's `Cleanup.Annotations` list is explicit and short (`last-applied-configuration`, two legacy `fluxcd.io` checksums) and does not include it. The controller then copies the value into `status.lastHandledReconcileAt` and *leaves the annotation in place* — that pair is what our pending-request check compares. There is no race to lose, so gating Reconcile would be wrong. There's a comment saying so, to stop a future reader "fixing" it.

**3. An explicit field manager on our writes.**

Writes now set `?fieldManager=giantswarm-backstage`. Previously the apiserver derived the manager name from the request's User-Agent, which for a write proxied through the Backstage backend is both unpredictable and useless in an audit trail.

The suggestion in the thread was to *masquerade as `flux`* so the controller would treat our writes like CLI writes. I checked the source, and there is nothing to imitate:

- flux2 never sets a field manager at all — `internal/utils/utils.go` builds the client as `client.NewWithWatch(cfg, client.Options{Scheme: scheme})`. The `manager: flux` visible in `--show-managed-fields` is just the apiserver deriving it from client-go's default User-Agent.
- kustomize-controller's disallowed-manager list (`kustomization_controller.go`, feeding `ApplyOptions.Cleanup.FieldManagers`) covers `kubectl`/Apply, `kubectl`/Update, `before-first-apply`/Update and its own name with Update, plus any `--override-manager` values. `flux` is absent, so a CLI suspend gets no special treatment in either direction.

So impersonation would buy nothing and destroy attribution. An honest name also gives operators a value they can pass to a controller's `--override-manager` if they want these changes force-reverted.

**4. Corrects the ImagePolicy justification** from #2001.

The comment claimed Flux supports neither operation for `ImagePolicy`. That was wrong: both `crds.fluxcd.v1.ImagePolicy` and `v1beta2` declare `spec.suspend` and `status.lastHandledReconcileAt`, and the CLI covers the kind too — `cmd/flux/reconcile_image_policy.go`, `suspend_image_policy.go`, `resume_image_policy.go` all exist. Including the kind was right; the reason given was not. (The claim also appeared in #2001's description and changeset, which are already merged — noted here for the record.)

### What is the effect of this change to users?

On a resource whose `spec.suspend` comes from Git, the Suspend/Resume button is now visibly disabled and says why, instead of appearing to work and then quietly undoing itself minutes later. This is the Adidas case from the thread, where Kustomizations in the `default` namespace set `spec.suspend` explicitly.

Everything else is unchanged: Reconcile works everywhere it did before, and Suspend/Resume still works on resources whose suspend field is not declaratively managed.

Accepted trade-off: you can no longer take a deliberate short-lived suspend on a managed resource from the UI, and if such a resource was suspended elsewhere you cannot resume it here. Both were already true of `flux suspend`/`resume` in the sense that the change wouldn't stick; the difference is that now we say so up front rather than letting it fail silently. The fix in that situation is to change it in Git.

### How does it look like?

```
unmanaged spec.suspend:
  [ ⟳ Reconcile ]  [ ⏸ Suspend ]

spec.suspend applied by kustomize-controller:
  [ ⟳ Reconcile ]  [ ⏸ Suspend ]
                    (disabled)
   tooltip: "spec.suspend is applied by kustomize-controller,
             so a change made here would be reverted on the
             next reconciliation. Change it in Git instead."
```

### Any background context you can provide?

The Slack thread asked whether the Flux controllers handle a CLI-set `spec.suspend` specially — e.g. keying off the field manager. They don't; see point 3 above. The behaviour difference between "suspend sticks" and "suspend evaporates" is entirely about what's in the applied manifest.

Three per-object annotations exclude a resource from apply and therefore make manual changes durable — `kustomize.toolkit.fluxcd.io/reconcile: disabled`, `kustomize.toolkit.fluxcd.io/ssa: Ignore`, and `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` (from `applyOpts` in `kustomization_controller.go`).

An earlier revision of this PR claimed these "will correctly show an enabled toggle, since no apply-owner claims the field". That was wrong, as [pointed out in review](https://github.com/giantswarm/backstage/pull/2004#discussion_r3672300856): a `managedFields` entry is only ever rewritten by a write, so it survives the applier walking away. An object handed over for manual control keeps its stale `Apply` entry, and an `ssa: IfNotPresent` object carries one from creation onwards despite never being applied again — so both would have shown a permanently disabled toggle. Those three annotations now short-circuit the check.

Verify on a real MC with:

```bash
kubectl -n default get ks pcn01 -o yaml --show-managed-fields | \
  yq '.metadata.managedFields[] | select(.manager == "kustomize-controller")'
```

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

