### PR TITLE
fix(agent-platform): correct six defects in the session detail page

### DIFF
--- a/.changeset/agent-platform-session-detail-review-fixes.md
+++ b/.changeset/agent-platform-session-detail-review-fixes.md
@@ -1,0 +1,39 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': patch
+---
+
+Fix six defects found reviewing the session detail page.
+
+- **A click on a session title navigated twice.** The Sessions table has both an
+  anchor in the title cell and a whole-row click, and react-aria's row press fires
+  for a press anywhere in the row — the anchor included. So one click navigated
+  twice: two identical history entries, meaning Back needed two presses to return
+  to the list, and with cmd held the session opened in a new tab _and_ took the
+  current tab with it, which is the opposite of why the anchor is there. The title
+  anchor now swallows the press (`pointerdown`/`pointerup`, which is what
+  `usePress` listens to) so exactly one of the two affordances acts on any click.
+- **A wholly unreadable session claimed to be empty.** The timeline's "N messages
+  could not be read" warning sat below an early return for an item-less timeline —
+  so the one case it exists for, every history entry failing to parse, reported
+  "This session has no messages yet." and never warned at all. The warning now
+  renders in that branch too, with wording that does not deny the messages existed.
+- **A blank text part could still lose an `ask_user` reply.** The reply is recovered
+  from `ask_user_answers` only when the decision message carries no text part, but
+  the check counted a `{ text: "" }` part as words while the renderer drops text
+  that trims to nothing — losing the answer both ways. The check now agrees with
+  what actually renders.
+- **A `call_tool` shape change would have dropped a call's arguments.**
+  `unwrapProxiedCall` promised to degrade to showing muster's proxy rather than
+  losing a call, but keyed only on the inner `name`: had muster renamed or nested
+  the inner arguments, every proxied row would have named the real tool with its
+  arguments silently `undefined`, rendering as an entry with nothing to expand.
+  Unwrapping now also requires that the payload carries no key beyond `name` and
+  `arguments`. An argument-less proxied call (`{ name }` alone) still unwraps.
+- **Turns were keyed on `taskIndex`.** `groupIntoTurns` deliberately emits two turns
+  with the same index if a task index ever repeats non-contiguously, which made the
+  React key ambiguous — one turn's entries could reconcile under the other's
+  timestamp. Keyed on position now.
+- **A known 404 sat behind a spinner.** "Not found" is decided by the session read
+  alone, but the loading flag waited for the tasks read too, so a missing session
+  stayed on a spinner for the whole retry ladder — or the fetch timeout on an
+  unreachable installation — with the answer already in hand.

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -430,8 +430,16 @@ the arguments — the problem reported in
 [klaus-gateway#163](https://github.com/giantswarm/klaus-gateway/issues/163). The
 parser looks through the wrapper (`unwrapProxiedCall`), so the row names the tool
 actually invoked and carries a `via Muster` badge; on a real gazelle session that
-unwrapped 7 of 17 calls. If `call_tool`'s payload ever stops matching the wrapper
-shape, the call degrades to showing the proxy rather than being lost.
+unwrapped 7 of 17 calls.
+
+Unwrapping requires the payload to be _nothing but_ the wrapper: a non-empty `name`,
+and no key besides `name` and `arguments`. That second half is what keeps the
+degradation honest — keying on `name` alone would mean that if muster renamed or
+nested the inner arguments, the row would still name the real tool while its
+arguments silently became `undefined`, leaving an entry with nothing to expand. As
+written, an unfamiliar key means the call degrades to showing the proxy, payload
+intact, rather than being partly lost. `{ name }` with no `arguments` still unwraps:
+that is an argument-less proxied call, and there is nothing there to lose.
 
 Approvals are deliberately **not** governed by the activity control: an approval
 records the _user's_ decision, so hiding it would erase the trace of their own
@@ -441,6 +449,13 @@ Two things real payloads taught us, both now relied on: kagent repeats each user
 message under the **same `messageId`** on every turn, so the session-wide dedupe is
 required rather than defensive; and one message can carry prose plus several tool
 calls, always text first.
+
+**A message the parser cannot read is counted, not hidden.** `skippedMessages`
+counts history entries that failed the schema outright — artifact and status updates
+are deliberately excluded, being healthy entries we simply have no renderer for —
+and the timeline warns "N messages could not be read". That warning renders even
+when _every_ entry failed and there are therefore no items at all; otherwise the one
+case it exists for would report as an ordinary empty session.
 
 ### What it cannot show
 

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -250,6 +250,27 @@ describe('SessionTimeline', () => {
       ).toBeInTheDocument();
     });
 
