### PR TITLE
fix(flux): show the failure cause on the HelmRelease details card

### DIFF
--- a/.changeset/flux-helmrelease-failure-condition.md
+++ b/.changeset/flux-helmrelease-failure-condition.md
@@ -1,0 +1,54 @@
+---
+'@giantswarm/backstage-plugin-kubernetes-react': minor
+'@giantswarm/backstage-plugin-flux-react': minor
+---
+
+Show the condition that explains the failure on the Flux HelmRelease details
+card, instead of the rollback that hides it.
+
+- helm-controller summarizes a release into `Ready` by mirroring one of
+  `Released`, `TestSuccess` or `Remediated` into it verbatim — same reason, same
+  message. So a failed upgrade showed its real error only until the failure was
+  remediated: the rollback then overwrote `Ready` with "Helm rollback to previous
+  release … succeeded", and the card switched from the error to information about
+  the previous, working release. The new
+  `HelmRelease.findFailureCauseCondition()` returns the failing `Released` (or
+  `TestSuccess`) condition, which keeps the error until the next release attempt,
+  and the card takes its Status, Message and failure time from there. Where
+  several release conditions are failing, the most recent transition wins — an
+  upgrade that succeeded with failing Helm tests leaves `Released` true and
+  `TestSuccess` false, and a failed upgrade can leave a stale failing
+  `TestSuccess` from an earlier cycle behind.
+- The same substitution fixes a stalled release, observed live: helm-controller
+  stops retrying, sets `Stalled`, and leaves `Ready` at `Unknown` with
+  "reconciliation in progress" — so the card reported a release that failed two
+  months ago as "Last reconciled". `Ready` is treated as uninformative when it is
+  `Unknown` on a stalled release, which is safe because `Unknown` never reports a
+  failure; a blocker always writes `False`.
+- Substitution otherwise requires `Ready` to be a verbatim mirror of `Remediated`
+  (or of a `True` `Stalled`), not an allow-list of remediation reasons. The mirror
+  test keeps a newer, unrelated blocker visible: when the object fails again
+  after the rollback for a reason that never reaches a release attempt
+  (`ArtifactFailed`, `DependencyNotReady`, a missing `valuesFrom` Secret, a
+  denied release), `Ready` carries that current blocker, no longer equals the
+  remediation, and the older — now misleading — upgrade error is not shown. It
+  also covers remediation flavours a reason list would miss: a failed _install_
+  is remediated by an uninstall, and the rollback itself can fail (`Remediated`
+  is then `False`, and still mirrored into `Ready`).
+- Nothing is substituted while the release is ready or a reconciliation is in
+  flight. A HelmRelease with `spec.test.ignoreFailures` stays ready with
+  `TestSuccess` failing, and a fresh reconcile of a previously failed object can
+  be progressing with a stale failing `Released` left over from the previous
+  generation — in neither case is that failure the current state.
+- The remediation is kept as a single line ("Rollback succeeded", "Uninstall
+  succeeded", …) rather than dropped, since its full message only restates the
+  chart version shown above it. The exception is a remediation that failed
+  itself, where the message is the news and is shown in full. A new `Attempted`
+  row names the revision the failed release tried, so the running `Chart Version`
+  and the version the error talks about can be told apart, and the Status line
+  notes when the retries are exhausted.
+- The card's AI chat prompt and the resource tree's search over failure messages
+  use the same condition, so neither asks about — nor matches on — the rollback
+  message any more. The button also offers to troubleshoot whenever a release
+  failure is known, rather than only when `Ready` is `False`, which is what a
+  stalled release with an `Unknown` `Ready` condition needs.

--- a/.changeset/flux-helmrelease-failure-condition.md
+++ b/.changeset/flux-helmrelease-failure-condition.md
@@ -26,8 +26,9 @@ card, instead of the rollback that hides it.
   `Unknown` on a stalled release, which is safe because `Unknown` never reports a
   failure; a blocker always writes `False`.
 - Substitution otherwise requires `Ready` to be a verbatim mirror of `Remediated`
-  (or of a `True` `Stalled`), not an allow-list of remediation reasons. The mirror
-  test keeps a newer, unrelated blocker visible: when the object fails again
+  (or of a `RetriesExceeded` `Stalled`), not an allow-list of remediation reasons.
+  The mirror test keeps a newer, unrelated blocker visible: when the object fails
+  again
   after the rollback for a reason that never reaches a release attempt
   (`ArtifactFailed`, `DependencyNotReady`, a missing `valuesFrom` Secret, a
   denied release), `Ready` carries that current blocker, no longer equals the
@@ -45,10 +46,13 @@ card, instead of the rollback that hides it.
   chart version shown above it. The exception is a remediation that failed
   itself, where the message is the news and is shown in full. A new `Attempted`
   row names the revision the failed release tried, so the running `Chart Version`
-  and the version the error talks about can be told apart, and the Status line
-  notes when the retries are exhausted.
+  and the version the error talks about can be told apart. The Status line notes
+  when the release stopped — "(retries exhausted)" only for a `RetriesExceeded`
+  stall, "(stalled)" for a terminal one, since helm-controller also stalls on
+  errors it never retried.
 - The card's AI chat prompt and the resource tree's search over failure messages
   use the same condition, so neither asks about — nor matches on — the rollback
-  message any more. The button also offers to troubleshoot whenever a release
-  failure is known, rather than only when `Ready` is `False`, which is what a
-  stalled release with an `Unknown` `Ready` condition needs.
+  message any more. Both consult it before looking at the `Ready` status, which a
+  stalled release leaves at `Unknown`: the button now offers to troubleshoot such
+  a release rather than "show me basic details", and its error is searchable in
+  the tree.

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceCard.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceCard.tsx
@@ -23,13 +23,11 @@ import {
 } from '@backstage/ui';
 import { makeStyles } from '@material-ui/core';
 import classNames from 'classnames';
-import {
-  AIChatButton,
-  buildExplainErrorMessage,
-} from '@giantswarm/backstage-plugin-ai-chat-react';
+import { AIChatButton } from '@giantswarm/backstage-plugin-ai-chat-react';
 import { CopyCommandMenu } from './CopyCommandMenu';
 import { FluxResourceActions } from './FluxResourceActions';
 import { ResourceMetadata } from './ResourceMetadata';
+import { buildResourceAiChatPrompt } from './utils/buildResourceAiChatPrompt';
 import { makeResourceCardColorVariants } from './utils/makeResourceCardColorVariants';
 import { ResourceInfo } from './ResourceInfo';
 
@@ -186,26 +184,14 @@ export const ResourceCard = ({
 
   const inactive = isSuspended || isDependencyNotReady;
 
-  const readyCondition =
-    readyStatus === 'False' ? resource?.findReadyCondition() : undefined;
-  const failureMessage = readyCondition?.message;
-  const namespacePart = namespace ? ` in namespace '${namespace}'` : '';
-
-  let aiChatMessage: string;
-  if (readyStatus === 'False' && failureMessage) {
-    aiChatMessage = buildExplainErrorMessage({
-      kind,
-      name,
-      namespace,
-      cluster,
-      message: failureMessage,
-      reason: readyCondition?.reason,
-    });
-  } else if (readyStatus === 'False') {
-    aiChatMessage = `Please read the ${kind} resource named '${name}'${namespacePart} on management cluster '${cluster}' and help me understand why it is not in a Ready state.`;
-  } else {
-    aiChatMessage = `Please read the ${kind} resource named '${name}'${namespacePart} on management cluster '${cluster}', and show me basic details, so that I can ask further questions about it.`;
-  }
+  const aiChatPrompt = buildResourceAiChatPrompt({
+    kind,
+    name,
+    namespace,
+    cluster,
+    resource,
+    readyStatus,
+  });
 
   const resourceInfo = (
     <ResourceInfo
@@ -302,8 +288,8 @@ export const ResourceCard = ({
               <FluxResourceActions resource={resource} />
               <CopyCommandMenu resource={resource} />
               <AIChatButton
-                troubleshoot={readyStatus === 'False'}
-                items={[{ message: aiChatMessage }]}
+                troubleshoot={aiChatPrompt.troubleshoot}
+                items={[{ message: aiChatPrompt.message }]}
               />
             </Flex>
           </Flex>

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.test.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.test.tsx
@@ -1,0 +1,278 @@
+import { screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import {
+  HelmRelease,
+  Kustomization,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+import { ResourceMetadata } from './ResourceMetadata';
+
+type Condition = {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason: string;
+  message: string;
+  lastTransitionTime: string;
+};
+
+const UPGRADE_ERROR =
+  'Helm upgrade failed for release agentic-platform/muster-runbooks with chart muster-runbooks@0.2.15+800a0275a0f0: cannot patch "failing-pods" with kind Workflow';
+const ROLLBACK_MESSAGE =
+  'Helm rollback to previous release agentic-platform/muster-runbooks.v53 with chart muster-runbooks@0.2.14+6a5dea276262 succeeded';
+
+function createHelmRelease(options: {
+  conditions?: Condition[];
+  lastAttemptedRevision?: string;
+  upgradeFailures?: number;
+}): HelmRelease {
+  const json = {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: { name: 'muster-runbooks', namespace: 'flux-giantswarm' },
+    spec: { interval: '10m' },
+    status: {
+      conditions: options.conditions,
+      history: [
+        {
+          chartVersion: '0.2.14+6a5dea276262',
+          lastDeployed: '2026-07-30T09:26:32Z',
+          status: 'deployed',
+        },
+      ],
+      lastAttemptedRevision: options.lastAttemptedRevision,
+      lastAttemptedReleaseAction: 'upgrade',
+      upgradeFailures: options.upgradeFailures,
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new HelmRelease(json as any, 'test-installation');
+}
+
+function createFailedUpgrade(): HelmRelease {
+  return createHelmRelease({
+    lastAttemptedRevision: '0.2.15+800a0275a0f0',
+    upgradeFailures: 9,
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'RollbackSucceeded',
+        message: ROLLBACK_MESSAGE,
+        lastTransitionTime: '2026-07-30T09:26:44Z',
+      },
+      {
+        type: 'Released',
+        status: 'False',
+        reason: 'UpgradeFailed',
+        message: UPGRADE_ERROR,
+        lastTransitionTime: '2026-07-30T09:25:31Z',
+      },
+      {
+        type: 'Remediated',
+        status: 'True',
+        reason: 'RollbackSucceeded',
+        message: ROLLBACK_MESSAGE,
+        lastTransitionTime: '2026-07-30T09:26:44Z',
+      },
+    ],
+  });
+}
+
+function createKustomization(readyStatus: 'True' | 'False'): Kustomization {
+  const json = {
+    apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+    kind: 'Kustomization',
+    metadata: { name: 'my-app', namespace: 'flux-system' },
+    spec: { path: './apps' },
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: readyStatus,
+          reason:
+            readyStatus === 'True'
+              ? 'ReconciliationSucceeded'
+              : 'ReconciliationFailed',
+          message: 'Applied revision main@sha1:abc',
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+      ],
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Kustomization(json as any, 'test-installation');
+}
+
+describe('ResourceMetadata', () => {
+  describe('HelmRelease with a failed upgrade', () => {
+    it('shows the failing release condition instead of the rollback', async () => {
+      await renderInTestApp(
+        <ResourceMetadata resource={createFailedUpgrade()} />,
+      );
+
+      expect(screen.getByText(/Upgrade failed/)).toBeInTheDocument();
+      expect(screen.getByText(UPGRADE_ERROR)).toBeInTheDocument();
+      // The rollback message describes the previous, working release. Showing it
+      // as the failure message is the bug this component must not reintroduce.
+      expect(
+        screen.queryByText(/Helm rollback to previous release/),
+      ).not.toBeInTheDocument();
+    });
+
+    it('keeps the remediation as a single line', async () => {
+      await renderInTestApp(
+        <ResourceMetadata resource={createFailedUpgrade()} />,
+      );
+
+      expect(screen.getByText('Remediation')).toBeInTheDocument();
+      expect(screen.getByText(/Rollback succeeded/)).toBeInTheDocument();
+    });
+
+    it('shows the attempted version next to the running one', async () => {
+      await renderInTestApp(
+        <ResourceMetadata resource={createFailedUpgrade()} />,
+      );
+
+      expect(screen.getByText('Chart Version')).toBeInTheDocument();
+      expect(screen.getByText('0.2.14+6a5dea276262')).toBeInTheDocument();
+      expect(screen.getByText('Attempted')).toBeInTheDocument();
+      expect(screen.getByText('0.2.15+800a0275a0f0')).toBeInTheDocument();
+      expect(screen.getByText('Upgrade Failures')).toBeInTheDocument();
+    });
+
+    it('notes when the retries are exhausted', async () => {
+      const helmRelease = createHelmRelease({
+        conditions: [
+          {
+            type: 'Stalled',
+            status: 'True',
+            reason: 'RetriesExceeded',
+            message: 'Failed to upgrade after 10 attempt(s)',
+            lastTransitionTime: '2026-07-30T09:30:00Z',
+          },
+          {
+            type: 'Ready',
+            status: 'False',
+            reason: 'RetriesExceeded',
+            message: 'Failed to upgrade after 10 attempt(s)',
+            lastTransitionTime: '2026-07-30T09:30:00Z',
+          },
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: UPGRADE_ERROR,
+            lastTransitionTime: '2026-07-30T09:25:31Z',
+          },
+        ],
+      });
+
+      await renderInTestApp(<ResourceMetadata resource={helmRelease} />);
+
+      expect(screen.getByText(/retries exhausted/)).toBeInTheDocument();
+      expect(screen.getByText(UPGRADE_ERROR)).toBeInTheDocument();
+      expect(screen.queryByText('Remediation')).not.toBeInTheDocument();
+    });
+
+    it('shows the message of a remediation that failed itself', async () => {
+      const helmRelease = createHelmRelease({
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+            reason: 'RollbackFailed',
+            message: 'Helm rollback failed: no revision for release',
+            lastTransitionTime: '2026-07-30T09:26:44Z',
+          },
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: UPGRADE_ERROR,
+            lastTransitionTime: '2026-07-30T09:25:31Z',
+          },
+          {
+            type: 'Remediated',
+            status: 'False',
+            reason: 'RollbackFailed',
+            message: 'Helm rollback failed: no revision for release',
+            lastTransitionTime: '2026-07-30T09:26:44Z',
+          },
+        ],
+      });
+
+      await renderInTestApp(<ResourceMetadata resource={helmRelease} />);
+
+      expect(screen.getByText(/Rollback failed/)).toBeInTheDocument();
+      expect(screen.getByText(/no revision for release/)).toBeInTheDocument();
+    });
+  });
+
+  describe('HelmRelease without a masked failure', () => {
+    it('falls back to the Ready condition when it carries the failure', async () => {
+      const helmRelease = createHelmRelease({
+        lastAttemptedRevision: '0.2.15+800a0275a0f0',
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: UPGRADE_ERROR,
+            lastTransitionTime: '2026-07-30T09:25:31Z',
+          },
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: UPGRADE_ERROR,
+            lastTransitionTime: '2026-07-30T09:25:31Z',
+          },
+        ],
+      });
+
+      await renderInTestApp(<ResourceMetadata resource={helmRelease} />);
+
+      expect(
+        screen.getByText(/Last reconciliation failed/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(UPGRADE_ERROR)).toBeInTheDocument();
+      expect(screen.queryByText('Remediation')).not.toBeInTheDocument();
+      expect(screen.queryByText('Attempted')).not.toBeInTheDocument();
+    });
+
+    it('reports a ready release as reconciled', async () => {
+      const helmRelease = createHelmRelease({
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            reason: 'UpgradeSucceeded',
+            message: 'Helm upgrade succeeded',
+            lastTransitionTime: '2026-07-30T09:26:44Z',
+          },
+        ],
+      });
+
+      await renderInTestApp(<ResourceMetadata resource={helmRelease} />);
+
+      expect(screen.getByText(/Last reconciled/)).toBeInTheDocument();
+      expect(screen.getByText('Helm upgrade succeeded')).toBeInTheDocument();
+    });
+  });
+
+  describe('other kinds', () => {
+    it('keeps reporting a failing Kustomization from its Ready condition', async () => {
+      await renderInTestApp(
+        <ResourceMetadata resource={createKustomization('False')} />,
+      );
+
+      expect(
+        screen.getByText(/Last reconciliation failed/),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Applied revision main@sha1:abc'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.test.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.test.tsx
@@ -175,6 +175,43 @@ describe('ResourceMetadata', () => {
       expect(screen.queryByText('Remediation')).not.toBeInTheDocument();
     });
 
+    it('does not claim the retries ran out on a terminal stall', async () => {
+      // helm-controller stalls on errors it never retried, too. Ready is a
+      // progress placeholder here, so the release error is still substituted —
+      // but the wording must not assert a retry count that never happened.
+      const helmRelease = createHelmRelease({
+        conditions: [
+          {
+            type: 'Stalled',
+            status: 'True',
+            reason: 'InvalidChartReference',
+            message: 'invalid chart reference',
+            lastTransitionTime: '2026-07-30T11:33:09Z',
+          },
+          {
+            type: 'Ready',
+            status: 'Unknown',
+            reason: 'Progressing',
+            message: 'reconciliation in progress',
+            lastTransitionTime: '2026-07-30T11:33:09Z',
+          },
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: UPGRADE_ERROR,
+            lastTransitionTime: '2026-07-30T09:25:31Z',
+          },
+        ],
+      });
+
+      await renderInTestApp(<ResourceMetadata resource={helmRelease} />);
+
+      expect(screen.getByText(/\(stalled\)/)).toBeInTheDocument();
+      expect(screen.queryByText(/retries exhausted/)).not.toBeInTheDocument();
+      expect(screen.getByText(UPGRADE_ERROR)).toBeInTheDocument();
+    });
+
     it('shows the message of a remediation that failed itself', async () => {
       const helmRelease = createHelmRelease({
         conditions: [

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.tsx
@@ -129,16 +129,24 @@ function buildReleaseFailureMetadata(
   cause: StatusCondition,
 ): Metadata {
   const metadata: Metadata = {};
-  const stalledCondition = helmRelease.findStalledCondition();
   const phrase = formatReleaseFailurePhrase(
     cause,
     helmRelease.getLastAttemptedReleaseAction(),
   );
 
+  // helm-controller also stalls on terminal errors that were never retried, so
+  // only an exhausted-retries stall may claim the retries ran out.
+  let stalledSuffix = '';
+  if (helmRelease.hasExhaustedRetries()) {
+    stalledSuffix = ' (retries exhausted)';
+  } else if (helmRelease.isStalled()) {
+    stalledSuffix = ' (stalled)';
+  }
+
   metadata.Status = (
     <>
       {phrase} <DateComponent value={cause.lastTransitionTime} relative />
-      {stalledCondition?.status === 'True' ? ' (retries exhausted)' : ''}
+      {stalledSuffix}
     </>
   );
   metadata.Message = <ConditionMessage message={cause.message ?? ''} />;

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.tsx
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/ResourceMetadata/ResourceMetadata.tsx
@@ -59,6 +59,106 @@ function buildStatusMetadata(
   return metadata;
 }
 
+type StatusCondition = {
+  type: string;
+  reason: string;
+  status: string;
+  lastTransitionTime?: string;
+  message?: string;
+};
+
+function formatReleaseFailurePhrase(
+  cause: StatusCondition,
+  lastAttemptedReleaseAction?: string,
+): string {
+  if (cause.type === 'TestSuccess') {
+    return 'Helm test failed';
+  }
+
+  switch (cause.reason) {
+    case 'InstallFailed':
+      return 'Installation failed';
+    case 'UpgradeFailed':
+      return 'Upgrade failed';
+    default:
+      break;
+  }
+
+  // Unrecognized reason: the release action the controller last attempted still
+  // tells us what kind of release failed.
+  switch (lastAttemptedReleaseAction) {
+    case 'install':
+      return 'Installation failed';
+    case 'upgrade':
+      return 'Upgrade failed';
+    default:
+      return 'Release failed';
+  }
+}
+
+function formatRemediationPhrase(remediated: StatusCondition): string {
+  switch (remediated.reason) {
+    case 'RollbackSucceeded':
+      return 'Rollback succeeded';
+    case 'RollbackFailed':
+      return 'Rollback failed';
+    case 'UninstallSucceeded':
+      return 'Uninstall succeeded';
+    case 'UninstallFailed':
+      return 'Uninstall failed';
+    default:
+      return remediated.status === 'False'
+        ? 'Remediation failed'
+        : 'Remediated';
+  }
+}
+
+/**
+ * Status rows for a HelmRelease whose last release attempt failed.
+ *
+ * The `Ready` condition is not the source here: once helm-controller has
+ * remediated the failure, `Ready` only restates the rollback (see
+ * {@link HelmRelease.findFailureCauseCondition}). The failing condition provides
+ * both the error and the time the release actually failed, and the remediation is
+ * kept as a single line — its full message merely restates the chart version we
+ * already show, except when the remediation itself failed, where the message is
+ * the news.
+ */
+function buildReleaseFailureMetadata(
+  helmRelease: HelmRelease,
+  cause: StatusCondition,
+): Metadata {
+  const metadata: Metadata = {};
+  const stalledCondition = helmRelease.findStalledCondition();
+  const phrase = formatReleaseFailurePhrase(
+    cause,
+    helmRelease.getLastAttemptedReleaseAction(),
+  );
+
+  metadata.Status = (
+    <>
+      {phrase} <DateComponent value={cause.lastTransitionTime} relative />
+      {stalledCondition?.status === 'True' ? ' (retries exhausted)' : ''}
+    </>
+  );
+  metadata.Message = <ConditionMessage message={cause.message ?? ''} />;
+
+  const remediated = helmRelease.findRemediatedCondition();
+  if (remediated) {
+    metadata.Remediation = (
+      <>
+        {formatRemediationPhrase(remediated)}{' '}
+        <DateComponent value={remediated.lastTransitionTime} relative />
+        {remediated.status === 'False' && (
+          <ConditionMessage message={remediated.message ?? ''} />
+        )}
+      </>
+    );
+  }
+
+  return metadata;
+}
+
 // --- Kustomization ---
 
 function getKustomizationSpec(
@@ -158,7 +258,9 @@ function getHelmReleaseSpec(
 
 function getHelmReleaseStatus(helmRelease: HelmRelease): Metadata {
   const readyCondition = helmRelease.findReadyCondition();
+  const failureCause = helmRelease.findFailureCauseCondition();
   const chartVersion = helmRelease.getLastAppliedRevision();
+  const attemptedVersion = helmRelease.getLastAttemptedRevision();
   const installFailures = helmRelease.getInstallFailures();
   const upgradeFailures = helmRelease.getUpgradeFailures();
 
@@ -166,6 +268,12 @@ function getHelmReleaseStatus(helmRelease: HelmRelease): Metadata {
 
   if (chartVersion) {
     metadata['Chart Version'] = chartVersion;
+  }
+
+  // Which version the failed release attempted, so that the running version
+  // above and the one the error talks about can be told apart.
+  if (failureCause && attemptedVersion && attemptedVersion !== chartVersion) {
+    metadata.Attempted = attemptedVersion;
   }
 
   if (installFailures && installFailures > 0) {
@@ -176,7 +284,12 @@ function getHelmReleaseStatus(helmRelease: HelmRelease): Metadata {
     metadata['Upgrade Failures'] = upgradeFailures;
   }
 
-  Object.assign(metadata, buildStatusMetadata(readyCondition));
+  Object.assign(
+    metadata,
+    failureCause
+      ? buildReleaseFailureMetadata(helmRelease, failureCause)
+      : buildStatusMetadata(readyCondition),
+  );
 
   return metadata;
 }

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/buildResourceAiChatPrompt.test.ts
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/buildResourceAiChatPrompt.test.ts
@@ -1,0 +1,184 @@
+import {
+  HelmRelease,
+  Kustomization,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+import { buildResourceAiChatPrompt } from './buildResourceAiChatPrompt';
+
+const UPGRADE_ERROR =
+  'Helm upgrade failed for release agentic-platform/muster-runbooks: cannot patch "failing-pods" with kind Workflow';
+const ROLLBACK_MESSAGE =
+  'Helm rollback to previous release agentic-platform/muster-runbooks.v53 succeeded';
+
+function createFailedUpgrade(): HelmRelease {
+  const json = {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: { name: 'muster-runbooks', namespace: 'flux-giantswarm' },
+    spec: {},
+    status: {
+      lastAttemptedRevision: '0.2.15+800a0275a0f0',
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'RollbackSucceeded',
+          message: ROLLBACK_MESSAGE,
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+        {
+          type: 'Remediated',
+          status: 'True',
+          reason: 'RollbackSucceeded',
+          message: ROLLBACK_MESSAGE,
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+      ],
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new HelmRelease(json as any, 'test-installation');
+}
+
+function createKustomization(readyStatus: 'True' | 'False'): Kustomization {
+  const json = {
+    apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+    kind: 'Kustomization',
+    metadata: { name: 'my-app', namespace: 'flux-system' },
+    spec: {},
+    status: {
+      conditions: [
+        {
+          type: 'Ready',
+          status: readyStatus,
+          reason: 'BuildFailed',
+          message: 'kustomize build failed: accumulating resources',
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+      ],
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Kustomization(json as any, 'test-installation');
+}
+
+describe('buildResourceAiChatPrompt', () => {
+  it('explains the release failure rather than the rollback that masks it', () => {
+    const { message, troubleshoot } = buildResourceAiChatPrompt({
+      kind: 'HelmRelease',
+      name: 'muster-runbooks',
+      namespace: 'flux-giantswarm',
+      cluster: 'test-installation',
+      resource: createFailedUpgrade(),
+      readyStatus: 'False',
+    });
+
+    expect(message).toContain(UPGRADE_ERROR);
+    expect(message).not.toContain(ROLLBACK_MESSAGE);
+    expect(message).toContain("reason 'UpgradeFailed'");
+    expect(message).toContain("revision '0.2.15+800a0275a0f0'");
+    expect(troubleshoot).toBe(true);
+  });
+
+  it('troubleshoots a stalled release that never reports Ready as False', () => {
+    // Observed live: helm-controller stopped retrying and left the
+    // "reconciliation in progress" Ready condition behind, so keying the prompt
+    // on a False Ready status would ask for basic details on a failed release.
+    const json = {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: 'hello-world', namespace: 'org-giantswarm' },
+      spec: {},
+      status: {
+        lastAttemptedRevision: '3.0.2+306e35548098',
+        conditions: [
+          {
+            type: 'Stalled',
+            status: 'True',
+            reason: 'RetriesExceeded',
+            message: 'Failed to upgrade after 1 attempt(s)',
+            lastTransitionTime: '2026-07-30T11:33:09Z',
+          },
+          {
+            type: 'Ready',
+            status: 'Unknown',
+            reason: 'Progressing',
+            message: 'reconciliation in progress',
+            lastTransitionTime: '2026-07-30T11:33:09Z',
+          },
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: UPGRADE_ERROR,
+            lastTransitionTime: '2026-05-28T12:55:44Z',
+          },
+        ],
+      },
+    };
+
+    const { message, troubleshoot } = buildResourceAiChatPrompt({
+      kind: 'HelmRelease',
+      name: 'hello-world',
+      namespace: 'org-giantswarm',
+      cluster: 'test-installation',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      resource: new HelmRelease(json as any, 'test-installation'),
+      readyStatus: 'Unknown',
+    });
+
+    expect(message).toContain(UPGRADE_ERROR);
+    expect(message).not.toContain('reconciliation in progress');
+    expect(troubleshoot).toBe(true);
+  });
+
+  it('explains a failing resource from its Ready condition', () => {
+    const { message, troubleshoot } = buildResourceAiChatPrompt({
+      kind: 'Kustomization',
+      name: 'my-app',
+      namespace: 'flux-system',
+      cluster: 'test-installation',
+      resource: createKustomization('False'),
+      readyStatus: 'False',
+    });
+
+    expect(message).toContain('kustomize build failed: accumulating resources');
+    expect(message).toContain("reason 'BuildFailed'");
+    expect(troubleshoot).toBe(true);
+  });
+
+  it('asks about the Ready state when there is no message to explain', () => {
+    const { message, troubleshoot } = buildResourceAiChatPrompt({
+      kind: 'Kustomization',
+      name: 'my-app',
+      cluster: 'test-installation',
+      readyStatus: 'False',
+    });
+
+    expect(message).toContain('why it is not in a Ready state');
+    expect(troubleshoot).toBe(true);
+  });
+
+  it('asks for basic details when the resource is not failing', () => {
+    const { message, troubleshoot } = buildResourceAiChatPrompt({
+      kind: 'Kustomization',
+      name: 'my-app',
+      namespace: 'flux-system',
+      cluster: 'test-installation',
+      resource: createKustomization('True'),
+      readyStatus: 'True',
+    });
+
+    expect(message).toContain('show me basic details');
+    expect(message).not.toContain('kustomize build failed');
+    expect(troubleshoot).toBe(false);
+  });
+});

--- a/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/buildResourceAiChatPrompt.ts
+++ b/plugins/flux-react/src/components/FluxOverview/ResourceCard/utils/buildResourceAiChatPrompt.ts
@@ -1,0 +1,99 @@
+import {
+  FluxObject,
+  FluxResourceStatus,
+  HelmRelease,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+import { buildExplainErrorMessage } from '@giantswarm/backstage-plugin-ai-chat-react';
+
+/**
+ * The condition to quote to the AI, and the revision it applies to.
+ *
+ * For a HelmRelease the `Ready` condition can describe the rollback that
+ * remediated a failure, or a progress placeholder left behind on a stalled
+ * release, rather than the failure itself (see
+ * `HelmRelease.findFailureCauseCondition`) — asking the AI to explain "Helm
+ * rollback … succeeded" is useless, so the failing release condition wins. It
+ * also wins independently of the `Ready` status, since a stalled release keeps
+ * `Ready` at `Unknown`.
+ */
+function getFailureContext(
+  resource: FluxObject,
+  readyStatus: FluxResourceStatus['readyStatus'],
+) {
+  if (resource instanceof HelmRelease) {
+    const cause = resource.findFailureCauseCondition();
+    if (cause?.message) {
+      return {
+        message: cause.message,
+        reason: cause.reason,
+        revision: resource.getLastAttemptedRevision(),
+      };
+    }
+  }
+
+  if (readyStatus !== 'False') {
+    return undefined;
+  }
+
+  const readyCondition = resource.findReadyCondition();
+
+  return readyCondition?.message
+    ? { message: readyCondition.message, reason: readyCondition.reason }
+    : undefined;
+}
+
+type BuildResourceAiChatPromptOptions = {
+  kind: string;
+  name: string;
+  namespace?: string;
+  cluster: string;
+  resource?: FluxObject;
+  readyStatus: FluxResourceStatus['readyStatus'];
+};
+
+/**
+ * The prompt the resource card's AI chat button sends, and whether it is a
+ * troubleshooting one — an explanation request for a failure, a "why is this not
+ * ready" question, or an open-ended "show me this resource".
+ */
+export function buildResourceAiChatPrompt({
+  kind,
+  name,
+  namespace,
+  cluster,
+  resource,
+  readyStatus,
+}: BuildResourceAiChatPromptOptions): {
+  message: string;
+  troubleshoot: boolean;
+} {
+  const namespacePart = namespace ? ` in namespace '${namespace}'` : '';
+  const failure = resource
+    ? getFailureContext(resource, readyStatus)
+    : undefined;
+
+  if (failure) {
+    return {
+      message: buildExplainErrorMessage({
+        kind,
+        name,
+        namespace,
+        cluster,
+        ...failure,
+      }),
+      troubleshoot: true,
+    };
+  }
+
+  if (readyStatus === 'False') {
+    return {
+      message: `Please read the ${kind} resource named '${name}'${namespacePart} on management cluster '${cluster}' and help me understand why it is not in a Ready state.`,
+      troubleshoot: true,
+    };
+  }
+
+  return {
+    message: `Please read the ${kind} resource named '${name}'${namespacePart} on management cluster '${cluster}', and show me basic details, so that I can ask further questions about it.`,
+    troubleshoot: false,
+  };
+}

--- a/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.test.ts
+++ b/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.test.ts
@@ -201,6 +201,53 @@ describe('findMatchingNodes', () => {
     ]);
   });
 
+  it('matches a stalled HelmRelease, whose Ready condition is not False', () => {
+    // A stalled release keeps Ready at Unknown/Progressing, so the failure the
+    // card reports would be unsearchable if the Ready status gated the lookup.
+    const json = {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: 'my-app', namespace: 'default' },
+      spec: {},
+      status: {
+        conditions: [
+          {
+            type: 'Stalled',
+            status: 'True',
+            reason: 'RetriesExceeded',
+            message: 'Failed to upgrade after 1 attempt(s)',
+            lastTransitionTime: '2026-01-01T00:01:00Z',
+          },
+          {
+            type: 'Ready',
+            status: 'Unknown',
+            reason: 'Progressing',
+            message: 'reconciliation in progress',
+            lastTransitionTime: '2026-01-01T00:01:00Z',
+          },
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: 'Helm upgrade failed: cannot patch my-new-service',
+            lastTransitionTime: '2026-01-01T00:00:00Z',
+          },
+        ],
+      },
+    };
+    const tree = [
+      createNode({
+        name: 'my-app',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        resource: new HelmRelease(json as any, 'test-installation'),
+      }),
+    ];
+
+    expect(findMatchingNodes(tree, 'my-new-service', false).matches).toEqual([
+      'test-cluster-Kustomization-flux-system-my-app',
+    ]);
+  });
+
   it('does not match messages of suspended resources', () => {
     // Suspended resources keep their last Ready condition frozen, so a
     // stale failure message must not be searchable.

--- a/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.test.ts
+++ b/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.test.ts
@@ -154,6 +154,53 @@ describe('findMatchingNodes', () => {
     ]);
   });
 
+  it('matches failing HelmReleases by the release error a rollback masks', () => {
+    // The Ready condition only describes the rollback here, so the error a user
+    // would search for lives in the failing Released condition.
+    const json = {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: 'my-app', namespace: 'default' },
+      spec: {},
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+            reason: 'RollbackSucceeded',
+            message: 'Helm rollback to previous release default/my-app.v3',
+            lastTransitionTime: '2026-01-01T00:01:00Z',
+          },
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: 'Helm upgrade failed: cannot patch my-new-service',
+            lastTransitionTime: '2026-01-01T00:00:00Z',
+          },
+          {
+            type: 'Remediated',
+            status: 'True',
+            reason: 'RollbackSucceeded',
+            message: 'Helm rollback to previous release default/my-app.v3',
+            lastTransitionTime: '2026-01-01T00:01:00Z',
+          },
+        ],
+      },
+    };
+    const tree = [
+      createNode({
+        name: 'my-app',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        resource: new HelmRelease(json as any, 'test-installation'),
+      }),
+    ];
+
+    expect(findMatchingNodes(tree, 'my-new-service', false).matches).toEqual([
+      'test-cluster-Kustomization-flux-system-my-app',
+    ]);
+  });
+
   it('does not match messages of suspended resources', () => {
     // Suspended resources keep their last Ready condition frozen, so a
     // stale failure message must not be searchable.

--- a/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.ts
+++ b/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.ts
@@ -15,21 +15,26 @@ function getFailureMessage(node: KustomizationTreeNode): string | undefined {
     return undefined;
   }
 
+  if (resource instanceof HelmRelease) {
+    // After a failed release is remediated, the Ready message only describes the
+    // rollback; the error a user would search for lives in the failing release
+    // condition. See HelmRelease.findFailureCauseCondition.
+    //
+    // Checked before the Ready-status gate below: a stalled release keeps Ready
+    // at Unknown, so gating on a False Ready first would make the very failures
+    // the card reports unsearchable. The selector applies its own gating, and
+    // only ever returns a condition that is currently failing.
+    const cause = resource.findFailureCauseCondition();
+    if (cause) {
+      return cause.message;
+    }
+  }
+
   const readyCondition = resource?.findReadyCondition();
   if (readyCondition?.status !== 'False') {
     // Only failure messages are searchable. Messages of healthy resources
     // (e.g. "Applied revision main@sha1:...") would match almost any query.
     return undefined;
-  }
-
-  if (resource instanceof HelmRelease) {
-    // After a failed release is remediated, the Ready message only describes the
-    // rollback; the error a user would search for lives in the failing release
-    // condition. See HelmRelease.findFailureCauseCondition.
-    const cause = resource.findFailureCauseCondition();
-    if (cause) {
-      return cause.message;
-    }
   }
 
   return readyCondition.message;

--- a/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.ts
+++ b/plugins/flux-react/src/hooks/useTreeSearch/findMatchingNodes.ts
@@ -1,3 +1,4 @@
+import { HelmRelease } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { KustomizationTreeNode } from '../../components/FluxOverview/utils/KustomizationTreeBuilder';
 
 export type SearchResult = {
@@ -21,12 +22,22 @@ function getFailureMessage(node: KustomizationTreeNode): string | undefined {
     return undefined;
   }
 
+  if (resource instanceof HelmRelease) {
+    // After a failed release is remediated, the Ready message only describes the
+    // rollback; the error a user would search for lives in the failing release
+    // condition. See HelmRelease.findFailureCauseCondition.
+    const cause = resource.findFailureCauseCondition();
+    if (cause) {
+      return cause.message;
+    }
+  }
+
   return readyCondition.message;
 }
 
 /**
  * Finds tree nodes matching the query by resource name or, for failing
- * resources, by the Ready condition message. The latter lets users find the
+ * resources, by their failure message. The latter lets users find the
  * Kustomization that fails to apply a resource by searching for the resource's
  * name, which Flux includes in its build/apply error messages.
  *

--- a/plugins/kubernetes-react/src/lib/k8s/FluxObject.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/FluxObject.test.ts
@@ -78,6 +78,57 @@ describe('FluxObject.isReconcileRequestPending', () => {
   });
 });
 
+describe('FluxObject.findStatusCondition', () => {
+  function withConditions(conditions?: unknown[]): Kustomization {
+    return new Kustomization(
+      {
+        apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+        kind: 'Kustomization',
+        metadata: { name: 'my-app', namespace: 'flux-system' },
+        spec: {},
+        status: conditions ? { conditions } : {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      'test-installation',
+    );
+  }
+
+  const readyCondition = {
+    type: 'Ready',
+    status: 'True',
+    reason: 'ReconciliationSucceeded',
+    message: 'Applied revision',
+    lastTransitionTime: '2026-07-28T10:00:00Z',
+  };
+  const reconcilingCondition = {
+    type: 'Reconciling',
+    status: 'True',
+    reason: 'Progressing',
+    message: 'Reconciliation in progress',
+    lastTransitionTime: '2026-07-28T10:00:00Z',
+  };
+
+  it('finds a condition by type', () => {
+    const resource = withConditions([readyCondition, reconcilingCondition]);
+
+    expect(resource.findStatusCondition('Reconciling')).toBe(
+      resource.getStatusConditions()?.[1],
+    );
+    expect(resource.findReadyCondition()).toMatchObject({ type: 'Ready' });
+  });
+
+  it('returns nothing for an absent type', () => {
+    expect(
+      withConditions([readyCondition]).findStatusCondition('Remediated'),
+    ).toBeUndefined();
+  });
+
+  it('returns nothing when the resource has no conditions', () => {
+    expect(withConditions().findStatusCondition('Ready')).toBeUndefined();
+    expect(withConditions().findReadyCondition()).toBeUndefined();
+  });
+});
+
 describe('FluxObject suspend field ownership', () => {
   function withManagedFields(managedFields: unknown[]): Kustomization {
     return new Kustomization(

--- a/plugins/kubernetes-react/src/lib/k8s/FluxObject.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/FluxObject.ts
@@ -55,13 +55,17 @@ export class FluxObject<
     return this.jsonData.status?.conditions;
   }
 
-  findReadyCondition() {
+  findStatusCondition(type: string) {
     const conditions = this.getStatusConditions();
     if (!conditions) {
       return undefined;
     }
 
-    return conditions.find(c => c.type === 'Ready');
+    return conditions.find(c => c.type === type);
+  }
+
+  findReadyCondition() {
+    return this.findStatusCondition('Ready');
   }
 
   isReconciling() {

--- a/plugins/kubernetes-react/src/lib/k8s/HelmRelease.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/HelmRelease.test.ts
@@ -432,6 +432,41 @@ describe('HelmRelease.findFailureCauseCondition', () => {
     expect(cause).toMatchObject({ type: 'Released', reason: 'UpgradeFailed' });
   });
 
+  it('returns nothing when Ready reports a terminal stall', () => {
+    // helm-controller also stalls on errors it never retries, and mirrors those
+    // into Ready. That message is the current reason the object is stuck, so it
+    // must not be replaced by an older release error.
+    const terminalMessage =
+      'invalid chart reference: OCIRepository/flux-giantswarm/missing not found';
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Stalled',
+          status: 'True',
+          reason: 'InvalidChartReference',
+          message: terminalMessage,
+          lastTransitionTime: '2026-07-30T11:33:09Z',
+        },
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'InvalidChartReference',
+          message: terminalMessage,
+          lastTransitionTime: '2026-07-30T11:33:09Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-05-28T12:55:44Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toBeUndefined();
+  });
+
   it('handles a resource without conditions', () => {
     expect(createHelmRelease().findFailureCauseCondition()).toBeUndefined();
     expect(
@@ -481,5 +516,26 @@ describe('HelmRelease status getters', () => {
       reason: 'RollbackSucceeded',
     });
     expect(helmRelease.findStalledCondition()).toBeUndefined();
+    expect(helmRelease.isStalled()).toBe(false);
+    expect(helmRelease.hasExhaustedRetries()).toBe(false);
+  });
+
+  it('distinguishes exhausted retries from a terminal stall', () => {
+    const stalled = (reason: string) =>
+      createHelmRelease({
+        conditions: [
+          {
+            type: 'Stalled',
+            status: 'True',
+            reason,
+            message: 'stopped',
+            lastTransitionTime: '2026-07-30T11:33:09Z',
+          },
+        ],
+      });
+
+    expect(stalled('RetriesExceeded').hasExhaustedRetries()).toBe(true);
+    expect(stalled('InvalidChartReference').hasExhaustedRetries()).toBe(false);
+    expect(stalled('InvalidChartReference').isStalled()).toBe(true);
   });
 });

--- a/plugins/kubernetes-react/src/lib/k8s/HelmRelease.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/HelmRelease.test.ts
@@ -1,0 +1,485 @@
+import { HelmRelease } from './HelmRelease';
+
+type Condition = {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason: string;
+  message: string;
+  lastTransitionTime: string;
+};
+
+type HistoryEntry = {
+  chartVersion: string;
+  lastDeployed: string;
+  status: string;
+};
+
+const UPGRADE_ERROR =
+  'Helm upgrade failed for release agentic-platform/muster-runbooks with chart muster-runbooks@0.2.15+800a0275a0f0: cannot patch "failing-pods" with kind Workflow: Workflow.muster.giantswarm.io "failing-pods" is invalid: [spec.description: Too long: may not be more than 1000 bytes]';
+const ROLLBACK_MESSAGE =
+  'Helm rollback to previous release agentic-platform/muster-runbooks.v53 with chart muster-runbooks@0.2.14+6a5dea276262 succeeded';
+
+function createHelmRelease(
+  options: {
+    conditions?: Condition[];
+    history?: HistoryEntry[];
+    lastAttemptedRevision?: string;
+    lastAttemptedReleaseAction?: 'install' | 'upgrade';
+    hasStatus?: boolean;
+  } = {},
+): HelmRelease {
+  const json = {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: {
+      name: 'muster-runbooks',
+      namespace: 'flux-giantswarm',
+    },
+    spec: {},
+    status:
+      options.hasStatus === false
+        ? undefined
+        : {
+            conditions: options.conditions,
+            history: options.history,
+            lastAttemptedRevision: options.lastAttemptedRevision,
+            lastAttemptedReleaseAction: options.lastAttemptedReleaseAction,
+          },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new HelmRelease(json as any, 'test-installation');
+}
+
+/**
+ * The real-world shape this selector exists for: an upgrade failed, and the
+ * rollback that remediated it has been mirrored into `Ready` verbatim, hiding the
+ * error. Taken from a live HelmRelease.
+ */
+function failedUpgradeConditions(): Condition[] {
+  return [
+    {
+      type: 'Reconciling',
+      status: 'True',
+      reason: 'ProgressingWithRetry',
+      message: ROLLBACK_MESSAGE,
+      lastTransitionTime: '2026-07-30T09:26:44Z',
+    },
+    {
+      type: 'Ready',
+      status: 'False',
+      reason: 'RollbackSucceeded',
+      message: ROLLBACK_MESSAGE,
+      lastTransitionTime: '2026-07-30T09:26:44Z',
+    },
+    {
+      type: 'Released',
+      status: 'False',
+      reason: 'UpgradeFailed',
+      message: UPGRADE_ERROR,
+      lastTransitionTime: '2026-07-30T09:25:31Z',
+    },
+    {
+      type: 'Remediated',
+      status: 'True',
+      reason: 'RollbackSucceeded',
+      message: ROLLBACK_MESSAGE,
+      lastTransitionTime: '2026-07-30T09:26:44Z',
+    },
+  ];
+}
+
+describe('HelmRelease.findFailureCauseCondition', () => {
+  it('returns the failing Released condition when a rollback masks the error', () => {
+    const cause = createHelmRelease({
+      conditions: failedUpgradeConditions(),
+    }).findFailureCauseCondition();
+
+    expect(cause).toMatchObject({
+      type: 'Released',
+      reason: 'UpgradeFailed',
+      message: UPGRADE_ERROR,
+    });
+  });
+
+  it('returns the failing Released condition when an uninstall masks the error', () => {
+    // A failed *install* is remediated by an uninstall, not a rollback.
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'UninstallSucceeded',
+          message: 'Helm uninstall for release agentic-platform/app succeeded',
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'InstallFailed',
+          message: 'Helm install failed: timed out waiting for the condition',
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+        {
+          type: 'Remediated',
+          status: 'True',
+          reason: 'UninstallSucceeded',
+          message: 'Helm uninstall for release agentic-platform/app succeeded',
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toMatchObject({ type: 'Released', reason: 'InstallFailed' });
+  });
+
+  it('returns the cause when the remediation itself failed', () => {
+    // A failed remediation is reported as Remediated=False, and still mirrored
+    // into Ready — so the gate must not require Remediated to be True.
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'RollbackFailed',
+          message: 'Helm rollback failed: no revision for release',
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+        {
+          type: 'Remediated',
+          status: 'False',
+          reason: 'RollbackFailed',
+          message: 'Helm rollback failed: no revision for release',
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toMatchObject({ type: 'Released', reason: 'UpgradeFailed' });
+  });
+
+  it('returns the failing TestSuccess condition when the release succeeded', () => {
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'RollbackSucceeded',
+          message: ROLLBACK_MESSAGE,
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+        {
+          type: 'Released',
+          status: 'True',
+          reason: 'UpgradeSucceeded',
+          message: 'Helm upgrade succeeded for release agentic-platform/app',
+          lastTransitionTime: '2026-07-30T09:25:00Z',
+        },
+        {
+          type: 'TestSuccess',
+          status: 'False',
+          reason: 'TestFailed',
+          message:
+            'Helm test failed for release agentic-platform/app: pod smoke-test failed',
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+        {
+          type: 'Remediated',
+          status: 'True',
+          reason: 'RollbackSucceeded',
+          message: ROLLBACK_MESSAGE,
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toMatchObject({ type: 'TestSuccess', reason: 'TestFailed' });
+  });
+
+  it('prefers the most recent of several failing conditions', () => {
+    // A failed upgrade can leave a stale failing TestSuccess from an earlier
+    // cycle behind, and vice versa.
+    const conditions = (releasedAt: string, testedAt: string): Condition[] => [
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'RollbackSucceeded',
+        message: ROLLBACK_MESSAGE,
+        lastTransitionTime: '2026-07-30T09:26:44Z',
+      },
+      {
+        type: 'Released',
+        status: 'False',
+        reason: 'UpgradeFailed',
+        message: UPGRADE_ERROR,
+        lastTransitionTime: releasedAt,
+      },
+      {
+        type: 'TestSuccess',
+        status: 'False',
+        reason: 'TestFailed',
+        message: 'Helm test failed',
+        lastTransitionTime: testedAt,
+      },
+      {
+        type: 'Remediated',
+        status: 'True',
+        reason: 'RollbackSucceeded',
+        message: ROLLBACK_MESSAGE,
+        lastTransitionTime: '2026-07-30T09:26:44Z',
+      },
+    ];
+
+    expect(
+      createHelmRelease({
+        conditions: conditions('2026-07-30T09:25:31Z', '2026-07-29T10:00:00Z'),
+      }).findFailureCauseCondition(),
+    ).toMatchObject({ type: 'Released' });
+
+    expect(
+      createHelmRelease({
+        conditions: conditions('2026-07-29T10:00:00Z', '2026-07-30T09:25:31Z'),
+      }).findFailureCauseCondition(),
+    ).toMatchObject({ type: 'TestSuccess' });
+  });
+
+  it('returns nothing when Ready reports a newer, different failure', () => {
+    // After the rollback the object failed again for a reason that never reaches
+    // a release attempt. Ready no longer mirrors the remediation, so it carries
+    // the current blocker and the older upgrade error must not replace it.
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'ArtifactFailed',
+          message: 'failed to get chart source: OCIRepository is not ready',
+          lastTransitionTime: '2026-07-30T09:30:00Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+        {
+          type: 'Remediated',
+          status: 'True',
+          reason: 'RollbackSucceeded',
+          message: ROLLBACK_MESSAGE,
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toBeUndefined();
+  });
+
+  it('returns nothing when Ready already carries the failure', () => {
+    // Without remediation (e.g. remediation disabled) Ready is a mirror of the
+    // failing Released condition, so there is nothing to substitute.
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toBeUndefined();
+  });
+
+  it('returns nothing while the release is ready', () => {
+    // `spec.test.ignoreFailures` keeps a release ready with failing tests.
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'True',
+          reason: 'UpgradeSucceeded',
+          message: 'Helm upgrade succeeded',
+          lastTransitionTime: '2026-07-30T09:26:44Z',
+        },
+        {
+          type: 'TestSuccess',
+          status: 'False',
+          reason: 'TestFailed',
+          message: 'Helm test failed',
+          lastTransitionTime: '2026-07-30T09:26:00Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toBeUndefined();
+  });
+
+  it('returns nothing while a fresh reconciliation is in flight', () => {
+    // The failing Released condition is stale, left over from a previous
+    // generation, and must not be reported as the current state.
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Ready',
+          status: 'Unknown',
+          reason: 'Progressing',
+          message: 'Running upgrade action',
+          lastTransitionTime: '2026-07-30T09:30:00Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-07-30T09:25:31Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toBeUndefined();
+  });
+
+  it('substitutes the cause when Ready only reports that the release stalled', () => {
+    const stalledMessage = 'Failed to upgrade after 10 attempt(s)';
+    const stalledConditions: Condition[] = [
+      {
+        type: 'Stalled',
+        status: 'True',
+        reason: 'RetriesExceeded',
+        message: stalledMessage,
+        lastTransitionTime: '2026-07-30T09:30:00Z',
+      },
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'RetriesExceeded',
+        message: stalledMessage,
+        lastTransitionTime: '2026-07-30T09:30:00Z',
+      },
+    ];
+
+    expect(
+      createHelmRelease({
+        conditions: [
+          ...stalledConditions,
+          {
+            type: 'Released',
+            status: 'False',
+            reason: 'UpgradeFailed',
+            message: UPGRADE_ERROR,
+            lastTransitionTime: '2026-07-30T09:25:31Z',
+          },
+        ],
+      }).findFailureCauseCondition(),
+    ).toMatchObject({ type: 'Released', reason: 'UpgradeFailed' });
+
+    // Nothing to substitute without a failing release condition.
+    expect(
+      createHelmRelease({
+        conditions: stalledConditions,
+      }).findFailureCauseCondition(),
+    ).toBeUndefined();
+  });
+
+  it('substitutes the cause when a stalled release keeps a progress placeholder', () => {
+    // Observed on a live HelmRelease: helm-controller stopped retrying and left
+    // the "reconciliation in progress" Ready condition behind, so Ready reports
+    // neither the failure nor the stall.
+    const cause = createHelmRelease({
+      conditions: [
+        {
+          type: 'Stalled',
+          status: 'True',
+          reason: 'RetriesExceeded',
+          message: 'Failed to upgrade after 1 attempt(s)',
+          lastTransitionTime: '2026-07-30T11:33:09Z',
+        },
+        {
+          type: 'Ready',
+          status: 'Unknown',
+          reason: 'Progressing',
+          message: 'reconciliation in progress',
+          lastTransitionTime: '2026-07-30T11:33:09Z',
+        },
+        {
+          type: 'Released',
+          status: 'False',
+          reason: 'UpgradeFailed',
+          message: UPGRADE_ERROR,
+          lastTransitionTime: '2026-05-28T12:55:44Z',
+        },
+      ],
+    }).findFailureCauseCondition();
+
+    expect(cause).toMatchObject({ type: 'Released', reason: 'UpgradeFailed' });
+  });
+
+  it('handles a resource without conditions', () => {
+    expect(createHelmRelease().findFailureCauseCondition()).toBeUndefined();
+    expect(
+      createHelmRelease({ hasStatus: false }).findFailureCauseCondition(),
+    ).toBeUndefined();
+    expect(
+      createHelmRelease({ conditions: [] }).findFailureCauseCondition(),
+    ).toBeUndefined();
+  });
+});
+
+describe('HelmRelease status getters', () => {
+  it('reports the chart version of the most recently deployed release', () => {
+    const helmRelease = createHelmRelease({
+      history: [
+        {
+          chartVersion: '0.2.14+6a5dea276262',
+          lastDeployed: '2026-07-30T09:26:32Z',
+          status: 'deployed',
+        },
+        {
+          chartVersion: '0.2.15+800a0275a0f0',
+          lastDeployed: '2026-07-30T09:26:01Z',
+          status: 'failed',
+        },
+        {
+          chartVersion: '0.2.14+6a5dea276262',
+          lastDeployed: '2026-07-30T09:25:35Z',
+          status: 'superseded',
+        },
+      ],
+      lastAttemptedRevision: '0.2.15+800a0275a0f0',
+      lastAttemptedReleaseAction: 'upgrade',
+    });
+
+    expect(helmRelease.getLastAppliedRevision()).toBe('0.2.14+6a5dea276262');
+    expect(helmRelease.getLastAttemptedRevision()).toBe('0.2.15+800a0275a0f0');
+    expect(helmRelease.getLastAttemptedReleaseAction()).toBe('upgrade');
+  });
+
+  it('finds the remediation and stalled conditions', () => {
+    const helmRelease = createHelmRelease({
+      conditions: failedUpgradeConditions(),
+    });
+
+    expect(helmRelease.findRemediatedCondition()).toMatchObject({
+      reason: 'RollbackSucceeded',
+    });
+    expect(helmRelease.findStalledCondition()).toBeUndefined();
+  });
+});

--- a/plugins/kubernetes-react/src/lib/k8s/HelmRelease.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/HelmRelease.ts
@@ -4,6 +4,13 @@ import { compareDates } from '../../utils/compareDates';
 
 type HelmReleaseInterface = crds.fluxcd.v2.HelmRelease;
 
+/**
+ * The `Stalled` reason helm-controller uses when it gives up after exhausting
+ * `spec.install.remediation.retries`/`spec.upgrade.remediation.retries`, as
+ * opposed to the terminal-error reasons it also stalls on.
+ */
+const RETRIES_EXCEEDED_REASON = 'RetriesExceeded';
+
 export class HelmRelease extends FluxObject<HelmReleaseInterface> {
   static readonly supportedVersions = ['v2'] as const;
   static readonly group = 'helm.toolkit.fluxcd.io';
@@ -56,6 +63,28 @@ export class HelmRelease extends FluxObject<HelmReleaseInterface> {
   }
 
   /**
+   * Whether the controller has stopped acting on the release, either because the
+   * remediation retries ran out or because it hit a terminal error.
+   */
+  isStalled(): boolean {
+    return this.findStalledCondition()?.status === 'True';
+  }
+
+  /**
+   * Whether the release stopped specifically because its remediation retries ran
+   * out, as opposed to a terminal error that was never retried. Only the former
+   * may be described as exhausted retries.
+   */
+  hasExhaustedRetries(): boolean {
+    const stalledCondition = this.findStalledCondition();
+
+    return (
+      stalledCondition?.status === 'True' &&
+      stalledCondition.reason === RETRIES_EXCEEDED_REASON
+    );
+  }
+
+  /**
    * The condition explaining *why* the release failed, when the `Ready`
    * condition no longer does.
    *
@@ -69,11 +98,19 @@ export class HelmRelease extends FluxObject<HelmReleaseInterface> {
    * to show instead.
    *
    * Substitution requires `Ready` to be uninformative, which is the case when it
-   * is a verbatim mirror of `Remediated` or of a `True` `Stalled`, or when it is
-   * `Unknown` on a stalled release — helm-controller leaves the "reconciliation
-   * in progress" placeholder behind on an object that has stopped retrying, so
-   * the last release attempt is still the current state. `Unknown` is safe to
-   * override because it never reports a failure; a blocker always writes `False`.
+   * is a verbatim mirror of `Remediated` or of a `RetriesExceeded` `Stalled`, or
+   * when it is `Unknown` on a stalled release — helm-controller leaves the
+   * "reconciliation in progress" placeholder behind on an object that has stopped
+   * retrying, so the last release attempt is still the current state. `Unknown` is
+   * safe to override because it never reports a failure; a blocker always writes
+   * `False`.
+   *
+   * The `Stalled` mirror is restricted to `RetriesExceeded`, whose message only
+   * counts attempts ("Failed to upgrade after N attempt(s)"). helm-controller also
+   * stalls on *terminal* errors that were never retried (an invalid chart
+   * reference, a terminal values error) and mirrors those into `Ready` too — there
+   * `Ready` states the current reason the object is stuck, and replacing it with an
+   * older release error would hide it.
    *
    * Testing for a mirror rather than for an allow-list of remediation reasons is
    * what keeps a *newer, unrelated* blocker visible. If the object fails again
@@ -106,12 +143,10 @@ export class HelmRelease extends FluxObject<HelmReleaseInterface> {
         condition.message === readyCondition.message,
       );
 
-    const stalledCondition = this.findStalledCondition();
-    const isStalled = stalledCondition?.status === 'True';
     const readyIsUninformative =
       mirrors(this.findRemediatedCondition()) ||
-      (isStalled && mirrors(stalledCondition)) ||
-      (isStalled && readyCondition.status === 'Unknown');
+      (this.hasExhaustedRetries() && mirrors(this.findStalledCondition())) ||
+      (this.isStalled() && readyCondition.status === 'Unknown');
 
     if (!readyIsUninformative) {
       return undefined;

--- a/plugins/kubernetes-react/src/lib/k8s/HelmRelease.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/HelmRelease.ts
@@ -36,6 +36,99 @@ export class HelmRelease extends FluxObject<HelmReleaseInterface> {
     return this.jsonData.status?.lastAttemptedRevision;
   }
 
+  getLastAttemptedReleaseAction() {
+    return this.jsonData.status?.lastAttemptedReleaseAction;
+  }
+
+  /**
+   * The `Remediated` condition, whatever its status.
+   *
+   * Deliberately not restricted to status `True`: a rollback or uninstall that
+   * itself fails is reported as `Remediated` with status `False` and reason
+   * `RollbackFailed`/`UninstallFailed`.
+   */
+  findRemediatedCondition() {
+    return this.findStatusCondition('Remediated');
+  }
+
+  findStalledCondition() {
+    return this.findStatusCondition('Stalled');
+  }
+
+  /**
+   * The condition explaining *why* the release failed, when the `Ready`
+   * condition no longer does.
+   *
+   * helm-controller summarizes the release into `Ready` by mirroring one of
+   * `Released`, `TestSuccess` or `Remediated` into it verbatim — same reason,
+   * same message. So a failed upgrade shows its real error in `Ready` only until
+   * the failure is remediated: the rollback overwrites `Ready` with "Helm
+   * rollback to previous release ... succeeded", which describes the *previous,
+   * working* release and says nothing about the failure. The failing `Released`
+   * condition keeps the error until the next release attempt, so that is the one
+   * to show instead.
+   *
+   * Substitution requires `Ready` to be uninformative, which is the case when it
+   * is a verbatim mirror of `Remediated` or of a `True` `Stalled`, or when it is
+   * `Unknown` on a stalled release — helm-controller leaves the "reconciliation
+   * in progress" placeholder behind on an object that has stopped retrying, so
+   * the last release attempt is still the current state. `Unknown` is safe to
+   * override because it never reports a failure; a blocker always writes `False`.
+   *
+   * Testing for a mirror rather than for an allow-list of remediation reasons is
+   * what keeps a *newer, unrelated* blocker visible. If the object fails again
+   * after the rollback for a reason that never reaches a release attempt
+   * (`ArtifactFailed`, `DependencyNotReady`, a missing `valuesFrom` Secret, a
+   * denied release), `Ready` carries that newer message, no longer equals the
+   * remediation, and the older — now misleading — upgrade error is not shown.
+   * The mirror test also covers remediation flavours a reason list would miss: a
+   * failed install is remediated by an uninstall, and the rollback itself can
+   * fail.
+   *
+   * Returns nothing while `Ready` is `True`. A HelmRelease with
+   * `spec.test.ignoreFailures` stays ready with `TestSuccess` failing, and a
+   * fresh reconcile of a previously failed object can be in flight
+   * (`Ready`/`Progressing`, without `Stalled`) with a stale failing `Released`
+   * left over from the previous generation.
+   */
+  findFailureCauseCondition() {
+    const readyCondition = this.findReadyCondition();
+    if (!readyCondition || readyCondition.status === 'True') {
+      return undefined;
+    }
+
+    const mirrors = (
+      condition: ReturnType<HelmRelease['findStatusCondition']>,
+    ) =>
+      Boolean(
+        condition &&
+        condition.reason === readyCondition.reason &&
+        condition.message === readyCondition.message,
+      );
+
+    const stalledCondition = this.findStalledCondition();
+    const isStalled = stalledCondition?.status === 'True';
+    const readyIsUninformative =
+      mirrors(this.findRemediatedCondition()) ||
+      (isStalled && mirrors(stalledCondition)) ||
+      (isStalled && readyCondition.status === 'Unknown');
+
+    if (!readyIsUninformative) {
+      return undefined;
+    }
+
+    // An upgrade that succeeded but whose Helm tests failed leaves `Released`
+    // true and `TestSuccess` false, while an upgrade that failed outright can
+    // leave a stale failing `TestSuccess` from an earlier cycle behind. The most
+    // recent transition is the actual cause in both cases.
+    const causes = ['Released', 'TestSuccess']
+      .flatMap(type => this.findStatusCondition(type) ?? [])
+      .filter(condition => condition.status === 'False')
+      .sort((a, b) => compareDates(b.lastTransitionTime, a.lastTransitionTime));
+
+    return causes[0];
+  }
+
   getChart() {
     return this.jsonData.spec?.chart;
   }


### PR DESCRIPTION
### What does this PR do?

The HelmRelease details card in the Flux UI derived its Status and Message rows
from the `Ready` condition alone. helm-controller summarizes a release by
mirroring one of `Released`, `TestSuccess` or `Remediated` into `Ready`
*verbatim*, so a failed upgrade showed its real error only until the failure was
remediated: the rollback then overwrote `Ready`, and the card switched to
information about the previous, working release.

`HelmRelease.findFailureCauseCondition()` returns the failing `Released` (or
`TestSuccess`) condition, which keeps the error until the next release attempt.
Where several are failing, the most recent transition wins — an upgrade that
succeeded with failing Helm tests leaves `Released` true and `TestSuccess`
false, and a failed upgrade can leave a stale failing `TestSuccess` behind.

Substitution requires `Ready` to be *uninformative*: a verbatim mirror of
`Remediated` or of a `True` `Stalled`, or `Unknown` on a stalled release.
Testing for a mirror rather than for an allow-list of remediation reasons is what
keeps a newer, unrelated blocker visible — when an object fails again after the
rollback for a reason that never reaches a release attempt (`ArtifactFailed`,
`DependencyNotReady`, a missing `valuesFrom` Secret, a denied release), `Ready`
carries that current blocker, no longer equals the remediation, and the older —
now misleading — error is not shown. The mirror test also covers remediation
flavours a reason list would miss: a failed *install* is remediated by an
uninstall, and the rollback itself can fail (`Remediated` is then `False`, and
still mirrored into `Ready`).

Nothing is substituted while the release is ready or a fresh reconciliation is in
flight: `spec.test.ignoreFailures` keeps a release ready with `TestSuccess`
failing, and a progressing object can carry a stale failing `Released` from the
previous generation.

### What is the effect of this change to users?

For a failed release, the card now shows the error and the time the release
actually failed, plus an `Attempted` row naming the revision it tried (so the
running `Chart Version` and the version the error talks about can be told apart)
and a one-line `Remediation` row — expanded to the full message only when the
remediation itself failed. The AI chat button and the resource tree's search over
failure messages use the same condition, so neither asks about nor matches on the
rollback message any more, and the button offers to troubleshoot whenever a
release failure is known rather than only when `Ready` is `False`.

Note that the long controller error now wraps over several lines, so a failing
card is visibly taller than before. Status badges, card colours and tree failure
propagation are untouched.

### How does it look like?

Verified against live objects on `gazelle`.

`org-giantswarm-production/operations-hello-world-test` — a stalled release
(`Stalled`=True/`RetriesExceeded`, `Ready`=Unknown/`Progressing`,
`Released`=False/`UpgradeFailed`):

| | before | after |
| --- | --- | --- |
| Status | Last reconciled 2 minutes ago | Upgrade failed 2 months ago (retries exhausted) |
| Message | reconciliation in progress | Helm upgrade failed … admission webhook `vingress.elbv2.k8s.aws` denied the request: invalid ingress class: IngressClass `nginx` not found |
| AI button | Inspect with AI | Troubleshoot with AI |

`flux-giantswarm/appcatalog-giantswarm-operations-platform-test`
(`Ready`=False/`SourceNotReady`) is unchanged, i.e. the fallback still applies:

```
Status   Last reconciliation failed about 2 hours ago
Message  OCIRepository 'flux-giantswarm/appcatalog' is not ready: does not have an artifact
```

`buildStatusMetadata` is untouched, so the seven other Flux kinds the card
renders cannot regress.

### Any background context you can provide?

Reported from a live `HelmRelease` whose upgrade failed on a CRD validation
error: the informative message appeared briefly and was then replaced by the
rollback's. The full status of that object is the basis of the test fixtures.
No currently-failing HelmRelease on `gazelle`, `glean` or `graveler` is in the
rollback-masked state right now, so that path is covered by unit tests; the
stalled variant above is the live reproduction.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
