### PR TITLE
feat(agent-platform): show agent readiness in the agents list

### DIFF
--- a/.changeset/agent-platform-agents-readiness.md
+++ b/.changeset/agent-platform-agents-readiness.md
@@ -1,6 +1,7 @@
 ---
 '@giantswarm/backstage-plugin-agent-platform': minor
 '@giantswarm/backstage-plugin-kubernetes-react': minor
+'@giantswarm/backstage-plugin-ui-react': minor
 ---
 
 Show readiness for each agent in the Agent Platform agents list
@@ -32,6 +33,15 @@ Show readiness for each agent in the Agent Platform agents list
   meaning made the bar flash during steady state, and since it sits above the
   table it pushed the table down on every poll. Its slot is also a fixed height
   now, so toggling it can never shift the table.
+- `ui-react`: new shared `StatusLabel` — an icon plus a label describing the
+  state of something, built on bui (`Flex`/`Text` plus a `--bui-fg-*` intent
+  token) rather than on `@backstage/core-components`' `Status*`. Each intent has a
+  distinct silhouette as well as a distinct colour, so a status survives
+  greyscale and colour blindness, and the label is a sibling of the icon so
+  assistive tech reads it (`Status*` puts `aria-hidden` on a span wrapping both
+  its icon _and_ its children, which silently hides any label passed as a child).
+  The agents list is the first consumer; `gs`, `muster` and `flux-react` each
+  still have their own implementation and can migrate as their pages move to bui.
 - `kubernetes-react`: add readiness to `Agent` — `getReadiness()`,
   `getReadinessMessage()`, `getUnsupportedFeaturesWarning()`, `getConditions()`,
   `getCondition()` — plus the free functions `deriveAgentReadiness()`,

--- a/.changeset/agent-platform-agents-readiness.md
+++ b/.changeset/agent-platform-agents-readiness.md
@@ -1,0 +1,42 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+'@giantswarm/backstage-plugin-kubernetes-react': minor
+---
+
+Show readiness for each agent in the Agent Platform agents list
+(`/agent-platform/agents`), which previously gave no health signal at all.
+
+- New "Status" column with four states derived from the `Agent`'s status
+  conditions: **Ready**, **Not ready** (accepted, but the backing workload has no
+  available replica), **Not accepted** (the controller rejected the spec), and
+  **Pending**. Hovering a non-ready agent shows the controller's own explanation
+  — the reconcile error, or "Deployment is not ready, N/M pods are ready" — so
+  the common cases don't need a `kubectl` round-trip. Any
+  `UnsupportedFeatures` warning is appended to the same tooltip.
+- The table is now sortable on every column, like the sessions list. Status sorts
+  by severity rather than alphabetically, so one click brings the agents needing
+  attention to the top. The default order is unchanged (installation, then name).
+- **Pending** covers an agent the controller has not reconciled yet, or whose
+  `status.observedGeneration` still lags `metadata.generation` — so a just-edited
+  agent reads as "not known yet" instead of showing stale conditions as fact.
+  kagent's own UI has no equivalent state.
+- The list now polls, on a two-tier interval evaluated per installation: 60s
+  normally (matching the query client's `staleTime`, so it doesn't undercut the
+  cache), dropping to 5s for an installation that has an agent still converging.
+  An agent that has been non-ready for over 3 minutes is treated as durably
+  broken rather than converging, so it falls back to the baseline instead of
+  pinning its installation to the fast interval for as long as the tab stays
+  open. Interval refetches only run while the tab is focused.
+- The "loading more agents" bar now means "an installation has not reported its
+  first result yet" rather than "a request is in flight". With polling, the old
+  meaning made the bar flash during steady state, and since it sits above the
+  table it pushed the table down on every poll. Its slot is also a fixed height
+  now, so toggling it can never shift the table.
+- `kubernetes-react`: add readiness to `Agent` — `getReadiness()`,
+  `getReadinessMessage()`, `getUnsupportedFeaturesWarning()`, `getConditions()`,
+  `getCondition()` — plus the free functions `deriveAgentReadiness()`,
+  `isAgentTransitional()` and `getAgentStatusChangedAt()` for callers that hold
+  raw list data rather than hydrated instances, and the `AgentConditionType`
+  constants. The `ready` derivation matches kagent's REST API exactly: it keys on
+  the `Ready` condition's _reason_ (`DeploymentReady`/`WorkloadReady`), so a
+  missing Deployment (`Ready=Unknown`/`DeploymentNotFound`) counts as not ready.

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import type { AgentReadiness } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { buildResourceErrors } from '../resourceErrorFixtures';
 import { AgentsDataProvider, useAgents } from './AgentsDataProvider';
 
@@ -41,6 +42,7 @@ type AgentSpec = {
   name: string;
   resourceVersion?: string;
   description?: string;
+  readiness?: AgentReadiness;
 };
 
 // Duck-typed stand-in for an Agent instance — only the getters toAgentRow uses.
@@ -53,6 +55,9 @@ function fakeAgent(cluster: string, spec: AgentSpec) {
     getDescription: () => spec.description ?? '',
     getModelConfigName: () => undefined,
     getSkillCount: () => 0,
+    getReadiness: () => spec.readiness ?? 'ready',
+    getReadinessMessage: () => undefined,
+    getUnsupportedFeaturesWarning: () => undefined,
   };
 }
 