+    it('recovers the reply when the text part is present but blank', async () => {
+      // A blank text part is not the user's words: the text run trims to nothing
+      // and renders no message at all, so treating it as "there is text" skipped
+      // the structured fallback and lost the reply entirely.
+      const blankText = structuredClone(tasksAskUser) as typeof tasksAskUser;
+      const decision = blankText.data[0].history.find(
+        item => item.messageId === 'm-decision-1',
+      ) as { parts: unknown[] };
+      decision.parts = decision.parts.map(part =>
+        (part as { kind?: string }).kind === 'text'
+          ? { kind: 'text', text: '   ' }
+          : part,
+      );
+
+      await render(blankText, 'SRE Agent');
+
+      expect(
+        screen.getByText(/Still no reply to messages with image/),
+      ).toBeInTheDocument();
+    });
+
     it('reports an unanswered question as awaiting a reply', async () => {
       const pending = structuredClone(tasksAskUser) as typeof tasksAskUser;
       pending.data[0].history = pending.data[0].history.filter(
@@ -346,5 +367,82 @@ describe('SessionTimeline', () => {
       screen.getByText('Some messages could not be read'),
     ).toBeInTheDocument();
     expect(screen.getByText(/2 messages/)).toBeInTheDocument();
+  });
+
+  it('warns when *every* message could not be read', async () => {
+    // The case the warning exists for. A session whose entire history fails to
+    // parse yields no items at all, so an empty-state early return would swallow
+    // the warning and report total data loss as an ordinary empty session.
+    await renderInTestApp(
+      <SessionTimeline
+        timeline={{
+          items: [],
+          tokens: { total: 0, prompt: 0, completion: 0 },
+          skippedMessages: 3,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText('Some messages could not be read'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/3 messages/)).toBeInTheDocument();
+    // And it must not claim there were none.
+    expect(
+      screen.queryByText('This session has no messages yet.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders every turn when a task index repeats non-contiguously', async () => {
+    // `groupIntoTurns` deliberately groups on runs rather than on the index, so
+    // this input produces two separate turns numbered 0. Both must render, and
+    // must not collide: React would then be free to reconcile the second against
+    // the first and render one turn's entries under the other's timestamp.
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    await renderInTestApp(
+      <SessionTimeline
+        timeline={{
+          items: [
+            {
+              kind: 'user-message',
+              id: '0:0:0',
+              taskIndex: 0,
+              at: '2026-07-23T16:05:00Z',
+              text: 'first turn',
+            },
+            {
+              kind: 'user-message',
+              id: '1:0:1',
+              taskIndex: 1,
+              at: '2026-07-23T16:06:00Z',
+              text: 'second turn',
+            },
+            {
+              kind: 'user-message',
+              id: '0:1:2',
+              taskIndex: 0,
+              at: '2026-07-23T16:07:00Z',
+              text: 'back to the first index',
+            },
+          ],
+          tokens: { total: 0, prompt: 0, completion: 0 },
+          skippedMessages: 0,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('first turn')).toBeInTheDocument();
+    expect(screen.getByText('second turn')).toBeInTheDocument();
+    expect(screen.getByText('back to the first index')).toBeInTheDocument();
+    expect(screen.getAllByText(/UTC$/)).toHaveLength(3);
+
+    // Filtered to the duplicate-key warning: rendering here also trips MUI v4's
+    // pre-existing `findDOMNode` deprecation notice, which is not ours.
+    const duplicateKeyWarnings = consoleError.mock.calls.filter(([first]) =>
+      String(first).includes('same key'),
+    );
+    expect(duplicateKeyWarnings).toHaveLength(0);
+    consoleError.mockRestore();
   });
 });

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.tsx
@@ -73,11 +73,33 @@ export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
     [timeline.items],
   );
 
+  // Rendered in both branches below. An unreadable session produces *no* items
+  // and a non-zero `skippedMessages`, so keeping this inside the populated branch
+  // meant the one case the warning exists for — every history entry failing to
+  // parse — reported "no messages yet" and never warned at all, presenting total
+  // data loss as an ordinary empty session.
+  const skippedAlert = timeline.skippedMessages > 0 && (
+    <Alert
+      status="warning"
+      title="Some messages could not be read"
+      description={`${timeline.skippedMessages} ${
+        timeline.skippedMessages === 1 ? 'message' : 'messages'
+      } in this session did not match the shape we expect from kagent and are not shown.`}
+    />
+  );
+
   if (timeline.items.length === 0) {
     return (
-      <Text variant="body-medium" color="secondary">
-        This session has no messages yet.
-      </Text>
+      <Flex direction="column" gap="3">
+        {skippedAlert}
+        <Text variant="body-medium" color="secondary">
+          {timeline.skippedMessages > 0
+            ? // "No messages yet" would be a lie here: there were messages, we
+              // just could not read any of them.
+              'None of this session’s messages could be displayed.'
+            : 'This session has no messages yet.'}
+        </Text>
+      </Flex>
     );
   }
 
@@ -122,17 +144,9 @@ export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
         )}
       </Flex>
 
-      {timeline.skippedMessages > 0 && (
-        <Alert
-          status="warning"
-          title="Some messages could not be read"
-          description={`${timeline.skippedMessages} ${
-            timeline.skippedMessages === 1 ? 'message' : 'messages'
-          } in this session did not match the shape we expect from kagent and are not shown.`}
-        />
-      )}
+      {skippedAlert}
 
-      {turns.map(turn => {
+      {turns.map((turn, turnIndex) => {
         const visible =
           detail === 'hidden'
             ? turn.items.filter(item => !isActivityItem(item))
@@ -141,7 +155,11 @@ export function SessionTimeline({ timeline, agentName }: SessionTimelineProps) {
           return null;
         }
         return (
-          <Flex key={turn.taskIndex} direction="column" gap="3">
+          // Keyed on the position in `turns`, not on `taskIndex`: `groupIntoTurns`
+          // deliberately emits two turns with the same index if a task index ever
+          // repeats non-contiguously, and a duplicate key would let React
+          // reconcile one turn's entries under the other's timestamp.
+          <Flex key={turnIndex} direction="column" gap="3">
             {/* Absolute, not relative: every turn of a session usually falls on
                 the same day, so the relative form printed "1 day ago" three times
                 and hid the progression entirely. An exact time shows how the

--- a/plugins/agent-platform/src/components/SessionsTable/SessionsTable.test.tsx
+++ b/plugins/agent-platform/src/components/SessionsTable/SessionsTable.test.tsx
@@ -14,6 +14,16 @@ jest.mock('../../hooks/useAgentAvatarUrl', () => ({
   useAgentAvatarUrl: () => mockBuildAvatarUrl,
 }));
 
+// The row's programmatic navigation, and *only* it: `Link` resolves `useNavigate`
+// internally within react-router-dom, so its own client-side navigation is
+// untouched by this mock. A call here therefore means the row handler ran.
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
 const rows: SessionRow[] = [
   {
     id: 'gazelle/abc',
@@ -39,6 +49,7 @@ const rows: SessionRow[] = [
 describe('SessionsTable', () => {
   beforeEach(() => {
     mockBuildAvatarUrl.mockClear();
+    mockNavigate.mockClear();
   });
 
   it('renders every column header', async () => {
@@ -75,6 +86,56 @@ describe('SessionsTable', () => {
       'href',
       '/agent-platform/sessions/golem/def',
     );
+  });
+
+  describe('navigation', () => {
+    // The row's onClick is react-aria's `onAction`, which fires for a press
+    // anywhere in the row — the anchor included. Both firing for one click
+    // navigated twice: two identical history entries, so Back needed two presses,
+    // and with a modifier held the session opened in a new tab *and* took the
+    // current one with it.
+    it('does not also navigate the row when the title link is clicked', async () => {
+      await renderInTestApp(<SessionsTable rows={rows} />, {
+        mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+      });
+
+      await userEvent.click(
+        screen.getByRole('link', { name: 'What issues are assi...' }),
+      );
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('still navigates the row when a modifier key is held on the link', async () => {
+      // The browser opens the anchor in a new tab and react-router stays out of
+      // the way; the row must stay out of the way too, or the current tab is
+      // navigated away from the list the user wanted to keep.
+      await renderInTestApp(<SessionsTable rows={rows} />, {
+        mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+      });
+
+      await userEvent.keyboard('{Meta>}');
+      await userEvent.click(
+        screen.getByRole('link', { name: 'What issues are assi...' }),
+      );
+      await userEvent.keyboard('{/Meta}');
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates when a cell other than the title is clicked', async () => {
+      // The whole-row click is the convenience affordance and must keep working.
+      await renderInTestApp(<SessionsTable rows={rows} />, {
+        mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef },
+      });
+
+      await userEvent.click(screen.getByText('Issue tracker'));
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/agent-platform/sessions/gazelle/abc',
+      );
+    });
   });
 
   it('renders session titles as kagent supplied them', async () => {

--- a/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
+++ b/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { SyntheticEvent, useCallback, useMemo } from 'react';
 import {
   Avatar,
   Cell,
@@ -25,6 +25,27 @@ import {
 
 /** The avatar is one line of text tall; request 2× for hi-dpi crispness. */
 const ROW_AVATAR_SIZE: AvatarSize = 48;
+
+/**
+ * Keep a press on the title anchor from also reaching the row.
+ *
+ * The row's `onClick` is react-aria's `onAction`, which fires for a press anywhere
+ * inside the row — the anchor included, since `usePress` has no exemption for
+ * interactive descendants. So a single click on the title used to navigate
+ * *twice*: once through the anchor, once through the row. On a plain click that
+ * pushed the same path onto the history stack twice, and Back needed two presses
+ * to return to the list; with cmd held it was worse, because react-router leaves a
+ * modified event to the browser, so the session opened in a new tab *and* the
+ * current tab navigated away — defeating the reason the anchor exists.
+ *
+ * `usePress` works off pointer events rather than `click`, so `pointerdown` and
+ * `pointerup` are the ones that have to be stopped; `click` is stopped too, for
+ * the synthetic-click path. Stopping propagation does not set `defaultPrevented`,
+ * so the anchor's own react-router navigation still happens.
+ */
+function stopRowPress(event: SyntheticEvent) {
+  event.stopPropagation();
+}
 
 /** Dash shown where a value is genuinely unknown. */
 function Unknown() {
@@ -57,10 +78,20 @@ function getColumnConfig(
         // which `rowConfig.getHref` would not: BUIProvider is not mounted in this
         // app, so react-aria's RouterProvider is inactive and a bui `href` would
         // trigger a full page reload.
+        //
+        // The two affordances must not both fire for one click — see
+        // {@link stopRowPress}.
         return (
           <Cell>
             {href ? (
-              <Link to={href}>{row.title}</Link>
+              <Link
+                to={href}
+                onPointerDown={stopRowPress}
+                onPointerUp={stopRowPress}
+                onClick={stopRowPress}
+              >
+                {row.title}
+              </Link>
             ) : (
               <Text variant="body-medium">{row.title}</Text>
             )}

--- a/plugins/agent-platform/src/hooks/useSessionDetail.test.tsx
+++ b/plugins/agent-platform/src/hooks/useSessionDetail.test.tsx
@@ -1,0 +1,91 @@
+import { PropsWithChildren } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { kagentApiRef } from '../apis';
+import { KagentApi } from '../apis/types';
+import { useSessionDetail } from './useSessionDetail';
+
+const getSessionDetail = jest.fn();
+const listSessionTasks = jest.fn();
+
+const kagentApi = {
+  getSessionDetail,
+  listSessionTasks,
+} as unknown as KagentApi;
+
+function notFoundError() {
+  const error = new Error('session not found');
+  error.name = 'NotFoundError';
+  return error;
+}
+
+/** A tasks read that never settles, standing in for a slow installation. */
+function neverSettles() {
+  return new Promise(() => {});
+}
+
+function renderWith() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: PropsWithChildren<{}>) => (
+    <TestApiProvider apis={[[kagentApiRef, kagentApi]]}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </TestApiProvider>
+  );
+  return renderHook(() => useSessionDetail('gazelle', 'abc'), { wrapper });
+}
+
+beforeEach(() => {
+  getSessionDetail.mockReset();
+  listSessionTasks.mockReset();
+});
+
+describe('useSessionDetail', () => {
+  it('reports not found when kagent has no such session', async () => {
+    // 404 covers deleted, never-existed and belongs-to-someone-else alike.
+    getSessionDetail.mockRejectedValue(notFoundError());
+    listSessionTasks.mockRejectedValue(notFoundError());
+
+    const { result } = renderWith();
+
+    await waitFor(() => expect(result.current.isNotFound).toBe(true));
+    // An expected outcome, not something to report as a read failure.
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('stops loading as soon as the session is known to be missing', async () => {
+    // The session read decides "not found" on its own, and the page checks
+    // `isLoading` first — so leaving loading true until the *tasks* read settles
+    // kept the user on a spinner for the whole retry ladder, or for the fetch
+    // timeout on an unreachable installation, with the answer already known.
+    getSessionDetail.mockRejectedValue(notFoundError());
+    listSessionTasks.mockImplementation(neverSettles);
+
+    const { result } = renderWith();
+
+    await waitFor(() => expect(result.current.isNotFound).toBe(true));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('keeps loading while a readable session’s tasks are still in flight', async () => {
+    // The other side of that short-circuit: with the session present there is
+    // nothing to show until its conversation arrives.
+    getSessionDetail.mockResolvedValue({
+      session: {
+        id: 'gazelle/abc',
+        sessionId: 'abc',
+        installation: 'gazelle',
+        title: 'Chat',
+      },
+    });
+    listSessionTasks.mockImplementation(neverSettles);
+
+    const { result } = renderWith();
+
+    await waitFor(() => expect(getSessionDetail).toHaveBeenCalled());
+    expect(result.current.isNotFound).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/plugins/agent-platform/src/hooks/useSessionDetail.ts
+++ b/plugins/agent-platform/src/hooks/useSessionDetail.ts
@@ -100,7 +100,14 @@ export function useSessionDetail(
     timeline,
     state,
     taskCount: tasks?.length ?? 0,
-    isLoading: sessionQuery.isLoading || tasksQuery.isLoading,
+    // `isNotFound` short-circuits loading, because it is decided by the session
+    // read alone and the page checks `isLoading` first. Without this, a session
+    // that 404s immediately — `NotFoundError` is not retried, so that read settles
+    // at once — still sat behind a spinner for as long as the *tasks* request took:
+    // the full retry ladder (2s/4s/8s) for a non-404 failure, or the fetch timeout
+    // on an unreachable installation. The answer was already known; nothing the
+    // tasks read can return would change it.
+    isLoading: !isNotFound && (sessionQuery.isLoading || tasksQuery.isLoading),
     isNotFound,
     error,
   };

--- a/plugins/agent-platform/src/lib/kagentParts.ts
+++ b/plugins/agent-platform/src/lib/kagentParts.ts
@@ -73,10 +73,18 @@ export const MUSTER_PROXY_LABEL = 'Muster';
  * giantswarm/klaus-gateway#163 for the Slack surface. Unwrapped, the row names
  * `x_kubernetes_get` and carries `via: 'muster'`.
  *
- * Only unwraps when the payload actually has the wrapper's shape (`name` a
- * non-empty string, with the inner call's `arguments`). Anything else is returned
+ * Only unwraps when the payload really is *nothing but* the wrapper: a non-empty
+ * `name`, and no key other than `name` and `arguments`. Anything else is returned
  * untouched, so a future change to `call_tool` degrades to showing the wrapper
  * rather than losing the call.
+ *
+ * That second condition is what makes the promise true. Keying only on `name`
+ * would mean that if muster renamed or nested the inner arguments, every proxied
+ * row would still show the real tool name while `args` silently became
+ * `undefined` — the call's whole payload gone, rendered as a row with nothing to
+ * expand. Checking that no other key exists distinguishes that case from a
+ * genuinely argument-less proxied call (`{ name }` alone), which still unwraps
+ * because there is nothing there to lose.
  */
 export function unwrapProxiedCall(call: FunctionCall): FunctionCall & {
   /** Set when the call reached its tool through a proxy. */
@@ -88,6 +96,12 @@ export function unwrapProxiedCall(call: FunctionCall): FunctionCall & {
   const args = asRecord(call.args);
   const innerName = asNonEmptyString(args?.name);
   if (!innerName) {
+    return call;
+  }
+  const carriesOnlyWrapperKeys = Object.keys(args ?? {}).every(
+    key => key === 'name' || key === 'arguments',
+  );
+  if (!carriesOnlyWrapperKeys) {
     return call;
   }
   return {

--- a/plugins/agent-platform/src/lib/kagentTimeline.test.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.test.ts
@@ -397,6 +397,38 @@ describe('buildTimeline', () => {
       expect((items[0] as { via?: string }).via).toBeUndefined();
     });
 
+    it('unwraps a proxied call that genuinely has no arguments', () => {
+      // `{ name }` alone is an argument-less tool reached through the proxy. There
+      // is nothing to lose by unwrapping, so it still names the real tool.
+      const { items } = buildTimeline(proxiedTasks({ name: 'x_core_list' }));
+
+      expect(items[0]).toMatchObject({
+        kind: 'tool-call',
+        toolName: 'x_core_list',
+        via: 'Muster',
+      });
+    });
+
+    it('keeps the wrapper when the payload carries a key we do not know', () => {
+      // The promise the docstring makes: degrade to showing the proxy, never to a
+      // call whose arguments were silently dropped. Keying only on `name` would
+      // name the real tool here and lose `parameters` entirely, leaving a row with
+      // nothing to expand.
+      const { items } = buildTimeline(
+        proxiedTasks({
+          name: 'x_kubernetes_get',
+          parameters: { ns: 'default' },
+        }),
+      );
+
+      expect(items[0]).toMatchObject({
+        kind: 'tool-call',
+        toolName: 'call_tool',
+        args: { name: 'x_kubernetes_get', parameters: { ns: 'default' } },
+      });
+      expect((items[0] as { via?: string }).via).toBeUndefined();
+    });
+
     it('marks nothing as proxied when the tool was called directly', () => {
       const { items } = timelineFor(kagentPrefixed);
       const direct = items.find(

--- a/plugins/agent-platform/src/lib/kagentTimeline.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.ts
@@ -584,13 +584,20 @@ function readDecision(
 }
 
 /**
- * Whether any part of a message carries text.
+ * Whether any part of a message carries text that will actually render.
  *
  * Decides whether a decision message already contains the user's own words, in
  * which case they render from the text part and `ask_user_answers` is not needed.
+ *
+ * **Blank text does not count.** `flushText` drops a run that trims to nothing, so
+ * treating a `{ text: '' }` part as words would lose the reply twice over: the
+ * `ask_user_answers` fallback skipped because "there is text", and the text itself
+ * dropped for being empty — the exact "the user's answer vanished" symptom this
+ * fallback exists to prevent. The predicate has to agree with what `flushText`
+ * will keep.
  */
 function hasTextPart(parts: unknown[]): boolean {
-  return parts.some(rawPart => parsePart(rawPart)?.text !== undefined);
+  return parts.some(rawPart => Boolean(parsePart(rawPart)?.text?.trim()));
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Fixes six defects found in a review pass over #2005. Each one has a test that fails without its fix — verified by stashing the fixes and re-running.

| # | Defect | Symptom |
| --- | --- | --- |
| 1 | Row click and title anchor both navigate | Back needs two presses; cmd-click steals the current tab |
| 2 | `skippedMessages` warning unreachable when there are no items | A wholly unreadable session reports "no messages yet" |
| 3 | `hasTextPart` counts blank text as words | An `ask_user` reply can still vanish |
| 4 | `unwrapProxiedCall` keys only on the inner `name` | A `call_tool` shape change would drop a call's arguments |
| 5 | Turns keyed on `taskIndex` | Duplicate React key in the case `groupIntoTurns` exists for |
| 6 | `isLoading` waits for the tasks read | A known 404 sits behind a spinner |

### What is the effect of this change to users?

**Clicking a session title no longer navigates twice.** The Sessions table deliberately has two affordances — a real anchor in the title cell, plus a whole-row click — and they were both firing for a single click, because the row's `onClick` is react-aria's `onAction`, which fires for a press anywhere in the row with no exemption for interactive descendants. Two consequences, both user-visible:

- Plain click: react-router's `Link` pushed the path, then the row pushed the *same* path again → two identical history entries, so **Back needed two presses** to get back to the list.
- **cmd-click:** react-router leaves a modified event to the browser, so the session opened in a new tab — and the row handler then navigated the current tab away too. Exactly the opposite of why the anchor was added.

The anchor now swallows the press. `usePress` works off pointer events, so `pointerdown`/`pointerup` are what has to be stopped; stopping propagation doesn't set `defaultPrevented`, so the anchor's own client-side navigation and its analytics event are untouched. The whole-row click keeps working everywhere else in the row.

**A session whose messages can't be read now says so.** The "N messages could not be read" warning sat *below* the early return for an item-less timeline — so the single case the counter exists for, every history entry failing the schema, rendered "This session has no messages yet." and no warning at all. Total data loss presented as an ordinary empty session. The warning now renders in that branch too, and the accompanying line no longer denies the messages existed.

**A known-missing session stops loading immediately.** "Not found" is decided by the session read alone (deliberately — the tasks endpoint also 404s on a kagent too old to serve it), but `isLoading` waited for both reads. A 404 settles at once since `NotFoundError` isn't retried, yet the page stayed on a spinner for however long the *tasks* request took: the full 2s/4s/8s retry ladder for a non-404 failure, or the fetch timeout on an unreachable installation — with the answer already in hand.

### Any background context you can provide?

Two of the six are cases where a comment promised more than the code delivered, which is worth calling out because both promises are still worth keeping:

**`unwrapProxiedCall`** said it "only unwraps when the payload actually has the wrapper's shape (`name` a non-empty string, with the inner call's `arguments`)" and that anything else "degrades to showing the wrapper rather than losing the call". It checked only `name`. Had muster renamed or nested the inner arguments, every proxied row would have kept naming the real tool while `args` silently became `undefined` — a call with its payload gone, rendered as an entry with nothing to expand.

The fix is not "require `arguments`", which would have regressed genuinely argument-less proxied calls back to reading `call_tool`. It unwraps when the payload is *nothing but* the wrapper: a non-empty `name`, and no key besides `name` and `arguments`. That separates the three cases cleanly — `{ name, arguments }` unwraps, `{ name }` unwraps (nothing to lose), `{ name, somethingElse }` degrades to the proxy with its payload intact.

**`hasTextPart`** decides whether an `ask_user` reply needs recovering from `ask_user_answers`, and counted a `{ text: "" }` part as the user's words — while `flushText` drops a run that trims to nothing. A decision message with a blank text part therefore lost the reply *both* ways: fallback skipped because "there is text", text dropped for being empty. The predicate now agrees with what actually renders. This is the same symptom #2005 fixed from the other direction, which is why it's worth a guard rather than a shrug.

The **turn key** is the mildest of the six and the fix is a one-liner, but it is worth doing precisely because `groupIntoTurns` was written to tolerate a non-contiguous `taskIndex` — it groups on runs specifically so items keep `buildTimeline`'s order in that case. The key then made the two resulting turns ambiguous to React. Its test asserts no duplicate-key warning is emitted, filtered to that message since MUI v4's `findDOMNode` notice fires here regardless.

### Do the docs need to be updated?

Yes, done. `docs/agent-platform.md` now states the unwrap rule precisely (and why both halves are load-bearing), and gains a note that an unreadable message is counted and reported rather than hidden — including when *every* entry failed.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added.

---

391 tests in the plugin, clean `tsc`, `lint` and `prettier`. The three navigation assertions run against the real bui `Table`, so they exercise react-aria's press behaviour rather than a stand-in.
