### PR TITLE
feat(agent-platform): add the session detail page

### DIFF
--- a/.changeset/agent-platform-session-detail-page.md
+++ b/.changeset/agent-platform-session-detail-page.md
@@ -14,7 +14,7 @@ The page has three parts:
 - **Header** — title, status badge, agent (name and avatar, resolved through the
   same `Agent` CR join the list uses), installation, started/last-activity, and the
   session id.
-- **Stats** — turn count and token totals.
+- **Stats** — turns, wall-clock duration, and input/output tokens.
 - **Timeline** — the conversation, with the agent's internal work collapsible behind
   a Hidden/Collapsed/Expanded control. Collapsed by default: the working is the
   point of the screen, but a wall of tool payloads is unreadable.
@@ -33,10 +33,25 @@ Decisions worth knowing:
   no `messageId`), so a task's timestamp is the finest granularity that exists. The
   timeline shows it once per turn rather than repeating it on every entry, which
   would imply precision we do not have.
-- **Token totals are labelled "billed, cumulative"** because the raw number is
+- **Input tokens are labelled "billed, cumulative"** because the raw number is
   startling: every model call re-sends the whole context, so a 4-turn session with a
-  large tool catalogue reached 1.5M prompt tokens across 14 calls. Genuine billed
+  large tool catalogue reached 1.4M prompt tokens across 14 calls. Genuine billed
   usage — kagent's own UI sums it identically — but unlabelled it reads as a bug.
+  There is deliberately **no combined total**: input and output are priced
+  differently, so their sum is not a number anyone acts on.
+- **Duration is wall-clock** (`updated_at − created_at`), since kagent records no
+  per-turn durations — it includes however long the user was away between turns.
+- **Timestamps here are absolute** (`28 Jul 2026, 10:07 UTC`), unlike the list.
+  Both ends of a session usually fall on the same day, so the relative form read
+  "Started 1 day ago · last activity 1 day ago" for a session that took three
+  minutes, and printed "1 day ago" identically on every turn marker — hiding the
+  progression the timeline exists to show.
+- **Calls through Muster are unwrapped.** Agents reach most MCP tools via muster's
+  `call_tool`, so untreated every row reads `call_tool` with the real tool buried in
+  the arguments (giantswarm/klaus-gateway#163). Rows now name the tool actually
+  invoked and carry a `via Muster` badge; on a real session that unwrapped 7 of 17
+  calls. A `call_tool` payload that stops matching the wrapper shape degrades to
+  showing the proxy rather than being lost.
 - **A missing session is a not-found state, not an error.** kagent answers 404 for
   deleted, never-existed and belonging-to-someone-else alike, and none of those is a
   fault worth an error alert.

--- a/.changeset/agent-platform-session-detail-page.md
+++ b/.changeset/agent-platform-session-detail-page.md
@@ -12,12 +12,13 @@ offers all three — none are wired up, so this ships without a write path.
 The page has three parts:
 
 - **Header** — title, status badge, agent (name and avatar, resolved through the
-  same `Agent` CR join the list uses), installation, started/last-activity, and the
-  session id.
+  same `Agent` CR join the list uses), installation, and started/last-activity. The
+  session id is deliberately not shown: it is a 64-character opaque string that
+  told the reader nothing, and it is already in the URL for anyone who needs it.
 - **Stats** — turns, wall-clock duration, and input/output tokens.
 - **Timeline** — the conversation, with the agent's internal work collapsible behind
-  a Hidden/Collapsed/Expanded control. Collapsed by default: the working is the
-  point of the screen, but a wall of tool payloads is unreadable.
+  a Details control. Collapsed by default: the working is the point of the screen,
+  but a wall of tool payloads is unreadable.
 
 Timeline entries cover user and agent messages (as markdown), reasoning, tool calls
 with their arguments and results folded into one entry, delegations to other agents

--- a/.changeset/agent-platform-session-detail-page.md
+++ b/.changeset/agent-platform-session-detail-page.md
@@ -1,0 +1,59 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+---
+
+Add the session detail page. Clicking a row in the Sessions list now opens
+`/agent-platform/sessions/<installation>/<id>`, showing what the session was, how it
+ended, and what the agent actually did.
+
+**Read-only.** kagent can rename, delete and continue a session, and the prototype
+offers all three — none are wired up, so this ships without a write path.
+
+The page has three parts:
+
+- **Header** — title, status badge, agent (name and avatar, resolved through the
+  same `Agent` CR join the list uses), installation, started/last-activity, and the
+  session id.
+- **Stats** — turn count and token totals.
+- **Timeline** — the conversation, with the agent's internal work collapsible behind
+  a Hidden/Collapsed/Expanded control. Collapsed by default: the working is the
+  point of the screen, but a wall of tool payloads is unreadable.
+
+Timeline entries cover user and agent messages (as markdown), reasoning, tool calls
+with their arguments and results folded into one entry, delegations to other agents
+with the child's own token usage, and approval requests with the user's verdict.
+Approvals are deliberately not governed by the activity control — an approval records
+the _user's_ decision, so hiding it would erase the trace of their own action rather
+than the agent's working.
+
+Decisions worth knowing:
+
+- **Timestamps are per turn, not per item.** A2A messages carry no time of their own
+  and kagent's stored events cannot be correlated with them (they are ADK events with
+  no `messageId`), so a task's timestamp is the finest granularity that exists. The
+  timeline shows it once per turn rather than repeating it on every entry, which
+  would imply precision we do not have.
+- **Token totals are labelled "billed, cumulative"** because the raw number is
+  startling: every model call re-sends the whole context, so a 4-turn session with a
+  large tool catalogue reached 1.5M prompt tokens across 14 calls. Genuine billed
+  usage — kagent's own UI sums it identically — but unlabelled it reads as a bug.
+- **A missing session is a not-found state, not an error.** kagent answers 404 for
+  deleted, never-existed and belonging-to-someone-else alike, and none of those is a
+  fault worth an error alert.
+- **Rows link with a real anchor** in the title cell as well as a whole-row click, so
+  cmd- and middle-click open a new tab and keyboard users have something focusable.
+  Not `rowConfig.getHref`: `BUIProvider` is not mounted in this app, so react-aria's
+  `RouterProvider` is inactive and a bui `href` would trigger a full page reload.
+- **`session` and `session-tasks` queries are excluded from `localStorage`**, for two
+  independent reasons — a conversation is user-scoped data that must not outlive
+  sign-out on disk, and at ~500 KB per session it would evict the fleet lists the
+  persistence exists for.
+
+What the page cannot show, because kagent stores none of it: cost, tokens/second,
+context-window usage, the owning team, the trigger that started the session, a linked
+work item, produced results, and evaluation. Delegation entries are inert, since the
+response does not reliably carry the child session's id.
+
+The Sessions tab's content is now a `SessionsRouter`, which hoists the query client
+and the fleet-wide `Agent` list above both screens so opening a session reuses what
+the list already loaded.

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -424,6 +424,15 @@ wall of tool payloads is unreadable.
 | Delegation           | a `function_call` whose name contains `__NS__`, plus the child's own usage |
 | Approval             | ADK's `adk_request_confirmation`, with the user's verdict                  |
 
+**Calls through Muster are unwrapped.** Agents reach most MCP tools via muster's
+`call_tool`, so untreated every row reads `call_tool` with the real tool buried in
+the arguments — the problem reported in
+[klaus-gateway#163](https://github.com/giantswarm/klaus-gateway/issues/163). The
+parser looks through the wrapper (`unwrapProxiedCall`), so the row names the tool
+actually invoked and carries a `via Muster` badge; on a real gazelle session that
+unwrapped 7 of 17 calls. If `call_tool`'s payload ever stops matching the wrapper
+shape, the call degrades to showing the proxy rather than being lost.
+
 Approvals are deliberately **not** governed by the activity control: an approval
 records the _user's_ decision, so hiding it would erase the trace of their own
 action rather than the agent's working.
@@ -443,13 +452,35 @@ session, a **linked work item**, produced **results**, and **evaluation**.
 Delegation entries are inert — the response does not reliably carry the child
 session's id, and subagent sessions are filtered out of the list anyway.
 
-### Token totals are cumulative, and look alarming
+### The stats strip
 
-The stats strip labels input tokens "billed, cumulative" on purpose. Every model
-call re-sends the whole context, so a 4-turn session with a large tool catalogue
-reached **1.5M prompt tokens across 14 calls** (3.9k–144k each). That is genuine
-billed usage and kagent's own UI sums it identically — but unlabelled it reads as a
-bug.
+`Turns · Duration · Input tokens (billed, cumulative) · Output tokens`.
+
+**Input tokens are labelled "billed, cumulative" on purpose.** Every model call
+re-sends the whole context, so a 4-turn session with a large tool catalogue reached
+**1.4M prompt tokens across 14 calls** (3.9k–144k each). That is genuine billed
+usage and kagent's own UI sums it identically — but unlabelled it reads as a bug.
+
+There is deliberately **no combined total**: input and output tokens are priced
+differently, so their sum is not a number anyone acts on.
+
+One kagent quirk to know: `adk_usage_metadata` carries only `promptTokenCount` and
+`candidatesTokenCount` on some sessions — no `totalTokenCount` at all — so a total
+is derived from the parts when kagent reports none. A reported total still wins,
+since a model billing thinking tokens separately counts them in the total but in
+neither part.
+
+**Duration is wall-clock**, `updated_at − created_at`: kagent records no per-turn
+durations, so it includes however long the user was away between turns.
+
+### Timestamps are absolute here, relative in the list
+
+The detail header and the turn markers show `28 Jul 2026, 10:07 UTC`, not "1 day
+ago". Both ends of a session usually fall on the same day, so the relative form
+rendered "Started 1 day ago · last activity 1 day ago" for a session that took
+three minutes, and printed "1 day ago" identically on every turn marker — hiding
+the progression the timeline exists to show. The list keeps the relative form,
+where scanning for recency is the point.
 
 ## Configuration
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -324,13 +324,19 @@ The plugin's `QueryClientProvider` persists its cache to `localStorage` for an
 hour, which is right for the Agents and ModelConfig lists — that is installation
 state, identical for every user, and caching it across reloads is the point.
 
-Sessions are different: the rows are one user's chat titles, and the identity probe
-caches their subject (an email). Those two query keys are therefore excluded from
+Sessions are different: the rows are one user's chat titles, the identity probe
+caches their subject (an email), and a session's tasks are the whole conversation
+including tool arguments and results. Those query keys are therefore excluded from
 persistence via `dehydrateOptions.shouldDehydrateQuery`, so they live in memory
 only. Without that, on a shared workstation the data would outlive sign-out on
 disk, and `PersistQueryClientProvider` would rehydrate the previous user's sessions
 for the next one — under the same origin and key, and with `staleTime: 60_000` an
 entry under a minute old would not even be refetched.
+
+`session-tasks` has a second, independent reason: **size**. A real 4-turn session's
+tasks were ~500 KB against a localStorage budget of roughly 5 MB for the whole
+origin, so a handful of opened conversations would evict everything else — including
+the fleet lists this persistence exists for in the first place.
 
 The filter composes with `defaultShouldDehydrateQuery` rather than replacing it, so
 the library's "only persist successful queries" rule still applies.
@@ -370,6 +376,80 @@ live v0.9.9 response, asserting v0.9.9 and v0.10 payloads normalise identically.
 `source === 'agent'` (A2A subagent) sessions are excluded — though note live
 v0.9.9 responses omit `source` entirely, so this is forward-compatibility rather
 than active filtering today.
+
+## The session detail page
+
+`/agent-platform/sessions/<installation>/<id>` shows one session: its metadata, a
+stats strip, and the conversation. The installation is in the path because it is
+part of the session's identity — kagent ids are only unique within one.
+
+**Read-only.** kagent can rename, delete and continue a session, and the prototype
+offers all three. None are wired up, so this screen ships without a write path.
+
+### Two reads, and why the events are ignored
+
+| Endpoint                 | Used for                                                |
+| ------------------------ | ------------------------------------------------------- |
+| `…/sessions/:id?limit=1` | the session object: title, agent, timestamps, existence |
+| `…/sessions/:id/tasks`   | the conversation, its state, and token usage            |
+
+The conversation comes from **tasks**, which is what kagent's own UI renders from.
+The `events` array on the first response is ignored entirely, and `limit=1` keeps it
+off the wire. kagent's Go type calls each event's `data` a
+`JSON-serialized protocol.Message`, which suggested events could supply the
+per-message timestamps A2A messages lack. A real gazelle session disproved it: the
+decoded value is an **ADK event** (`author`, `content`, `invocation_id`, `partial`,
+`timestamp`, …) with no `messageId` at all, so nothing correlates with task history.
+On that session the events were 591 KB against 261 bytes of session metadata.
+(`limit` must be `1`, not `0` — kagent gates its LIMIT clause on `opts.Limit > 0`,
+so zero reads as _unlimited_.)
+
+**Consequence for the UI: timestamps are per turn, not per item.** A task's
+timestamp is the finest granularity that exists, so the timeline shows it once per
+turn rather than repeating it on every entry, which would imply precision we do not
+have.
+
+### What the timeline shows
+
+Built by `lib/kagentTimeline.ts` from task history. Conversation messages render in
+full; the agent's internal work is collapsible, with a Hidden/Collapsed/Expanded
+control — collapsed by default, because the working is the point of the screen but a
+wall of tool payloads is unreadable.
+
+| Entry                | Where it comes from                                                        |
+| -------------------- | -------------------------------------------------------------------------- |
+| User / agent message | `role` plus text parts, rendered as markdown                               |
+| Reasoning            | a text part flagged `{adk,kagent}_thought`                                 |
+| Tool call            | a `function_call` data part, with its `function_response` folded in        |
+| Delegation           | a `function_call` whose name contains `__NS__`, plus the child's own usage |
+| Approval             | ADK's `adk_request_confirmation`, with the user's verdict                  |
+
+Approvals are deliberately **not** governed by the activity control: an approval
+records the _user's_ decision, so hiding it would erase the trace of their own
+action rather than the agent's working.
+
+Two things real payloads taught us, both now relied on: kagent repeats each user
+message under the **same `messageId`** on every turn, so the session-wide dedupe is
+required rather than defensive; and one message can carry prose plus several tool
+calls, always text first.
+
+### What it cannot show
+
+kagent stores none of this, so the prototype's remaining fields have no data behind
+them and should not be re-added speculatively: **cost**, **tokens/second**,
+**context-window usage**, the owning **team**, the **trigger** that started the
+session, a **linked work item**, produced **results**, and **evaluation**.
+
+Delegation entries are inert — the response does not reliably carry the child
+session's id, and subagent sessions are filtered out of the list anyway.
+
+### Token totals are cumulative, and look alarming
+
+The stats strip labels input tokens "billed, cumulative" on purpose. Every model
+call re-sends the whole context, so a 4-turn session with a large tool catalogue
+reached **1.5M prompt tokens across 14 calls** (3.9k–144k each). That is genuine
+billed usage and kagent's own UI sums it identically — but unlabelled it reads as a
+bug.
 
 ## Configuration
 

--- a/packages/app/src/utils/telemetry.test.ts
+++ b/packages/app/src/utils/telemetry.test.ts
@@ -287,6 +287,19 @@ describe('getTelemetryPageViewPayload', () => {
     });
   });
 