@@ -213,8 +218,12 @@ describe('AgentsDataProvider', () => {
   });
 
   it('surfaces failing installations without dropping loaded rows', async () => {
+    // Every reachable installation reports, so the fleet is genuinely settled and
+    // `isLoadingMore` is false. beta is included (with no agents) deliberately:
+    // an installation that has reported neither data nor an error still has a
+    // query in flight, which *is* "loading more" — see the test above.
     mockUseResources.mockReturnValue(
-      result({ succeeded: { alpha: ['a1'] }, failed: ['gaggle'] }),
+      result({ succeeded: { alpha: ['a1'], beta: [] }, failed: ['gaggle'] }),
     );
 
     const { result: hook } = renderUseAgents();
@@ -225,6 +234,36 @@ describe('AgentsDataProvider', () => {
     expect(hook.current.rows).toHaveLength(1);
     expect(hook.current.isLoading).toBe(false);
     expect(hook.current.isLoadingMore).toBe(false);
+  });
+
+  // Regression: the list polls, and the cluster-access probe independently
+  // returns installations to `connecting`. Deriving "loading more" from that
+  // activity flashed the progress bar during steady state, and because the bar
+  // sits above the table it pushed the table down on every poll.
+  it('does not report loading more while a settled fleet refetches or reprobes', async () => {
+    const settled = {
+      succeeded: { alpha: ['a1'], beta: ['b1'], gaggle: ['g1'] },
+    };
+    mockUseResources.mockReturnValue(result(settled));
+
+    const { result: hook, rerender } = renderUseAgents();
+
+    await waitFor(() => expect(hook.current.rows).toHaveLength(3));
+    expect(hook.current.isLoadingMore).toBe(false);
+
+    // A background poll is in flight for every installation.
+    mockUseResources.mockReturnValue(result({ ...settled, isLoading: true }));
+    rerender();
+    expect(hook.current.isLoadingMore).toBe(false);
+
+    // ...and the access probe has put an installation back to `connecting`.
+    mockReachable = {
+      installations: ['alpha', 'beta', 'gaggle'],
+      isProbing: true,
+    };
+    rerender();
+    expect(hook.current.isLoadingMore).toBe(false);
+    expect(hook.current.rows).toHaveLength(3);
   });
 
   it('treats a 404 (kagent not installed) as zero agents, not a failure', async () => {

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.test.tsx
@@ -236,11 +236,10 @@ describe('AgentsDataProvider', () => {
     expect(hook.current.isLoadingMore).toBe(false);
   });
 
-  // Regression: the list polls, and the cluster-access probe independently
-  // returns installations to `connecting`. Deriving "loading more" from that
-  // activity flashed the progress bar during steady state, and because the bar
-  // sits above the table it pushed the table down on every poll.
-  it('does not report loading more while a settled fleet refetches or reprobes', async () => {
+  // A settled fleet must not claim to be loading just because a poll is in
+  // flight: every installation refetches on an interval now, and the bar sits
+  // above the table.
+  it('does not report loading more while a settled fleet refetches', async () => {
     const settled = {
       succeeded: { alpha: ['a1'], beta: ['b1'], gaggle: ['g1'] },
     };
@@ -255,15 +254,26 @@ describe('AgentsDataProvider', () => {
     mockUseResources.mockReturnValue(result({ ...settled, isLoading: true }));
     rerender();
     expect(hook.current.isLoadingMore).toBe(false);
-
-    // ...and the access probe has put an installation back to `connecting`.
-    mockReachable = {
-      installations: ['alpha', 'beta', 'gaggle'],
-      isProbing: true,
-    };
-    rerender();
-    expect(hook.current.isLoadingMore).toBe(false);
     expect(hook.current.rows).toHaveLength(3);
+  });
+
+  // The converse, and the reason `isProbing` stays in the signal: an
+  // installation still `connecting` is absent from the healthy-only reachable
+  // set, so it can never show up as a "pending installation" — but it may
+  // resolve and contribute rows. Dropping the probe switched the bar off during
+  // exactly this fan-in.
+  it('reports loading more while installations are still being probed', async () => {
+    // Only alpha is healthy so far; beta and gaggle are still connecting.
+    mockReachable = { installations: ['alpha'], isProbing: true };
+    mockUseResources.mockReturnValue(result({ succeeded: { alpha: ['a1'] } }));
+
+    const { result: hook } = renderUseAgents();
+
+    await waitFor(() => expect(hook.current.rows).toHaveLength(1));
+    // alpha has reported, so nothing is "pending" — the probe is the only signal
+    // that more rows are coming.
+    expect(hook.current.isLoading).toBe(false);
+    expect(hook.current.isLoadingMore).toBe(true);
   });
 
   it('treats a 404 (kagent not installed) as zero agents, not a failure', async () => {

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
@@ -231,16 +231,22 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
     const hasInstallations = allInstallations.length > 0;
     const isBusy = hasInstallations && (isProbing || isLoading);
 
-    // "More rows may still arrive" means an installation has not reported its
-    // first result yet — deliberately *not* "some query is fetching".
+    // "More rows may still arrive", from two independent sources.
     //
-    // Now that the list polls, every installation refetches on an interval, and
-    // the cluster-access probe independently returns installations to
-    // `connecting` every few seconds. Deriving this from fetch/probe activity
-    // therefore flashed the progress bar during steady state, and because the bar
-    // sits above the table in a flex column, each flash pushed the table down.
-    // Once an installation has an entry — even an empty one — it can only ever
-    // *replace* its rows, never contribute the first ones, so it is settled.
+    // `pendingInstallations` covers an installation we already know is healthy
+    // but which has not reported its first result yet. Once it has an entry —
+    // even an empty one — it can only ever *replace* its rows, never contribute
+    // the first ones, so it is settled and a background refetch of it is not
+    // "loading more".
+    //
+    // `isProbing` covers the other half, and is why it cannot be dropped: an
+    // installation still `connecting` is not in `reachableInstallations` at all
+    // (that set is `healthy`-only), so it cannot appear in `pendingInstallations`
+    // — yet it may resolve to healthy and contribute rows seconds later. Without
+    // it the bar switches off during exactly the cold-load fan-in it exists for.
+    // It does not churn: the cluster-access connector only seeds `connecting` for
+    // installations it is not already tracking, so this settles once and stays
+    // settled across re-probes.
     const pendingInstallations = reachableInstallations.filter(
       cluster =>
         !(cluster in agentsByInstallation) &&
@@ -250,7 +256,8 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
     return {
       rows,
       isLoading: isBusy && rows.length === 0,
-      isLoadingMore: rows.length > 0 && pendingInstallations.length > 0,
+      isLoadingMore:
+        rows.length > 0 && (pendingInstallations.length > 0 || isProbing),
       hasInstallations,
       unreachableInstallations,
     };

--- a/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/AgentsDataProvider.tsx
@@ -14,7 +14,12 @@ import {
 import { useInstallations } from '@giantswarm/backstage-plugin-gs';
 import { useReachableInstallations } from '../../hooks/useReachableInstallations';
 import { useModelConfigs } from '../ModelConfigsProvider';
-import { AgentRow, sortAgentRows, toAgentRow } from './helpers';
+import {
+  AgentRow,
+  getAgentsRefetchInterval,
+  sortAgentRows,
+  toAgentRow,
+} from './helpers';
 
 export type AgentsContextValue = {
   /** Agents flattened into plain rows, ordered by installation + name. */
@@ -68,11 +73,15 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
   // round-trips per cluster for no benefit here. `clustersData` is the raw
   // per-cluster list result (present, and possibly empty, only for clusters that
   // responded successfully); `resources` are those hydrated into Agent instances.
+  // The refetch interval is two-tier and evaluated per installation — see
+  // `getAgentsRefetchInterval`. It keeps agent readiness fresh without polling
+  // the whole fleet fast: only installations with an agent that is still
+  // converging get the short interval.
   const { resources, clustersData, isLoading, errors } = useResources(
     reachableInstallations,
     Agent,
     {},
-    { enableDiscovery: false },
+    { enableDiscovery: false, refetchInterval: getAgentsRefetchInterval },
   );
 
   // Model labels resolve progressively as ModelConfigs arrive; we deliberately
@@ -221,10 +230,27 @@ export function AgentsDataProvider({ children }: { children: ReactNode }) {
     // pin isLoading true and hide the "no installations configured" empty state.
     const hasInstallations = allInstallations.length > 0;
     const isBusy = hasInstallations && (isProbing || isLoading);
+
+    // "More rows may still arrive" means an installation has not reported its
+    // first result yet — deliberately *not* "some query is fetching".
+    //
+    // Now that the list polls, every installation refetches on an interval, and
+    // the cluster-access probe independently returns installations to
+    // `connecting` every few seconds. Deriving this from fetch/probe activity
+    // therefore flashed the progress bar during steady state, and because the bar
+    // sits above the table in a flex column, each flash pushed the table down.
+    // Once an installation has an entry — even an empty one — it can only ever
+    // *replace* its rows, never contribute the first ones, so it is settled.
+    const pendingInstallations = reachableInstallations.filter(
+      cluster =>
+        !(cluster in agentsByInstallation) &&
+        !erroredInstallations.includes(cluster),
+    );
+
     return {
       rows,
       isLoading: isBusy && rows.length === 0,
-      isLoadingMore: isBusy && rows.length > 0,
+      isLoadingMore: rows.length > 0 && pendingInstallations.length > 0,
       hasInstallations,
       unreachableInstallations,
     };

--- a/plugins/agent-platform/src/components/AgentsDataProvider/helpers.test.ts
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/helpers.test.ts
@@ -3,10 +3,20 @@ import {
   Agent,
   ModelConfig,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
-import { resolveModelLabel, sortAgentRows, toAgentRow } from './helpers';
+import type { AgentRow } from './helpers';
+import {
+  getAgentsRefetchInterval,
+  resolveModelLabel,
+  sortAgentRows,
+  sortAgentsBy,
+  toAgentRow,
+} from './helpers';
 
 type AgentInterface = crds.kagent.v1alpha2.Agent;
 type ModelConfigInterface = crds.kagent.v1alpha2.ModelConfig;
+type AgentCondition = NonNullable<
+  NonNullable<AgentInterface['status']>['conditions']
+>[number];
 
 function makeAgent(
   partial: {
@@ -17,6 +27,10 @@ function makeAgent(
     modelConfig?: string;
     skills?: number;
     type?: 'Declarative' | 'BYO';
+    conditions?: AgentCondition[];
+    generation?: number;
+    observedGeneration?: number;
+    creationTimestamp?: string;
   },
   cluster = 'installation-1',
 ): Agent {
@@ -28,6 +42,10 @@ function makeAgent(
     modelConfig,
     skills = 0,
     type = 'Declarative',
+    conditions,
+    generation = 1,
+    observedGeneration = 1,
+    creationTimestamp,
   } = partial;
 
   const json = {
@@ -36,10 +54,13 @@ function makeAgent(
     metadata: {
       name,
       namespace,
+      generation,
+      creationTimestamp,
       annotations: displayName
         ? { 'ui.giantswarm.io/display-name': displayName }
         : undefined,
     },
+    status: conditions ? { conditions, observedGeneration } : undefined,
     spec: {
       type,
       description,
@@ -166,7 +187,37 @@ describe('toAgentRow', () => {
       description: 'Triages incidents',
       model: 'Claude Sonnet 4.6',
       skillCount: 3,
+      // No status written by the fixture, so the controller has not reconciled.
+      readiness: 'pending',
     });
+  });
+
+  it('carries readiness and its explanation through from the conditions', () => {
+    const agent = makeAgent({
+      name: 'triager',
+      conditions: [
+        {
+          type: 'Accepted',
+          status: 'True',
+          reason: 'Reconciled',
+          message: 'Agent configuration accepted',
+          lastTransitionTime: '2026-07-31T10:00:00Z',
+        },
+        {
+          type: 'Ready',
+          status: 'False',
+          reason: 'DeploymentNotReady',
+          message: 'Deployment is not ready, 0/1 pods are ready',
+          lastTransitionTime: '2026-07-31T10:00:00Z',
+        },
+      ],
+    });
+
+    const row = toAgentRow(agent, []);
+    expect(row.readiness).toBe('notReady');
+    expect(row.readinessMessage).toBe(
+      'Deployment is not ready, 0/1 pods are ready',
+    );
   });
 
   it('uses the resource name and empty description as fallbacks', () => {
@@ -177,6 +228,220 @@ describe('toAgentRow', () => {
     expect(row.description).toBe('');
     expect(row.model).toBeUndefined();
     expect(row.skillCount).toBe(0);
+  });
+});
+
+describe('getAgentsRefetchInterval', () => {
+  const BASELINE = 60_000;
+  const FAST = 5_000;
+  const NOW = Date.parse('2026-07-31T12:00:00Z');
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** A query whose data is the raw list items for one installation. */
+  function query(agents: Agent[]) {
+    return {
+      state: { data: agents.map(agent => agent.jsonData) },
+    } as Parameters<typeof getAgentsRefetchInterval>[0];
+  }
+
+  function condition(
+    type: string,
+    status: 'True' | 'False' | 'Unknown',
+    reason: string,
+    ageMs = 0,
+  ): AgentCondition {
+    return {
+      type,
+      status,
+      reason,
+      message: '',
+      lastTransitionTime: new Date(NOW - ageMs).toISOString(),
+    };
+  }
+
+  const readyAgent = (name: string, ageMs = 0) =>
+    makeAgent({
+      name,
+      conditions: [
+        condition('Accepted', 'True', 'Reconciled', ageMs),
+        condition('Ready', 'True', 'DeploymentReady', ageMs),
+      ],
+    });
+
+  const notReadyAgent = (name: string, ageMs = 0) =>
+    makeAgent({
+      name,
+      conditions: [
+        condition('Accepted', 'True', 'Reconciled', ageMs),
+        condition('Ready', 'False', 'DeploymentNotReady', ageMs),
+      ],
+    });
+
+  it('uses the baseline interval when every agent is ready', () => {
+    expect(
+      getAgentsRefetchInterval(query([readyAgent('a'), readyAgent('b')])),
+    ).toBe(BASELINE);
+  });
+
+  it('uses the baseline interval for an empty installation', () => {
+    expect(getAgentsRefetchInterval(query([]))).toBe(BASELINE);
+  });
+
+  it('uses the baseline interval before the first fetch resolves', () => {
+    const pending = { state: { data: undefined } } as Parameters<
+      typeof getAgentsRefetchInterval
+    >[0];
+
+    expect(getAgentsRefetchInterval(pending)).toBe(BASELINE);
+  });
+
+  it('polls fast while an agent is still converging', () => {
+    expect(
+      getAgentsRefetchInterval(query([readyAgent('a'), notReadyAgent('b')])),
+    ).toBe(FAST);
+  });
+
+  it('polls fast for an agent the controller has not reconciled yet', () => {
+    const fresh = makeAgent({
+      name: 'brand-new',
+      creationTimestamp: new Date(NOW - 2_000).toISOString(),
+    });
+
+    expect(getAgentsRefetchInterval(query([fresh]))).toBe(FAST);
+  });
+
+  // The bound that stops a permanently broken agent pinning its installation to
+  // the fast interval forever (which is what kagent's own UI does).
+  it('backs off to the baseline for an agent stuck non-ready', () => {
+    const stuck = notReadyAgent('stuck', 10 * 60_000);
+
+    expect(getAgentsRefetchInterval(query([stuck]))).toBe(BASELINE);
+  });
+
+  it('still polls fast just inside the converging window', () => {
+    const recent = notReadyAgent('recent', 2 * 60_000);
+
+    expect(getAgentsRefetchInterval(query([recent]))).toBe(FAST);
+  });
+
+  // Documents a deliberate limit of the age bound: editing a long-broken agent
+  // makes it `pending`, but the age basis is still its last *condition*
+  // transition, which is old — so the fix is picked up on the baseline (within a
+  // minute) rather than immediately. Accepted in exchange for keeping the bound
+  // hard: a "pending always polls fast" rule would let a stalled controller
+  // fast-poll forever, which is the failure mode this bound exists to prevent.
+  it('keeps a long-broken agent on the baseline even after an edit', () => {
+    const edited = makeAgent({
+      name: 'stuck',
+      generation: 2,
+      observedGeneration: 1,
+      conditions: [
+        condition('Accepted', 'True', 'Reconciled', 10 * 60_000),
+        condition('Ready', 'False', 'DeploymentNotReady', 10 * 60_000),
+      ],
+    });
+
+    expect(edited.getReadiness()).toBe('pending');
+    expect(getAgentsRefetchInterval(query([edited]))).toBe(BASELINE);
+  });
+
+  it('ignores a stuck agent when another one is actively converging', () => {
+    const stuck = notReadyAgent('stuck', 10 * 60_000);
+    const converging = notReadyAgent('converging', 5_000);
+
+    expect(getAgentsRefetchInterval(query([stuck, converging]))).toBe(FAST);
+  });
+});
+
+describe('sortAgentsBy', () => {
+  const row = (name: string, overrides: Partial<AgentRow> = {}): AgentRow => ({
+    ...toAgentRow(makeAgent({ name, displayName: name }), []),
+    ...overrides,
+  });
+
+  const names = (rows: AgentRow[]) => rows.map(r => r.name);
+
+  it('orders the status column by severity, worst first', () => {
+    const rows = [
+      row('ready-one', { readiness: 'ready' }),
+      row('pending-one', { readiness: 'pending' }),
+      row('rejected-one', { readiness: 'notAccepted' }),
+      row('down-one', { readiness: 'notReady' }),
+    ];
+
+    expect(
+      names(
+        sortAgentsBy(rows, { column: 'readiness', direction: 'ascending' }),
+      ),
+    ).toEqual(['rejected-one', 'down-one', 'pending-one', 'ready-one']);
+  });
+
+  it('reverses the status order when descending', () => {
+    const rows = [
+      row('rejected-one', { readiness: 'notAccepted' }),
+      row('ready-one', { readiness: 'ready' }),
+    ];
+
+    expect(
+      names(
+        sortAgentsBy(rows, { column: 'readiness', direction: 'descending' }),
+      ),
+    ).toEqual(['ready-one', 'rejected-one']);
+  });
+
+  it('breaks status ties by name so equal rows keep a stable order', () => {
+    const rows = [
+      row('zeta', { readiness: 'ready' }),
+      row('alpha', { readiness: 'ready' }),
+      row('mid', { readiness: 'ready' }),
+    ];
+
+    expect(
+      names(
+        sortAgentsBy(rows, { column: 'readiness', direction: 'ascending' }),
+      ),
+    ).toEqual(['alpha', 'mid', 'zeta']);
+  });
+
+  it('sorts skills numerically, not as strings', () => {
+    const rows = [
+      row('ten', { skillCount: 10 }),
+      row('two', { skillCount: 2 }),
+      row('nine', { skillCount: 9 }),
+    ];
+
+    expect(
+      names(sortAgentsBy(rows, { column: 'skills', direction: 'ascending' })),
+    ).toEqual(['two', 'nine', 'ten']);
+  });
+
+  // The initial sort, which must reproduce the ordering the list had before it
+  // became sortable (installation, then name).
+  it('groups by installation and then name, matching the previous default', () => {
+    const rows = [
+      row('beta', { installation: 'inst-b' }),
+      row('zeta', { installation: 'inst-a' }),
+      row('alpha', { installation: 'inst-a' }),
+    ];
+
+    const sorted = sortAgentsBy(rows, {
+      column: 'installation',
+      direction: 'ascending',
+    });
+
+    expect(sorted.map(r => `${r.installation}:${r.name}`)).toEqual([
+      'inst-a:alpha',
+      'inst-a:zeta',
+      'inst-b:beta',
+    ]);
+    expect(names(sorted)).toEqual(names(sortAgentRows(rows)));
   });
 });
 

--- a/plugins/agent-platform/src/components/AgentsDataProvider/helpers.ts
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/helpers.ts
@@ -1,7 +1,88 @@
+import type { crds } from '@giantswarm/k8s-types';
+import type { Query } from '@tanstack/react-query';
 import {
   Agent,
+  AgentReadiness,
+  deriveAgentReadiness,
+  getAgentStatusChangedAt,
+  isAgentTransitional,
+  KubeObjectInterface,
   ModelConfig,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
+
+/**
+ * Baseline poll for the fleet-wide agent list. Deliberately equal to the query
+ * client's `staleTime` (see `QueryClientProvider`): interval refetches are *not*
+ * gated by staleness, so a shorter interval would refetch data the client still
+ * considers fresh and reintroduce exactly the background-refetch churn that
+ * `staleTime` was set to avoid.
+ *
+ * This tier only exists to notice agents created, edited or deleted elsewhere
+ * (kubectl, another tab, the scaffolder) — not to watch one converge, which is
+ * what the transitional tier below is for.
+ */
+const BASELINE_REFETCH_INTERVAL_MS = 60_000;
+
+/**
+ * Poll for an installation that has an agent still converging. Matches kagent's
+ * own UI, and roughly the controller's reconcile cadence.
+ */
+const TRANSITIONAL_REFETCH_INTERVAL_MS = 5_000;
+
+/**
+ * How long an agent may sit in a non-ready state before we stop treating it as
+ * "converging" and let its installation fall back to the baseline.
+ *
+ * Without this bound a *permanently* broken agent — an unpullable image, a spec
+ * the controller keeps rejecting — is transitional forever and would pin its
+ * installation at the fast interval for as long as anyone leaves the tab open.
+ * kagent's own UI has that bug. A healthy agent converges well inside this
+ * window, and past it polling faster cannot help: the fix is a spec change,
+ * which bumps the generation and starts the window again.
+ */
+const TRANSITIONAL_MAX_AGE_MS = 3 * 60_000;
+
+/**
+ * Per-installation refetch interval for the agent list.
+ *
+ * `useResources` applies this to each installation's list query separately, and
+ * react-query re-evaluates it after every fetch resolves — so this needs no
+ * provider state and is self-correcting: the installation an agent was just
+ * created on tightens to the fast interval, converges, and relaxes on its own,
+ * while installations whose agents are all ready never leave the baseline.
+ *
+ * Note that interval refetches only fire while the tab is focused
+ * (`refetchIntervalInBackground` defaults to `false`), which is the same
+ * guard kagent's UI implements by hand with `document.hidden`.
+ */
+export function getAgentsRefetchInterval(
+  query: Query<KubeObjectInterface[]>,
+): number {
+  const items = query.state.data;
+  if (!items?.length) {
+    return BASELINE_REFETCH_INTERVAL_MS;
+  }
+
+  const now = Date.now();
+
+  // This query lists Agents, so its items are Agent JSON — narrow to read the
+  // status conditions the shared derivation expects.
+  const isConverging = (items as crds.kagent.v1alpha2.Agent[]).some(json => {
+    if (!isAgentTransitional(deriveAgentReadiness(json))) {
+      return false;
+    }
+
+    const changedAt = getAgentStatusChangedAt(json);
+
+    // No usable timestamp: treat the agent as just-changed rather than as stuck,
+    // so a genuinely new agent is still picked up quickly.
+    return changedAt === undefined || now - changedAt < TRANSITIONAL_MAX_AGE_MS;
+  });
+
+  return isConverging
+    ? TRANSITIONAL_REFETCH_INTERVAL_MS
+    : BASELINE_REFETCH_INTERVAL_MS;
+}
 
 /**
  * A single agent flattened into a plain row for the table. Plain objects (not
@@ -27,6 +108,19 @@ export type AgentRow = {
    */
   model?: string;
   skillCount: number;
+  /** Readiness derived from the agent's status conditions. */
+  readiness: AgentReadiness;
+  /**
+   * Detail explaining a non-ready readiness (the reconcile error, or
+   * "N/M pods are ready"), for a tooltip. `undefined` when there is nothing to
+   * explain.
+   */
+  readinessMessage?: string;
+  /**
+   * Soft warning that the spec uses features the chosen runtime does not
+   * support. Independent of readiness — a ready agent can carry one.
+   */
+  unsupportedFeaturesWarning?: string;
 };
 
 /**
@@ -74,6 +168,9 @@ export function toAgentRow(
     description: agent.getDescription() ?? '',
     model: resolveModelLabel(agent, modelConfigs),
     skillCount: agent.getSkillCount(),
+    readiness: agent.getReadiness(),
+    readinessMessage: agent.getReadinessMessage(),
+    unsupportedFeaturesWarning: agent.getUnsupportedFeaturesWarning(),
   };
 }
 
@@ -84,4 +181,63 @@ export function sortAgentRows(rows: AgentRow[]): AgentRow[] {
       a.installation.localeCompare(b.installation) ||
       a.name.localeCompare(b.name),
   );
+}
+
+/**
+ * Severity order for the readiness column: ascending sorts worst-first, so one
+ * click puts the agents that need attention at the top. Alphabetical order on
+ * the label would be meaningless ("Not accepted" < "Not ready" < "Pending" <
+ * "Ready" only by accident).
+ */
+const READINESS_SEVERITY: Record<AgentReadiness, number> = {
+  notAccepted: 0,
+  notReady: 1,
+  pending: 2,
+  ready: 3,
+};
+
+/**
+ * Client-side sort for the agents table, mirroring `sortSessionsBy`.
+ *
+ * Every column falls back to the display name as a tiebreaker so equal values
+ * (one installation, or a whole table of ready agents) keep a stable, readable
+ * order rather than the arbitrary one the fleet queries happened to resolve in.
+ */
+export function sortAgentsBy(
+  rows: AgentRow[],
+  sort: { column: unknown; direction: 'ascending' | 'descending' },
+): AgentRow[] {
+  const column = String(sort.column);
+  const factor = sort.direction === 'ascending' ? 1 : -1;
+
+  return [...rows].sort((a, b) => {
+    if (column === 'readiness') {
+      const bySeverity =
+        READINESS_SEVERITY[a.readiness] - READINESS_SEVERITY[b.readiness];
+      return bySeverity !== 0
+        ? bySeverity * factor
+        : a.name.localeCompare(b.name);
+    }
+
+    if (column === 'skills') {
+      return a.skillCount === b.skillCount
+        ? a.name.localeCompare(b.name)
+        : (a.skillCount - b.skillCount) * factor;
+    }
+
+    // Keep the default view grouped by installation, then name — the ordering
+    // the list had before it was sortable.
+    if (column === 'installation') {
+      return (
+        a.installation.localeCompare(b.installation) * factor ||
+        a.name.localeCompare(b.name)
+      );
+    }
+
+    const aValue = String(a[column as keyof AgentRow] ?? '');
+    const bValue = String(b[column as keyof AgentRow] ?? '');
+    return (
+      aValue.localeCompare(bValue) * factor || a.name.localeCompare(b.name)
+    );
+  });
 }

--- a/plugins/agent-platform/src/components/AgentsDataProvider/helpers.ts
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/helpers.ts
@@ -47,9 +47,19 @@ const TRANSITIONAL_MAX_AGE_MS = 3 * 60_000;
  *
  * `useResources` applies this to each installation's list query separately, and
  * react-query re-evaluates it after every fetch resolves — so this needs no
- * provider state and is self-correcting: the installation an agent was just
- * created on tightens to the fast interval, converges, and relaxes on its own,
- * while installations whose agents are all ready never leave the baseline.
+ * provider state and is self-correcting: an installation whose agents are all
+ * ready stays on the baseline, and one whose agent starts converging tightens to
+ * the fast interval and relaxes again once it settles.
+ *
+ * What this does **not** do is accelerate the first sighting of a *newly created*
+ * agent. The decision is made from the data already in hand, so an installation
+ * whose cached list predates the new agent stays on the baseline until the next
+ * poll reveals it. Nothing invalidates the Agent list after creation (the flow
+ * hands off to the scaffolder task page, and the agent does not exist yet at that
+ * point), and `staleTime` suppresses a refetch on mount for a cache entry under a
+ * minute old — so a new agent can take up to the baseline interval to appear, and
+ * only then does the fast tier engage. Invalidating on creation would be the fix
+ * if that wait proves annoying in practice.
  *
  * Note that interval refetches only fire while the tab is focused
  * (`refetchIntervalInBackground` defaults to `false`), which is the same

--- a/plugins/agent-platform/src/components/AgentsDataProvider/index.ts
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/index.ts
@@ -1,3 +1,4 @@
 export { AgentsDataProvider, useAgents } from './AgentsDataProvider';
 export type { AgentsContextValue } from './AgentsDataProvider';
+export { sortAgentsBy } from './helpers';
 export type { AgentRow } from './helpers';

--- a/plugins/agent-platform/src/components/AgentsIndexPage/AgentsIndexPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsIndexPage/AgentsIndexPage.test.tsx
@@ -23,11 +23,13 @@ jest.mock('../ModelConfigsProvider', () => ({
   ),
 }));
 
-// Only the header-actions hook is used from ui-react here; stub it so the test
-// doesn't need the PageHeaderActionsProvider (supplied by GSPageLayout in the
-// real app).
+// Stub ui-react so the test doesn't need the PageHeaderActionsProvider (supplied
+// by GSPageLayout in the real app). `StatusLabel` is stubbed to its label only —
+// this suite covers the page's state branches, and the real status rendering is
+// exercised in AgentsTable.test.tsx, which uses the actual component.
 jest.mock('@giantswarm/backstage-plugin-ui-react', () => ({
   useProvidePageHeaderActions: jest.fn(),
+  StatusLabel: ({ label }: { label: string }) => <span>{label}</span>,
 }));
 
 const renderPage = () =>

--- a/plugins/agent-platform/src/components/AgentsIndexPage/AgentsIndexPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsIndexPage/AgentsIndexPage.test.tsx
@@ -87,6 +87,7 @@ describe('AgentsIndexPage', () => {
           description: 'Triages incidents',
           model: 'Claude Sonnet 4.6',
           skillCount: 3,
+          readiness: 'ready' as const,
         },
       ],
     });
@@ -111,6 +112,7 @@ describe('AgentsIndexPage', () => {
           description: '',
           model: undefined,
           skillCount: 0,
+          readiness: 'ready' as const,
         },
       ],
     });

--- a/plugins/agent-platform/src/components/AgentsIndexPage/AgentsIndexPage.tsx
+++ b/plugins/agent-platform/src/components/AgentsIndexPage/AgentsIndexPage.tsx
@@ -13,6 +13,13 @@ import { AgentsDataProvider, useAgents } from '../AgentsDataProvider';
 import { AgentsTable } from '../AgentsTable';
 import { UnreachableInstallationsAlert } from '../UnreachableInstallationsAlert';
 
+/**
+ * Height reserved for the "loading more" bar, matching MUI's `LinearProgress`
+ * default track height. Reserved permanently so toggling the bar never shifts
+ * the table.
+ */
+const LOADING_BAR_SLOT_HEIGHT = '4px';
+
 // Content of the "Agents" tab. The section header + tabs are provided by the
 // Agent Platform page (GSPageLayout), so this renders content only — no
 // PluginHeader of its own, and the "New agent" action is surfaced in that shared
@@ -69,10 +76,16 @@ function AgentsIndexPageContent() {
           <>
             {/* Rows are in, but more installations are still resolving. A thin
                 bar signals background activity without a blocking skeleton or
-                extra text. */}
-            {isLoadingMore && (
-              <LinearProgress aria-label="Loading more agents" />
-            )}
+                extra text.
+
+                The slot is always rendered at a fixed height and only its
+                contents toggle, so the bar appearing or disappearing can never
+                move the table underneath it. */}
+            <Box height={LOADING_BAR_SLOT_HEIGHT}>
+              {isLoadingMore && (
+                <LinearProgress aria-label="Loading more agents" />
+              )}
+            </Box>
 
             <Box>
               <AgentsTable rows={rows} />

--- a/plugins/agent-platform/src/components/AgentsTable/AgentsTable.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/AgentsTable.test.tsx
@@ -22,6 +22,7 @@ const rows: AgentRow[] = [
     description: 'Triages incidents',
     model: 'Claude Sonnet 4.6',
     skillCount: 3,
+    readiness: 'ready',
   },
   {
     id: 'inst-1/dev/byo',
@@ -32,6 +33,8 @@ const rows: AgentRow[] = [
     description: '',
     model: undefined,
     skillCount: 0,
+    readiness: 'notReady',
+    readinessMessage: 'Deployment is not ready, 0/1 pods are ready',
   },
 ];
 
@@ -47,6 +50,42 @@ describe('AgentsTable', () => {
     expect(screen.getByText('Namespace')).toBeInTheDocument();
     expect(screen.getByText('Model')).toBeInTheDocument();
     expect(screen.getByText('Skills')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  it('renders each row readiness, explaining a non-ready one on hover', async () => {
+    await renderInTestApp(<AgentsTable rows={rows} />);
+
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(screen.getByText('Not ready')).toBeInTheDocument();
+    expect(
+      screen.getByTitle('Deployment is not ready, 0/1 pods are ready'),
+    ).toBeInTheDocument();
+  });
+
+  it('labels a rejected agent distinctly from a not-ready one', async () => {
+    await renderInTestApp(
+      <AgentsTable
+        rows={[
+          {
+            ...rows[0],
+            readiness: 'notAccepted',
+            readinessMessage: 'bad spec',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Not accepted')).toBeInTheDocument();
+    expect(screen.getByTitle('bad spec')).toBeInTheDocument();
+  });
+
+  it('shows an unreconciled agent as pending', async () => {
+    await renderInTestApp(
+      <AgentsTable rows={[{ ...rows[0], readiness: 'pending' }]} />,
+    );
+
+    expect(screen.getByText('Pending')).toBeInTheDocument();
   });
 
   it('renders agent rows with resolved model and skill count', async () => {

--- a/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
@@ -125,16 +125,24 @@ export function AgentsTable({ rows }: AgentsTableProps) {
     [buildAvatarUrl],
   );
 
-  // Client-side sorting, same shape as SessionsTable. The initial sort is
-  // installation-then-name, which is the ordering this list had before it was
-  // sortable (see `sortAgentsBy`), so enabling sorting doesn't change the default
-  // view. Sorting by Status once puts the agents needing attention on top.
+  // Client-side sorting. The initial sort is installation-then-name, which is the
+  // ordering this list had before it was sortable (see `sortAgentsBy`), so
+  // enabling sorting doesn't change the default view. Sorting by Status once puts
+  // the agents needing attention on top.
+  //
+  // Pagination stays off, unlike SessionsTable. `useCompletePagination` only
+  // resets its offset when the page size or the sort/filter/search query changes
+  // — never when the data shrinks. Since this list polls, a deletion elsewhere
+  // (or an installation dropping out of the reachable set, which prunes its
+  // cached rows) could leave the offset past the end of a shrunken list, slicing
+  // to nothing and showing "No agents found." while agents exist, recoverable
+  // only by paging back. `type: 'none'` skips the slice entirely.
   const { tableProps } = useTable<AgentRow>({
     mode: 'complete',
     data: rows,
     sortFn: sortAgentsBy,
     initialSort: { column: 'installation', direction: 'ascending' },
-    paginationOptions: { pageSize: 25, pageSizeOptions: [25, 50, 100] },
+    paginationOptions: { type: 'none' },
   });
 
   return (

--- a/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
@@ -7,10 +7,12 @@ import {
   Flex,
   Table,
   Text,
+  useTable,
 } from '@backstage/ui';
-import { AgentRow } from '../AgentsDataProvider';
+import { AgentRow, sortAgentsBy } from '../AgentsDataProvider';
 import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
 import { AvatarSize } from '../../lib/agentAvatar';
+import { AgentReadinessCell } from './readinessStatus';
 
 /**
  * The avatar spans roughly two lines of text (`large` = 40px). Request 2× that
@@ -25,6 +27,7 @@ function getColumnConfig(
     {
       id: 'name',
       label: 'Agent',
+      isSortable: true,
       isRowHeader: true,
       // Hand-rolled (rather than CellProfile) so the avatar can be larger than
       // CellProfile's fixed x-small and stay top-aligned, and so it always
@@ -66,23 +69,33 @@ function getColumnConfig(
       ),
     },
     {
+      id: 'readiness',
+      label: 'Status',
+      isSortable: true,
+      cell: row => <AgentReadinessCell row={row} />,
+    },
+    {
       id: 'installation',
       label: 'Installation',
+      isSortable: true,
       cell: row => <CellText title={row.installation} />,
     },
     {
       id: 'namespace',
       label: 'Namespace',
+      isSortable: true,
       cell: row => <CellText title={row.namespace || '—'} />,
     },
     {
       id: 'model',
       label: 'Model',
+      isSortable: true,
       cell: row => <CellText title={row.model ?? '—'} />,
     },
     {
       id: 'skills',
       label: 'Skills',
+      isSortable: true,
       width: '10%',
       cell: row => (
         <Cell>
@@ -112,11 +125,22 @@ export function AgentsTable({ rows }: AgentsTableProps) {
     [buildAvatarUrl],
   );
 
+  // Client-side sorting, same shape as SessionsTable. The initial sort is
+  // installation-then-name, which is the ordering this list had before it was
+  // sortable (see `sortAgentsBy`), so enabling sorting doesn't change the default
+  // view. Sorting by Status once puts the agents needing attention on top.
+  const { tableProps } = useTable<AgentRow>({
+    mode: 'complete',
+    data: rows,
+    sortFn: sortAgentsBy,
+    initialSort: { column: 'installation', direction: 'ascending' },
+    paginationOptions: { pageSize: 25, pageSizeOptions: [25, 50, 100] },
+  });
+
   return (
     <Table<AgentRow>
+      {...tableProps}
       columnConfig={columnConfig}
-      data={rows}
-      pagination={{ type: 'none' }}
       emptyState={
         <Text variant="body-medium" color="secondary">
           No agents found.

--- a/plugins/agent-platform/src/components/AgentsTable/readinessStatus.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/readinessStatus.tsx
@@ -1,0 +1,105 @@
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import ErrorIcon from '@material-ui/icons/Error';
+import HourglassEmptyIcon from '@material-ui/icons/HourglassEmpty';
+import ReportProblemIcon from '@material-ui/icons/ReportProblem';
+import { Cell, Flex, Text } from '@backstage/ui';
+import type { AgentReadiness } from '@giantswarm/backstage-plugin-kubernetes-react';
+import type { AgentRow } from '../AgentsDataProvider';
+
+/**
+ * Icon size, pinned rather than inherited.
+ *
+ * `1.2rem` reproduces the size the shared `Status*` components produced, but the
+ * two icon families they mix size by different mechanisms (`0.8em` against
+ * `MuiSvgIcon`'s hardcoded 24px, versus `1.2em` against the inherited font
+ * size), which agree only while the wrapper is 16px. Setting it here keeps all
+ * four states the same size regardless of surrounding typography.
+ */
+const ICON_SIZE = '1.2rem';
+
+/**
+ * Label, icon and colour per readiness state.
+ *
+ * Wording follows kagent's own UI so the two agree. Icons are the filled
+ * Material variants (rather than `@backstage/core-components`' `Status*`, whose
+ * icons are hardcoded), each carrying a distinct shape — tick, triangle, circle,
+ * hourglass — so the state is legible without relying on colour alone.
+ *
+ * Colours are bui's current semantic foreground tokens, so the icon and the rest
+ * of the table share one theming source and adapt to light/dark. `token` is
+ * applied as the wrapper's `color`, which the icon picks up via
+ * `fill: currentColor`.
+ *
+ * Note the intent tokens are `positive`/`negative`, not `success`/`danger` —
+ * the latter are deprecated (`@backstage/no-deprecated-bui-tokens`), even though
+ * bui's `Text`/`CellText` `color` prop still spells them the old way.
+ *
+ * `pending` is deliberately neutral rather than a warning: it means the
+ * controller has not caught up with the current spec yet, which is "not known
+ * yet", not "broken".
+ */
+const READINESS_PRESENTATION: Record<
+  AgentReadiness,
+  { label: string; Icon: typeof CheckCircleIcon; token: string }
+> = {
+  ready: {
+    label: 'Ready',
+    Icon: CheckCircleIcon,
+    token: '--bui-fg-positive',
+  },
+  notReady: {
+    label: 'Not ready',
+    Icon: ReportProblemIcon,
+    token: '--bui-fg-warning',
+  },
+  notAccepted: {
+    label: 'Not accepted',
+    Icon: ErrorIcon,
+    token: '--bui-fg-negative',
+  },
+  pending: {
+    label: 'Pending',
+    Icon: HourglassEmptyIcon,
+    token: '--bui-fg-secondary',
+  },
+};
+
+/**
+ * Tooltip for the readiness cell: the controller's own explanation for the
+ * state, plus any unsupported-features warning. The warning is independent of
+ * readiness, so a ready agent can still have one.
+ */
+function getReadinessTitle(row: AgentRow): string | undefined {
+  const lines = [
+    row.readinessMessage,
+    row.unsupportedFeaturesWarning &&
+      `Unsupported features: ${row.unsupportedFeaturesWarning}`,
+  ].filter(Boolean);
+
+  return lines.length > 0 ? lines.join('\n') : undefined;
+}
+
+export function AgentReadinessCell({ row }: { row: AgentRow }) {
+  const { label, Icon, token } = READINESS_PRESENTATION[row.readiness];
+
+  // The label is real text alongside the icon, never inside it: MUI renders the
+  // icon `aria-hidden`, so a label passed as its child would be hidden from
+  // assistive tech too and the cell would read as empty. Keeping it a sibling
+  // also means it uses bui's `body-medium`, matching every other cell here.
+  return (
+    <Cell>
+      <Flex align="center" gap="2" title={getReadinessTitle(row)}>
+        <span
+          style={{
+            display: 'flex',
+            color: `var(${token})`,
+            fontSize: ICON_SIZE,
+          }}
+        >
+          <Icon fontSize="inherit" />
+        </span>
+        <Text variant="body-medium">{label}</Text>
+      </Flex>
+    </Cell>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentsTable/readinessStatus.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/readinessStatus.tsx
@@ -2,66 +2,35 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ErrorIcon from '@material-ui/icons/Error';
 import HourglassEmptyIcon from '@material-ui/icons/HourglassEmpty';
 import ReportProblemIcon from '@material-ui/icons/ReportProblem';
-import { Cell, Flex, Text } from '@backstage/ui';
+import { Cell } from '@backstage/ui';
+import {
+  StatusLabel,
+  type StatusLabelIntent,
+} from '@giantswarm/backstage-plugin-ui-react';
 import type { AgentReadiness } from '@giantswarm/backstage-plugin-kubernetes-react';
 import type { AgentRow } from '../AgentsDataProvider';
 
 /**
- * Icon size, pinned rather than inherited.
+ * How each readiness state presents. Wording follows kagent's own UI so the two
+ * agree; the icon and colour handling lives in `StatusLabel`.
  *
- * `1.2rem` reproduces the size the shared `Status*` components produced, but the
- * two icon families they mix size by different mechanisms (`0.8em` against
- * `MuiSvgIcon`'s hardcoded 24px, versus `1.2em` against the inherited font
- * size), which agree only while the wrapper is 16px. Setting it here keeps all
- * four states the same size regardless of surrounding typography.
- */
-const ICON_SIZE = '1.2rem';
-
-/**
- * Label, icon and colour per readiness state.
+ * Icons are passed explicitly rather than relying on `StatusLabel`'s per-intent
+ * defaults: `pending` reads far better as an hourglass than as the neutral
+ * default circle, and naming the other three keeps the whole set visible in one
+ * place.
  *
- * Wording follows kagent's own UI so the two agree. Icons are the filled
- * Material variants (rather than `@backstage/core-components`' `Status*`, whose
- * icons are hardcoded), each carrying a distinct shape — tick, triangle, circle,
- * hourglass — so the state is legible without relying on colour alone.
- *
- * Colours are bui's current semantic foreground tokens, so the icon and the rest
- * of the table share one theming source and adapt to light/dark. `token` is
- * applied as the wrapper's `color`, which the icon picks up via
- * `fill: currentColor`.
- *
- * Note the intent tokens are `positive`/`negative`, not `success`/`danger` —
- * the latter are deprecated (`@backstage/no-deprecated-bui-tokens`), even though
- * bui's `Text`/`CellText` `color` prop still spells them the old way.
- *
- * `pending` is deliberately neutral rather than a warning: it means the
+ * `pending` is deliberately `neutral` rather than a warning: it means the
  * controller has not caught up with the current spec yet, which is "not known
  * yet", not "broken".
  */
 const READINESS_PRESENTATION: Record<
   AgentReadiness,
-  { label: string; Icon: typeof CheckCircleIcon; token: string }
+  { label: string; intent: StatusLabelIntent; icon: typeof CheckCircleIcon }
 > = {
-  ready: {
-    label: 'Ready',
-    Icon: CheckCircleIcon,
-    token: '--bui-fg-positive',
-  },
-  notReady: {
-    label: 'Not ready',
-    Icon: ReportProblemIcon,
-    token: '--bui-fg-warning',
-  },
-  notAccepted: {
-    label: 'Not accepted',
-    Icon: ErrorIcon,
-    token: '--bui-fg-negative',
-  },
-  pending: {
-    label: 'Pending',
-    Icon: HourglassEmptyIcon,
-    token: '--bui-fg-secondary',
-  },
+  ready: { label: 'Ready', intent: 'positive', icon: CheckCircleIcon },
+  notReady: { label: 'Not ready', intent: 'warning', icon: ReportProblemIcon },
+  notAccepted: { label: 'Not accepted', intent: 'negative', icon: ErrorIcon },
+  pending: { label: 'Pending', intent: 'neutral', icon: HourglassEmptyIcon },
 };
 
 /**
@@ -80,26 +49,16 @@ function getReadinessTitle(row: AgentRow): string | undefined {
 }
 
 export function AgentReadinessCell({ row }: { row: AgentRow }) {
-  const { label, Icon, token } = READINESS_PRESENTATION[row.readiness];
+  const { label, intent, icon } = READINESS_PRESENTATION[row.readiness];
 
-  // The label is real text alongside the icon, never inside it: MUI renders the
-  // icon `aria-hidden`, so a label passed as its child would be hidden from
-  // assistive tech too and the cell would read as empty. Keeping it a sibling
-  // also means it uses bui's `body-medium`, matching every other cell here.
   return (
     <Cell>
-      <Flex align="center" gap="2" title={getReadinessTitle(row)}>
-        <span
-          style={{
-            display: 'flex',
-            color: `var(${token})`,
-            fontSize: ICON_SIZE,
-          }}
-        >
-          <Icon fontSize="inherit" />
-        </span>
-        <Text variant="body-medium">{label}</Text>
-      </Flex>
+      <StatusLabel
+        label={label}
+        intent={intent}
+        icon={icon}
+        title={getReadinessTitle(row)}
+      />
     </Cell>
   );
 }

--- a/plugins/agent-platform/src/components/QueryClientProvider.tsx
+++ b/plugins/agent-platform/src/components/QueryClientProvider.tsx
@@ -16,6 +16,20 @@ const gcTime = 1000 * 60 * 60;
 const maxAge = gcTime;
 
 /**
+ * How often the cache may be written to localStorage, raised from the library
+ * default of 1s.
+ *
+ * Every write dehydrates the *whole* agent-platform cache and `JSON.stringify`s
+ * it synchronously on the main thread. That was near-free while these queries
+ * only ran on page visits, but the agents list now polls — as often as every 5s
+ * for an installation with a converging agent — so at the default throttle a
+ * large fleet's cache would be re-serialised and rewritten for as long as a tab
+ * stays open. Persistence here exists to make a *reload* cheap, not to be
+ * durable to the second, so coalescing writes costs nothing that matters.
+ */
+const PERSIST_THROTTLE_MS = 1000 * 30;
+
+/**
  * Query keys whose data belongs to one *user* rather than to the fleet, and which
  * must therefore never be written to localStorage.
  *
@@ -93,7 +107,11 @@ export const QueryClientProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const persister = useMemo(
-    () => createAsyncStoragePersister({ storage: window.localStorage }),
+    () =>
+      createAsyncStoragePersister({
+        storage: window.localStorage,
+        throttleTime: PERSIST_THROTTLE_MS,
+      }),
     [],
   );
 

--- a/plugins/agent-platform/src/components/SessionsDataProvider/helpers.test.ts
+++ b/plugins/agent-platform/src/components/SessionsDataProvider/helpers.test.ts
@@ -22,6 +22,7 @@ function agent(overrides: Partial<AgentRow> = {}): AgentRow {
     technicalName: 'sre-agent',
     description: '',
     skillCount: 0,
+    readiness: 'ready',
     ...overrides,
   };
 }

--- a/plugins/kubernetes-react/src/lib/k8s/Agent.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/Agent.test.ts
@@ -1,5 +1,5 @@
 import { crds } from '@giantswarm/k8s-types';
-import { Agent } from './Agent';
+import { Agent, getAgentStatusChangedAt, isAgentTransitional } from './Agent';
 
 type AgentInterface = crds.kagent.v1alpha2.Agent;
 
@@ -83,6 +83,237 @@ describe('Agent', () => {
       expect(agent.getType()).toBe('BYO');
       expect(agent.getModelConfigName()).toBeUndefined();
       expect(agent.getSkillCount()).toBe(0);
+    });
+  });
+
+  describe('readiness', () => {
+    const AT = '2026-07-31T10:00:00Z';
+
+    function condition(
+      type: string,
+      status: 'True' | 'False' | 'Unknown',
+      reason: string,
+      message = '',
+    ) {
+      return { type, status, reason, message, lastTransitionTime: AT };
+    }
+
+    function withStatus(
+      conditions: ReturnType<typeof condition>[],
+      { generation, observedGeneration } = {
+        generation: 1,
+        observedGeneration: 1,
+      },
+    ): Agent {
+      return makeAgent({
+        metadata: { name: 'my-agent', namespace: 'team-a', generation },
+        status: { conditions, observedGeneration },
+      } as Partial<AgentInterface>);
+    }
+
+    const accepted = () =>
+      condition(
+        'Accepted',
+        'True',
+        'Reconciled',
+        'Agent configuration accepted',
+      );
+
+    it('is ready when accepted and the deployment is ready', () => {
+      const agent = withStatus([
+        accepted(),
+        condition('Ready', 'True', 'DeploymentReady', 'Deployment is ready'),
+      ]);
+
+      expect(agent.getReadiness()).toBe('ready');
+      expect(agent.getReadinessMessage()).toBeUndefined();
+    });
+
+    it('treats a sandbox WorkloadReady agent as ready', () => {
+      const agent = withStatus([
+        accepted(),
+        condition('Ready', 'True', 'WorkloadReady', 'Workload is ready'),
+      ]);
+
+      expect(agent.getReadiness()).toBe('ready');
+    });
+
+    it('is notReady when the deployment has no available replica', () => {
+      const agent = withStatus([
+        accepted(),
+        condition(
+          'Ready',
+          'False',
+          'DeploymentNotReady',
+          'Deployment is not ready, 0/1 pods are ready',
+        ),
+      ]);
+
+      expect(agent.getReadiness()).toBe('notReady');
+      expect(agent.getReadinessMessage()).toBe(
+        'Deployment is not ready, 0/1 pods are ready',
+      );
+    });
+
+    // The controller reports a missing Deployment as Ready=Unknown, and kagent's
+    // REST API keys readiness on the *reason*, so this must not read as ready.
+    it('is notReady when the deployment is missing (Ready=Unknown)', () => {
+      const agent = withStatus([
+        accepted(),
+        condition('Ready', 'Unknown', 'DeploymentNotFound', 'not found'),
+      ]);
+
+      expect(agent.getReadiness()).toBe('notReady');
+    });
+
+    it('is notReady when Ready=True carries an unrecognised reason', () => {
+      const agent = withStatus([
+        accepted(),
+        condition('Ready', 'True', 'SomethingElse'),
+      ]);
+
+      expect(agent.getReadiness()).toBe('notReady');
+    });
+
+    it('is notAccepted when reconciliation failed, and surfaces the error', () => {
+      const agent = withStatus([
+        condition(
+          'Accepted',
+          'False',
+          'ReconcileFailed',
+          'model config "missing" not found',
+        ),
+        condition('Ready', 'True', 'DeploymentReady'),
+      ]);
+
+      expect(agent.getReadiness()).toBe('notAccepted');
+      expect(agent.getReadinessMessage()).toBe(
+        'model config "missing" not found',
+      );
+    });
+
+    it('is pending when the controller has written no status yet', () => {
+      expect(makeAgent().getReadiness()).toBe('pending');
+    });
+
+    it('is pending when the status lags the current generation', () => {
+      const agent = withStatus(
+        [
+          accepted(),
+          condition('Ready', 'True', 'DeploymentReady', 'Deployment is ready'),
+        ],
+        { generation: 4, observedGeneration: 3 },
+      );
+
+      // The conditions still say ready, but they describe the previous spec.
+      expect(agent.getReadiness()).toBe('pending');
+    });
+
+    it('is not pending once the controller observes the current generation', () => {
+      const agent = withStatus(
+        [
+          accepted(),
+          condition('Ready', 'True', 'DeploymentReady', 'Deployment is ready'),
+        ],
+        { generation: 4, observedGeneration: 4 },
+      );
+
+      expect(agent.getReadiness()).toBe('ready');
+    });
+
+    // The controller stamps observedGeneration even when reconciliation fails,
+    // so a rejected spec must settle on notAccepted rather than stick at pending.
+    it('reports a rejected current generation as notAccepted, not pending', () => {
+      const agent = withStatus(
+        [condition('Accepted', 'False', 'ReconcileFailed', 'bad spec')],
+        { generation: 2, observedGeneration: 2 },
+      );
+
+      expect(agent.getReadiness()).toBe('notAccepted');
+    });
+  });
+
+  describe('getUnsupportedFeaturesWarning', () => {
+    it('returns the warning message when the condition is True', () => {
+      const agent = makeAgent({
+        status: {
+          observedGeneration: 1,
+          conditions: [
+            {
+              type: 'UnsupportedFeatures',
+              status: 'True',
+              reason: 'UnsupportedFeatures',
+              message: 'memory is not supported by the go runtime',
+              lastTransitionTime: '2026-07-31T10:00:00Z',
+            },
+          ],
+        },
+      } as Partial<AgentInterface>);
+
+      expect(agent.getUnsupportedFeaturesWarning()).toBe(
+        'memory is not supported by the go runtime',
+      );
+    });
+
+    it('returns undefined when no warning is set', () => {
+      expect(makeAgent().getUnsupportedFeaturesWarning()).toBeUndefined();
+    });
+  });
+
+  describe('getAgentStatusChangedAt', () => {
+    it('returns the most recent condition transition time', () => {
+      const agent = makeAgent({
+        status: {
+          observedGeneration: 1,
+          conditions: [
+            {
+              type: 'Accepted',
+              status: 'True',
+              reason: 'Reconciled',
+              message: '',
+              lastTransitionTime: '2026-07-31T10:00:00Z',
+            },
+            {
+              type: 'Ready',
+              status: 'False',
+              reason: 'DeploymentNotReady',
+              message: '',
+              lastTransitionTime: '2026-07-31T10:05:00Z',
+            },
+          ],
+        },
+      } as Partial<AgentInterface>);
+
+      expect(getAgentStatusChangedAt(agent.jsonData)).toBe(
+        Date.parse('2026-07-31T10:05:00Z'),
+      );
+    });
+
+    it('falls back to the creation timestamp when there are no conditions', () => {
+      const agent = makeAgent({
+        metadata: {
+          name: 'my-agent',
+          namespace: 'team-a',
+          creationTimestamp: '2026-07-31T09:00:00Z',
+        },
+      } as Partial<AgentInterface>);
+
+      expect(getAgentStatusChangedAt(agent.jsonData)).toBe(
+        Date.parse('2026-07-31T09:00:00Z'),
+      );
+    });
+
+    it('returns undefined when neither is available', () => {
+      expect(getAgentStatusChangedAt(makeAgent().jsonData)).toBeUndefined();
+    });
+  });
+
+  describe('isAgentTransitional', () => {
+    it('treats every non-ready state as transitional', () => {
+      expect(isAgentTransitional('ready')).toBe(false);
+      expect(isAgentTransitional('notReady')).toBe(true);
+      expect(isAgentTransitional('notAccepted')).toBe(true);
+      expect(isAgentTransitional('pending')).toBe(true);
     });
   });
 });

--- a/plugins/kubernetes-react/src/lib/k8s/Agent.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/Agent.test.ts
@@ -166,13 +166,16 @@ describe('Agent', () => {
       expect(agent.getReadiness()).toBe('notReady');
     });
 
-    it('is notReady when Ready=True carries an unrecognised reason', () => {
+    // Deliberate divergence from kagent's REST API, which also requires the
+    // reason to be DeploymentReady/WorkloadReady. A future kagent adding a third
+    // ready reason must not make a healthy fleet read as broken.
+    it('is ready when Ready=True carries an unrecognised reason', () => {
       const agent = withStatus([
         accepted(),
-        condition('Ready', 'True', 'SomethingElse'),
+        condition('Ready', 'True', 'StatefulSetReady', 'StatefulSet is ready'),
       ]);
 
-      expect(agent.getReadiness()).toBe('notReady');
+      expect(agent.getReadiness()).toBe('ready');
     });
 
     it('is notAccepted when reconciliation failed, and surfaces the error', () => {
@@ -219,6 +222,42 @@ describe('Agent', () => {
       );
 
       expect(agent.getReadiness()).toBe('ready');
+    });
+
+    // observedGeneration is optional in the CRD while metadata.generation always
+    // exists, so treating "absent" as "stale" would make every agent on such an
+    // installation read pending — hiding both healthy and broken agents.
+    it('does not report pending when observedGeneration is absent', () => {
+      const agent = makeAgent({
+        metadata: { name: 'my-agent', namespace: 'team-a', generation: 3 },
+        status: {
+          conditions: [
+            accepted(),
+            condition(
+              'Ready',
+              'True',
+              'DeploymentReady',
+              'Deployment is ready',
+            ),
+          ],
+        },
+      } as Partial<AgentInterface>);
+
+      expect(agent.getReadiness()).toBe('ready');
+    });
+
+    it('still surfaces a failure when observedGeneration is absent', () => {
+      const agent = makeAgent({
+        metadata: { name: 'my-agent', namespace: 'team-a', generation: 3 },
+        status: {
+          conditions: [
+            condition('Accepted', 'False', 'ReconcileFailed', 'bad spec'),
+          ],
+        },
+      } as Partial<AgentInterface>);
+
+      expect(agent.getReadiness()).toBe('notAccepted');
+      expect(agent.getReadinessMessage()).toBe('bad spec');
     });
 
     // The controller stamps observedGeneration even when reconciliation fails,

--- a/plugins/kubernetes-react/src/lib/k8s/Agent.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/Agent.ts
@@ -2,6 +2,131 @@ import { crds } from '@giantswarm/k8s-types';
 import { KubeObject } from './KubeObject';
 
 type AgentInterface = crds.kagent.v1alpha2.Agent;
+type AgentCondition = NonNullable<
+  NonNullable<AgentInterface['status']>['conditions']
+>[number];
+
+/**
+ * Condition types the kagent controller sets on an Agent. `Accepted` reports
+ * whether the spec reconciled, `Ready` whether the backing workload is up, and
+ * `UnsupportedFeatures` is a soft warning that does not block reconciliation
+ * (the controller removes the condition entirely once the warning clears).
+ */
+export const AgentConditionType = {
+  Accepted: 'Accepted',
+  Ready: 'Ready',
+  UnsupportedFeatures: 'UnsupportedFeatures',
+} as const;
+
+/**
+ * Reasons the controller uses for `Ready=True`: `DeploymentReady` for a
+ * Deployment-backed agent, `WorkloadReady` for a sandbox workload.
+ *
+ * kagent's own REST API keys its `deploymentReady` flag on this reason set
+ * rather than on `Ready=True` alone, so any other reason — notably
+ * `Ready=Unknown` / `DeploymentNotFound`, which is what a missing Deployment
+ * produces — counts as not ready. We match that deliberately, so this list and
+ * kagent's UI agree on what "ready" means.
+ */
+const READY_REASONS: string[] = ['DeploymentReady', 'WorkloadReady'];
+
+/**
+ * Readiness of an agent, derived from its status conditions.
+ *
+ * - `ready` — accepted, and the backing workload has an available replica.
+ * - `notReady` — accepted, but the workload is not up.
+ * - `notAccepted` — the controller rejected the spec.
+ * - `pending` — not reconciled yet, or reconciled against an older generation,
+ *   so the conditions do not describe the current spec. Distinct from
+ *   `notReady`: it means "not known yet", not "broken".
+ */
+export type AgentReadiness = 'ready' | 'notReady' | 'notAccepted' | 'pending';
+
+function findAgentCondition(
+  json: AgentInterface,
+  type: string,
+): AgentCondition | undefined {
+  return json.status?.conditions?.find(condition => condition.type === type);
+}
+
+/**
+ * Derive an agent's readiness from its raw status conditions.
+ *
+ * Exported as a free function (rather than only as an {@link Agent} method) so
+ * callers holding raw list data — e.g. a react-query `refetchInterval`
+ * callback, which sees `KubeObjectInterface[]` and not hydrated instances — can
+ * reuse the exact same derivation instead of reimplementing it.
+ */
+export function deriveAgentReadiness(json: AgentInterface): AgentReadiness {
+  const conditions = json.status?.conditions;
+
+  // The controller has not written a status at all yet.
+  if (!conditions?.length) {
+    return 'pending';
+  }
+
+  // The controller stamps `status.observedGeneration` on every status write,
+  // including when reconciliation *fails* — so a spec it genuinely rejects
+  // settles on `notAccepted` rather than sticking at `pending` forever.
+  const { generation } = json.metadata ?? {};
+  const observedGeneration = json.status?.observedGeneration;
+  if (
+    typeof generation === 'number' &&
+    (typeof observedGeneration !== 'number' || observedGeneration < generation)
+  ) {
+    return 'pending';
+  }
+
+  if (
+    findAgentCondition(json, AgentConditionType.Accepted)?.status !== 'True'
+  ) {
+    return 'notAccepted';
+  }
+
+  const ready = findAgentCondition(json, AgentConditionType.Ready);
+  if (ready?.status !== 'True' || !READY_REASONS.includes(ready.reason)) {
+    return 'notReady';
+  }
+
+  return 'ready';
+}
+
+/**
+ * Whether an agent has not settled into a healthy state, and so is worth
+ * re-checking sooner than the rest of the fleet. Mirrors kagent's own
+ * `!accepted || !deploymentReady`, plus our `pending`.
+ */
+export function isAgentTransitional(readiness: AgentReadiness): boolean {
+  return readiness !== 'ready';
+}
+
+/**
+ * When the agent's status last changed, as epoch milliseconds: the most recent
+ * `lastTransitionTime` across its conditions, falling back to the creation
+ * timestamp for an agent the controller has not written a status for yet.
+ * `undefined` when neither is parseable.
+ *
+ * "Most recent across all conditions" is deliberately an *activity* signal, not
+ * a per-condition age: while the controller is actively flipping an agent's
+ * conditions it keeps moving, and once the agent is durably stuck it stops. That
+ * is what lets a caller back off from polling an agent that is broken rather
+ * than still converging.
+ */
+export function getAgentStatusChangedAt(
+  json: AgentInterface,
+): number | undefined {
+  const transitionTimes = (json.status?.conditions ?? [])
+    .map(condition => Date.parse(condition.lastTransitionTime))
+    .filter(time => !Number.isNaN(time));
+
+  if (transitionTimes.length > 0) {
+    return Math.max(...transitionTimes);
+  }
+
+  const createdAt = Date.parse(json.metadata?.creationTimestamp ?? '');
+
+  return Number.isNaN(createdAt) ? undefined : createdAt;
+}
 
 /**
  * kagent Agent — a reusable agent definition, deployed via the
@@ -54,5 +179,54 @@ export class Agent extends KubeObject<AgentInterface> {
   /** Number of skills mounted by the agent. */
   getSkillCount() {
     return this.getSkillRefs().length;
+  }
+
+  getConditions() {
+    return this.jsonData.status?.conditions;
+  }
+
+  getCondition(type: string) {
+    return findAgentCondition(this.jsonData, type);
+  }
+
+  /** Readiness derived from the status conditions. See {@link AgentReadiness}. */
+  getReadiness(): AgentReadiness {
+    return deriveAgentReadiness(this.jsonData);
+  }
+
+  /**
+   * Human-readable detail for the current readiness, taken from whichever
+   * condition determined it: the reconcile error for `notAccepted`, and the
+   * controller's "N/M pods are ready" (or the Deployment lookup error) for
+   * `notReady`. `undefined` when the agent is ready, or when the state needs no
+   * explanation.
+   */
+  getReadinessMessage(): string | undefined {
+    switch (this.getReadiness()) {
+      case 'notAccepted':
+        return (
+          this.getCondition(AgentConditionType.Accepted)?.message || undefined
+        );
+      case 'notReady':
+        return (
+          this.getCondition(AgentConditionType.Ready)?.message || undefined
+        );
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Soft warning from the controller when the spec uses features the chosen
+   * runtime does not support. Independent of readiness — an agent can be fully
+   * ready and still carry this — so it is reported separately rather than
+   * folded into {@link getReadiness}.
+   */
+  getUnsupportedFeaturesWarning(): string | undefined {
+    const condition = this.getCondition(AgentConditionType.UnsupportedFeatures);
+
+    return condition?.status === 'True'
+      ? condition.message || undefined
+      : undefined;
   }
 }

--- a/plugins/kubernetes-react/src/lib/k8s/Agent.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/Agent.ts
@@ -19,16 +19,26 @@ export const AgentConditionType = {
 } as const;
 
 /**
- * Reasons the controller uses for `Ready=True`: `DeploymentReady` for a
- * Deployment-backed agent, `WorkloadReady` for a sandbox workload.
+ * Note on readiness and condition *reasons*.
  *
- * kagent's own REST API keys its `deploymentReady` flag on this reason set
- * rather than on `Ready=True` alone, so any other reason — notably
- * `Ready=Unknown` / `DeploymentNotFound`, which is what a missing Deployment
- * produces — counts as not ready. We match that deliberately, so this list and
- * kagent's UI agree on what "ready" means.
+ * kagent's own REST API gates its `deploymentReady` flag on both
+ * `Ready=True` *and* the reason being one of `DeploymentReady` (a
+ * Deployment-backed agent) or `WorkloadReady` (a sandbox workload). We
+ * deliberately do **not** copy that allowlist, and key on the condition's status
+ * alone.
+ *
+ * The allowlist's apparent purpose is to reject a missing Deployment, which the
+ * controller reports as `Ready=Unknown` / `DeploymentNotFound` — but that is
+ * already excluded by the status check, so the allowlist adds nothing for the
+ * case that motivates it. What it does add is a failure mode on version skew: a
+ * kagent that introduces a third ready reason (say `StatefulSetReady`) would make
+ * a healthy fleet render as "not ready", with a tooltip showing that condition's
+ * own message ("Deployment is ready") and thus contradicting the label.
+ *
+ * Trusting `Ready=True` fails in the opposite direction — a kagent that sets
+ * `Ready=True` to mean something other than ready — which would be a bug
+ * upstream rather than an expected evolution.
  */
-const READY_REASONS: string[] = ['DeploymentReady', 'WorkloadReady'];
 
 /**
  * Readiness of an agent, derived from its status conditions.
@@ -65,14 +75,22 @@ export function deriveAgentReadiness(json: AgentInterface): AgentReadiness {
     return 'pending';
   }
 
-  // The controller stamps `status.observedGeneration` on every status write,
-  // including when reconciliation *fails* — so a spec it genuinely rejects
-  // settles on `notAccepted` rather than sticking at `pending` forever.
+  // Staleness is only claimed when observedGeneration is actually present and
+  // behind. The controller stamps it on every status write (including when
+  // reconciliation *fails*, so a rejected spec settles on `notAccepted` rather
+  // than sticking at `pending`), but the CRD marks it optional — whereas
+  // `metadata.generation` is always set by the apiserver. Treating "absent" as
+  // "stale" would therefore fail closed: against a build that writes conditions
+  // but not `status.observedGeneration`, *every* agent on that installation would
+  // read `pending`, hiding healthy and broken agents behind the same
+  // explanation-free label. Absent means "cannot tell", so fall through and
+  // report what the conditions actually say.
   const { generation } = json.metadata ?? {};
   const observedGeneration = json.status?.observedGeneration;
   if (
     typeof generation === 'number' &&
-    (typeof observedGeneration !== 'number' || observedGeneration < generation)
+    typeof observedGeneration === 'number' &&
+    observedGeneration < generation
   ) {
     return 'pending';
   }
@@ -83,8 +101,8 @@ export function deriveAgentReadiness(json: AgentInterface): AgentReadiness {
     return 'notAccepted';
   }
 
-  const ready = findAgentCondition(json, AgentConditionType.Ready);
-  if (ready?.status !== 'True' || !READY_REASONS.includes(ready.reason)) {
+  // Status only, not reason — see the note above READY_REASONS' removal.
+  if (findAgentCondition(json, AgentConditionType.Ready)?.status !== 'True') {
     return 'notReady';
   }
 

--- a/plugins/kubernetes-react/src/lib/k8s/index.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/index.ts
@@ -6,7 +6,14 @@ export * from './versionUtils';
 export * from './CustomResourceMatcher';
 export * from './errorMessages';
 
-export { Agent } from './Agent';
+export {
+  Agent,
+  AgentConditionType,
+  deriveAgentReadiness,
+  getAgentStatusChangedAt,
+  isAgentTransitional,
+} from './Agent';
+export type { AgentReadiness } from './Agent';
 export { App } from './App';
 export { ClusterSecretStore } from './ClusterSecretStore';
 export { ConfigMap } from './ConfigMap';

--- a/plugins/ui-react/src/components/StatusLabel/StatusLabel.stories.tsx
+++ b/plugins/ui-react/src/components/StatusLabel/StatusLabel.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import HourglassEmptyIcon from '@material-ui/icons/HourglassEmpty';
+import { Flex } from '@backstage/ui';
+import { StatusLabel } from './StatusLabel';
+import { componentDocs } from '../../storybook/docs';
+
+const meta = {
+  title: 'Components/StatusLabel',
+  component: StatusLabel,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: componentDocs({
+          summary:
+            'An icon plus a label describing the state of something — a ' +
+            "workload's readiness, a run's outcome, a resource's health. The " +
+            'icon carries the colour (from a bui `--bui-fg-*` token) and the ' +
+            'label stays full-contrast text.',
+          whenToUse:
+            'Any time a status needs a name and a colour. Prefer this over ' +
+            "`@backstage/core-components`' `Status*`, which puts `aria-hidden` " +
+            'on a span wrapping both its icon and its children — so a label ' +
+            'passed as its child is hidden from screen readers and the status ' +
+            'reads as empty. Presentation only: wrap it in a table `Cell`, a ' +
+            'metadata row, or a card as needed.',
+          migration: 'none',
+        }),
+      },
+    },
+  },
+} satisfies Meta<typeof StatusLabel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { label: 'Ready', intent: 'positive' },
+};
+
+export const AllIntents: Story = {
+  args: { label: 'Ready', intent: 'positive' },
+  render: () => (
+    <Flex direction="column" gap="2">
+      <StatusLabel label="Ready" intent="positive" />
+      <StatusLabel label="Not ready" intent="warning" />
+      <StatusLabel label="Not accepted" intent="negative" />
+      <StatusLabel label="Informational" intent="info" />
+      <StatusLabel label="Unknown" intent="neutral" />
+    </Flex>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every intent has a distinct silhouette as well as a distinct ' +
+          'colour, so the state survives greyscale and colour blindness.',
+      },
+    },
+  },
+};
+
+export const WithDetail: Story = {
+  args: {
+    label: 'Not ready',
+    intent: 'warning',
+    title: 'Deployment is not ready, 0/1 pods are ready',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hover to see the underlying reason. Useful for surfacing a ' +
+          "controller's own message without spending a column on it.",
+      },
+    },
+  },
+};
+
+export const CustomIcon: Story = {
+  args: {
+    label: 'Pending',
+    intent: 'neutral',
+    icon: HourglassEmptyIcon,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Override the intent's default glyph when a domain has a more " +
+          'specific one — here an hourglass for "waiting", which reads better ' +
+          'than the neutral default circle.',
+      },
+    },
+  },
+};

--- a/plugins/ui-react/src/components/StatusLabel/StatusLabel.test.tsx
+++ b/plugins/ui-react/src/components/StatusLabel/StatusLabel.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import HourglassEmptyIcon from '@material-ui/icons/HourglassEmpty';
+import { StatusLabel, StatusLabelIntent } from './StatusLabel';
+
+const INTENTS: StatusLabelIntent[] = [
+  'positive',
+  'warning',
+  'negative',
+  'info',
+  'neutral',
+];
+
+describe('StatusLabel', () => {
+  it('renders the label as readable text', () => {
+    render(<StatusLabel label="Ready" intent="positive" />);
+
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+  });
+
+  // The reason this component exists: `core-components`' Status* hides its
+  // children from assistive tech, so a status rendered that way reads as empty.
+  it('keeps the label out of the icon, so it is not aria-hidden', () => {
+    const { container } = render(
+      <StatusLabel label="Not ready" intent="warning" />,
+    );
+
+    const icon = container.querySelector('svg');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon).not.toHaveTextContent('Not ready');
+    expect(screen.getByText('Not ready')).toBeInTheDocument();
+  });
+
+  it.each(INTENTS)('colours the icon from the %s bui token', intent => {
+    const { container } = render(<StatusLabel label="State" intent={intent} />);
+
+    const wrapper = container.querySelector('span[style]');
+    // Deliberately asserts a `--bui-fg-*` custom property is used rather than a
+    // literal colour, so the status themes with the rest of the app.
+    expect(wrapper?.getAttribute('style')).toMatch(/var\(--bui-fg-[a-z]+\)/);
+  });
+
+  it('gives each intent a distinct default icon, so colour is not the only cue', () => {
+    const paths = INTENTS.map(intent => {
+      const { container, unmount } = render(
+        <StatusLabel label="State" intent={intent} />,
+      );
+      const d = container.querySelector('path')?.getAttribute('d') ?? '';
+      unmount();
+      return d;
+    });
+
+    expect(paths.every(Boolean)).toBe(true);
+    expect(new Set(paths).size).toBe(INTENTS.length);
+  });
+
+  it('accepts an icon override for domain-specific glyphs', () => {
+    const { container: withDefault } = render(
+      <StatusLabel label="Pending" intent="neutral" />,
+    );
+    const defaultPath = withDefault.querySelector('path')?.getAttribute('d');
+
+    const { container: withOverride } = render(
+      <StatusLabel
+        label="Pending"
+        intent="neutral"
+        icon={HourglassEmptyIcon}
+      />,
+    );
+    const overriddenPath = withOverride
+      .querySelector('path')
+      ?.getAttribute('d');
+
+    expect(overriddenPath).toBeTruthy();
+    expect(overriddenPath).not.toBe(defaultPath);
+  });
+
+  it('exposes the detail as a hover title', () => {
+    render(
+      <StatusLabel
+        label="Not ready"
+        intent="warning"
+        title="Deployment is not ready, 0/1 pods are ready"
+      />,
+    );
+
+    expect(
+      screen.getByTitle('Deployment is not ready, 0/1 pods are ready'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders no title attribute when there is no detail', () => {
+    const { container } = render(
+      <StatusLabel label="Ready" intent="positive" />,
+    );
+
+    expect(container.querySelector('[title]')).toBeNull();
+  });
+});

--- a/plugins/ui-react/src/components/StatusLabel/StatusLabel.tsx
+++ b/plugins/ui-react/src/components/StatusLabel/StatusLabel.tsx
@@ -1,0 +1,116 @@
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import ErrorIcon from '@material-ui/icons/Error';
+import InfoIcon from '@material-ui/icons/Info';
+import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
+import ReportProblemIcon from '@material-ui/icons/ReportProblem';
+import { Flex, Text } from '@backstage/ui';
+
+/**
+ * What a status *means*, independent of the colour it happens to render as.
+ *
+ * These follow bui's current token vocabulary (`--bui-fg-positive` and friends)
+ * rather than the `success`/`danger` spelling still used by bui's `Text` `color`
+ * prop — at the token level those names are deprecated
+ * (`@backstage/no-deprecated-bui-tokens`), and `neutral` has no equivalent in the
+ * prop set at all.
+ */
+export type StatusLabelIntent =
+  'positive' | 'warning' | 'negative' | 'info' | 'neutral';
+
+/**
+ * bui's current semantic foreground token per intent. Applied as the icon
+ * wrapper's `color`, which the icon inherits through `fill: currentColor`, so a
+ * status has exactly one colour source and adapts to light and dark.
+ */
+const INTENT_TOKEN: Record<StatusLabelIntent, string> = {
+  positive: '--bui-fg-positive',
+  warning: '--bui-fg-warning',
+  negative: '--bui-fg-negative',
+  info: '--bui-fg-announcement',
+  neutral: '--bui-fg-secondary',
+};
+
+/**
+ * Default icon per intent. Each is a filled Material variant with a distinct
+ * silhouette — tick, triangle, circle, and so on — so a status stays legible
+ * when colour is unavailable or unreliable (colour blindness, greyscale print).
+ * Override via {@link StatusLabelProps.icon} when a domain has a more specific
+ * glyph, e.g. an hourglass for "waiting".
+ */
+const INTENT_ICON: Record<StatusLabelIntent, typeof CheckCircleIcon> = {
+  positive: CheckCircleIcon,
+  warning: ReportProblemIcon,
+  negative: ErrorIcon,
+  info: InfoIcon,
+  neutral: RadioButtonUncheckedIcon,
+};
+
+/**
+ * Icon size, pinned rather than inherited, so every status in a list is the same
+ * size regardless of the surrounding typography. (Material's icons size against
+ * `MuiSvgIcon`'s own hardcoded font size, which does not track the label's.)
+ */
+const ICON_SIZE = '1.2rem';
+
+export type StatusLabelProps = {
+  /** Visible text. Kept as real text so assistive tech reads the status. */
+  label: string;
+  /** What the status means; selects the colour and the default icon. */
+  intent: StatusLabelIntent;
+  /**
+   * Icon override for domains with a more specific glyph than the intent's
+   * default. Pass a Material icon component, e.g. `HourglassEmpty`.
+   */
+  icon?: typeof CheckCircleIcon;
+  /**
+   * Detail shown on hover — typically the underlying reason a status is not
+   * healthy. Rendered as a `title`, so keep it short enough to read as a
+   * tooltip.
+   */
+  title?: string;
+};
+
+/**
+ * An icon plus a label describing the state of something: a workload's
+ * readiness, a run's outcome, a resource's health.
+ *
+ * Presentation only, and deliberately not wrapped in any layout — put it inside
+ * a table `Cell`, a metadata row, or a card as needed.
+ *
+ * Two details it exists to get right once, both of which are easy to get wrong
+ * per call site:
+ *
+ * - **The label is a sibling of the icon, never its child.** Material renders
+ *   icons `aria-hidden`, so a label nested inside one is hidden from assistive
+ *   tech too and the status reads as empty. (This is also why this does not
+ *   build on `@backstage/core-components`' `Status*`, which puts `aria-hidden`
+ *   on a span wrapping both its icon *and* its children.)
+ * - **Colour comes from a single bui token**, inherited by the icon via
+ *   `currentColor`, instead of the icon and text being coloured independently.
+ *
+ * The label itself stays in the default text colour: colour is carried by the
+ * icon, so the text keeps full contrast against the background.
+ */
+export const StatusLabel = ({
+  label,
+  intent,
+  icon,
+  title,
+}: StatusLabelProps) => {
+  const Icon = icon ?? INTENT_ICON[intent];
+
+  return (
+    <Flex align="center" gap="2" title={title}>
+      <span
+        style={{
+          display: 'flex',
+          color: `var(${INTENT_TOKEN[intent]})`,
+          fontSize: ICON_SIZE,
+        }}
+      >
+        <Icon fontSize="inherit" />
+      </span>
+      <Text variant="body-medium">{label}</Text>
+    </Flex>
+  );
+};

--- a/plugins/ui-react/src/components/StatusLabel/index.ts
+++ b/plugins/ui-react/src/components/StatusLabel/index.ts
@@ -1,0 +1,2 @@
+export { StatusLabel } from './StatusLabel';
+export type { StatusLabelIntent, StatusLabelProps } from './StatusLabel';

--- a/plugins/ui-react/src/components/index.ts
+++ b/plugins/ui-react/src/components/index.ts
@@ -18,6 +18,7 @@ export * from './PageHeaderActions';
 export * from './SectionHeader';
 export * from './SingleSelect';
 export * from './StackedBarChart';
+export * from './StatusLabel';
 export * from './StructuredMetadataList';
 export * from './YamlEditor';
 export * from './YamlEditorFormField';


### PR DESCRIPTION
### What does this PR do?

Adds a **Status** column to the agents list (`/agent-platform/agents`), which previously showed no readiness signal at all, and makes the list poll so that status stays current.

Readiness is derived from the kagent `Agent`'s `status.conditions` — the same data kagent's own REST API projects into its `accepted` / `deploymentReady` flags, so our states and kagent's UI agree on what each state means.

One deliberate divergence: kagent's API additionally requires the `Ready` condition's **reason** to be `DeploymentReady` or `WorkloadReady`, and we key on the status alone. That allowlist's only apparent purpose is to reject a missing Deployment (`Ready=Unknown`/`DeploymentNotFound`), which the status check already rejects — while a kagent that adds a third ready reason would make a healthy fleet render as "not ready" with a tooltip contradicting the label.

Because we already read the `Agent` CRs directly, this needs no new requests and no dependency on the kagent REST transport.

| State | Meaning |
|---|---|
| **Ready** | Accepted, and the backing workload has an available replica |
| **Not ready** | Accepted, but the workload is not up |
| **Not accepted** | The controller rejected the spec |
| **Pending** | Not reconciled yet, or reconciled against an older generation |

**Pending** has no equivalent in kagent's UI. It covers an agent whose `status.observedGeneration` still lags `metadata.generation`, so a just-edited agent reads as "not known yet" instead of presenting stale conditions as fact.

Also in scope:

- A new shared **`StatusLabel`** in `ui-react` (icon + label + intent colour), which this list is the first consumer of. It is built on bui rather than `core-components`, and exists mainly to get two things right once: keeping the label readable by assistive tech, and giving each intent a distinct silhouette so a status does not depend on colour alone.
- **Polling**, two-tier and evaluated per installation: 60s normally (equal to the query client's `staleTime`, so an interval refetch never undercuts data the client considers fresh), dropping to 5s for an installation that has an agent still converging. An agent non-ready for over 3 minutes is treated as durably broken and falls back to the baseline — without that bound a permanently broken agent pins its installation to the fast interval for as long as a tab stays open, which is what kagent's own UI does. Interval refetches only run while the tab is focused.
- **Sortable columns**, matching the sessions list. Status sorts by severity rather than alphabetically, so one click brings problems to the top. The default order is unchanged (installation, then name).
- The **"loading more agents" bar** now means "an installation has not reported its first result yet" rather than "a request is in flight". With polling the old meaning made it flash during steady state, and since it sits above the table it pushed the table down every minute. Its slot is now a fixed height so toggling it cannot shift the table.

### What is the effect of this change to users?

Agent health is visible directly in the list, and non-ready agents explain themselves on hover using the controller's own message — the reconcile error, or `"Deployment is not ready, N/M pods are ready"`. In testing, a real broken agent surfaced its full Kyverno admission rejection (`disallow-capabilities-strict`, `disallow-privilege-escalation`, `require-run-as-nonroot`) without needing a `kubectl` round-trip.

The list also keeps itself current instead of needing a manual reload after creating an agent.

Pagination stays off, unlike the sessions list. bui's `useCompletePagination` never resets its offset when the data shrinks, so in a polling list a deletion elsewhere could leave the offset past the end of a shrunken list and show "No agents found." while agents exist. Sorting works without it.

### How does it look like?

<img width="734" height="362" alt="image" src="https://github.com/user-attachments/assets/a517eb0f-da7e-4988-bd77-b870117720ba" />


Icons are the filled Material variants with four distinct silhouettes — circle-with-tick, triangle, circle-with-`!`, hourglass — so the state is legible without relying on colour alone. Colours use bui's current semantic tokens (`--bui-fg-positive` / `-warning` / `-negative` / `-secondary`), so they adapt to light and dark.

| State | Icon | Colour |
|---|---|---|
| Ready | `CheckCircle` | positive (green) |
| Not ready | `ReportProblem` | warning (amber) |
| Not accepted | `Error` | negative (red) |
| Pending | `HourglassEmpty` | secondary (grey) |

All four states were verified in the running app, along with a full poll cycle showing no layout shift.

### Any background context you can provide?

The behaviour is deliberately aligned with kagent upstream (`kagent-dev/kagent`), specifically `go/core/internal/controller/reconciler/reconciler.go` for which conditions and reasons the controller sets, `go/core/internal/httpserver/handlers/agents.go` for how the REST API projects them, and `ui/src/components/AgentListView.tsx` for the state naming and wording.

Two implementation notes for reviewers:

- The status presentation lives in the new shared `ui-react` `StatusLabel`, not in `@backstage/core-components`' `Status*`. `Status*` puts `aria-hidden="true"` on the span wrapping both its icon *and* its children, so a label passed as its child is hidden from assistive tech and the cell reads as empty. It also hardcodes its icons and applies `position: relative; top: 3px` plus an 8px right margin sized for a 16px label rendered inside it, and its colours come from `theme.palette.status.*` so they cannot be themed with bui tokens. `StatusLabel` owns the markup instead, letting the icon inherit its colour from a single `--bui-fg-*` token via `currentColor`. `agent-platform` keeps only the readiness-to-presentation mapping.
- The readiness derivation lives in `kubernetes-react` as both `Agent` methods and free functions over the raw interface, so the `refetchInterval` callback — which sees `KubeObjectInterface[]`, not hydrated instances — reuses the identical logic rather than reimplementing it.

The remaining `Status*` users — `gs`'s `DeploymentStatus` (15 consumers) and `ClusterStatus`, `muster`'s `ExecutionStatusBadge`, and `flux-react`'s hand-rolled dot — are deliberately left alone. They sit in MUI tables where their current MUI typography matches its surroundings, so converting them now would introduce a font mismatch; they can adopt `StatusLabel` as their pages move to bui.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

