### PR TITLE
feat(agent-platform): move the installation picker to the top of the new-agent form

### DIFF
--- a/.changeset/agent-platform-installation-top.md
+++ b/.changeset/agent-platform-installation-top.md
@@ -1,0 +1,17 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': patch
+'@giantswarm/backstage-plugin-ui-react': minor
+---
+
+Move the Installation picker to its own card at the top of the "Create an
+agent" form (`/agent-platform/agents/new`), ahead of Identity and
+Configuration, since the avatar preview and model picker both depend on it.
+
+When only one installation is configured for access, the picker is hidden
+entirely and that installation is auto-selected — customer Backstage
+instances wired to a single management cluster no longer see a single-option
+dropdown with nothing to choose.
+
+`ui-react`: add the shared `SectionHeader` component (title + description
+pair used to introduce a card's contents), extracted from the agent-platform
+form so it can be reused across plugins.

--- a/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.test.tsx
+++ b/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.test.tsx
@@ -1,0 +1,110 @@
+import { render } from '@testing-library/react';
+import { InstallationSelect } from './InstallationSelect';
+
+type FormState = { installation: string | undefined };
+
+let mockState: FormState;
+const mockSetInstallation = jest.fn();
+
+let mockInstallations: { name: string }[];
+
+let mockModelConfigs: {
+  isLoading: boolean;
+  hasInstallations: boolean;
+  availableInstallations: string[];
+  unreachableInstallations: string[];
+};
+
+jest.mock('../NewAgentFormProvider', () => ({
+  useNewAgentForm: () => ({
+    state: mockState,
+    setInstallation: mockSetInstallation,
+  }),
+}));
+
+jest.mock('@giantswarm/backstage-plugin-gs', () => ({
+  useInstallations: () => ({
+    installations: mockInstallations,
+    isLoading: false,
+  }),
+}));
+
+jest.mock('../ModelConfigsProvider', () => ({
+  useModelConfigs: () => mockModelConfigs,
+}));
+
+describe('InstallationSelect', () => {
+  beforeEach(() => {
+    mockSetInstallation.mockClear();
+    mockState = { installation: undefined };
+    mockInstallations = [{ name: 'alpha' }, { name: 'beta' }];
+    mockModelConfigs = {
+      isLoading: false,
+      hasInstallations: true,
+      availableInstallations: ['alpha', 'beta'],
+      unreachableInstallations: [],
+    };
+  });
+
+  it('renders the picker when more than one installation is configured', () => {
+    const { getAllByText, getByText } = render(<InstallationSelect />);
+
+    expect(getAllByText('Installation').length).toBeGreaterThan(0);
+    expect(getByText('alpha')).toBeInTheDocument();
+    expect(getByText('beta')).toBeInTheDocument();
+    expect(mockSetInstallation).not.toHaveBeenCalled();
+  });
+
+  it('hides the picker and auto-selects the sole installation when only one is configured', () => {
+    mockInstallations = [{ name: 'solo' }];
+    mockModelConfigs = {
+      ...mockModelConfigs,
+      availableInstallations: ['solo'],
+    };
+
+    const { container } = render(<InstallationSelect />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockSetInstallation).toHaveBeenCalledTimes(1);
+    expect(mockSetInstallation).toHaveBeenCalledWith('solo');
+  });
+
+  it('does not re-select once the sole installation is already selected', () => {
+    mockInstallations = [{ name: 'solo' }];
+    mockState = { installation: 'solo' };
+    mockModelConfigs = {
+      ...mockModelConfigs,
+      availableInstallations: ['solo'],
+    };
+
+    render(<InstallationSelect />);
+
+    expect(mockSetInstallation).not.toHaveBeenCalled();
+  });
+
+  it('still shows the loading state while models are still resolving across the fleet', () => {
+    mockModelConfigs = {
+      isLoading: true,
+      hasInstallations: true,
+      availableInstallations: [],
+      unreachableInstallations: [],
+    };
+
+    const { getByText } = render(<InstallationSelect />);
+
+    expect(getByText('Finding installations with models…')).toBeInTheDocument();
+  });
+
+  it('surfaces the empty state when no reachable installation has a model', () => {
+    mockModelConfigs = {
+      isLoading: false,
+      hasInstallations: true,
+      availableInstallations: [],
+      unreachableInstallations: [],
+    };
+
+    const { getByText } = render(<InstallationSelect />);
+
+    expect(getByText('No installations with models')).toBeInTheDocument();
+  });
+});

--- a/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.test.tsx
+++ b/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.test.tsx
@@ -7,6 +7,7 @@ let mockState: FormState;
 const mockSetInstallation = jest.fn();
 
 let mockInstallations: { name: string }[];
+let mockIsLoadingInstallations: boolean;
 
 let mockModelConfigs: {
   isLoading: boolean;
@@ -25,7 +26,7 @@ jest.mock('../NewAgentFormProvider', () => ({
 jest.mock('@giantswarm/backstage-plugin-gs', () => ({
   useInstallations: () => ({
     installations: mockInstallations,
-    isLoading: false,
+    isLoading: mockIsLoadingInstallations,
   }),
 }));
 
@@ -38,6 +39,7 @@ describe('InstallationSelect', () => {
     mockSetInstallation.mockClear();
     mockState = { installation: undefined };
     mockInstallations = [{ name: 'alpha' }, { name: 'beta' }];
+    mockIsLoadingInstallations = false;
     mockModelConfigs = {
       isLoading: false,
       hasInstallations: true,
@@ -46,65 +48,148 @@ describe('InstallationSelect', () => {
     };
   });
 
-  it('renders the picker when more than one installation is configured', () => {
-    const { getAllByText, getByText } = render(<InstallationSelect />);
+  describe('with more than one installation configured', () => {
+    it('renders the picker', () => {
+      const { getByRole, getByText } = render(<InstallationSelect />);
 
-    expect(getAllByText('Installation').length).toBeGreaterThan(0);
-    expect(getByText('alpha')).toBeInTheDocument();
-    expect(getByText('beta')).toBeInTheDocument();
-    expect(mockSetInstallation).not.toHaveBeenCalled();
+      expect(
+        getByRole('heading', { name: 'Installation', level: 3 }),
+      ).toBeInTheDocument();
+      expect(getByText('alpha')).toBeInTheDocument();
+      expect(getByText('beta')).toBeInTheDocument();
+      expect(mockSetInstallation).not.toHaveBeenCalled();
+    });
+
+    it('names the field for assistive tech without repeating the card heading', () => {
+      const { getAllByText, getByLabelText } = render(<InstallationSelect />);
+
+      // The section heading is the only visible "Installation" text; the select
+      // carries the same name via aria-label instead of a second visible label.
+      expect(getAllByText('Installation')).toHaveLength(1);
+      expect(getByLabelText('Installation')).toBeInTheDocument();
+    });
+
+    it('shows the loading state while models are still resolving across the fleet', () => {
+      mockModelConfigs = {
+        ...mockModelConfigs,
+        isLoading: true,
+        availableInstallations: [],
+      };
+
+      const { getByText } = render(<InstallationSelect />);
+
+      expect(
+        getByText('Finding installations with models…'),
+      ).toBeInTheDocument();
+    });
+
+    it('flags that the list is still growing once some installations have responded', () => {
+      mockModelConfigs = {
+        ...mockModelConfigs,
+        isLoading: true,
+        availableInstallations: ['alpha'],
+      };
+
+      const { getByText } = render(<InstallationSelect />);
+
+      expect(
+        getByText('Still checking the remaining installations…'),
+      ).toBeInTheDocument();
+    });
+
+    it('surfaces the empty state when no reachable installation has a model', () => {
+      mockModelConfigs = {
+        ...mockModelConfigs,
+        availableInstallations: [],
+      };
+
+      const { getByText } = render(<InstallationSelect />);
+
+      expect(getByText('No installations with models')).toBeInTheDocument();
+    });
   });
 
-  it('hides the picker and auto-selects the sole installation when only one is configured', () => {
-    mockInstallations = [{ name: 'solo' }];
+  describe('with a single installation configured', () => {
+    beforeEach(() => {
+      mockInstallations = [{ name: 'solo' }];
+      mockModelConfigs = {
+        ...mockModelConfigs,
+        availableInstallations: ['solo'],
+      };
+    });
+
+    it('hides the picker and auto-selects it', () => {
+      const { container } = render(<InstallationSelect />);
+
+      expect(container).toBeEmptyDOMElement();
+      expect(mockSetInstallation).toHaveBeenCalledTimes(1);
+      expect(mockSetInstallation).toHaveBeenCalledWith('solo');
+    });
+
+    it('does not re-select once it is already selected', () => {
+      mockState = { installation: 'solo' };
+
+      render(<InstallationSelect />);
+
+      expect(mockSetInstallation).not.toHaveBeenCalled();
+    });
+
+    it('renders nothing while the fleet query is still settling', () => {
+      // Rendering the loading card here would make it appear only to vanish
+      // once the sole installation turns out to be usable.
+      mockModelConfigs = {
+        ...mockModelConfigs,
+        isLoading: true,
+        availableInstallations: [],
+      };
+
+      const { container } = render(<InstallationSelect />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('still explains itself when the sole installation has no models', () => {
+      mockModelConfigs = {
+        ...mockModelConfigs,
+        availableInstallations: [],
+      };
+
+      const { getByText } = render(<InstallationSelect />);
+
+      // Hiding the card here would leave the model picker's "no ModelConfigs on
+      // X" fallback as the only feedback, which misdiagnoses the problem.
+      expect(getByText('No installations with models')).toBeInTheDocument();
+      expect(mockSetInstallation).toHaveBeenCalledWith('solo');
+    });
+
+    it('still explains itself when the sole installation is unreachable', () => {
+      mockModelConfigs = {
+        ...mockModelConfigs,
+        availableInstallations: [],
+        unreachableInstallations: ['solo'],
+      };
+
+      const { getByText, queryByText } = render(<InstallationSelect />);
+
+      expect(getByText(/Couldn't read 1 installation/)).toBeInTheDocument();
+      // Don't claim "no models" when the read never succeeded.
+      expect(queryByText('No installations with models')).toBeNull();
+    });
+  });
+
+  it('renders nothing until the installations config resolves', () => {
+    mockIsLoadingInstallations = true;
+    mockInstallations = [];
     mockModelConfigs = {
-      ...mockModelConfigs,
-      availableInstallations: ['solo'],
+      isLoading: true,
+      hasInstallations: false,
+      availableInstallations: [],
+      unreachableInstallations: [],
     };
 
     const { container } = render(<InstallationSelect />);
 
     expect(container).toBeEmptyDOMElement();
-    expect(mockSetInstallation).toHaveBeenCalledTimes(1);
-    expect(mockSetInstallation).toHaveBeenCalledWith('solo');
-  });
-
-  it('does not re-select once the sole installation is already selected', () => {
-    mockInstallations = [{ name: 'solo' }];
-    mockState = { installation: 'solo' };
-    mockModelConfigs = {
-      ...mockModelConfigs,
-      availableInstallations: ['solo'],
-    };
-
-    render(<InstallationSelect />);
-
     expect(mockSetInstallation).not.toHaveBeenCalled();
-  });
-
-  it('still shows the loading state while models are still resolving across the fleet', () => {
-    mockModelConfigs = {
-      isLoading: true,
-      hasInstallations: true,
-      availableInstallations: [],
-      unreachableInstallations: [],
-    };
-
-    const { getByText } = render(<InstallationSelect />);
-
-    expect(getByText('Finding installations with models…')).toBeInTheDocument();
-  });
-
-  it('surfaces the empty state when no reachable installation has a model', () => {
-    mockModelConfigs = {
-      isLoading: false,
-      hasInstallations: true,
-      availableInstallations: [],
-      unreachableInstallations: [],
-    };
-
-    const { getByText } = render(<InstallationSelect />);
-
-    expect(getByText('No installations with models')).toBeInTheDocument();
   });
 });

--- a/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.tsx
+++ b/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { Alert, Card, CardBody, Flex, Select } from '@backstage/ui';
+import { useEffect, type ReactNode } from 'react';
+import { Alert, Card, CardBody, Flex, Select, Text } from '@backstage/ui';
 import { CircularProgress } from '@material-ui/core';
 import { SectionHeader } from '@giantswarm/backstage-plugin-ui-react';
 import { useInstallations } from '@giantswarm/backstage-plugin-gs';
@@ -8,12 +8,29 @@ import { useNewAgentForm } from '../NewAgentFormProvider';
 import { useModelConfigs } from '../ModelConfigsProvider';
 import { UnreachableInstallationsAlert } from '../UnreachableInstallationsAlert';
 
-const description =
+const DESCRIPTION =
   'The management cluster this agent runs on. Determines which models are available and where the agent is deployed.';
+
+/**
+ * Card shell, so every branch below gets the same heading and description. The
+ * heading names the field, so the controls inside use `aria-label` rather than a
+ * visible label that would repeat it.
+ */
+function InstallationCard({ children }: { children: ReactNode }) {
+  return (
+    <Card>
+      <CardBody>
+        <SectionHeader title="Installation" description={DESCRIPTION} />
+        {children}
+      </CardBody>
+    </Card>
+  );
+}
 
 export function InstallationSelect() {
   const { state, setInstallation } = useNewAgentForm();
-  const { installations } = useInstallations();
+  const { installations, isLoading: isLoadingInstallations } =
+    useInstallations();
   const {
     isLoading,
     hasInstallations,
@@ -21,12 +38,14 @@ export function InstallationSelect() {
     unreachableInstallations,
   } = useModelConfigs();
 
-  // With only one installation configured for access, there's nothing to
-  // choose — auto-select it and skip the field entirely rather than showing a
-  // single-option dropdown. `installations` is empty while useInstallations()
-  // is still loading, so this never fires on partial data.
+  // The sole installation on a single-management-cluster instance: there is
+  // nothing to choose, so pick it for the user instead of offering a one-option
+  // dropdown. Keyed on the configured list rather than the narrower "has a
+  // usable model" one, so the choice lands as soon as it is knowable.
   const singleInstallation =
-    installations.length === 1 ? installations[0].name : undefined;
+    !isLoadingInstallations && installations.length === 1
+      ? installations[0].name
+      : undefined;
 
   useEffect(() => {
     if (singleInstallation && state.installation !== singleInstallation) {
@@ -34,7 +53,18 @@ export function InstallationSelect() {
     }
   }, [singleInstallation, state.installation, setInstallation]);
 
-  if (singleInstallation) {
+  // Until the installations config resolves we don't know whether this field
+  // belongs on the page at all — render nothing rather than a loading card that
+  // would vanish a moment later on a single-installation instance.
+  if (isLoadingInstallations) {
+    return null;
+  }
+
+  // Hide the field only once the sole installation proves usable. While the
+  // fleet query is still settling we can't tell yet, so stay out of the way; if
+  // it turns out to be unreachable or model-less we fall through, because the
+  // guidance below is then the only thing that explains why the form is stuck.
+  if (singleInstallation && (isLoading || availableInstallations.length > 0)) {
     return null;
   }
 
@@ -51,66 +81,63 @@ export function InstallationSelect() {
   if (availableInstallations.length === 0) {
     if (isLoading) {
       return (
-        <Card>
-          <CardBody>
-            <SectionHeader title="Installation" description={description} />
-            <Select
-              label="Installation"
-              isRequired
-              isDisabled
-              icon={<CircularProgress size={16} color="inherit" />}
-              options={[]}
-              placeholder="Finding installations with models…"
-            />
-          </CardBody>
-        </Card>
+        <InstallationCard>
+          <Select
+            aria-label="Installation"
+            isRequired
+            isDisabled
+            icon={<CircularProgress size={16} color="inherit" />}
+            options={[]}
+            placeholder="Finding installations with models…"
+          />
+        </InstallationCard>
       );
     }
 
     if (hasInstallations) {
       return (
-        <Card>
-          <CardBody>
-            <SectionHeader title="Installation" description={description} />
-            <Flex direction="column" gap="2">
-              {/* If every queried installation errored, the warning explains it;
-                  only claim "no models" when reads actually succeeded. */}
-              {unreachableNote}
-              {unreachableInstallations.length === 0 && (
-                <Alert
-                  status="info"
-                  title="No installations with models"
-                  description="None of the reachable installations have a kagent ModelConfig provisioned yet. A platform admin needs to add one before you can create an agent."
-                />
-              )}
-            </Flex>
-          </CardBody>
-        </Card>
+        <InstallationCard>
+          <Flex direction="column" gap="2">
+            {/* If every queried installation errored, the warning explains it;
+                only claim "no models" when reads actually succeeded. */}
+            {unreachableNote}
+            {unreachableInstallations.length === 0 && (
+              <Alert
+                status="info"
+                title="No installations with models"
+                description="None of the reachable installations have a kagent ModelConfig provisioned yet. A platform admin needs to add one before you can create an agent."
+              />
+            )}
+          </Flex>
+        </InstallationCard>
       );
     }
   }
 
   return (
-    <Card>
-      <CardBody>
-        <SectionHeader title="Installation" description={description} />
-        <Flex direction="column" gap="2">
-          <Select
-            label="Installation"
-            secondaryLabel={isLoading ? 'still checking…' : undefined}
-            isRequired
-            options={availableInstallations.map(name => ({
-              id: name,
-              label: name,
-            }))}
-            selectedKey={state.installation ?? null}
-            onSelectionChange={key =>
-              setInstallation(key ? String(key) : undefined)
-            }
-          />
-          {unreachableNote}
-        </Flex>
-      </CardBody>
-    </Card>
+    <InstallationCard>
+      <Flex direction="column" gap="2">
+        <Select
+          aria-label="Installation"
+          isRequired
+          options={availableInstallations.map(name => ({
+            id: name,
+            label: name,
+          }))}
+          selectedKey={state.installation ?? null}
+          onSelectionChange={key =>
+            setInstallation(key ? String(key) : undefined)
+          }
+        />
+        {/* The list grows as slower installations respond, so say so rather than
+            letting a short list look complete. */}
+        {isLoading && (
+          <Text variant="body-small" color="secondary">
+            Still checking the remaining installations…
+          </Text>
+        )}
+        {unreachableNote}
+      </Flex>
+    </InstallationCard>
   );
 }

--- a/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.tsx
+++ b/plugins/agent-platform/src/components/InstallationSelect/InstallationSelect.tsx
@@ -1,12 +1,19 @@
-import { Alert, Flex, Select, Text } from '@backstage/ui';
+import { useEffect } from 'react';
+import { Alert, Card, CardBody, Flex, Select } from '@backstage/ui';
 import { CircularProgress } from '@material-ui/core';
+import { SectionHeader } from '@giantswarm/backstage-plugin-ui-react';
+import { useInstallations } from '@giantswarm/backstage-plugin-gs';
 
 import { useNewAgentForm } from '../NewAgentFormProvider';
 import { useModelConfigs } from '../ModelConfigsProvider';
 import { UnreachableInstallationsAlert } from '../UnreachableInstallationsAlert';
 
+const description =
+  'The management cluster this agent runs on. Determines which models are available and where the agent is deployed.';
+
 export function InstallationSelect() {
   const { state, setInstallation } = useNewAgentForm();
+  const { installations } = useInstallations();
   const {
     isLoading,
     hasInstallations,
@@ -14,8 +21,22 @@ export function InstallationSelect() {
     unreachableInstallations,
   } = useModelConfigs();
 
-  const description =
-    'The management cluster this agent runs on. Determines which models are available and where the agent is deployed.';
+  // With only one installation configured for access, there's nothing to
+  // choose — auto-select it and skip the field entirely rather than showing a
+  // single-option dropdown. `installations` is empty while useInstallations()
+  // is still loading, so this never fires on partial data.
+  const singleInstallation =
+    installations.length === 1 ? installations[0].name : undefined;
+
+  useEffect(() => {
+    if (singleInstallation && state.installation !== singleInstallation) {
+      setInstallation(singleInstallation);
+    }
+  }, [singleInstallation, state.installation, setInstallation]);
+
+  if (singleInstallation) {
+    return null;
+  }
 
   const unreachableNote = (
     <UnreachableInstallationsAlert
@@ -30,54 +51,66 @@ export function InstallationSelect() {
   if (availableInstallations.length === 0) {
     if (isLoading) {
       return (
-        <Select
-          label="Installation"
-          description={description}
-          isRequired
-          isDisabled
-          icon={<CircularProgress size={16} color="inherit" />}
-          options={[]}
-          placeholder="Finding installations with models…"
-        />
+        <Card>
+          <CardBody>
+            <SectionHeader title="Installation" description={description} />
+            <Select
+              label="Installation"
+              isRequired
+              isDisabled
+              icon={<CircularProgress size={16} color="inherit" />}
+              options={[]}
+              placeholder="Finding installations with models…"
+            />
+          </CardBody>
+        </Card>
       );
     }
 
     if (hasInstallations) {
       return (
-        <Flex direction="column" gap="2">
-          <Text weight="bold">Installation</Text>
-          {/* If every queried installation errored, the warning explains it;
-              only claim "no models" when reads actually succeeded. */}
-          {unreachableNote}
-          {unreachableInstallations.length === 0 && (
-            <Alert
-              status="info"
-              title="No installations with models"
-              description="None of the reachable installations have a kagent ModelConfig provisioned yet. A platform admin needs to add one before you can create an agent."
-            />
-          )}
-        </Flex>
+        <Card>
+          <CardBody>
+            <SectionHeader title="Installation" description={description} />
+            <Flex direction="column" gap="2">
+              {/* If every queried installation errored, the warning explains it;
+                  only claim "no models" when reads actually succeeded. */}
+              {unreachableNote}
+              {unreachableInstallations.length === 0 && (
+                <Alert
+                  status="info"
+                  title="No installations with models"
+                  description="None of the reachable installations have a kagent ModelConfig provisioned yet. A platform admin needs to add one before you can create an agent."
+                />
+              )}
+            </Flex>
+          </CardBody>
+        </Card>
       );
     }
   }
 
   return (
-    <Flex direction="column" gap="2">
-      <Select
-        label="Installation"
-        secondaryLabel={isLoading ? 'still checking…' : undefined}
-        description={description}
-        isRequired
-        options={availableInstallations.map(name => ({
-          id: name,
-          label: name,
-        }))}
-        selectedKey={state.installation ?? null}
-        onSelectionChange={key =>
-          setInstallation(key ? String(key) : undefined)
-        }
-      />
-      {unreachableNote}
-    </Flex>
+    <Card>
+      <CardBody>
+        <SectionHeader title="Installation" description={description} />
+        <Flex direction="column" gap="2">
+          <Select
+            label="Installation"
+            secondaryLabel={isLoading ? 'still checking…' : undefined}
+            isRequired
+            options={availableInstallations.map(name => ({
+              id: name,
+              label: name,
+            }))}
+            selectedKey={state.installation ?? null}
+            onSelectionChange={key =>
+              setInstallation(key ? String(key) : undefined)
+            }
+          />
+          {unreachableNote}
+        </Flex>
+      </CardBody>
+    </Card>
   );
 }

--- a/plugins/agent-platform/src/components/NewAgentPage/NewAgentPage.tsx
+++ b/plugins/agent-platform/src/components/NewAgentPage/NewAgentPage.tsx
@@ -13,7 +13,10 @@ import {
   TextField,
 } from '@backstage/ui';
 import { makeStyles } from '@material-ui/core';
-import { useProvidePageHeaderActions } from '@giantswarm/backstage-plugin-ui-react';
+import {
+  SectionHeader,
+  useProvidePageHeaderActions,
+} from '@giantswarm/backstage-plugin-ui-react';
 
 import { agentsRouteRef, newAgentReviewRouteRef } from '../../routes';
 import { useAgentChart } from '../../hooks/useAgentChart';
@@ -36,43 +39,11 @@ const useStyles = makeStyles(theme => ({
     maxWidth: '70ch',
     marginBottom: theme.spacing(3),
   },
-  sectionTitle: {
-    marginBottom: theme.spacing(0.5),
-  },
-  sectionDescription: {
-    maxWidth: '70ch',
-    marginBottom: theme.spacing(3),
-  },
   footerNote: {
     maxWidth: '70ch',
     marginBottom: theme.spacing(2),
   },
 }));
-
-function SectionHeader({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  const classes = useStyles();
-  return (
-    <div>
-      <Text
-        as="h3"
-        variant="title-small"
-        weight="bold"
-        className={classes.sectionTitle}
-      >
-        {title}
-      </Text>
-      <Text as="p" color="secondary" className={classes.sectionDescription}>
-        {description}
-      </Text>
-    </div>
-  );
-}
 
 export function NewAgentPage() {
   return (
@@ -170,6 +141,8 @@ function NewAgentPageContent() {
         </Text>
 
         <Flex direction="column" gap="4">
+          <InstallationSelect />
+
           <Card>
             <CardBody>
               <SectionHeader
@@ -240,7 +213,6 @@ function NewAgentPageContent() {
                   }
                   description="The agent's system message. Pre-filled from the chart's default — edit it to fit the role, or leave it empty to keep the default."
                 />
-                <InstallationSelect />
                 <ModelConfigPicker />
                 <SkillPicker />
               </Flex>

--- a/plugins/agent-platform/src/components/NewAgentPage/NewAgentPage.tsx
+++ b/plugins/agent-platform/src/components/NewAgentPage/NewAgentPage.tsx
@@ -196,7 +196,7 @@ function NewAgentPageContent() {
             <CardBody>
               <SectionHeader
                 title="Configuration"
-                description="What powers the agent and shapes how it behaves: where it runs, which model it uses, its system prompt, and its skills."
+                description="What powers the agent and shapes how it behaves: which model it uses, its system prompt, and its skills."
               />
               <Flex direction="column" gap="5">
                 <TextAreaField

--- a/plugins/ui-react/src/components/SectionHeader/SectionHeader.stories.tsx
+++ b/plugins/ui-react/src/components/SectionHeader/SectionHeader.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card, CardBody, Flex, TextField } from '@backstage/ui';
+import { SectionHeader } from './SectionHeader';
+import { componentDocs } from '../../storybook/docs';
+
+const meta = {
+  title: 'Components/SectionHeader',
+  component: SectionHeader,
+  tags: ['autodocs'],
+  args: {
+    title: 'Identity',
+    description: 'How this agent appears across the platform.',
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: componentDocs({
+          summary:
+            'An `h3` section title with a secondary description below it, sized ' +
+            'and spaced to introduce the contents of a card.',
+          whenToUse:
+            'At the top of a card that groups related form fields or content, so ' +
+            'a multi-card page reads as a sequence of named sections. Use it for ' +
+            'the *group* name — if the card holds a single control, prefer an ' +
+            '`aria-label` on that control over a visible label repeating this title.',
+          migration: 'mixed',
+          extra:
+            'The description is capped at `70ch` for readability, so it wraps ' +
+            'independently of the card width.',
+        }),
+      },
+    },
+  },
+} satisfies Meta<typeof SectionHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const InACard: Story = {
+  name: 'In a card',
+  render: args => (
+    <Card>
+      <CardBody>
+        <SectionHeader {...args} />
+        <Flex direction="column" gap="4">
+          <TextField label="Name" placeholder="e.g. Go service reviewer" />
+          <TextField label="Slug" placeholder="go-service-reviewer" />
+        </Flex>
+      </CardBody>
+    </Card>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The intended usage: introducing the fields grouped inside a card.',
+      },
+    },
+  },
+};
+
+export const LongDescription: Story = {
+  name: 'Long description',
+  args: {
+    title: 'Configuration',
+    description:
+      'What powers the agent and shapes how it behaves: which model it uses, ' +
+      'its system prompt, and its skills. Longer copy wraps at 70 characters ' +
+      'per line so it stays readable even in a full-width card.',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The description wraps at `70ch` rather than the card width.',
+      },
+    },
+  },
+};

--- a/plugins/ui-react/src/components/SectionHeader/SectionHeader.tsx
+++ b/plugins/ui-react/src/components/SectionHeader/SectionHeader.tsx
@@ -1,0 +1,37 @@
+import { Text } from '@backstage/ui';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  title: {
+    marginBottom: theme.spacing(0.5),
+  },
+  description: {
+    maxWidth: '70ch',
+    marginBottom: theme.spacing(3),
+  },
+}));
+
+export type SectionHeaderProps = {
+  title: string;
+  description: string;
+};
+
+/** Title + description pair used to introduce a card's contents. */
+export function SectionHeader({ title, description }: SectionHeaderProps) {
+  const classes = useStyles();
+  return (
+    <div>
+      <Text
+        as="h3"
+        variant="title-small"
+        weight="bold"
+        className={classes.title}
+      >
+        {title}
+      </Text>
+      <Text as="p" color="secondary" className={classes.description}>
+        {description}
+      </Text>
+    </div>
+  );
+}

--- a/plugins/ui-react/src/components/SectionHeader/index.ts
+++ b/plugins/ui-react/src/components/SectionHeader/index.ts
@@ -1,0 +1,2 @@
+export { SectionHeader } from './SectionHeader';
+export type { SectionHeaderProps } from './SectionHeader';

--- a/plugins/ui-react/src/components/index.ts
+++ b/plugins/ui-react/src/components/index.ts
@@ -15,6 +15,7 @@ export * from './MultiplePicker';
 export * from './MultipleSelect';
 export * from './NotAvailable';
 export * from './PageHeaderActions';
+export * from './SectionHeader';
 export * from './SingleSelect';
 export * from './StackedBarChart';
 export * from './StructuredMetadataList';


### PR DESCRIPTION
### What does this PR do?

Reorders the "Create an agent" form (`/agent-platform/agents/new`) so the
**Installation** picker comes first, in its own card ahead of *Identity* and
*Configuration*. It previously sat in the middle of the *Configuration* card,
after the system prompt — even though both the avatar preview (rendered in the
*Identity* card **above** it) and the model picker depend on which installation
is selected.

Additionally, the picker is **hidden and the sole installation auto-selected**
when the instance has only one installation configured *and it's usable* — so
customer instances wired to a single management cluster don't see a one-option
dropdown with nothing to choose.

Those two conditions are deliberately separate (see review discussion):

- **Auto-select** keys on the configured list (`useInstallations()`) — with one
  configured installation there is only one possible choice, and selecting it
  doesn't assert it's healthy.
- **Hiding** additionally requires the installation to be usable
  (`availableInstallations`). If the sole installation is unreachable,
  session-expired, or has no kagent `ModelConfig`, the card keeps rendering so
  `UnreachableInstallationsAlert` / "No installations with models" can explain
  why the form is stuck — otherwise the model picker's "no ModelConfigs
  provisioned on X" fallback would be the only feedback, and it misdiagnoses
  the cause.

Both the installations-config fetch and the fleet-wide ModelConfig query are
treated as "don't render the field yet", so on a single-installation instance
the card never appears-then-vanishes.

Also extracts the form's private `SectionHeader` helper (title + description
pair introducing a card) into `ui-react` — with a Storybook story, per the
`plugins/ui-react` story-coverage gate — so the new Installation card can reuse
it rather than duplicating it inside `agent-platform`.

### What is the effect of this change to users?

- The installation is now chosen at the top of the form, before the fields that
  depend on it, instead of part-way down.
- Customer instances connected to a single management cluster no longer see a
  single-option "Installation" dropdown with nothing to choose — it disappears
  and the sole installation is selected automatically.
- If that single installation *isn't* reachable or has no models, the form still
  says so rather than silently blaming missing ModelConfigs.

### How does it look like?

The form now reads: **Installation** → **Identity** → **Configuration** →
actions. Verified locally against a two-installation dev config:

- The Installation card renders first, above *Identity*.
- Selecting an installation still clears/reloads the model list (existing
  `setInstallation` behaviour) — the *Model* section switches from "Select an
  installation first" to the installation's ModelConfigs.
- The avatar preview resolves against the selected installation, i.e.
  `https://avatars.$BASE_DOMAIN/v1/preview/128/go-service-reviewer.png`.

The card heading names the field, so the select uses `aria-label` rather than a
visible label that would print "Installation" twice.

### Any background context you can provide?

Follow-up polish on the Agent Platform agent-creation flow. The
single-installation case matters for customer Backstage instances that are only
connected to one management cluster.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))