+  it('should return correct payload for one session', () => {
+    // No `view`: the path carries an installation name and an opaque session id,
+    // so echoing them would emit a page name per session — and record which
+    // installations a user reads.
+    const result = getTelemetryPageViewPayload(
+      '/agent-platform/sessions/gazelle/019f8a13-c6c2-73af-a1d9-ab0abeeb6734',
+    );
+    expect(result).toEqual({
+      page: 'Session detail',
+      path: '/agent-platform/sessions/gazelle/019f8a13-c6c2-73af-a1d9-ab0abeeb6734',
+    });
+  });
+
   it('should return correct payload for metrics page', () => {
     const result = getTelemetryPageViewPayload('/metrics');
     expect(result).toEqual({
@@ -348,6 +361,7 @@ describe('getTelemetryPageViewPayload', () => {
       '/agent-platform/agents/new',
       '/agent-platform/agents/new/review',
       '/agent-platform/sessions',
+      '/agent-platform/sessions/gazelle/abc123',
       '/metrics',
       '/search',
     ];

--- a/packages/app/src/utils/telemetry.ts
+++ b/packages/app/src/utils/telemetry.ts
@@ -146,6 +146,14 @@ export function getTelemetryPageViewPayload(pathname: string): {
       payload = { page: 'Sessions index' };
       break;
 
+    // One session: `/agent-platform/sessions/<installation>/<id>`. Deliberately
+    // carries no `view`: those segments are an installation name and an opaque
+    // session id, so including them would emit a distinct page name per session —
+    // useless as a metric, and it would record which installations a user reads.
+    case pathname.startsWith('/agent-platform/sessions/'):
+      payload = { page: 'Session detail' };
+      break;
+
     case pathname === '/agent-platform':
       payload = { page: 'Agents index' };
       break;

--- a/plugins/agent-platform/src/components/QueryClientProvider.tsx
+++ b/plugins/agent-platform/src/components/QueryClientProvider.tsx
@@ -21,20 +21,34 @@ const maxAge = gcTime;
  *
  * Everything else cached here (Agents, ModelConfigs, the kagent installation
  * list) is installation state: identical for every user, and safe to persist.
- * kagent sessions are not — the rows are one user's chat titles, and the identity
- * probe caches their subject (an email address).
+ * kagent sessions are not — the rows are one user's chat titles, the identity
+ * probe caches their subject (an email address), and a session's tasks are the
+ * whole conversation, including tool arguments and results.
  *
  * Persisting them would be wrong twice over on a shared workstation: the data
  * outlives sign-out on disk, and `PersistQueryClientProvider` would rehydrate the
  * previous user's sessions for the next one under the same origin and key — which
  * `staleTime` would not even refetch if the entry is under a minute old.
+ *
+ * `session-tasks` has a second, independent reason: **size**. A real 4-turn
+ * session's tasks were ~500 KB against a localStorage budget of roughly 5 MB for
+ * the entire origin, so a handful of opened conversations would evict everything
+ * else — including the fleet lists this persistence exists for in the first place.
  */
+const USER_SCOPED_RESOURCES = new Set([
+  'sessions',
+  'me',
+  'session',
+  'session-tasks',
+]);
+
 function isUserScopedQueryKey(queryKey: QueryKey): boolean {
   const [scope, subsystem, resource] = queryKey as unknown[];
   return (
     scope === 'agent-platform' &&
     subsystem === 'kagent' &&
-    (resource === 'sessions' || resource === 'me')
+    typeof resource === 'string' &&
+    USER_SCOPED_RESOURCES.has(resource)
   );
 }
 

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
@@ -113,6 +113,15 @@ describe('SessionDetailPage', () => {
       screen.getByText('Input tokens (billed, cumulative)'),
     ).toBeInTheDocument();
     expect(screen.getByText('Turns')).toBeInTheDocument();
+    expect(screen.getByText('Output tokens')).toBeInTheDocument();
+  });
+
+  it('shows the wall-clock duration', async () => {
+    // kagent records no per-turn durations, so this is updated_at - created_at:
+    // the session's span, including time the user was away.
+    await render();
+
+    expect(screen.getByText('Duration')).toBeInTheDocument();
   });
 
   it('renders the timeline', async () => {

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
@@ -1,0 +1,193 @@
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { sessionsRouteRef } from '../../routes';
+import type { AgentsContextValue } from '../AgentsDataProvider';
+import type { SessionDetailView } from '../../hooks/useSessionDetail';
+import { buildTimeline } from '../../lib/kagentTimeline';
+import { normalizeTaskList } from '../../lib/kagentSessionDetail';
+import { normalizeSessionDetail } from '../../lib/kagentSessionDetail';
+import { deriveSessionState } from '../../lib/kagentSessionState';
+import { SessionDetailPage } from './SessionDetailPage';
+
+import tasksV099 from '../../lib/__fixtures__/tasks.v0-9-9.json';
+import detailV099 from '../../lib/__fixtures__/session-detail.v0-9-9.json';
+
+// The route params the page reads. Driven directly rather than through a router so
+// each state can be rendered in isolation.
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ installation: 'gazelle', sessionId: 'abc' }),
+}));
+
+const mockUseSessionDetail = jest.fn<SessionDetailView, []>();
+jest.mock('../../hooks/useSessionDetail', () => ({
+  useSessionDetail: () => mockUseSessionDetail(),
+}));
+
+const mockUseAgents = jest.fn<AgentsContextValue, []>();
+jest.mock('../AgentsDataProvider', () => ({
+  AgentsDataProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  useAgents: () => mockUseAgents(),
+}));
+
+jest.mock('../../hooks/useAgentAvatarUrl', () => ({
+  useAgentAvatarUrl: () => () => 'https://avatars.example/agent.png',
+}));
+
+const tasks = normalizeTaskList(tasksV099).tasks;
+const timeline = buildTimeline(tasks);
+const detail = normalizeSessionDetail(detailV099, 'gazelle').detail!;
+
+const loadedView: SessionDetailView = {
+  detail,
+  timeline,
+  state: deriveSessionState(tasks),
+  taskCount: tasks.length,
+  isLoading: false,
+  isNotFound: false,
+  error: undefined,
+};
+
+const emptyTimeline = {
+  items: [],
+  tokens: timeline.tokens,
+  skippedMessages: 0,
+};
+
+async function render() {
+  await renderInTestApp(<SessionDetailPage />, {
+    mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+  });
+}
+
+describe('SessionDetailPage', () => {
+  beforeEach(() => {
+    mockUseSessionDetail.mockReturnValue(loadedView);
+    mockUseAgents.mockReturnValue({
+      rows: [
+        {
+          id: 'gazelle/kagent/issue-tracker',
+          installation: 'gazelle',
+          namespace: 'kagent',
+          name: 'Issue tracker',
+          technicalName: 'issue-tracker',
+        },
+      ],
+      isLoading: false,
+      isLoadingMore: false,
+      hasInstallations: true,
+      unreachableInstallations: [],
+    } as unknown as AgentsContextValue);
+  });
+
+  it('shows the session, its agent and its installation', async () => {
+    await render();
+
+    expect(screen.getByText('Which GitHub issues...')).toBeInTheDocument();
+    // Resolved through the same Agent CR join the list uses, so both name it
+    // identically rather than showing the raw `issue_tracker` identifier. Appears
+    // twice on purpose: in the header, and as the author of its messages.
+    expect(screen.getAllByText('Issue tracker').length).toBeGreaterThan(0);
+    expect(screen.getByText('on gazelle')).toBeInTheDocument();
+  });
+
+  it('shows the state from the most recent task', async () => {
+    // The fixture's last task is `working`; an earlier one completed. Reporting the
+    // earlier one would claim a running session had finished.
+    await render();
+
+    expect(screen.getByText('Working')).toBeInTheDocument();
+  });
+
+  it('labels token totals as cumulative, since the raw number is startling', async () => {
+    // Every model call re-sends the whole context, so a short session can total
+    // millions of prompt tokens. Genuine billed usage, but it reads as a bug
+    // without the label.
+    await render();
+
+    expect(
+      screen.getByText('Input tokens (billed, cumulative)'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Turns')).toBeInTheDocument();
+  });
+
+  it('renders the timeline', async () => {
+    await render();
+
+    expect(screen.getByText(/You have two open issues/)).toBeInTheDocument();
+  });
+
+  it('shows a not-found state rather than an error for a missing session', async () => {
+    // kagent answers 404 for deleted, never-existed and someone-else's alike, so
+    // all three land here — and none of them is a fault worth an error alert.
+    mockUseSessionDetail.mockReturnValue({
+      ...loadedView,
+      detail: undefined,
+      timeline: emptyTimeline,
+      isNotFound: true,
+    });
+
+    await render();
+
+    expect(screen.getByText('Session not found')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Could not load this session'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Back to sessions')).toBeInTheDocument();
+  });
+
+  it('surfaces a genuine read failure with its message', async () => {
+    const error = new Error('kagent returned status 500');
+    error.name = 'UpstreamError';
+    mockUseSessionDetail.mockReturnValue({
+      ...loadedView,
+      detail: undefined,
+      timeline: emptyTimeline,
+      error,
+    });
+
+    await render();
+
+    expect(screen.getByText('Could not load this session')).toBeInTheDocument();
+    expect(screen.getByText(/status 500/)).toBeInTheDocument();
+  });
+
+  it('shows progress while loading', async () => {
+    mockUseSessionDetail.mockReturnValue({
+      ...loadedView,
+      detail: undefined,
+      timeline: emptyTimeline,
+      isLoading: true,
+    });
+
+    await render();
+
+    // `Progress` renders a hidden placeholder until a ~250ms timer fires, so it
+    // doesn't flash for fast loads. `data-testid="progress"` is present in both
+    // states and is the hook it ships for exactly this.
+    expect(screen.getByTestId('progress')).toBeInTheDocument();
+    expect(screen.queryByText('Session not found')).not.toBeInTheDocument();
+  });
+
+  it('says so when a session has no activity at all', async () => {
+    // A session created but never run: distinct from every state kagent can
+    // report, so it must not borrow one of them.
+    mockUseSessionDetail.mockReturnValue({
+      ...loadedView,
+      timeline: emptyTimeline,
+      state: undefined,
+      taskCount: 0,
+    });
+
+    await render();
+
+    expect(screen.getByText('no activity')).toBeInTheDocument();
+    expect(
+      screen.getByText('This session has no messages yet.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
@@ -1,0 +1,236 @@
+import { ReactNode, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Content,
+  EmptyState,
+  Link,
+  Progress,
+} from '@backstage/core-components';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { Alert, Avatar, Badge, Box, Flex, Text } from '@backstage/ui';
+import { makeStyles } from '@material-ui/core';
+import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
+
+import { useSessionDetail } from '../../hooks/useSessionDetail';
+import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
+import { AvatarSize } from '../../lib/agentAvatar';
+import { sessionsRouteRef } from '../../routes';
+import { useAgents } from '../AgentsDataProvider';
+import {
+  buildAgentIndex,
+  SESSION_TITLE_FALLBACK,
+  toSessionRow,
+} from '../SessionsDataProvider/helpers';
+import { formatTokens, SessionTimeline } from '../SessionTimeline';
+
+/** Matches the list's row avatar: one line of text, 2× for hi-dpi. */
+const AVATAR_SIZE: AvatarSize = 48;
+
+const useStyles = makeStyles(theme => ({
+  stats: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(4),
+    paddingTop: theme.spacing(1.5),
+    paddingBottom: theme.spacing(1.5),
+    borderTop: `1px solid ${theme.palette.divider}`,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  statValue: {
+    fontVariantNumeric: 'tabular-nums',
+  },
+  sessionId: {
+    fontFamily: 'monospace',
+    fontSize: '0.75rem',
+    color: theme.palette.text.secondary,
+    wordBreak: 'break-all',
+  },
+}));
+
+/**
+ * Link back to the list.
+ *
+ * `useRouteRef` returns undefined when the route is not bound — which in practice
+ * means the Agent Platform extension is disabled, and then this page isn't
+ * rendering either. Rendering nothing is still better than hardcoding the path,
+ * which would silently rot if the route moved.
+ */
+function BackToSessions({ children }: { children: ReactNode }) {
+  const sessionsRoute = useRouteRef(sessionsRouteRef);
+  if (!sessionsRoute) {
+    return null;
+  }
+  return <Link to={sessionsRoute()}>{children}</Link>;
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  const classes = useStyles();
+  return (
+    <Flex direction="column" gap="1">
+      <Text variant="body-small" color="secondary">
+        {label}
+      </Text>
+      <Text variant="title-small" className={classes.statValue}>
+        {value}
+      </Text>
+    </Flex>
+  );
+}
+
+/**
+ * One kagent session: what it was, how it ended, and what the agent did.
+ *
+ * Read-only. kagent supports renaming, deleting and continuing a session, and the
+ * prototype offers all three — none are wired up here, deliberately, so this
+ * screen can ship without a write path.
+ *
+ * What the prototype shows and this cannot, because kagent stores none of it:
+ * cost, tokens-per-second, context-window usage, the owning team, the trigger that
+ * started the session, a linked work item, produced results, and evaluation. Please
+ * don't re-add them speculatively — there is no data behind them.
+ */
+export function SessionDetailPage() {
+  const classes = useStyles();
+  const { installation = '', sessionId = '' } = useParams();
+  const buildAvatarUrl = useAgentAvatarUrl();
+
+  const { detail, timeline, state, taskCount, isLoading, isNotFound, error } =
+    useSessionDetail(installation, sessionId);
+
+  // The same join the list uses, so a session's agent is named identically in both
+  // places — and falls back to the same lossy decode when no Agent CR matched.
+  const { rows: agentRows } = useAgents();
+  const agentRowsKey = agentRows
+    .map(agent => `${agent.id}@${agent.name}`)
+    .join('|');
+  const agentIndex = useMemo(
+    () => buildAgentIndex(agentRows),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [agentRowsKey],
+  );
+
+  const row = useMemo(
+    () => (detail ? toSessionRow(detail.session, agentIndex) : undefined),
+    [detail, agentIndex],
+  );
+
+  if (isLoading) {
+    return (
+      <Content>
+        <Progress aria-label="Loading session" />
+      </Content>
+    );
+  }
+
+  if (isNotFound) {
+    return (
+      <Content>
+        <EmptyState
+          missing="data"
+          title="Session not found"
+          description={`No session with this id exists on ${
+            installation || 'that installation'
+          }. It may have been deleted, or belong to another user — kagent only lets you read your own sessions.`}
+          action={<BackToSessions>Back to sessions</BackToSessions>}
+        />
+      </Content>
+    );
+  }
+
+  if (error || !detail || !row) {
+    return (
+      <Content>
+        <Flex direction="column" gap="3">
+          <Alert
+            status="danger"
+            title="Could not load this session"
+            description={
+              error?.message ??
+              'kagent returned a response we could not read. The session may still exist.'
+            }
+          />
+          <BackToSessions>Back to sessions</BackToSessions>
+        </Flex>
+      </Content>
+    );
+  }
+
+  const avatarUrl = row.agentTechnicalName
+    ? buildAvatarUrl(row.installation, row.agentTechnicalName, {
+        size: AVATAR_SIZE,
+      })
+    : undefined;
+
+  return (
+    <Content>
+      <Flex direction="column" gap="4">
+        <Flex direction="column" gap="2">
+          <BackToSessions>← Sessions</BackToSessions>
+          <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
+            <Text variant="title-medium">
+              {row.title || SESSION_TITLE_FALLBACK}
+            </Text>
+            {/* The raw A2A state is kept as the label for anything we don't
+                recognise, so a future kagent state shows as itself. */}
+            {state && <Badge size="small">{state.label}</Badge>}
+            {!state && <Badge size="small">no activity</Badge>}
+          </Flex>
+
+          <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
+            {row.agentName && (
+              <Flex align="center" gap="2">
+                <Avatar
+                  size="small"
+                  purpose="decoration"
+                  name={row.agentName}
+                  src={avatarUrl ?? ''}
+                />
+                <Text variant="body-medium">{row.agentName}</Text>
+              </Flex>
+            )}
+            <Text variant="body-medium" color="secondary">
+              on {row.installation}
+            </Text>
+          </Flex>
+
+          <Text variant="body-small" color="secondary">
+            Started{' '}
+            {row.createdAt ? (
+              <DateComponent value={row.createdAt} relative />
+            ) : (
+              '—'
+            )}
+            {' · last activity '}
+            {row.updatedAt ? (
+              <DateComponent value={row.updatedAt} relative />
+            ) : (
+              '—'
+            )}
+          </Text>
+
+          <Text className={classes.sessionId}>{row.id}</Text>
+        </Flex>
+
+        <Box className={classes.stats}>
+          <Stat label="Turns" value={String(taskCount)} />
+          {/* Labelled "billed", because the raw sum is startling: every model call
+              re-sends the whole context, so a 4-turn session with a large tool
+              catalogue reached 1.5M prompt tokens across 14 calls. That is genuine
+              cumulative usage — kagent's own UI sums it the same way — but without
+              the label it reads as a bug. */}
+          <Stat
+            label="Input tokens (billed, cumulative)"
+            value={formatTokens(timeline.tokens.prompt)}
+          />
+          <Stat
+            label="Output tokens"
+            value={formatTokens(timeline.tokens.completion)}
+          />
+          <Stat label="Total" value={formatTokens(timeline.tokens.total)} />
+        </Box>
+
+        <SessionTimeline timeline={timeline} agentName={row.agentName} />
+      </Flex>
+    </Content>
+  );
+}

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
@@ -21,7 +21,11 @@ import {
   SESSION_TITLE_FALLBACK,
   toSessionRow,
 } from '../SessionsDataProvider/helpers';
-import { formatTokens, SessionTimeline } from '../SessionTimeline';
+import {
+  formatDuration,
+  formatTokens,
+  SessionTimeline,
+} from '../SessionTimeline';
 
 /** Matches the list's row avatar: one line of text, 2× for hi-dpi. */
 const AVATAR_SIZE: AvatarSize = 48;
@@ -193,19 +197,17 @@ export function SessionDetailPage() {
             </Text>
           </Flex>
 
+          {/* Absolute, not relative. Both ends of a session are frequently within
+              the same day, so the relative form rendered "1 day ago · 1 day ago" —
+              identical for two timestamps 34 minutes apart, which told the reader
+              nothing. The Duration stat below now carries the span, so an exact
+              start time is the more useful thing to show here. The list keeps the
+              relative form, where scanning for recency is the point. */}
           <Text variant="body-small" color="secondary">
             Started{' '}
-            {row.createdAt ? (
-              <DateComponent value={row.createdAt} relative />
-            ) : (
-              '—'
-            )}
+            {row.createdAt ? <DateComponent value={row.createdAt} /> : '—'}
             {' · last activity '}
-            {row.updatedAt ? (
-              <DateComponent value={row.updatedAt} relative />
-            ) : (
-              '—'
-            )}
+            {row.updatedAt ? <DateComponent value={row.updatedAt} /> : '—'}
           </Text>
 
           <Text className={classes.sessionId}>{row.id}</Text>
@@ -213,11 +215,20 @@ export function SessionDetailPage() {
 
         <Box className={classes.stats}>
           <Stat label="Turns" value={String(taskCount)} />
-          {/* Labelled "billed", because the raw sum is startling: every model call
-              re-sends the whole context, so a 4-turn session with a large tool
-              catalogue reached 1.5M prompt tokens across 14 calls. That is genuine
+          {/* Wall-clock span, not compute time — kagent records no per-turn
+              durations, so this includes however long the user was away between
+              turns. */}
+          <Stat
+            label="Duration"
+            value={formatDuration(row.createdAt, row.updatedAt) ?? '—'}
+          />
+          {/* Labelled "billed", because the raw number is startling: every model
+              call re-sends the whole context, so a 4-turn session with a large tool
+              catalogue reached 1.4M prompt tokens across 14 calls. That is genuine
               cumulative usage — kagent's own UI sums it the same way — but without
-              the label it reads as a bug. */}
+              the label it reads as a bug.
+              There is deliberately no combined total: input and output are priced
+              differently, so the sum is not a number anyone acts on. */}
           <Stat
             label="Input tokens (billed, cumulative)"
             value={formatTokens(timeline.tokens.prompt)}
@@ -226,7 +237,6 @@ export function SessionDetailPage() {
             label="Output tokens"
             value={formatTokens(timeline.tokens.completion)}
           />
-          <Stat label="Total" value={formatTokens(timeline.tokens.total)} />
         </Box>
 
         <SessionTimeline timeline={timeline} agentName={row.agentName} />

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
@@ -43,12 +43,6 @@ const useStyles = makeStyles(theme => ({
   statValue: {
     fontVariantNumeric: 'tabular-nums',
   },
-  sessionId: {
-    fontFamily: 'monospace',
-    fontSize: '0.75rem',
-    color: theme.palette.text.secondary,
-    wordBreak: 'break-all',
-  },
 }));
 
 /**
@@ -209,8 +203,6 @@ export function SessionDetailPage() {
             {' · last activity '}
             {row.updatedAt ? <DateComponent value={row.updatedAt} /> : '—'}
           </Text>
-
-          <Text className={classes.sessionId}>{row.id}</Text>
         </Flex>
 
         <Box className={classes.stats}>

--- a/plugins/agent-platform/src/components/SessionDetailPage/index.ts
+++ b/plugins/agent-platform/src/components/SessionDetailPage/index.ts
@@ -1,0 +1,1 @@
+export { SessionDetailPage } from './SessionDetailPage';

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -128,6 +128,43 @@ describe('SessionTimeline', () => {
     expect(screen.getByText('approved')).toBeInTheDocument();
   });
 
+  it('offers no expander for an entry with nothing behind it', async () => {
+    // The approval in this fixture carries proposed arguments, so it *is*
+    // expandable. Strip them and it must render as a plain row: an accordion that
+    // opens onto an empty panel invites a click and answers with nothing.
+    const timeline = timelineFor(tasksApproval);
+    const stripped = {
+      ...timeline,
+      items: timeline.items.map(item =>
+        item.kind === 'approval' ? { ...item, args: undefined } : item,
+      ),
+    };
+
+    await renderInTestApp(
+      <SessionTimeline timeline={stripped} agentName="Issue tracker" />,
+    );
+
+    // Still shown, and still carries its verdict.
+    expect(screen.getByText('Approval requested')).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+    // But not as something you can open.
+    expect(
+      screen.queryByRole('button', { name: /Approval requested/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an approval’s proposed arguments when it has them', async () => {
+    await render(tasksApproval);
+
+    const trigger = screen.getByRole('button', { name: /Approval requested/ });
+    await userEvent.click(trigger);
+
+    // Labelled "proposed", because these are arguments the agent asked to run —
+    // not something it did.
+    expect(screen.getByText('Proposed arguments')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
   it('names a delegation and its token cost', async () => {
     await render(tasksV099);
 

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -135,14 +135,21 @@ describe('SessionTimeline', () => {
     expect(screen.getByText('3.1k tokens')).toBeInTheDocument();
   });
 
-  it('shows one timestamp per turn, not per item', async () => {
+  it('shows one absolute timestamp per turn, not per item', async () => {
     // A2A messages carry no time of their own and kagent's events cannot be
     // correlated with them, so a task's timestamp is the finest granularity there
     // is. Two turns in the fixture means two markers, not one per item.
+    //
+    // Absolute rather than relative, because every turn of a session usually falls
+    // on the same day: the relative form printed "1 day ago" for both of these and
+    // hid the four minutes between them.
     await render(tasksV099);
 
-    const relativeDates = screen.getAllByText(/ago$/);
-    expect(relativeDates).toHaveLength(2);
+    const markers = screen.getAllByText(/UTC$/);
+    expect(markers.map(m => m.textContent)).toEqual([
+      '23 Jul 2026, 16:05 UTC',
+      '23 Jul 2026, 16:09 UTC',
+    ]);
   });
 
   it('renders an empty state for a session that never ran', async () => {

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -8,6 +8,7 @@ import { SessionTimeline } from './SessionTimeline';
 
 import tasksV099 from '../../lib/__fixtures__/tasks.v0-9-9.json';
 import tasksApproval from '../../lib/__fixtures__/tasks.approval.json';
+import tasksAskUser from '../../lib/__fixtures__/tasks.ask-user.json';
 import tasksEmpty from '../../lib/__fixtures__/tasks.empty-no-data.json';
 
 function timelineFor(fixture: unknown) {
@@ -125,7 +126,7 @@ describe('SessionTimeline', () => {
     expect(
       screen.getByRole('button', { name: /Approval requested/ }),
     ).toBeInTheDocument();
-    expect(screen.getByText('approved')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
   });
 
   it('offers the control when the only collapsible entry is an approval', async () => {
@@ -162,6 +163,50 @@ describe('SessionTimeline', () => {
     expect(screen.getByText('Proposed arguments')).toBeInTheDocument();
   });
 
+  describe('ask_user, which ADK wraps like an approval', () => {
+    it('asks for input rather than approval', async () => {
+      // Same `adk_request_confirmation` envelope as a permission request, but it
+      // puts a question to the user — so "Approval requested" describes the wrong
+      // thing. kagent's own UI branches at the same point.
+      await render(tasksAskUser, 'SRE Agent');
+
+      expect(screen.getByText('User input requested')).toBeInTheDocument();
+      expect(screen.queryByText('Approval requested')).not.toBeInTheDocument();
+    });
+
+    it('reports that the user responded, not that they approved', async () => {
+      // ADK records the reply as an "approve" decision, but "Approved" says nothing
+      // about a question — the user simply answered it.
+      await render(tasksAskUser, 'SRE Agent');
+
+      expect(screen.getByText('Responded')).toBeInTheDocument();
+      expect(screen.queryByText('Approved')).not.toBeInTheDocument();
+    });
+
+    it('calls the payload questions, and omits the redundant tool name', async () => {
+      await render(tasksAskUser, 'SRE Agent');
+
+      await userEvent.click(
+        screen.getByRole('button', { name: /User input requested/ }),
+      );
+
+      expect(screen.getByText('Questions')).toBeInTheDocument();
+      // `ask_user` on every such row carries no information.
+      expect(screen.queryByText('ask_user')).not.toBeInTheDocument();
+    });
+
+    it('reports an unanswered question as awaiting a reply', async () => {
+      const pending = structuredClone(tasksAskUser) as typeof tasksAskUser;
+      pending.data[0].history = pending.data[0].history.filter(
+        item => item.messageId !== 'm-decision-1',
+      );
+
+      await render(pending, 'SRE Agent');
+
+      expect(screen.getByText('Awaiting a reply')).toBeInTheDocument();
+    });
+  });
+
   it('offers no expander for an entry with nothing behind it', async () => {
     // The approval in this fixture carries proposed arguments, so it *is*
     // expandable. Strip them and it must render as a plain row: an accordion that
@@ -180,7 +225,7 @@ describe('SessionTimeline', () => {
 
     // Still shown, and still carries its verdict.
     expect(screen.getByText('Approval requested')).toBeInTheDocument();
-    expect(screen.getByText('approved')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
     // But not as something you can open.
     expect(
       screen.queryByRole('button', { name: /Approval requested/ }),

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -1,0 +1,172 @@
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { buildTimeline } from '../../lib/kagentTimeline';
+import { normalizeTaskList } from '../../lib/kagentSessionDetail';
+import { SessionTimeline } from './SessionTimeline';
+
+import tasksV099 from '../../lib/__fixtures__/tasks.v0-9-9.json';
+import tasksApproval from '../../lib/__fixtures__/tasks.approval.json';
+import tasksEmpty from '../../lib/__fixtures__/tasks.empty-no-data.json';
+
+function timelineFor(fixture: unknown) {
+  return buildTimeline(normalizeTaskList(fixture).tasks);
+}
+
+async function render(fixture: unknown, agentName = 'Issue tracker') {
+  await renderInTestApp(
+    <SessionTimeline timeline={timelineFor(fixture)} agentName={agentName} />,
+  );
+}
+
+/** The accordion trigger for the fixture's first tool call. */
+function toolTrigger(): HTMLElement {
+  return screen.getByRole('button', { name: /github_search_issues/ });
+}
+
+/**
+ * The disclosure panel a trigger controls.
+ *
+ * bui renders the panel as `role="group"` inside the same accordion, so it is
+ * reached through the DOM rather than by an accessible name — the panel has none.
+ */
+function panelFor(trigger: HTMLElement): HTMLElement {
+  // Scoped to the *group* container, not `[class*="bui-Accordion"]` — that also
+  // matches the trigger's own `bui-AccordionTrigger`, so `closest` would return the
+  // trigger and find no panel inside it. Each timeline entry renders its own
+  // group, so the container holds exactly one panel.
+  const panel = trigger
+    .closest('[class*="AccordionGroup"]')
+    ?.querySelector('[role="group"]');
+  if (!(panel instanceof HTMLElement)) {
+    throw new Error('no disclosure panel found for the trigger');
+  }
+  return panel;
+}
+
+describe('SessionTimeline', () => {
+  it('renders the conversation', async () => {
+    await render(tasksV099);
+
+    expect(
+      screen.getByText(/Which GitHub issues are assigned to me/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/You have two open issues/)).toBeInTheDocument();
+  });
+
+  it('labels the user and the resolved agent', async () => {
+    await render(tasksV099);
+
+    expect(screen.getAllByText('You').length).toBeGreaterThan(0);
+    // The display name from the Agent CR, not the raw `issue_tracker` identifier.
+    expect(screen.getAllByText('Issue tracker').length).toBeGreaterThan(0);
+  });
+
+  it('collapses the agent’s internal activity by default', async () => {
+    // The working is why this screen is worth opening, but a wall of expanded tool
+    // payloads is unreadable — so it starts collapsed and is one click away.
+    //
+    // Asserted on `aria-expanded`, not absence from the DOM: react-aria renders a
+    // collapsed disclosure panel and hides it, so its text is present throughout.
+    await render(tasksV099);
+
+    expect(toolTrigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(panelFor(toolTrigger())).not.toBeVisible();
+  });
+
+  it('shows a tool call’s arguments and result when expanded', async () => {
+    await render(tasksV099);
+
+    await userEvent.click(toolTrigger());
+
+    expect(toolTrigger()).toHaveAttribute('aria-expanded', 'true');
+    const panel = panelFor(toolTrigger());
+    expect(panel).toBeVisible();
+    expect(panel).toHaveTextContent('Arguments');
+    expect(panel).toHaveTextContent('Result');
+  });
+
+  it('expands everything when asked, and hides it when asked', async () => {
+    await render(tasksV099);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Expanded' }));
+    expect(toolTrigger()).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Hidden' }));
+    expect(
+      screen.queryByRole('button', { name: /github_search_issues/ }),
+    ).not.toBeInTheDocument();
+    // The conversation itself is never hidden — only the agent's working.
+    expect(screen.getByText(/You have two open issues/)).toBeInTheDocument();
+  });
+
+  it('keeps an approval visible even when activity is hidden', async () => {
+    // An approval records the *user's* decision, so hiding it would remove the
+    // trace of their own action rather than the agent's working.
+    //
+    // The approval fixture on its own has no activity items — which is why the
+    // control isn't offered for it at all — so the two timelines are combined here
+    // to get a session that has both.
+    const combined = timelineFor(tasksV099);
+    const approval = timelineFor(tasksApproval);
+    await renderInTestApp(
+      <SessionTimeline
+        timeline={{
+          ...combined,
+          items: [...combined.items, ...approval.items],
+        }}
+        agentName="Issue tracker"
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Hidden' }));
+
+    expect(
+      screen.getByRole('button', { name: /Approval requested/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+  });
+
+  it('names a delegation and its token cost', async () => {
+    await render(tasksV099);
+
+    expect(screen.getByText('Delegated to sre-agent')).toBeInTheDocument();
+    expect(screen.getByText('3.1k tokens')).toBeInTheDocument();
+  });
+
+  it('shows one timestamp per turn, not per item', async () => {
+    // A2A messages carry no time of their own and kagent's events cannot be
+    // correlated with them, so a task's timestamp is the finest granularity there
+    // is. Two turns in the fixture means two markers, not one per item.
+    await render(tasksV099);
+
+    const relativeDates = screen.getAllByText(/ago$/);
+    expect(relativeDates).toHaveLength(2);
+  });
+
+  it('renders an empty state for a session that never ran', async () => {
+    await render(tasksEmpty);
+
+    expect(
+      screen.getByText('This session has no messages yet.'),
+    ).toBeInTheDocument();
+    // No control to offer when there is no activity to govern.
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+
+  it('warns when messages could not be read', async () => {
+    const timeline = timelineFor(tasksV099);
+    await renderInTestApp(
+      <SessionTimeline
+        timeline={{ ...timeline, skippedMessages: 2 }}
+        agentName="Issue tracker"
+      />,
+    );
+
+    expect(
+      screen.getByText('Some messages could not be read'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2 messages/)).toBeInTheDocument();
+  });
+});

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -128,6 +128,40 @@ describe('SessionTimeline', () => {
     expect(screen.getByText('approved')).toBeInTheDocument();
   });
 
+  it('offers the control when the only collapsible entry is an approval', async () => {
+    // This fixture has no reasoning, tool calls or delegations — just an approval.
+    // Keying the control on *activity* left such sessions with a collapsed panel
+    // and no way to open it, which is what happens on a real ask_user session.
+    await render(tasksApproval);
+
+    expect(
+      screen.getByRole('radio', { name: 'Collapsed' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Expanded' })).toBeInTheDocument();
+  });
+
+  it('omits Hidden when there is no agent activity to hide', async () => {
+    // `hidden` removes the agent's working, and an approval is not that — it is the
+    // record of the user's own decision. With nothing else to hide, the option
+    // would do nothing.
+    await render(tasksApproval);
+
+    expect(
+      screen.queryByRole('radio', { name: 'Hidden' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('expands an approval through the control', async () => {
+    await render(tasksApproval);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Expanded' }));
+
+    expect(
+      screen.getByRole('button', { name: /Approval requested/ }),
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Proposed arguments')).toBeInTheDocument();
+  });
+
   it('offers no expander for an entry with nothing behind it', async () => {
     // The approval in this fixture carries proposed arguments, so it *is*
     // expandable. Strip them and it must render as a plain row: an accordion that

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -195,6 +195,61 @@ describe('SessionTimeline', () => {
       expect(screen.queryByText('ask_user')).not.toBeInTheDocument();
     });
 
+    it('shows what the user actually replied', async () => {
+      // The reply rides on the same message as the `decision_type` data part.
+      // Bailing out of that message discarded it, so the page showed the question
+      // and the agent's follow-up with the user's words missing in between.
+      await render(tasksAskUser, 'SRE Agent');
+
+      expect(
+        screen.getByText(/Still no reply to messages with image/),
+      ).toBeInTheDocument();
+    });
+
+    it('reads the reply as conversation, in order', async () => {
+      await render(tasksAskUser, 'SRE Agent');
+
+      const order = [
+        ...document.querySelectorAll('[data-testid^="timeline-"]'),
+      ].map(el => el.getAttribute('data-testid'));
+      expect(order).toEqual([
+        'timeline-user-message',
+        'timeline-approval',
+        'timeline-user-message',
+        'timeline-agent-message',
+      ]);
+    });
+
+    it('does not show the reply twice, though the payload carries it twice', async () => {
+      // It is in both the text part and `ask_user_answers`. The text part wins.
+      await render(tasksAskUser, 'SRE Agent');
+
+      expect(
+        screen.getAllByText(/Still no reply to messages with image/),
+      ).toHaveLength(1);
+    });
+
+    it('recovers the reply from ask_user_answers when there is no text part', async () => {
+      // kagent's own UI reads only the structured field, so a session may exist
+      // where it is the sole carrier — this one came through a Slack gateway that
+      // writes both.
+      const structuredOnly = structuredClone(
+        tasksAskUser,
+      ) as typeof tasksAskUser;
+      const decision = structuredOnly.data[0].history.find(
+        item => item.messageId === 'm-decision-1',
+      ) as { parts: unknown[] };
+      decision.parts = decision.parts.filter(
+        part => (part as { kind?: string }).kind !== 'text',
+      );
+
+      await render(structuredOnly, 'SRE Agent');
+
+      expect(
+        screen.getByText(/Still no reply to messages with image/),
+      ).toBeInTheDocument();
+    });
+
     it('reports an unanswered question as awaiting a reply', async () => {
       const pending = structuredClone(tasksAskUser) as typeof tasksAskUser;
       pending.data[0].history = pending.data[0].history.filter(

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Flex,
+  Text,
+  ToggleButton,
+  ToggleButtonGroup,
+} from '@backstage/ui';
+import { makeStyles } from '@material-ui/core';
+import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
+
+import { SessionTimeline as Timeline } from '../../lib/kagentTimeline';
+import { TimelineEntry } from './TimelineEntry';
+import { ActivityDetail, groupIntoTurns, isActivityItem } from './helpers';
+
+const useStyles = makeStyles(theme => ({
+  turnMarker: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1),
+  },
+  rule: {
+    flex: 1,
+    height: 1,
+    backgroundColor: theme.palette.divider,
+  },
+}));
+
+export type SessionTimelineProps = {
+  timeline: Timeline;
+  /** Display name of the session's agent, used to label its messages. */
+  agentName?: string;
+};
+
+/**
+ * The session's conversation, grouped into turns.
+ *
+ * **Timestamps are per turn, not per item.** A2A messages carry no time of their
+ * own, and kagent's stored events — which looked like a source for one — turned out
+ * to be ADK events with no `messageId` to correlate against. So a task's timestamp
+ * is the finest granularity that exists, and it is shown once per turn rather than
+ * repeated on every item, which would imply precision we don't have.
+ */
+export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
+  const classes = useStyles();
+  // Collapsed by default: the agent's working is why this screen is worth opening,
+  // but a wall of expanded tool payloads is unreadable.
+  const [detail, setDetail] = useState<ActivityDetail>('collapsed');
+
+  const turns = useMemo(() => groupIntoTurns(timeline.items), [timeline.items]);
+
+  const activityCount = useMemo(
+    () => timeline.items.filter(isActivityItem).length,
+    [timeline.items],
+  );
+
+  if (timeline.items.length === 0) {
+    return (
+      <Text variant="body-medium" color="secondary">
+        This session has no messages yet.
+      </Text>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="3">
+      <Flex
+        align="center"
+        justify="between"
+        gap="2"
+        style={{ flexWrap: 'wrap' }}
+      >
+        <Text variant="title-small">Timeline</Text>
+        {activityCount > 0 && (
+          <Flex align="center" gap="2">
+            <Text variant="body-small" color="secondary">
+              Agent activity
+            </Text>
+            <ToggleButtonGroup
+              selectionMode="single"
+              disallowEmptySelection
+              selectedKeys={[detail]}
+              onSelectionChange={keys => {
+                const next = [...keys][0];
+                if (
+                  next === 'hidden' ||
+                  next === 'collapsed' ||
+                  next === 'expanded'
+                ) {
+                  setDetail(next);
+                }
+              }}
+            >
+              <ToggleButton id="hidden">Hidden</ToggleButton>
+              <ToggleButton id="collapsed">Collapsed</ToggleButton>
+              <ToggleButton id="expanded">Expanded</ToggleButton>
+            </ToggleButtonGroup>
+          </Flex>
+        )}
+      </Flex>
+
+      {timeline.skippedMessages > 0 && (
+        <Alert
+          status="warning"
+          title="Some messages could not be read"
+          description={`${timeline.skippedMessages} ${
+            timeline.skippedMessages === 1 ? 'message' : 'messages'
+          } in this session did not match the shape we expect from kagent and are not shown.`}
+        />
+      )}
+
+      {turns.map(turn => {
+        const visible =
+          detail === 'hidden'
+            ? turn.items.filter(item => !isActivityItem(item))
+            : turn.items;
+        if (visible.length === 0) {
+          return null;
+        }
+        return (
+          <Flex key={turn.taskIndex} direction="column" gap="3">
+            <div className={classes.turnMarker}>
+              <Text variant="body-small" color="secondary">
+                {turn.at ? <DateComponent value={turn.at} relative /> : '—'}
+              </Text>
+              <span className={classes.rule} />
+            </div>
+            {visible.map(item => (
+              <TimelineEntry
+                // Keyed on the detail setting as well as the item: an
+                // AccordionGroup's expanded set is only read on mount, so the
+                // global control takes effect by remounting the entries.
+                key={`${item.id}:${detail}`}
+                item={item}
+                resolvedAgentName={agentName}
+                defaultExpanded={detail === 'expanded'}
+              />
+            ))}
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
+}

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
@@ -120,9 +120,13 @@ export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
         }
         return (
           <Flex key={turn.taskIndex} direction="column" gap="3">
+            {/* Absolute, not relative: every turn of a session usually falls on
+                the same day, so the relative form printed "1 day ago" three times
+                and hid the progression entirely. An exact time shows how the
+                session actually unfolded. */}
             <div className={classes.turnMarker}>
               <Text variant="body-small" color="secondary">
-                {turn.at ? <DateComponent value={turn.at} relative /> : '—'}
+                {turn.at ? <DateComponent value={turn.at} /> : '—'}
               </Text>
               <span className={classes.rule} />
             </div>

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
@@ -11,7 +11,12 @@ import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
 
 import { SessionTimeline as Timeline } from '../../lib/kagentTimeline';
 import { TimelineEntry } from './TimelineEntry';
-import { ActivityDetail, groupIntoTurns, isActivityItem } from './helpers';
+import {
+  ActivityDetail,
+  groupIntoTurns,
+  hasExpandableDetail,
+  isActivityItem,
+} from './helpers';
 
 const useStyles = makeStyles(theme => ({
   turnMarker: {
@@ -50,8 +55,21 @@ export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
 
   const turns = useMemo(() => groupIntoTurns(timeline.items), [timeline.items]);
 
-  const activityCount = useMemo(
-    () => timeline.items.filter(isActivityItem).length,
+  // Offered whenever *anything* can expand — not just when there is agent
+  // activity. An approval is excluded from `hidden` (it records the user's own
+  // decision, so hiding it would erase their action) but it still expands and
+  // collapses, so a session whose only collapsible entry is an approval must still
+  // get the control. Keying this on activity alone left such sessions with a
+  // collapsed panel and no way to open them all.
+  const hasExpandable = useMemo(
+    () => timeline.items.some(hasExpandableDetail),
+    [timeline.items],
+  );
+
+  // Whether `hidden` would actually remove anything, which decides if that option
+  // is worth offering.
+  const hasActivity = useMemo(
+    () => timeline.items.some(isActivityItem),
     [timeline.items],
   );
 
@@ -72,10 +90,10 @@ export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
         style={{ flexWrap: 'wrap' }}
       >
         <Text variant="title-small">Timeline</Text>
-        {activityCount > 0 && (
+        {hasExpandable && (
           <Flex align="center" gap="2">
             <Text variant="body-small" color="secondary">
-              Agent activity
+              Details
             </Text>
             <ToggleButtonGroup
               selectionMode="single"
@@ -92,7 +110,11 @@ export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
                 }
               }}
             >
-              <ToggleButton id="hidden">Hidden</ToggleButton>
+              {/* Only offered when it would remove something. `hidden` drops the
+                  agent's working, and approvals are not part of that — so a session
+                  whose only collapsible entry is an approval gets expand/collapse
+                  but nothing to hide. */}
+              {hasActivity && <ToggleButton id="hidden">Hidden</ToggleButton>}
               <ToggleButton id="collapsed">Collapsed</ToggleButton>
               <ToggleButton id="expanded">Expanded</ToggleButton>
             </ToggleButtonGroup>

--- a/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
@@ -75,6 +75,20 @@ function MessageBody({ text }: { text: string }) {
   return <GSMarkdownContent content={text} />;
 }
 
+/**
+ * What to call an entry's arguments.
+ *
+ * A confirmation request's payload is not something the agent did: for a permission
+ * request it is the call it *proposed*, and for `ask_user` it is the questions
+ * themselves.
+ */
+function argsLabel(item: TimelineItem): string {
+  if (item.kind !== 'approval') {
+    return 'Arguments';
+  }
+  return item.asks === 'input' ? 'Questions' : 'Proposed arguments';
+}
+
 /** Label and payloads for a tool call or a delegation. */
 function CallDetail({ item }: { item: TimelineItem }) {
   const classes = useStyles();
@@ -93,9 +107,7 @@ function CallDetail({ item }: { item: TimelineItem }) {
             color="secondary"
             className={classes.payloadLabel}
           >
-            {/* An approval's arguments are what the agent *proposed* to run, not
-                something it did — worth naming differently. */}
-            {item.kind === 'approval' ? 'Proposed arguments' : 'Arguments'}
+            {argsLabel(item)}
           </Text>
           <CodeBlock content={args} />
         </div>
@@ -162,9 +174,13 @@ function CollapsedSummary({ item }: { item: TimelineItem }) {
       return (
         <Flex align="center" gap="2" style={{ minWidth: 0 }}>
           <Text variant="body-medium" weight="bold">
-            Approval requested
+            {item.asks === 'input'
+              ? 'User input requested'
+              : 'Approval requested'}
           </Text>
-          {item.toolName && (
+          {/* The proposed tool names what needs approving, which is the point of
+              the row. For a question it is always `ask_user` — noise. */}
+          {item.asks === 'approval' && item.toolName && (
             <span className={classes.summary}>{item.toolName}</span>
           )}
           <ApprovalVerdict item={item} />
@@ -176,23 +192,33 @@ function CollapsedSummary({ item }: { item: TimelineItem }) {
 }
 
 /**
- * The verdict badge on an approval.
+ * How the user answered a confirmation request.
  *
- * An undefined verdict is rendered as "awaiting a decision" rather than assumed
- * approved: the parser deliberately declines to guess when kagent used wording it
- * doesn't recognise, and claiming consent would misreport the user's own action.
+ * The wording follows what was asked. ADK records both a permission request and a
+ * question as the same "approved"/"rejected" decision, but "Approved" says nothing
+ * about a question — the user simply replied. So a question reports
+ * "Responded"/"Declined" and a permission request "Approved"/"Rejected".
+ *
+ * An undefined verdict is never rendered as consent: the parser deliberately
+ * declines to guess when kagent used wording it doesn't recognise, and claiming
+ * approval would misreport the user's own action.
  */
 function ApprovalVerdict({ item }: { item: TimelineItem }) {
   if (item.kind !== 'approval') {
     return null;
   }
+  const isQuestion = item.asks === 'input';
   if (item.verdict === 'approved') {
-    return <Badge size="small">approved</Badge>;
+    return <Badge size="small">{isQuestion ? 'Responded' : 'Approved'}</Badge>;
   }
   if (item.verdict === 'rejected') {
-    return <Badge size="small">rejected</Badge>;
+    return <Badge size="small">{isQuestion ? 'Declined' : 'Rejected'}</Badge>;
   }
-  return <Badge size="small">awaiting a decision</Badge>;
+  return (
+    <Badge size="small">
+      {isQuestion ? 'Awaiting a reply' : 'Awaiting a decision'}
+    </Badge>
+  );
 }
 
 /**

--- a/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
@@ -15,8 +15,9 @@ import { CodeBlock } from '../CodeBlock';
 import {
   agentCallLabel,
   authorLabel,
-  formatPayload,
+  expandablePayloads,
   formatTokens,
+  hasExpandableDetail,
   summarizeArgs,
 } from './helpers';
 
@@ -75,36 +76,9 @@ function MessageBody({ text }: { text: string }) {
 }
 
 /** Label and payloads for a tool call or a delegation. */
-/**
- * The payloads an item can show when expanded, or `undefined` when it has none.
- *
- * Returning `undefined` is what lets the caller render a plain row instead of an
- * accordion: an expander that opens onto nothing is worse than no expander.
- */
-function payloadsOf(
-  item: TimelineItem,
-): { args?: string; result?: string } | undefined {
-  if (
-    item.kind !== 'tool-call' &&
-    item.kind !== 'agent-call' &&
-    item.kind !== 'approval'
-  ) {
-    return undefined;
-  }
-  const args = formatPayload(item.args);
-  // Approvals have no result — they carry the *proposed* call, which never ran as
-  // this item.
-  const result =
-    item.kind === 'approval' ? undefined : formatPayload(item.result);
-  if (!args && !result) {
-    return undefined;
-  }
-  return { args, result };
-}
-
 function CallDetail({ item }: { item: TimelineItem }) {
   const classes = useStyles();
-  const payloads = payloadsOf(item);
+  const payloads = expandablePayloads(item);
   if (!payloads) {
     return null;
   }
@@ -261,14 +235,9 @@ export function TimelineEntry({
     );
   }
 
-  // Reasoning always has text to show; everything else depends on whether kagent
-  // recorded any payload. An approval frequently has none — the verdict is already
-  // on the summary row — and a tool call can have neither arguments nor result.
-  const hasDetail = item.kind === 'reasoning' || Boolean(payloadsOf(item));
-
   // No expander when there is nothing behind it. An accordion that opens onto an
   // empty panel invites a click and answers with nothing.
-  if (!hasDetail) {
+  if (!hasExpandableDetail(item)) {
     return (
       <div className={classes.entry} data-testid={`timeline-${item.kind}`}>
         <div className={classes.inertSummary}>

--- a/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
@@ -1,0 +1,257 @@
+import {
+  Accordion,
+  AccordionGroup,
+  AccordionPanel,
+  AccordionTrigger,
+  Badge,
+  Flex,
+  Text,
+} from '@backstage/ui';
+import { makeStyles } from '@material-ui/core';
+import { GSMarkdownContent } from '@giantswarm/backstage-plugin-ui-react';
+
+import { TimelineItem } from '../../lib/kagentTimeline';
+import { CodeBlock } from '../CodeBlock';
+import {
+  agentCallLabel,
+  authorLabel,
+  formatPayload,
+  formatTokens,
+  summarizeArgs,
+} from './helpers';
+
+const useStyles = makeStyles(theme => ({
+  entry: {
+    // A left rule ties an entry's parts together and keeps the agent's internal
+    // work visually subordinate to the conversation.
+    paddingLeft: theme.spacing(1.5),
+    borderLeft: `2px solid ${theme.palette.divider}`,
+  },
+  userEntry: {
+    borderLeftColor: theme.palette.primary.main,
+  },
+  summary: {
+    fontFamily: 'monospace',
+    fontSize: '0.8rem',
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    minWidth: 0,
+  },
+  // AccordionTrigger has no bottom padding, so an expanded header sits flush
+  // against its panel and reads top-heavy.
+  accordion: {
+    '& [aria-expanded="true"]': {
+      paddingBottom: theme.spacing(0.75),
+    },
+  },
+  payloadLabel: {
+    display: 'block',
+    marginBottom: theme.spacing(0.5),
+  },
+}));
+
+export type TimelineEntryProps = {
+  item: TimelineItem;
+  /**
+   * Display name of the `Agent` CR this session belongs to, when one matched.
+   * Preferred over the raw author, since decoding a python identifier is lossy.
+   */
+  resolvedAgentName?: string;
+  /** Whether a collapsible entry starts open. */
+  defaultExpanded?: boolean;
+};
+
+/** Prose from the user or the agent, rendered as markdown. */
+function MessageBody({ text }: { text: string }) {
+  return <GSMarkdownContent content={text} />;
+}
+
+/** Label and payloads for a tool call or a delegation. */
+function CallDetail({ item }: { item: TimelineItem }) {
+  const classes = useStyles();
+  if (item.kind !== 'tool-call' && item.kind !== 'agent-call') {
+    return null;
+  }
+  const args = formatPayload(item.args);
+  const result = formatPayload(item.result);
+
+  return (
+    <Flex direction="column" gap="2">
+      {args && (
+        <div>
+          <Text
+            variant="body-small"
+            color="secondary"
+            className={classes.payloadLabel}
+          >
+            Arguments
+          </Text>
+          <CodeBlock content={args} />
+        </div>
+      )}
+      {result && (
+        <div>
+          <Text
+            variant="body-small"
+            color="secondary"
+            className={classes.payloadLabel}
+          >
+            Result
+          </Text>
+          <CodeBlock content={result} />
+        </div>
+      )}
+      {!args && !result && (
+        <Text variant="body-medium" color="secondary">
+          {item.isPending
+            ? 'No result was recorded for this call.'
+            : 'This call recorded no arguments or result.'}
+        </Text>
+      )}
+    </Flex>
+  );
+}
+
+/** The one-line header of a collapsible entry. */
+function CollapsedSummary({ item }: { item: TimelineItem }) {
+  const classes = useStyles();
+
+  switch (item.kind) {
+    case 'reasoning':
+      return (
+        <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+          <Text variant="body-medium" weight="bold">
+            Reasoning
+          </Text>
+          <span className={classes.summary}>
+            {item.text.replace(/\s+/g, ' ').trim()}
+          </span>
+        </Flex>
+      );
+    case 'tool-call':
+      return (
+        <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+          <Text variant="body-medium" weight="bold">
+            {item.toolName}
+          </Text>
+          {item.isPending && <Badge size="small">no result</Badge>}
+          <span className={classes.summary}>{summarizeArgs(item.args)}</span>
+        </Flex>
+      );
+    case 'agent-call':
+      return (
+        <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+          <Text variant="body-medium" weight="bold">
+            Delegated to {agentCallLabel(item.agentId)}
+          </Text>
+          {item.tokens && (
+            <Badge size="small">{formatTokens(item.tokens.total)} tokens</Badge>
+          )}
+          {item.isPending && <Badge size="small">no result</Badge>}
+        </Flex>
+      );
+    case 'approval':
+      return (
+        <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+          <Text variant="body-medium" weight="bold">
+            Approval requested
+          </Text>
+          {item.toolName && (
+            <span className={classes.summary}>{item.toolName}</span>
+          )}
+          <ApprovalVerdict item={item} />
+        </Flex>
+      );
+    default:
+      return null;
+  }
+}
+
+/**
+ * The verdict badge on an approval.
+ *
+ * An undefined verdict is rendered as "awaiting a decision" rather than assumed
+ * approved: the parser deliberately declines to guess when kagent used wording it
+ * doesn't recognise, and claiming consent would misreport the user's own action.
+ */
+function ApprovalVerdict({ item }: { item: TimelineItem }) {
+  if (item.kind !== 'approval') {
+    return null;
+  }
+  if (item.verdict === 'approved') {
+    return <Badge size="small">approved</Badge>;
+  }
+  if (item.verdict === 'rejected') {
+    return <Badge size="small">rejected</Badge>;
+  }
+  return <Badge size="small">awaiting a decision</Badge>;
+}
+
+/**
+ * One entry in the session timeline.
+ *
+ * Conversation messages render in full; everything else — reasoning, tool calls,
+ * delegations, approvals — is collapsible, because the agent's working is what
+ * makes this screen worth opening but a wall of tool payloads is unreadable.
+ *
+ * `defaultExpanded` only applies on mount, which is a bui `AccordionGroup`
+ * constraint. The list keys each group on the global detail setting so changing it
+ * remounts them and the new default takes effect.
+ */
+export function TimelineEntry({
+  item,
+  resolvedAgentName,
+  defaultExpanded = false,
+}: TimelineEntryProps) {
+  const classes = useStyles();
+  const author = authorLabel(item, resolvedAgentName);
+
+  // Narrowed on the kinds rather than through `isCollapsible`, so the compiler
+  // knows `text` exists in this branch.
+  if (item.kind === 'user-message' || item.kind === 'agent-message') {
+    const isUser = item.kind === 'user-message';
+    return (
+      <div
+        className={`${classes.entry} ${isUser ? classes.userEntry : ''}`}
+        data-testid={`timeline-${item.kind}`}
+      >
+        <Text
+          variant="body-small"
+          color="secondary"
+          style={{ display: 'block' }}
+        >
+          {isUser ? 'You' : (author ?? 'Agent')}
+        </Text>
+        <MessageBody text={item.text} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.entry} data-testid={`timeline-${item.kind}`}>
+      {/* `defaultExpandedKeys` on the group rather than `defaultExpanded` on the
+          item: inside a DisclosureGroup react-aria owns the expanded set, so the
+          per-item prop is not what takes effect. It applies on mount only, which is
+          why the list keys each group on the global detail setting. */}
+      <AccordionGroup
+        className={classes.accordion}
+        defaultExpandedKeys={defaultExpanded ? new Set([item.id]) : new Set()}
+      >
+        <Accordion id={item.id}>
+          <AccordionTrigger>
+            <CollapsedSummary item={item} />
+          </AccordionTrigger>
+          <AccordionPanel>
+            {item.kind === 'reasoning' ? (
+              <MessageBody text={item.text} />
+            ) : (
+              <CallDetail item={item} />
+            )}
+          </AccordionPanel>
+        </Accordion>
+      </AccordionGroup>
+    </div>
+  );
+}

--- a/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
@@ -50,6 +50,12 @@ const useStyles = makeStyles(theme => ({
     display: 'block',
     marginBottom: theme.spacing(0.5),
   },
+  // Matches an AccordionTrigger's vertical rhythm, so a row with nothing to expand
+  // still lines up with the ones that do.
+  inertSummary: {
+    paddingTop: theme.spacing(0.75),
+    paddingBottom: theme.spacing(0.75),
+  },
 }));
 
 export type TimelineEntryProps = {
@@ -69,13 +75,40 @@ function MessageBody({ text }: { text: string }) {
 }
 
 /** Label and payloads for a tool call or a delegation. */
-function CallDetail({ item }: { item: TimelineItem }) {
-  const classes = useStyles();
-  if (item.kind !== 'tool-call' && item.kind !== 'agent-call') {
-    return null;
+/**
+ * The payloads an item can show when expanded, or `undefined` when it has none.
+ *
+ * Returning `undefined` is what lets the caller render a plain row instead of an
+ * accordion: an expander that opens onto nothing is worse than no expander.
+ */
+function payloadsOf(
+  item: TimelineItem,
+): { args?: string; result?: string } | undefined {
+  if (
+    item.kind !== 'tool-call' &&
+    item.kind !== 'agent-call' &&
+    item.kind !== 'approval'
+  ) {
+    return undefined;
   }
   const args = formatPayload(item.args);
-  const result = formatPayload(item.result);
+  // Approvals have no result — they carry the *proposed* call, which never ran as
+  // this item.
+  const result =
+    item.kind === 'approval' ? undefined : formatPayload(item.result);
+  if (!args && !result) {
+    return undefined;
+  }
+  return { args, result };
+}
+
+function CallDetail({ item }: { item: TimelineItem }) {
+  const classes = useStyles();
+  const payloads = payloadsOf(item);
+  if (!payloads) {
+    return null;
+  }
+  const { args, result } = payloads;
 
   return (
     <Flex direction="column" gap="2">
@@ -86,7 +119,9 @@ function CallDetail({ item }: { item: TimelineItem }) {
             color="secondary"
             className={classes.payloadLabel}
           >
-            Arguments
+            {/* An approval's arguments are what the agent *proposed* to run, not
+                something it did — worth naming differently. */}
+            {item.kind === 'approval' ? 'Proposed arguments' : 'Arguments'}
           </Text>
           <CodeBlock content={args} />
         </div>
@@ -102,13 +137,6 @@ function CallDetail({ item }: { item: TimelineItem }) {
           </Text>
           <CodeBlock content={result} />
         </div>
-      )}
-      {!args && !result && (
-        <Text variant="body-medium" color="secondary">
-          {item.isPending
-            ? 'No result was recorded for this call.'
-            : 'This call recorded no arguments or result.'}
-        </Text>
       )}
     </Flex>
   );
@@ -229,6 +257,23 @@ export function TimelineEntry({
           {isUser ? 'You' : (author ?? 'Agent')}
         </Text>
         <MessageBody text={item.text} />
+      </div>
+    );
+  }
+
+  // Reasoning always has text to show; everything else depends on whether kagent
+  // recorded any payload. An approval frequently has none — the verdict is already
+  // on the summary row — and a tool call can have neither arguments nor result.
+  const hasDetail = item.kind === 'reasoning' || Boolean(payloadsOf(item));
+
+  // No expander when there is nothing behind it. An accordion that opens onto an
+  // empty panel invites a click and answers with nothing.
+  if (!hasDetail) {
+    return (
+      <div className={classes.entry} data-testid={`timeline-${item.kind}`}>
+        <div className={classes.inertSummary}>
+          <CollapsedSummary item={item} />
+        </div>
       </div>
     );
   }

--- a/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
@@ -136,6 +136,10 @@ function CollapsedSummary({ item }: { item: TimelineItem }) {
           <Text variant="body-medium" weight="bold">
             {item.toolName}
           </Text>
+          {/* Agents reach most MCP tools through muster's `call_tool`, so the
+              parser looks through that wrapper and names the real tool. The badge
+              keeps the fact that it was proxied, which is otherwise lost. */}
+          {item.via && <Badge size="small">via {item.via}</Badge>}
           {item.isPending && <Badge size="small">no result</Badge>}
           <span className={classes.summary}>{summarizeArgs(item.args)}</span>
         </Flex>

--- a/plugins/agent-platform/src/components/SessionTimeline/helpers.test.ts
+++ b/plugins/agent-platform/src/components/SessionTimeline/helpers.test.ts
@@ -1,0 +1,99 @@
+import { formatDuration, formatTokens, groupIntoTurns } from './helpers';
+import { TimelineItem } from '../../lib/kagentTimeline';
+
+describe('formatDuration', () => {
+  const start = '2026-07-23T16:00:00.000Z';
+
+  function at(offsetMs: number): string {
+    return new Date(Date.parse(start) + offsetMs).toISOString();
+  }
+
+  it.each([
+    [0, '0s'],
+    [1_500, '2s'],
+    [45_000, '45s'],
+    [60_000, '1m'],
+    [34 * 60_000, '34m'],
+    [59 * 60_000 + 59_000, '59m'],
+    [60 * 60_000, '1h'],
+    [2 * 3_600_000 + 15 * 60_000, '2h 15m'],
+    [24 * 3_600_000, '1d'],
+    [27 * 3_600_000, '1d 3h'],
+  ])('formats a %pms span as %s', (offset, expected) => {
+    expect(formatDuration(start, at(offset as number))).toBe(expected);
+  });
+
+  it('shows seconds rather than rounding a quick answer to 0m', () => {
+    // A one-shot question answered immediately is a real session, and "0m" would
+    // read as missing data.
+    expect(formatDuration(start, at(4_000))).toBe('4s');
+  });
+
+  it.each([
+    [undefined, '2026-07-23T16:00:00.000Z'],
+    ['2026-07-23T16:00:00.000Z', undefined],
+    [undefined, undefined],
+    ['nonsense', '2026-07-23T16:00:00.000Z'],
+    ['2026-07-23T16:00:00.000Z', 'nonsense'],
+  ])('returns undefined for (%p, %p)', (from, to) => {
+    expect(formatDuration(from, to)).toBeUndefined();
+  });
+
+  it('returns undefined rather than a negative span', () => {
+    // Clock skew between whoever wrote the timestamps and us. "-3m" is worse than
+    // no answer.
+    expect(formatDuration(at(60_000), start)).toBeUndefined();
+  });
+});
+
+describe('formatTokens', () => {
+  it.each([
+    [0, '0'],
+    [999, '999'],
+    [1_000, '1.0k'],
+    [2_600, '2.6k'],
+    [1_400_000, '1.4M'],
+  ])('formats %p as %s', (value, expected) => {
+    expect(formatTokens(value as number)).toBe(expected);
+  });
+});
+
+describe('groupIntoTurns', () => {
+  function item(taskIndex: number, at?: string): TimelineItem {
+    return {
+      kind: 'user-message',
+      id: `i${taskIndex}`,
+      taskIndex,
+      at,
+      text: 'x',
+    } as TimelineItem;
+  }
+
+  it('groups consecutive items of the same task', () => {
+    const turns = groupIntoTurns([item(0), item(0), item(1)]);
+
+    expect(turns.map(t => t.items.length)).toEqual([2, 1]);
+    expect(turns.map(t => t.taskIndex)).toEqual([0, 1]);
+  });
+
+  it('takes the turn’s timestamp from its first item', () => {
+    const turns = groupIntoTurns([
+      item(0, '2026-07-23T16:05:00.000Z'),
+      item(0, '2026-07-23T16:05:00.000Z'),
+    ]);
+
+    expect(turns[0].at).toBe('2026-07-23T16:05:00.000Z');
+  });
+
+  it('starts a new group when a task index reappears non-contiguously', () => {
+    // Grouping on runs rather than a keyed map, so items can never be reordered
+    // relative to what buildTimeline produced.
+    const turns = groupIntoTurns([item(0), item(1), item(0)]);
+
+    expect(turns.map(t => t.taskIndex)).toEqual([0, 1, 0]);
+  });
+
+  it('returns nothing for an empty timeline', () => {
+    expect(groupIntoTurns([])).toEqual([]);
+  });
+});

--- a/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
+++ b/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
@@ -18,14 +18,56 @@ const ACTIVITY_KINDS = new Set<TimelineItem['kind']>([
 ]);
 
 /**
- * Whether an item is internal activity the `ActivityDetail` control governs.
+ * Whether an item is internal activity that `hidden` removes.
  *
  * Approvals are deliberately **not** included: an approval is a decision the user
  * was asked to make, so hiding it would remove the record of their own action, not
  * the agent's working.
+ *
+ * Note this governs *hiding* only. Approvals still expand and collapse with the
+ * control — see {@link hasExpandableDetail}.
  */
 export function isActivityItem(item: TimelineItem): boolean {
   return ACTIVITY_KINDS.has(item.kind);
+}
+
+/**
+ * The payloads an item reveals when expanded, or `undefined` when it has none.
+ *
+ * Shared by the entry (which renders them) and the list (which decides whether to
+ * offer the expand/collapse control at all), so the two cannot disagree about what
+ * is expandable.
+ */
+export function expandablePayloads(
+  item: TimelineItem,
+): { args?: string; result?: string } | undefined {
+  if (
+    item.kind !== 'tool-call' &&
+    item.kind !== 'agent-call' &&
+    item.kind !== 'approval'
+  ) {
+    return undefined;
+  }
+  const args = formatPayload(item.args);
+  // An approval has no result — it carries the *proposed* call, which never ran as
+  // this item.
+  const result =
+    item.kind === 'approval' ? undefined : formatPayload(item.result);
+  if (!args && !result) {
+    return undefined;
+  }
+  return { args, result };
+}
+
+/**
+ * Whether an entry has anything behind an expander.
+ *
+ * Reasoning always does. Everything else depends on what kagent recorded — an
+ * approval or tool call with no payload renders as a plain row instead, because an
+ * expander that opens onto nothing invites a click and answers with nothing.
+ */
+export function hasExpandableDetail(item: TimelineItem): boolean {
+  return item.kind === 'reasoning' || Boolean(expandablePayloads(item));
 }
 
 export type TimelineTurn = {

--- a/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
+++ b/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
@@ -1,0 +1,143 @@
+import { TimelineItem } from '../../lib/kagentTimeline';
+import { decodeAgentIdLabel } from '../SessionsDataProvider/helpers';
+
+/**
+ * How much of the agent's internal work the timeline shows.
+ *
+ * The prototype makes this a real control rather than a fixed state, because
+ * seeing "what the agent actually did" is the point of the screen — but a wall of
+ * expanded tool payloads is unreadable, so `collapsed` is the default.
+ */
+export type ActivityDetail = 'hidden' | 'collapsed' | 'expanded';
+
+/** Items that represent the agent's internal work rather than the conversation. */
+const ACTIVITY_KINDS = new Set<TimelineItem['kind']>([
+  'reasoning',
+  'tool-call',
+  'agent-call',
+]);
+
+/**
+ * Whether an item is internal activity the `ActivityDetail` control governs.
+ *
+ * Approvals are deliberately **not** included: an approval is a decision the user
+ * was asked to make, so hiding it would remove the record of their own action, not
+ * the agent's working.
+ */
+export function isActivityItem(item: TimelineItem): boolean {
+  return ACTIVITY_KINDS.has(item.kind);
+}
+
+export type TimelineTurn = {
+  taskIndex: number;
+  /**
+   * One timestamp for the whole turn. A2A messages carry none of their own and
+   * kagent's stored events cannot be correlated with them, so a task's timestamp
+   * is the finest granularity that exists — presenting it per turn is honest,
+   * repeating it on every item would imply precision we don't have.
+   */
+  at?: string;
+  items: TimelineItem[];
+};
+
+/**
+ * Group a flat timeline into turns, preserving order.
+ *
+ * Grouping is on `taskIndex` runs rather than a map keyed by it, so items always
+ * stay in the order `buildTimeline` produced even if a task index were ever to
+ * repeat non-contiguously.
+ */
+export function groupIntoTurns(items: TimelineItem[]): TimelineTurn[] {
+  const turns: TimelineTurn[] = [];
+  for (const item of items) {
+    const current = turns[turns.length - 1];
+    if (current && current.taskIndex === item.taskIndex) {
+      current.items.push(item);
+      continue;
+    }
+    turns.push({ taskIndex: item.taskIndex, at: item.at, items: [item] });
+  }
+  return turns;
+}
+
+/**
+ * Display name for whoever produced an item.
+ *
+ * `author` arrives as a python identifier (`sre_agent`), so it is decoded for
+ * display. `resolvedAgentName` — the matched `Agent` CR's display name — wins when
+ * available, since decoding is lossy: an agent whose name genuinely contains an
+ * underscore renders wrongly.
+ */
+export function authorLabel(
+  item: TimelineItem,
+  resolvedAgentName?: string,
+): string | undefined {
+  if (item.kind === 'user-message') {
+    return undefined;
+  }
+  if (resolvedAgentName) {
+    return resolvedAgentName;
+  }
+  return item.author ? decodeAgentIdLabel(item.author) : undefined;
+}
+
+/** Human label for a delegation target, decoded from its python identifier. */
+export function agentCallLabel(agentId: string): string {
+  const decoded = decodeAgentIdLabel(agentId);
+  // `ns/name` reads as noise in a timeline row; the name alone is the useful part.
+  const slash = decoded.lastIndexOf('/');
+  return slash === -1 ? decoded : decoded.slice(slash + 1);
+}
+
+/**
+ * Pretty-print a tool argument or result for display.
+ *
+ * Strings are returned as-is: tool results are frequently already-formatted text
+ * or JSON, and re-encoding them would show escaped quotes and `\n` instead of the
+ * content. Everything else is JSON with indentation.
+ */
+export function formatPayload(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    // Circular or otherwise unserializable. Nothing useful to show, and this must
+    // not take the page down.
+    return undefined;
+  }
+}
+
+/** One-line summary of a tool call's arguments, for the collapsed row. */
+export function summarizeArgs(args: unknown): string | undefined {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) {
+    return formatPayload(args)?.split('\n')[0];
+  }
+  const entries = Object.entries(args as Record<string, unknown>);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return entries
+    .map(([key, value]) => {
+      const rendered =
+        typeof value === 'string' ? value : (formatPayload(value) ?? '');
+      const flattened = rendered.replace(/\s+/g, ' ').trim();
+      return `${key}: ${flattened}`;
+    })
+    .join(', ');
+}
+
+/** Format a token count compactly (`1.5k`, `1.2M`). */
+export function formatTokens(total: number): string {
+  if (total < 1000) {
+    return String(total);
+  }
+  if (total < 1_000_000) {
+    return `${(total / 1000).toFixed(1)}k`;
+  }
+  return `${(total / 1_000_000).toFixed(1)}M`;
+}

--- a/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
+++ b/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
@@ -141,3 +141,52 @@ export function formatTokens(total: number): string {
   }
   return `${(total / 1_000_000).toFixed(1)}M`;
 }
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * How long a session spanned, from its first to its last activity.
+ *
+ * **Wall-clock, not compute time.** kagent records no per-turn durations, so this
+ * is `updated_at − created_at`: it includes however long the user was away between
+ * turns. A session answered in seconds and returned to the next day reads as a day
+ * — which is the truth about the session, just not about the agent's effort.
+ *
+ * Returns undefined when either end is unknown, or when the span is negative
+ * (clock skew between the writer and us) rather than rendering something absurd.
+ */
+export function formatDuration(
+  from: string | undefined,
+  to: string | undefined,
+): string | undefined {
+  if (!from || !to) {
+    return undefined;
+  }
+  const start = Date.parse(from);
+  const end = Date.parse(to);
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return undefined;
+  }
+  const ms = end - start;
+  if (ms < 0) {
+    return undefined;
+  }
+  // Sub-minute spans are real — a one-shot question answered immediately — so
+  // seconds are worth showing rather than rounding to "0m".
+  if (ms < MINUTE_MS) {
+    return `${Math.round(ms / 1000)}s`;
+  }
+  if (ms < HOUR_MS) {
+    return `${Math.floor(ms / MINUTE_MS)}m`;
+  }
+  if (ms < DAY_MS) {
+    const hours = Math.floor(ms / HOUR_MS);
+    const minutes = Math.floor((ms % HOUR_MS) / MINUTE_MS);
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  const days = Math.floor(ms / DAY_MS);
+  const hours = Math.floor((ms % DAY_MS) / HOUR_MS);
+  return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+}

--- a/plugins/agent-platform/src/components/SessionTimeline/index.ts
+++ b/plugins/agent-platform/src/components/SessionTimeline/index.ts
@@ -1,0 +1,4 @@
+export { SessionTimeline } from './SessionTimeline';
+export { TimelineEntry } from './TimelineEntry';
+export { formatTokens } from './helpers';
+export type { ActivityDetail } from './helpers';

--- a/plugins/agent-platform/src/components/SessionTimeline/index.ts
+++ b/plugins/agent-platform/src/components/SessionTimeline/index.ts
@@ -1,4 +1,4 @@
 export { SessionTimeline } from './SessionTimeline';
 export { TimelineEntry } from './TimelineEntry';
-export { formatTokens } from './helpers';
+export { formatDuration, formatTokens } from './helpers';
 export type { ActivityDetail } from './helpers';

--- a/plugins/agent-platform/src/components/SessionsDataProvider/helpers.test.ts
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/helpers.test.ts
@@ -172,6 +172,7 @@ describe('sortSessionRows', () => {
   function row(overrides: Partial<SessionRow>): SessionRow {
     return {
       id: 'gazelle/x',
+      sessionId: 'x',
       installation: 'gazelle',
       title: 'x',
       agentName: '',
@@ -212,6 +213,7 @@ describe('sortSessionsBy', () => {
   function row(overrides: Partial<SessionRow>): SessionRow {
     return {
       id: 'gazelle/x',
+      sessionId: 'x',
       installation: 'gazelle',
       title: 'x',
       agentName: '',
@@ -265,12 +267,14 @@ describe('sessionSearchFn', () => {
   const rows: SessionRow[] = [
     {
       id: '1',
+      sessionId: '1',
       installation: 'gazelle',
       title: 'Redis OOM triage',
       agentName: 'SRE agent',
     },
     {
       id: '2',
+      sessionId: '2',
       installation: 'golem',
       title: 'Ingress question',
       agentName: 'Issue tracker',

--- a/plugins/agent-platform/src/components/SessionsDataProvider/helpers.ts
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/helpers.ts
@@ -14,6 +14,14 @@ export const SESSION_TITLE_FALLBACK = 'Chat';
 export type SessionRow = {
   /** Stable unique key: `${installation}/${sessionId}`. */
   id: string;
+  /**
+   * kagent's own session id, verbatim — what a link to the session needs.
+   *
+   * Carried alongside `id` rather than parsed back out of it: ids are opaque and
+   * nothing guarantees one contains no `/`, so splitting would be a format
+   * assumption about exactly the value we promise not to assume things about.
+   */
+  sessionId: string;
   installation: string;
   /**
    * Display title. kagent derives these from the first message and truncates
@@ -106,6 +114,7 @@ export function toSessionRow(
 
   return {
     id: session.id,
+    sessionId: session.sessionId,
     installation: session.installation,
     title: session.title ?? SESSION_TITLE_FALLBACK,
     agentName,

--- a/plugins/agent-platform/src/components/SessionsIndexPage/SessionsIndexPage.tsx
+++ b/plugins/agent-platform/src/components/SessionsIndexPage/SessionsIndexPage.tsx
@@ -2,9 +2,6 @@ import { Content, EmptyState, Progress } from '@backstage/core-components';
 import { Alert, Box, Flex, Text } from '@backstage/ui';
 import { LinearProgress } from '@material-ui/core';
 
-import { QueryClientProvider } from '../QueryClientProvider';
-import { ModelConfigsProvider } from '../ModelConfigsProvider';
-import { AgentsDataProvider } from '../AgentsDataProvider';
 import { SessionsDataProvider, useSessions } from '../SessionsDataProvider';
 import { SessionsTable } from '../SessionsTable';
 import { UnreachableInstallationsAlert } from '../UnreachableInstallationsAlert';
@@ -92,21 +89,21 @@ function SessionsIndexPageContent() {
   );
 }
 
+/**
+ * The Sessions list.
+ *
+ * `QueryClientProvider`, `ModelConfigsProvider` and `AgentsDataProvider` are
+ * mounted by `SessionsRouter` rather than here, so this screen and the session
+ * detail share one query cache and one fleet-wide Agent list — opening a session
+ * then reuses the agents already loaded for this list.
+ *
+ * Only `SessionsDataProvider` is local, because only this screen fans out across
+ * the fleet: the detail page reads one installation, named in its own route.
+ */
 export function SessionsIndexPage() {
   return (
-    <QueryClientProvider>
-      <ModelConfigsProvider>
-        {/* AgentsDataProvider supplies the Agent CRs the session rows join
-            against for agent display names and avatars. It requires
-            ModelConfigsProvider above it, so the Sessions tab pays for a
-            fleet-wide ModelConfig list it doesn't itself use — cached,
-            persisted, and shared with the Agents tab, so effectively free. */}
-        <AgentsDataProvider>
-          <SessionsDataProvider>
-            <SessionsIndexPageContent />
-          </SessionsDataProvider>
-        </AgentsDataProvider>
-      </ModelConfigsProvider>
-    </QueryClientProvider>
+    <SessionsDataProvider>
+      <SessionsIndexPageContent />
+    </SessionsDataProvider>
   );
 }

--- a/plugins/agent-platform/src/components/SessionsRouter/SessionsRouter.tsx
+++ b/plugins/agent-platform/src/components/SessionsRouter/SessionsRouter.tsx
@@ -1,0 +1,42 @@
+import { Route, Routes } from 'react-router-dom';
+
+import { QueryClientProvider } from '../QueryClientProvider';
+import { ModelConfigsProvider } from '../ModelConfigsProvider';
+import { AgentsDataProvider } from '../AgentsDataProvider';
+import { SessionsIndexPage } from '../SessionsIndexPage';
+import { SessionDetailPage } from '../SessionDetailPage';
+
+/**
+ * Content of the "Sessions" tab: the fleet-wide list, and one session's detail.
+ *
+ * Mounted as the tab's content (a descendant `<Routes>`), so paths here are
+ * relative — no leading slash — matching AgentsRouter and muster's WorkflowsRouter.
+ *
+ * The providers are hoisted above the routes so both screens share one query cache
+ * and one fleet-wide Agent list. That matters for navigation between them: opening
+ * a session reuses the agents already loaded for the list, so its agent name and
+ * avatar render immediately instead of re-querying the fleet.
+ *
+ * `AgentsDataProvider` requires `ModelConfigsProvider` above it, so the Sessions
+ * tab pays for a fleet-wide ModelConfig list neither screen uses. It is cached,
+ * persisted, and shared with the Agents tab, so in practice it is free.
+ */
+export const SessionsRouter = () => {
+  return (
+    <QueryClientProvider>
+      <ModelConfigsProvider>
+        <AgentsDataProvider>
+          <Routes>
+            <Route index element={<SessionsIndexPage />} />
+            {/* Both parameters are needed to resolve a session: kagent ids are
+                only unique within an installation. */}
+            <Route
+              path=":installation/:sessionId"
+              element={<SessionDetailPage />}
+            />
+          </Routes>
+        </AgentsDataProvider>
+      </ModelConfigsProvider>
+    </QueryClientProvider>
+  );
+};

--- a/plugins/agent-platform/src/components/SessionsRouter/index.ts
+++ b/plugins/agent-platform/src/components/SessionsRouter/index.ts
@@ -1,0 +1,1 @@
+export { SessionsRouter } from './SessionsRouter';

--- a/plugins/agent-platform/src/components/SessionsTable/SessionsTable.test.tsx
+++ b/plugins/agent-platform/src/components/SessionsTable/SessionsTable.test.tsx
@@ -1,7 +1,8 @@
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SessionRow } from '../SessionsDataProvider/helpers';
+import { sessionsRouteRef } from '../../routes';
 import { SessionsTable } from './SessionsTable';
 
 const mockBuildAvatarUrl = jest.fn(
@@ -16,6 +17,7 @@ jest.mock('../../hooks/useAgentAvatarUrl', () => ({
 const rows: SessionRow[] = [
   {
     id: 'gazelle/abc',
+    sessionId: 'abc',
     installation: 'gazelle',
     title: 'What issues are assi...',
     agentName: 'Issue tracker',
@@ -25,6 +27,7 @@ const rows: SessionRow[] = [
   },
   {
     id: 'golem/def',
+    sessionId: 'def',
     installation: 'golem',
     title: 'Chat',
     agentName: '',
@@ -39,7 +42,11 @@ describe('SessionsTable', () => {
   });
 
   it('renders every column header', async () => {
-    await renderInTestApp(<SessionsTable rows={rows} />);
+    await renderInTestApp(<SessionsTable rows={rows} />, {
+      // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+      // SubRouteRef — and the detail sub-route resolves relative to it.
+      mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+    });
 
     for (const header of [
       'Session',
@@ -52,8 +59,30 @@ describe('SessionsTable', () => {
     }
   });
 
+  it('links each row to its session, carrying both installation and id', async () => {
+    // A real anchor, not only a row click: an anchor is what makes cmd- and
+    // middle-click open a new tab and gives keyboard users something focusable.
+    // Both path segments are needed because kagent ids are only unique within an
+    // installation.
+    await renderInTestApp(<SessionsTable rows={rows} />, {
+      mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+    });
+
+    expect(
+      screen.getByRole('link', { name: 'What issues are assi...' }),
+    ).toHaveAttribute('href', '/agent-platform/sessions/gazelle/abc');
+    expect(screen.getByRole('link', { name: 'Chat' })).toHaveAttribute(
+      'href',
+      '/agent-platform/sessions/golem/def',
+    );
+  });
+
   it('renders session titles as kagent supplied them', async () => {
-    await renderInTestApp(<SessionsTable rows={rows} />);
+    await renderInTestApp(<SessionsTable rows={rows} />, {
+      // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+      // SubRouteRef — and the detail sub-route resolves relative to it.
+      mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+    });
 
     // kagent truncates to 20 chars, so the ellipsis is real data, not ours.
     expect(screen.getByText('What issues are assi...')).toBeInTheDocument();
@@ -62,7 +91,11 @@ describe('SessionsTable', () => {
   });
 
   it('seeds the avatar from the resolved agent’s technical name', async () => {
-    await renderInTestApp(<SessionsTable rows={rows} />);
+    await renderInTestApp(<SessionsTable rows={rows} />, {
+      // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+      // SubRouteRef — and the detail sub-route resolves relative to it.
+      mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+    });
 
     expect(mockBuildAvatarUrl).toHaveBeenCalledWith(
       'gazelle',
@@ -74,7 +107,11 @@ describe('SessionsTable', () => {
   });
 
   it('shows a dash where a value is unknown', async () => {
-    await renderInTestApp(<SessionsTable rows={[rows[1]]} />);
+    await renderInTestApp(<SessionsTable rows={[rows[1]]} />, {
+      // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+      // SubRouteRef — and the detail sub-route resolves relative to it.
+      mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+    });
 
     // Missing agent, missing created/updated timestamps: three dashes. Explicit
     // because DateComponent renders null for a falsy value, which would leave the
@@ -83,7 +120,11 @@ describe('SessionsTable', () => {
   });
 
   it('renders the empty state when there are no rows', async () => {
-    await renderInTestApp(<SessionsTable rows={[]} />);
+    await renderInTestApp(<SessionsTable rows={[]} />, {
+      // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+      // SubRouteRef — and the detail sub-route resolves relative to it.
+      mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+    });
 
     expect(screen.getByText('No sessions found.')).toBeInTheDocument();
   });
@@ -91,14 +132,25 @@ describe('SessionsTable', () => {
   it('shows a skeleton rather than the empty state while loading', async () => {
     // The `data={undefined}` gotcha: passing `[]` would render "No sessions
     // found." before the first rows arrive.
-    await renderInTestApp(<SessionsTable rows={[]} isLoading />);
+    await renderInTestApp(<SessionsTable rows={[]} isLoading />, {
+      // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+      // SubRouteRef — and the detail sub-route resolves relative to it.
+      mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+    });
 
     expect(screen.queryByText('No sessions found.')).not.toBeInTheDocument();
   });
 
   describe('search', () => {
     it('filters by session title', async () => {
-      await renderInTestApp(<SessionsTable rows={rows} searchDebounceMs={0} />);
+      await renderInTestApp(
+        <SessionsTable rows={rows} searchDebounceMs={0} />,
+        {
+          // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+          // SubRouteRef — and the detail sub-route resolves relative to it.
+          mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+        },
+      );
 
       await userEvent.type(
         screen.getByRole('searchbox', { name: 'Search sessions' }),
@@ -110,7 +162,14 @@ describe('SessionsTable', () => {
     });
 
     it('filters by agent name', async () => {
-      await renderInTestApp(<SessionsTable rows={rows} searchDebounceMs={0} />);
+      await renderInTestApp(
+        <SessionsTable rows={rows} searchDebounceMs={0} />,
+        {
+          // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+          // SubRouteRef — and the detail sub-route resolves relative to it.
+          mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+        },
+      );
 
       await userEvent.type(
         screen.getByRole('searchbox', { name: 'Search sessions' }),
@@ -122,7 +181,14 @@ describe('SessionsTable', () => {
     });
 
     it('shows the empty state when nothing matches', async () => {
-      await renderInTestApp(<SessionsTable rows={rows} searchDebounceMs={0} />);
+      await renderInTestApp(
+        <SessionsTable rows={rows} searchDebounceMs={0} />,
+        {
+          // Only the parent RouteRef is mountable — `mountedRoutes` rejects a
+          // SubRouteRef — and the detail sub-route resolves relative to it.
+          mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+        },
+      );
 
       await userEvent.type(
         screen.getByRole('searchbox', { name: 'Search sessions' }),

--- a/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
+++ b/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   Avatar,
   Cell,
@@ -10,7 +10,11 @@ import {
   Text,
   useTable,
 } from '@backstage/ui';
+import { Link } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { useNavigate } from 'react-router-dom';
 import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
+import { sessionDetailRouteRef } from '../../routes';
 import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
 import { AvatarSize } from '../../lib/agentAvatar';
 import {
@@ -33,6 +37,7 @@ function Unknown() {
 
 function getColumnConfig(
   buildAvatarUrl: ReturnType<typeof useAgentAvatarUrl>,
+  hrefFor: (row: SessionRow) => string | undefined,
 ): ColumnConfig<SessionRow>[] {
   return [
     {
@@ -43,7 +48,25 @@ function getColumnConfig(
       label: 'Session',
       isRowHeader: true,
       isSortable: true,
-      cell: row => <CellText title={row.title} />,
+      cell: row => {
+        const href = hrefFor(row);
+        // A real anchor in the row-header cell, *as well as* the whole-row
+        // onClick below. The anchor is what makes cmd/middle-click open a new tab
+        // and what gives keyboard users something focusable; the row click is the
+        // convenience affordance. `Link` from core-components routes client-side,
+        // which `rowConfig.getHref` would not: BUIProvider is not mounted in this
+        // app, so react-aria's RouterProvider is inactive and a bui `href` would
+        // trigger a full page reload.
+        return (
+          <Cell>
+            {href ? (
+              <Link to={href}>{row.title}</Link>
+            ) : (
+              <Text variant="body-medium">{row.title}</Text>
+            )}
+          </Cell>
+        );
+      },
     },
     {
       id: 'agentName',
@@ -140,9 +163,24 @@ export function SessionsTable({
   searchDebounceMs = 150,
 }: SessionsTableProps) {
   const buildAvatarUrl = useAgentAvatarUrl();
+  const navigate = useNavigate();
+  const sessionDetailRoute = useRouteRef(sessionDetailRouteRef);
+
+  // Both parameters are needed: kagent session ids are only unique within an
+  // installation. Undefined when the route isn't bound, in which case rows render
+  // as plain text rather than as links that go nowhere.
+  const hrefFor = useCallback(
+    (row: SessionRow) =>
+      sessionDetailRoute?.({
+        installation: row.installation,
+        sessionId: row.sessionId,
+      }),
+    [sessionDetailRoute],
+  );
+
   const columnConfig = useMemo(
-    () => getColumnConfig(buildAvatarUrl),
-    [buildAvatarUrl],
+    () => getColumnConfig(buildAvatarUrl, hrefFor),
+    [buildAvatarUrl, hrefFor],
   );
 
   const { tableProps, search } = useTable<SessionRow>({
@@ -169,6 +207,17 @@ export function SessionsTable({
       <Table<SessionRow>
         {...tableProps}
         columnConfig={columnConfig}
+        rowConfig={{
+          // Whole-row click as a convenience, on top of the anchor in the title
+          // cell. `onClick` + navigate rather than `getHref`, because without
+          // BUIProvider a bui href does a full page reload (see the title cell).
+          onClick: row => {
+            const href = hrefFor(row);
+            if (href) {
+              navigate(href);
+            }
+          },
+        }}
         emptyState={
           <Text variant="body-medium" color="secondary">
             No sessions found.

--- a/plugins/agent-platform/src/hooks/useSessionDetail.ts
+++ b/plugins/agent-platform/src/hooks/useSessionDetail.ts
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { useQuery } from '@tanstack/react-query';
+import { kagentApiRef } from '../apis';
+import { KagentSessionDetail } from '../lib/kagentSessionDetail';
+import { buildTimeline, SessionTimeline } from '../lib/kagentTimeline';
+import { deriveSessionState, SessionState } from '../lib/kagentSessionState';
+
+/** Query key for one session's metadata. */
+export function sessionQueryKey(installation: string, sessionId: string) {
+  return ['agent-platform', 'kagent', 'session', installation, sessionId];
+}
+
+/** Query key for one session's tasks (the conversation). */
+export function sessionTasksQueryKey(installation: string, sessionId: string) {
+  return ['agent-platform', 'kagent', 'session-tasks', installation, sessionId];
+}
+
+export type SessionDetailView = {
+  /** Undefined while loading, or when the session does not exist. */
+  detail?: KagentSessionDetail;
+  timeline: SessionTimeline;
+  /** From the most recent task; undefined for a session that never ran. */
+  state?: SessionState;
+  /** Number of A2A tasks — the session's turn count. */
+  taskCount: number;
+  isLoading: boolean;
+  /**
+   * True when the session is not readable: it does not exist, was deleted, or
+   * belongs to another user. kagent answers all three with a 404 and they are not
+   * distinguishable, so the page shows one "not found" state.
+   */
+  isNotFound: boolean;
+  /** A read that failed for any other reason — worth showing the message. */
+  error?: Error;
+};
+
+const EMPTY_TIMELINE: SessionTimeline = {
+  items: [],
+  tokens: { total: 0, prompt: 0, completion: 0 },
+  skippedMessages: 0,
+};
+
+/**
+ * Read one session: its metadata and its conversation.
+ *
+ * Two queries rather than one because they are two kagent endpoints serving
+ * different things — the session object, and the A2A tasks that carry the
+ * conversation, its state and token usage. Neither request can see the other's
+ * result, so the merge happens here.
+ *
+ * They are deliberately **not** chained. Firing both immediately halves the
+ * time-to-first-paint, and the cost of a wasted tasks request when the session
+ * turns out not to exist is one 404 on a page the user explicitly navigated to.
+ */
+export function useSessionDetail(
+  installation: string,
+  sessionId: string,
+): SessionDetailView {
+  const kagentApi = useApi(kagentApiRef);
+
+  const sessionQuery = useQuery({
+    queryKey: sessionQueryKey(installation, sessionId),
+    queryFn: () => kagentApi.getSessionDetail(installation, sessionId),
+  });
+
+  const tasksQuery = useQuery({
+    queryKey: sessionTasksQueryKey(installation, sessionId),
+    queryFn: () => kagentApi.listSessionTasks(installation, sessionId),
+  });
+
+  const tasks = tasksQuery.data;
+
+  // Parsing the whole conversation is not free, so it runs when the tasks change
+  // rather than on every render (a parent re-render would otherwise rebuild every
+  // item and defeat the memoization in the timeline components).
+  const timeline = useMemo(
+    () => (tasks ? buildTimeline(tasks) : EMPTY_TIMELINE),
+    [tasks],
+  );
+  const state = useMemo(
+    () => (tasks ? deriveSessionState(tasks) : undefined),
+    [tasks],
+  );
+
+  // The session read is what decides "not found": the tasks endpoint 404s for the
+  // same session, but it also 404s on a kagent too old to serve it, and the two
+  // must not look the same to the user.
+  const isNotFound =
+    (sessionQuery.isSuccess && !sessionQuery.data) ||
+    (sessionQuery.error as Error | null)?.name === 'NotFoundError';
+
+  // A 404 is an expected outcome, not an error to report.
+  const error = isNotFound
+    ? undefined
+    : (((sessionQuery.error ?? tasksQuery.error) as Error | null) ?? undefined);
+
+  return {
+    detail: sessionQuery.data ?? undefined,
+    timeline,
+    state,
+    taskCount: tasks?.length ?? 0,
+    isLoading: sessionQuery.isLoading || tasksQuery.isLoading,
+    isNotFound,
+    error,
+  };
+}

--- a/plugins/agent-platform/src/lib/__fixtures__/tasks.ask-user.json
+++ b/plugins/agent-platform/src/lib/__fixtures__/tasks.ask-user.json
@@ -1,0 +1,66 @@
+{
+  "comment": "An ask_user request: ADK wraps it in the same adk_request_confirmation as a permission request, but it asks for an answer rather than consent. Shapes taken from a real gazelle session.",
+  "error": false,
+  "data": [
+    {
+      "id": "task-1",
+      "kind": "task",
+      "status": {
+        "state": "completed",
+        "timestamp": "2026-07-23T11:52:00.000Z"
+      },
+      "history": [
+        {
+          "kind": "message",
+          "messageId": "m-user-1",
+          "role": "user",
+          "parts": [
+            {
+              "kind": "text",
+              "text": "it's running the file attachment PR i think"
+            }
+          ]
+        },
+        {
+          "kind": "message",
+          "messageId": "m-ask-1",
+          "role": "agent",
+          "metadata": { "adk_author": "sre_agent" },
+          "parts": [
+            {
+              "kind": "data",
+              "metadata": {
+                "adk_type": "function_call",
+                "adk_is_long_running": true
+              },
+              "data": {
+                "id": "ask-1",
+                "name": "adk_request_confirmation",
+                "args": {
+                  "originalFunctionCall": {
+                    "id": "call-ask-1",
+                    "name": "ask_user",
+                    "args": {
+                      "questions": [
+                        {
+                          "question": "Which management cluster should I look at?"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "kind": "message",
+          "messageId": "m-decision-1",
+          "role": "user",
+          "parts": [{ "kind": "data", "data": { "decision_type": "approve" } }]
+        }
+      ]
+    }
+  ],
+  "message": "Successfully retrieved session tasks"
+}

--- a/plugins/agent-platform/src/lib/__fixtures__/tasks.ask-user.json
+++ b/plugins/agent-platform/src/lib/__fixtures__/tasks.ask-user.json
@@ -54,10 +54,43 @@
           ]
         },
         {
+          "comment": "Shaped after a real gazelle payload: the reply arrives BOTH as ask_user_answers in the decision data AND as a plain text part on the same message. One entry per question asked; skipped questions carry an empty answer array.",
           "kind": "message",
           "messageId": "m-decision-1",
           "role": "user",
-          "parts": [{ "kind": "data", "data": { "decision_type": "approve" } }]
+          "parts": [
+            {
+              "kind": "data",
+              "data": {
+                "ask_user_answers": [
+                  {
+                    "answer": [
+                      "Still no reply to messages with image. Maybe it's not that branch."
+                    ]
+                  },
+                  { "answer": [] },
+                  { "answer": [] }
+                ],
+                "decision_type": "approve"
+              }
+            },
+            {
+              "kind": "text",
+              "text": "Still no reply to messages with image. Maybe it's not that branch."
+            }
+          ]
+        },
+        {
+          "kind": "message",
+          "messageId": "m-agent-followup-1",
+          "role": "agent",
+          "metadata": { "adk_author": "sre_agent" },
+          "parts": [
+            {
+              "kind": "text",
+              "text": "Got it! It sounds like you're debugging an image attachment issue."
+            }
+          ]
         }
       ]
     }

--- a/plugins/agent-platform/src/lib/kagentMetadata.ts
+++ b/plugins/agent-platform/src/lib/kagentMetadata.ts
@@ -13,6 +13,11 @@
  * interop mechanism kagent itself relies on. Prefer `adk_`, fall back to
  * `kagent_`.
  *
+ * **Both prefixes really do occur, on the same installation.** Two gazelle
+ * sessions read a day apart carried `kagent_usage_metadata` and
+ * `adk_usage_metadata` respectively. This is therefore load-bearing rather than
+ * defensive: reading only one prefix makes a session's token totals silently zero.
+ *
  * This is deliberately the *only* place either prefix is spelled out. Everything
  * else asks for an unprefixed key.
  */

--- a/plugins/agent-platform/src/lib/kagentParts.ts
+++ b/plugins/agent-platform/src/lib/kagentParts.ts
@@ -172,21 +172,36 @@ export function isInternalToolName(name: string | undefined): boolean {
  *
  * The field names are Gemini's (`promptTokenCount` / `candidatesTokenCount`),
  * which is what ADK passes through. A partial bag yields zeros for the missing
- * counts rather than being discarded — a total with no breakdown is still worth
- * showing.
+ * counts rather than being discarded — a breakdown with no total, or a total with
+ * no breakdown, is still worth showing.
+ *
+ * **`totalTokenCount` is derived when kagent doesn't report one.** Confirmed on a
+ * real gazelle session, whose every message carried exactly
+ * `adk_usage_metadata: {promptTokenCount, candidatesTokenCount}` — no
+ * `totalTokenCount` at all. Summing the reported totals therefore gave "Total 0"
+ * next to 1.4M input, which reads as broken. kagent's own UI has the same hole
+ * (`total: usage.totalTokenCount ?? 0`).
+ *
+ * The reported total still wins when present: it can legitimately exceed
+ * prompt + completion, because a model that bills thinking tokens separately
+ * counts them in the total but in neither part.
  */
 export function readTokenUsage(metadata: unknown): TokenUsage | undefined {
   const usage = asRecord(readKagentMetadata(metadata, 'usage_metadata'));
   if (!usage) {
     return undefined;
   }
-  const total = asNumber(usage.totalTokenCount);
+  const reportedTotal = asNumber(usage.totalTokenCount);
   const prompt = asNumber(usage.promptTokenCount);
   const completion = asNumber(usage.candidatesTokenCount);
-  if (total === 0 && prompt === 0 && completion === 0) {
+  if (reportedTotal === 0 && prompt === 0 && completion === 0) {
     return undefined;
   }
-  return { total, prompt, completion };
+  return {
+    total: reportedTotal > 0 ? reportedTotal : prompt + completion,
+    prompt,
+    completion,
+  };
 }
 
 /**

--- a/plugins/agent-platform/src/lib/kagentParts.ts
+++ b/plugins/agent-platform/src/lib/kagentParts.ts
@@ -33,9 +33,21 @@ const AGENT_NAMESPACE_SEPARATOR = '__NS__';
  * rather than as a tool call. Showing them would be noise indistinguishable from
  * real work.
  */
-const INTERNAL_TOOL_NAMES = new Set(['adk_request_credential', 'ask_user']);
+/**
+ * ADK's tool for asking the user a question.
+ *
+ * Arrives wrapped in a confirmation request like an approval does, but it asks for
+ * an *answer*, not permission — so it reads quite differently, and kagent's own UI
+ * branches on this name for the same reason (`buildApprovalMessage`).
+ */
+export const ASK_USER_TOOL_NAME = 'ask_user';
 
-/** The tool name kagent uses for a human-in-the-loop approval request. */
+const INTERNAL_TOOL_NAMES = new Set([
+  'adk_request_credential',
+  ASK_USER_TOOL_NAME,
+]);
+
+/** The tool name kagent uses for a human-in-the-loop confirmation request. */
 export const CONFIRMATION_TOOL_NAME = 'adk_request_confirmation';
 
 /**

--- a/plugins/agent-platform/src/lib/kagentParts.ts
+++ b/plugins/agent-platform/src/lib/kagentParts.ts
@@ -38,6 +38,54 @@ const INTERNAL_TOOL_NAMES = new Set(['adk_request_credential', 'ask_user']);
 /** The tool name kagent uses for a human-in-the-loop approval request. */
 export const CONFIRMATION_TOOL_NAME = 'adk_request_confirmation';
 
+/**
+ * muster's proxy tool. Agents reach most MCP tools through it, so the tool a call
+ * *appears* to make is almost always this one.
+ */
+export const MUSTER_PROXY_TOOL_NAME = 'call_tool';
+
+/** What the UI shows as the origin of a proxied call — the product name. */
+export const MUSTER_PROXY_LABEL = 'Muster';
+
+/**
+ * Look through muster's `call_tool` wrapper to the tool actually invoked.
+ *
+ * Agents call most MCP tools via muster, so without this every row reads
+ * `call_tool` and the real tool is buried in the arguments:
+ *
+ * ```
+ * call_tool  arguments: {…}, name: x_kubernetes_get
+ * ```
+ *
+ * which makes a run of calls impossible to scan — the problem reported in
+ * giantswarm/klaus-gateway#163 for the Slack surface. Unwrapped, the row names
+ * `x_kubernetes_get` and carries `via: 'muster'`.
+ *
+ * Only unwraps when the payload actually has the wrapper's shape (`name` a
+ * non-empty string, with the inner call's `arguments`). Anything else is returned
+ * untouched, so a future change to `call_tool` degrades to showing the wrapper
+ * rather than losing the call.
+ */
+export function unwrapProxiedCall(call: FunctionCall): FunctionCall & {
+  /** Set when the call reached its tool through a proxy. */
+  via?: string;
+} {
+  if (call.name !== MUSTER_PROXY_TOOL_NAME) {
+    return call;
+  }
+  const args = asRecord(call.args);
+  const innerName = asNonEmptyString(args?.name);
+  if (!innerName) {
+    return call;
+  }
+  return {
+    id: call.id,
+    name: innerName,
+    args: args?.arguments,
+    via: MUSTER_PROXY_LABEL,
+  };
+}
+
 export type FunctionCall = {
   /** Correlates a call with its response; absent on malformed payloads. */
   id?: string;

--- a/plugins/agent-platform/src/lib/kagentTimeline.test.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.test.ts
@@ -418,6 +418,66 @@ describe('buildTimeline', () => {
       expect(tokens).toEqual({ total: 0, prompt: 0, completion: 0 });
     });
 
+    it('derives a total when kagent reports only the breakdown', () => {
+      // Found live on gazelle: every message carries promptTokenCount and
+      // candidatesTokenCount but no totalTokenCount, so summing reported totals
+      // rendered "Total 0" beside 1.4M input. kagent's own UI has the same hole
+      // (`total: usage.totalTokenCount ?? 0`).
+      const tasks = [
+        {
+          status: { state: 'completed', timestamp: '2026-07-24T09:00:00.000Z' },
+          history: [
+            {
+              kind: 'message',
+              messageId: 'm1',
+              role: 'agent',
+              metadata: {
+                kagent_usage_metadata: {
+                  promptTokenCount: 1000,
+                  candidatesTokenCount: 250,
+                },
+              },
+              parts: [{ kind: 'text', text: 'hi' }],
+            },
+          ],
+        },
+      ] as unknown as A2aTaskWire[];
+
+      expect(buildTimeline(tasks).tokens).toEqual({
+        total: 1250,
+        prompt: 1000,
+        completion: 250,
+      });
+    });
+
+    it('prefers a reported total over the sum of its parts', () => {
+      // A model billing thinking tokens separately counts them in the total but in
+      // neither part, so the reported total is not always prompt + completion and
+      // must not be recomputed away.
+      const tasks = [
+        {
+          status: { state: 'completed', timestamp: '2026-07-24T09:00:00.000Z' },
+          history: [
+            {
+              kind: 'message',
+              messageId: 'm1',
+              role: 'agent',
+              metadata: {
+                kagent_usage_metadata: {
+                  totalTokenCount: 2000,
+                  promptTokenCount: 1000,
+                  candidatesTokenCount: 250,
+                },
+              },
+              parts: [{ kind: 'text', text: 'hi' }],
+            },
+          ],
+        },
+      ] as unknown as A2aTaskWire[];
+
+      expect(buildTimeline(tasks).tokens.total).toBe(2000);
+    });
+
     it('returns an empty timeline for a session with no tasks', () => {
       expect(timelineFor(emptyNoData)).toEqual({
         items: [],

--- a/plugins/agent-platform/src/lib/kagentTimeline.test.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.test.ts
@@ -334,6 +334,107 @@ describe('buildTimeline', () => {
     });
   });
 
+  describe('calls proxied through Muster', () => {
+    /** A `call_tool` invocation wrapping the tool actually wanted. */
+    function proxiedTasks(args: unknown): A2aTaskWire[] {
+      return [
+        {
+          status: { state: 'completed', timestamp: '2026-07-24T09:00:00.000Z' },
+          history: [
+            {
+              kind: 'message',
+              messageId: 'm1',
+              role: 'agent',
+              parts: [
+                {
+                  kind: 'data',
+                  metadata: { kagent_type: 'function_call' },
+                  data: { id: 'c1', name: 'call_tool', args },
+                },
+              ],
+            },
+          ],
+        },
+      ] as unknown as A2aTaskWire[];
+    }
+
+    it('names the tool actually invoked, not the proxy', () => {
+      // Agents reach most MCP tools through muster's `call_tool`, so without this
+      // every row reads `call_tool` and the real tool is buried in the arguments —
+      // the problem reported in giantswarm/klaus-gateway#163.
+      const { items } = buildTimeline(
+        proxiedTasks({
+          name: 'x_kubernetes_get',
+          arguments: {
+            apiGroup: 'helm.toolkit.fluxcd.io',
+            resourceType: 'helmreleases',
+          },
+        }),
+      );
+
+      expect(items[0]).toMatchObject({
+        kind: 'tool-call',
+        toolName: 'x_kubernetes_get',
+        via: 'Muster',
+        // Unwrapped: the inner arguments, not the `{name, arguments}` envelope.
+        args: {
+          apiGroup: 'helm.toolkit.fluxcd.io',
+          resourceType: 'helmreleases',
+        },
+      });
+    });
+
+    it('leaves a call_tool whose payload lacks the wrapper shape alone', () => {
+      // Degrades to showing the proxy rather than losing the call, if `call_tool`
+      // ever changes shape.
+      const { items } = buildTimeline(proxiedTasks({ unexpected: true }));
+
+      expect(items[0]).toMatchObject({
+        kind: 'tool-call',
+        toolName: 'call_tool',
+        args: { unexpected: true },
+      });
+      expect((items[0] as { via?: string }).via).toBeUndefined();
+    });
+
+    it('marks nothing as proxied when the tool was called directly', () => {
+      const { items } = timelineFor(kagentPrefixed);
+      const direct = items.find(
+        item =>
+          item.kind === 'tool-call' && item.toolName === 'github_search_issues',
+      );
+
+      expect((direct as { via?: string }).via).toBeUndefined();
+    });
+
+    it('still resolves a proxied call’s result, which is keyed on the outer id', () => {
+      // The response carries the *wrapper's* call id and name, so unwrapping the
+      // request must not break the pairing.
+      const tasks = proxiedTasks({ name: 'x_kubernetes_get', arguments: {} });
+      (tasks[0].history as unknown[]).push({
+        kind: 'message',
+        messageId: 'm2',
+        role: 'agent',
+        parts: [
+          {
+            kind: 'data',
+            metadata: { kagent_type: 'function_response' },
+            data: { id: 'c1', name: 'call_tool', response: { ok: true } },
+          },
+        ],
+      });
+
+      const { items } = buildTimeline(tasks);
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toMatchObject({
+        toolName: 'x_kubernetes_get',
+        isPending: false,
+        result: { ok: true },
+      });
+    });
+  });
+
   describe('robustness', () => {
     it('survives a fixture full of malformed rows', () => {
       const { items, skippedMessages } = timelineFor(malformed);

--- a/plugins/agent-platform/src/lib/kagentTimeline.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.ts
@@ -3,6 +3,7 @@ import { readKagentMetadataString } from './kagentMetadata';
 import { normalizeTimestamp } from './kagentSessions';
 import {
   addTokenUsage,
+  ASK_USER_TOOL_NAME,
   CONFIRMATION_TOOL_NAME,
   isAgentToolName,
   isFunctionCallPart,
@@ -66,6 +67,15 @@ export type TimelineItem =
     })
   | (TimelineItemBase & {
       kind: 'approval';
+      /**
+       * What the agent actually asked for.
+       *
+       * ADK wraps both in the same confirmation request, but they read completely
+       * differently: `'approval'` is "may I run this tool", `'input'` is a question
+       * put to the user via `ask_user`. Discriminated here rather than by the UI
+       * matching on a tool name, and kagent's own UI branches at the same point.
+       */
+      asks: 'approval' | 'input';
       /** The tool the agent proposed to run, when the payload named one. */
       toolName?: string;
       args?: unknown;
@@ -376,6 +386,7 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
             at,
             author,
             taskIndex,
+            asks: proposed?.name === ASK_USER_TOOL_NAME ? 'input' : 'approval',
             toolName: proposed?.name,
             args: proposed?.args,
           });

--- a/plugins/agent-platform/src/lib/kagentTimeline.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.ts
@@ -17,6 +17,7 @@ import {
   readPartText,
   readTokenUsage,
   TokenUsage,
+  unwrapProxiedCall,
 } from './kagentParts';
 
 /** Fields every timeline item carries. */
@@ -40,7 +41,13 @@ export type TimelineItem =
   | (TimelineItemBase & { kind: 'reasoning'; text: string })
   | (TimelineItemBase & {
       kind: 'tool-call';
+      /**
+       * The tool actually invoked. For a call made through muster's `call_tool`
+       * this is the **inner** tool, not the proxy — see `unwrapProxiedCall`.
+       */
       toolName: string;
+      /** The proxy the call travelled through, when it went through one. */
+      via?: string;
       args?: unknown;
       /** The tool's result, once its `function_response` was seen. */
       result?: unknown;
@@ -379,6 +386,11 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
           return;
         }
 
+        // Agents reach most MCP tools through muster's `call_tool`, so without
+        // looking through that wrapper every row would read `call_tool` and the
+        // real tool would be buried in the arguments.
+        const effective = unwrapProxiedCall(call);
+
         const itemIndex = items.length;
         items.push(
           makeCallItem({
@@ -386,10 +398,11 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
             at,
             author,
             taskIndex,
-            name: call.name,
-            args: call.args,
+            name: effective.name,
+            args: effective.args,
             result: undefined,
             isPending: true,
+            via: effective.via,
           }),
         );
         if (call.id) {
@@ -425,8 +438,10 @@ function makeCallItem(input: {
   args: unknown;
   result: unknown;
   isPending: boolean;
+  /** Set when the name and args came out of a proxy wrapper. */
+  via?: string;
 }): TimelineItem {
-  const { name, ...rest } = input;
+  const { name, via, ...rest } = input;
   if (isAgentToolName(name)) {
     return {
       ...rest,
@@ -441,6 +456,7 @@ function makeCallItem(input: {
     // A call with no name is still activity worth showing; label it rather than
     // dropping the item.
     toolName: name ?? 'unknown tool',
+    ...(via ? { via } : {}),
   };
 }
 

--- a/plugins/agent-platform/src/lib/kagentTimeline.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.ts
@@ -212,8 +212,9 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
 
       const parts = Array.isArray(message.parts) ? message.parts : [];
 
-      // A verdict arrives as a data part on a *user* message, and is shown on the
-      // approval card rather than as a message of its own.
+      // A verdict arrives as a data part on a *user* message. The verdict itself is
+      // shown on the approval card rather than as a message of its own — but the
+      // message may also carry the user's actual words, and those are conversation.
       if (isUser) {
         const decision = readDecision(parts);
         if (decision) {
@@ -227,7 +228,27 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
             }
             openApprovalIndex = undefined;
           }
-          return;
+
+          // Deliberately **not** returning here. An `ask_user` reply arrives as a
+          // text part on this same message, and bailing out discarded it — the
+          // question and the agent's follow-up were shown, but what the user
+          // actually said vanished from the conversation.
+          //
+          // The text parts fall through to the normal handling below. When there
+          // are none, the answers are recovered from the decision payload's
+          // `ask_user_answers` instead: kagent's own UI reads only that field, so it
+          // may be the sole carrier on sessions that did not come through a
+          // gateway that also writes the text part.
+          if (decision.answers.length > 0 && !hasTextPart(parts)) {
+            items.push({
+              kind: 'user-message',
+              id: `${taskIndex}:${entryIndex}:${items.length}`,
+              at,
+              taskIndex,
+              text: decision.answers.join('\n\n'),
+            });
+            return;
+          }
         }
       }
 
@@ -502,21 +523,31 @@ function readProposedCall(
  * message. It is either a uniform verdict applying to every pending call, or
  * `'batch'` with a per-call map.
  *
- * Returning an object means "this message is a decision" and so it must not also
- * render as user prose. A `verdict` of `undefined` inside that object means the
- * wording was one we don't recognise: the approval is resolved, but we decline to
- * say how. Defaulting to `'approved'` there would put words in the user's mouth
- * about an action they may have refused.
+ * Returning an object means "this message is a decision", so its verdict belongs
+ * on the approval card rather than as a message of its own. A `verdict` of
+ * `undefined` inside that object means the wording was one we don't recognise: the
+ * approval is resolved, but we decline to say how. Defaulting to `'approved'` there
+ * would put words in the user's mouth about an action they may have refused.
+ *
+ * `answers` carries what the user actually typed in reply to an `ask_user`
+ * question, from the payload's `ask_user_answers`. It is a fallback: the same words
+ * usually arrive as a plain text part on this message, which reads better and is
+ * preferred. kagent's own UI reads only this structured field, so a session may
+ * exist where it is the sole carrier.
  */
 function readDecision(
   parts: unknown[],
-): { verdict?: 'approved' | 'rejected' } | undefined {
+): { verdict?: 'approved' | 'rejected'; answers: string[] } | undefined {
   for (const rawPart of parts) {
     const part = parsePart(rawPart);
     if (!part || !part.data || typeof part.data !== 'object') {
       continue;
     }
-    const data = part.data as { decision_type?: unknown; decisions?: unknown };
+    const data = part.data as {
+      decision_type?: unknown;
+      decisions?: unknown;
+      ask_user_answers?: unknown;
+    };
     const decisionType = data.decision_type;
     if (typeof decisionType !== 'string' || decisionType === '') {
       continue;
@@ -536,16 +567,54 @@ function readDecision(
           Boolean(verdict),
         );
       if (verdicts.length === 0) {
-        return {};
+        return { answers: readAskUserAnswers(data) };
       }
       return {
         verdict: verdicts.includes('rejected') ? 'rejected' : 'approved',
+        answers: readAskUserAnswers(data),
       };
     }
 
-    return { verdict: readVerdictWord(decisionType) };
+    return {
+      verdict: readVerdictWord(decisionType),
+      answers: readAskUserAnswers(data),
+    };
   }
   return undefined;
+}
+
+/**
+ * Whether any part of a message carries text.
+ *
+ * Decides whether a decision message already contains the user's own words, in
+ * which case they render from the text part and `ask_user_answers` is not needed.
+ */
+function hasTextPart(parts: unknown[]): boolean {
+  return parts.some(rawPart => parsePart(rawPart)?.text !== undefined);
+}
+
+/**
+ * The user's answers to an `ask_user` question, out of a decision payload.
+ *
+ * One entry per question asked, each with an `answer` array — questions the user
+ * skipped have an empty one, so those are dropped rather than rendered as blanks.
+ */
+function readAskUserAnswers(data: { ask_user_answers?: unknown }): string[] {
+  const entries = data.ask_user_answers;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .flatMap(entry => {
+      const answer = (entry as { answer?: unknown })?.answer;
+      if (typeof answer === 'string') {
+        return [answer];
+      }
+      return Array.isArray(answer) ? answer : [];
+    })
+    .filter(
+      (value): value is string => typeof value === 'string' && value !== '',
+    );
 }
 
 /**

--- a/plugins/agent-platform/src/plugin.tsx
+++ b/plugins/agent-platform/src/plugin.tsx
@@ -18,6 +18,7 @@ import {
   newAgentReviewRouteRef,
   newAgentRouteRef,
   rootRouteRef,
+  sessionDetailRouteRef,
   sessionsRouteRef,
 } from './routes';
 
@@ -66,9 +67,8 @@ const sessionsSubPage = SubPageBlueprint.make({
     title: 'Sessions',
     routeRef: sessionsRouteRef,
     loader: async () => {
-      const { SessionsIndexPage } =
-        await import('./components/SessionsIndexPage');
-      return <SessionsIndexPage />;
+      const { SessionsRouter } = await import('./components/SessionsRouter');
+      return <SessionsRouter />;
     },
   },
 });
@@ -102,5 +102,6 @@ export const agentPlatformPlugin = createFrontendPlugin({
     newAgent: newAgentRouteRef,
     newAgentReview: newAgentReviewRouteRef,
     sessions: sessionsRouteRef,
+    sessionDetail: sessionDetailRouteRef,
   },
 });

--- a/plugins/agent-platform/src/routes.ts
+++ b/plugins/agent-platform/src/routes.ts
@@ -24,3 +24,14 @@ export const newAgentReviewRouteRef = createSubRouteRef({
 
 // The "Sessions" tab (`/agent-platform/sessions`).
 export const sessionsRouteRef = createRouteRef();
+
+// One session (`/agent-platform/sessions/<installation>/<id>`).
+//
+// The installation is part of the path rather than a query parameter because it
+// is part of the session's identity: kagent session ids are only unique within an
+// installation, so a link needs both to resolve. Ids are opaque — real ones mix
+// 64-character hex strings and UUIDs — so nothing here constrains their shape.
+export const sessionDetailRouteRef = createSubRouteRef({
+  path: '/:installation/:sessionId',
+  parent: sessionsRouteRef,
+});


### PR DESCRIPTION
### What does this PR do?

Makes Sessions rows clickable. `/agent-platform/sessions/<installation>/<id>` shows one session: header, stats strip, and the conversation.

> **Stacked on #2003** (which is stacked on #2002). Base is `agent-platform-session-timeline` so the diff stays clean; GitHub retargets on merge.

**Read-only.** kagent can rename, delete and continue a session and the prototype offers all three — none are wired up, so this ships without a write path.

### How does it look like?

<img width="1320" height="1045" alt="image" src="https://github.com/user-attachments/assets/e4d19f95-7302-4eb8-b741-e2b1cd927867" />


Expanding a tool call shows its arguments and result in a `CodeBlock`; reasoning shows the full text.

### Any background context you can provide?

Decisions worth a second opinion:

**Timestamps are absolute here, relative in the list.** Both ends of a session usually fall on the same day, so the relative form read *"Started 1 day ago · last activity 1 day ago"* for a session that took three minutes, and printed "1 day ago" identically on every turn marker — hiding the progression the timeline exists to show. One marker per A2A task, since a task's timestamp is the finest granularity that exists (see #2003 for why).

**Input tokens are labelled "billed, cumulative".** Every model call re-sends the whole context, so a 4-turn session with a large tool catalogue reaches 1.4M prompt tokens across 14 calls. Genuine billed usage — kagent's own UI sums it identically — but unlabelled it reads as a bug. There is deliberately **no combined total**: input and output are priced differently, so the sum isn't a number anyone acts on.

**Duration is wall-clock** (`updated_at − created_at`), since kagent records no per-turn durations. It includes time the user was away between turns.

**Calls through Muster are unwrapped.** Agents reach most MCP tools via muster's `call_tool`, so untreated every row read `call_tool` with the real tool buried in the arguments — [klaus-gateway#163](https://github.com/giantswarm/klaus-gateway/issues/163). Done in the parser, and only when the payload really has the wrapper shape, so a future `call_tool` change degrades to showing the proxy rather than losing the call. Unwrapped 7 of 17 calls on a real session.

**`ask_user` is not an approval.** ADK wraps both a permission request and a question in the same `adk_request_confirmation`. The parser records which (`asks: 'approval' | 'input'`) so the UI doesn't string-match a tool name; a question reads *User input requested · Responded · Questions* rather than *Approval requested · approved*.

**A missing session is a not-found state, not an error.** kagent answers 404 for deleted, never-existed and belongs-to-someone-else alike. A genuine read failure gets a separate danger alert with its message.

**Row links use a real anchor plus a whole-row click.** Not `rowConfig.getHref`: `BUIProvider` isn't mounted in this app, so react-aria's `RouterProvider` is inactive and a bui `href` does a full page reload.

**`session` and `session-tasks` are excluded from `localStorage`** for two independent reasons: a conversation is user-scoped data that mustn't outlive sign-out on disk, and at ~500 KB per session it would evict the fleet lists the persistence exists for.

The tab's content is now a `SessionsRouter` hoisting the query client and fleet-wide `Agent` list above both screens, so opening a session reuses what the list already loaded.

### Fixes found by testing against real sessions

The page was built against fixtures, then driven against live gazelle sessions. Everything below is a bug that only real data exposed:

| Symptom | Cause |
| --- | --- |
| `Total 0` beside `Input 1.4M` | `adk_usage_metadata` carries no `totalTokenCount` at all; summing reported totals stayed at zero. kagent's own UI has the same hole. Now derived from the parts, with a reported total still winning when present. |
| "Approval requested" accordion opened onto nothing | `CallDetail` handled only tool/agent calls and returned `null` for approvals, while the proposed arguments sat unrendered. Entries with no payload are now plain rows, not accordions. |
| No Details control on an `ask_user` session | Its visibility keyed on *activity*, which excludes approvals. That exclusion is right for **Hidden** (an approval is the user's own action) but shouldn't govern expand/collapse. |
| The user's reply missing from the conversation | The reply rides on the same message as the `decision_type` data part, and the decision branch returned immediately — discarding it. The agent appeared to answer something nobody said. |

Also corrects a claim I made on #2003: real payloads **do** use `adk_`-prefixed metadata. Two gazelle sessions a day apart used `kagent_usage_metadata` and `adk_usage_metadata` respectively, so the dual-prefix reader is load-bearing — reading one prefix silently zeroes a session's tokens.

### What the page cannot show

kagent stores none of this, so the prototype's remaining fields have no data behind them and shouldn't be re-added speculatively: **cost**, **tokens/second**, **context-window usage**, the owning **team**, the **trigger** that started the session, a **linked work item**, produced **results**, and **evaluation**. Delegation entries are inert, since the response doesn't reliably carry the child session's id.

The session id is deliberately not displayed — a 64-character opaque string that told the reader nothing, and it's in the URL already.

### Do the docs need to be updated?

Yes, done — `docs/agent-platform.md` gains a "session detail page" section covering the two reads, why events are ignored, per-turn timestamps, the entry taxonomy, Muster unwrapping, cumulative-token labelling, and an explicit list of what the page cannot show.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.

---

540 tests, clean `tsc` and `lint`. Verified live against gazelle: two requests per load, deep-link reload, garbage id → 404 (not 5xx), `localStorage` at 51 KB with no bearer token and no conversation content, and no console warnings.