### PR TITLE
feat(agent-platform): add an agent details page

### DIFF
--- a/.changeset/agent-platform-agent-detail-page.md
+++ b/.changeset/agent-platform-agent-detail-page.md
@@ -94,6 +94,17 @@ does not exist. The "Deployed by" row remains, and is the whole truth for such a
 agent. The gs cluster and deployment pages gate on `isManagedByFlux` and so always
 have a Kustomization already; their behaviour is unchanged.
 
+**New in `ui-react`: `SimpleAccordion`** — one collapsible section, carrying the
+bottom padding bui's accordion trigger lacks, so an expanded header does not sit
+flush against its panel. Four places had composed bui's accordion primitives
+directly and fixed that locally in three different ways — one of them with a
+selector scoped to the trigger element rather than the button that actually carries
+`aria-expanded`, so it matched nothing. gs's `SimpleAccordion` re-exports this one
+and gains the fix; `useSimpleAccordionStyles` exposes the rule for cases needing
+controlled or exclusive expansion. `plans`' `MergedTab`, agent-platform's
+`TimelineEntry` and muster's `DisclosureAccordion` still carry their own and could
+adopt it.
+
 **New in `ui-react`: `ConditionsList`** — a bui renderer for a resource's status
 conditions. One collapsible entry per condition with its type, satisfaction, relative
 transition time, reason and message; newest transition first, and the first failing

--- a/.changeset/agent-platform-agent-detail-page.md
+++ b/.changeset/agent-platform-agent-detail-page.md
@@ -16,6 +16,13 @@ from, and deleting one must remove only that release and never the `OCIRepositor
 namespace's agents share — so neither is a menu item yet, and neither is "Launch
 session".
 
+Two columns from `lg` up, one below: the **status card takes a third of the width,
+beside the configuration**, and everything under that row spans the full width.
+Status is the one section that does not want the whole page — a rejected spec's
+admission-webhook message is several hundred words of prose, and across a full-width
+card it runs to line lengths nobody can follow. The sections below it do use the
+width: three skill cards per row, four columns in the sessions table.
+
 The page has seven sections:
 
 - **Header** — avatar, display name, derived readiness, technical name,

--- a/.changeset/agent-platform-agent-detail-page.md
+++ b/.changeset/agent-platform-agent-detail-page.md
@@ -16,7 +16,7 @@ from, and deleting one must remove only that release and never the `OCIRepositor
 namespace's agents share — so neither is a menu item yet, and neither is "Launch
 session".
 
-The page has six sections:
+The page has seven sections:
 
 - **Header** — avatar, display name, derived readiness, technical name,
   installation/namespace, creation age, description. A kebab in the shared plugin
@@ -25,7 +25,8 @@ The page has six sections:
   reconciled Agent) and the `last-applied-configuration` annotation. That dialog is
   the escape hatch for what the page does not surface — `deployment`, `sandbox`,
   `a2aConfig`, labels.
-- **GitOps** — the shared `GitOpsCard`, whenever a reconciler owns the agent.
+- **GitOps** — the shared `GitOpsCard`, but only when the agent's desired state
+  really is in Git.
 - **Status** — readiness, the controller's explanation, an `UnsupportedFeatures`
   warning when present, a note naming both generations when the status is stale, and
   every condition verbatim. This is what makes a broken agent debuggable without
@@ -36,6 +37,12 @@ The page has six sections:
   links to muster's Tool Explorer with the installation preselected.
 - **System prompt** — copyable. An unset value says so explicitly: the agent still
   has a prompt, just not one configured here.
+- **Skills** — the same card grid the create flow's picker uses, so an agent's
+  skills look like the things that were picked, plus the `ref` each is pinned to
+  (the picker has no equivalent: it always reads a repo's default branch). Via a new
+  read-only `StaticCard` sharing the picker's card shell — deliberately not a
+  `SelectableCard` with the indicator hidden, since a `role="checkbox"` button that
+  does nothing is announced as operable and invites a click with no effect.
 - **Recent sessions** — the newest few, over a single-installation query sharing the
   Sessions tab's cache key.
 
@@ -76,10 +83,16 @@ which is rendered by a Helm chart and so carries `helm.toolkit.fluxcd.io/*` rath
 than Kustomization labels. `GitOpsCard` therefore gained a hop — with no
 Kustomization label of its own it resolves the owning `HelmRelease` and follows
 _its_ labels to the Kustomization and GitRepository — and now takes any `KubeObject`
-as `resource` instead of an `App`/`HelmRelease` as `deployment`. Where that chain
-ends without a Kustomization it renders **without** a Source link rather than a dead
-one, which is exactly an agent created by this plugin: applied through the
-scaffolder, so Flux-reconciled but not in Git.
+as `resource` instead of an `App`/`HelmRelease` as `deployment`.
+
+It also stops equating "reconciled by Flux" with "GitOps-managed": where that chain
+ends without a Kustomization it now renders **nothing**. An agent created through
+this plugin is exactly that case, since the create flow applies its `HelmRelease` and
+`OCIRepository` through the scaffolder — Flux reconciles the agent, but no file in
+Git describes it, and saying otherwise sends the reader looking for something that
+does not exist. The "Deployed by" row remains, and is the whole truth for such an
+agent. The gs cluster and deployment pages gate on `isManagedByFlux` and so always
+have a Kustomization already; their behaviour is unchanged.
 
 **New in `ui-react`: `ConditionsList`** — a bui renderer for a resource's status
 conditions. One collapsible entry per condition with its type, satisfaction, relative

--- a/.changeset/agent-platform-agent-detail-page.md
+++ b/.changeset/agent-platform-agent-detail-page.md
@@ -99,11 +99,14 @@ bottom padding bui's accordion trigger lacks, so an expanded header does not sit
 flush against its panel. Four places had composed bui's accordion primitives
 directly and fixed that locally in three different ways — one of them with a
 selector scoped to the trigger element rather than the button that actually carries
-`aria-expanded`, so it matched nothing. gs's `SimpleAccordion` re-exports this one
-and gains the fix; `useSimpleAccordionStyles` exposes the rule for cases needing
-controlled or exclusive expansion. `plans`' `MergedTab`, agent-platform's
-`TimelineEntry` and muster's `DisclosureAccordion` still carry their own and could
-adopt it.
+`aria-expanded`, so it matched nothing. `useSimpleAccordionStyles` exposes the rule
+on its own, for cases needing controlled or exclusive expansion.
+
+gs's own `SimpleAccordion` is removed in favour of this one — its two call sites
+(the cluster access card and the workload details pane) import from `ui-react`
+directly and gain the spacing they never had. `plans`' `MergedTab`,
+agent-platform's `TimelineEntry` and muster's `DisclosureAccordion` still carry
+their own copies of the fix and could adopt it.
 
 **New in `ui-react`: `ConditionsList`** — a bui renderer for a resource's status
 conditions. One collapsible entry per condition with its type, satisfaction, relative

--- a/.changeset/agent-platform-agent-detail-page.md
+++ b/.changeset/agent-platform-agent-detail-page.md
@@ -1,0 +1,89 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+'@giantswarm/backstage-plugin-kubernetes-react': minor
+'@giantswarm/backstage-plugin-ui-react': minor
+'@giantswarm/backstage-plugin-flux-react': minor
+'@giantswarm/backstage-plugin-muster': patch
+'@giantswarm/backstage-plugin-gs': patch
+---
+
+Add the agent detail page. Clicking an agent in the list now opens
+`/agent-platform/agents/<installation>/<namespace>/<name>` — all three segments,
+because an `Agent` name is only unique within a namespace on one installation.
+
+**Read-only.** Editing an agent means changing the values its HelmRelease renders
+from, and deleting one must remove only that release and never the `OCIRepository` a
+namespace's agents share — so neither is a menu item yet, and neither is "Launch
+session".
+
+The page has six sections:
+
+- **Header** — avatar, display name, derived readiness, technical name,
+  installation/namespace, creation age, description. A kebab in the shared plugin
+  header opens a **manifest dialog** with the Agent CR as read-only YAML, minus
+  `metadata.managedFields` (server-side-apply bookkeeping, and the bulk of a
+  reconciled Agent) and the `last-applied-configuration` annotation. That dialog is
+  the escape hatch for what the page does not surface — `deployment`, `sandbox`,
+  `a2aConfig`, labels.
+- **GitOps** — the shared `GitOpsCard`, whenever a reconciler owns the agent.
+- **Status** — readiness, the controller's explanation, an `UnsupportedFeatures`
+  warning when present, a note naming both generations when the status is stale, and
+  every condition verbatim. This is what makes a broken agent debuggable without
+  `kubectl`, so it leads the page rather than following the configuration.
+- **Configuration** — type, model, installation, namespace, created, the owning
+  HelmRelease (linked to its deployment page, where the release's Flux status already
+  lives), and the MCP-server and agent tool references. A Muster gateway reference
+  links to muster's Tool Explorer with the installation preselected.
+- **System prompt** — copyable. An unset value says so explicitly: the agent still
+  has a prompt, just not one configured here.
+- **Recent sessions** — the newest few, over a single-installation query sharing the
+  Sessions tab's cache key.
+
+Decisions worth knowing:
+
+- **No stats strip.** The prototype's sessions all-time / sessions 30d / success rate
+  have no data behind them: kagent keeps no per-agent counters and scopes its session
+  list to the caller, so each would be a number invented from one person's history —
+  wrong by orders of magnitude on a shared agent. Creation age moved into the header
+  instead. The sessions section says whose sessions they are, and switches wording on
+  an installation whose kagent is not user-scoped rather than claiming ownership it
+  cannot.
+- **The agent is fetched directly**, not read out of the list's provider, so a deep
+  link works without the list having loaded. It polls on the same two tiers as the
+  list (`isAgentConverging` is now shared): 5 s while converging, 60 s once settled or
+  durably broken.
+- **The model is read by name in the agent's own namespace**, not through the
+  cluster-wide `ModelConfigsProvider` list, which is admin-only — reusing it would
+  deny a non-admin the model name on a page they can otherwise read in full. A failed
+  read falls back to the bare reference, never to "no model".
+- **A missing agent is a not-found state, not an error**, and the copy covers the
+  case where kagent simply isn't installed on that installation.
+- **Rows link with a real anchor** on the agent name as well as a whole-row click, so
+  cmd- and middle-click open a new tab and keyboard users have something focusable.
+  Not `rowConfig.getHref`: `BUIProvider` is not mounted in this app, so react-aria's
+  `RouterProvider` is inactive and a bui `href` would trigger a full page reload. The
+  `stopRowPress` guard that keeps both affordances from firing on one click is now
+  shared between the agents and sessions tables.
+
+**GitOps provenance is de-duplicated.** `readProvenance` / `isGitOpsManaged` /
+`provenanceReleaseId` (previously in `muster`) and `isManagedByFlux` with the
+Kustomization label readers (previously in `flux-react`) now live in one module in
+`kubernetes-react`, alongside new `getHelmReleaseName`/`getHelmReleaseNamespace`.
+`flux-react` and `muster` re-export from it, so their public APIs are unchanged.
+
+The distinction mattered here: `isManagedByFlux` is **false** for a kagent `Agent`,
+which is rendered by a Helm chart and so carries `helm.toolkit.fluxcd.io/*` rather
+than Kustomization labels. `GitOpsCard` therefore gained a hop — with no
+Kustomization label of its own it resolves the owning `HelmRelease` and follows
+_its_ labels to the Kustomization and GitRepository — and now takes any `KubeObject`
+as `resource` instead of an `App`/`HelmRelease` as `deployment`. Where that chain
+ends without a Kustomization it renders **without** a Source link rather than a dead
+one, which is exactly an agent created by this plugin: applied through the
+scaffolder, so Flux-reconciled but not in Git.
+
+**New in `ui-react`: `ConditionsList`** — a bui renderer for a resource's status
+conditions. One collapsible entry per condition with its type, satisfaction, relative
+transition time, reason and message; newest transition first, and the first failing
+condition expanded, because that is the one the reader came for. Takes an `isFailing`
+override for abnormal-true conditions (`Stalled`, `UnsupportedFeatures`), where
+`status: True` is the bad news.

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -541,6 +541,100 @@ three minutes, and printed "1 day ago" identically on every turn marker — hidi
 the progression the timeline exists to show. The list keeps the relative form,
 where scanning for recency is the point.
 
+## The agent detail page
+
+`/agent-platform/agents/<installation>/<namespace>/<name>`, reached by clicking an
+agent in the list. All three segments are in the path because all three are part of
+the agent's identity — an `Agent` name is only unique within a namespace on one
+installation.
+
+Read-only. Editing an agent means changing the values its HelmRelease renders from,
+and deleting one must remove only that release and never the `OCIRepository` a
+namespace's agents share (see "Shared OCIRepository per namespace"), so neither is
+a menu item yet.
+
+The agent is fetched with a **single targeted `useResource`**, not read out of the
+list's `AgentsDataProvider`, so a deep link works without the list having loaded.
+It polls on the same two tiers as the list (`isAgentConverging` is now shared):
+5 s while an agent is converging, 60 s once it settles or stays durably broken.
+
+### Sections
+
+- **Header** — avatar, display name, derived readiness, technical name,
+  installation/namespace, creation age, description. A kebab in the shared plugin
+  header opens the **manifest dialog**: the Agent CR as read-only YAML, minus
+  `metadata.managedFields` (server-side-apply bookkeeping, and the bulk of a
+  reconciled Agent) and the `last-applied-configuration` annotation. That dialog is
+  the escape hatch for everything the page does not surface — `deployment`,
+  `sandbox`, `a2aConfig`, labels.
+- **GitOps** — the shared `GitOpsCard` from `flux-react`, shown whenever a
+  reconciler owns the agent. See "GitOps provenance" below.
+- **Status** — the readiness label, the controller's own explanation, an
+  `UnsupportedFeatures` warning when present, a note naming both generations when
+  the status is stale, and every condition verbatim through the new
+  `ConditionsList` in `ui-react`. This is what makes a broken agent debuggable
+  without `kubectl`, so it leads the page.
+- **Configuration** — type, model, installation, namespace, created, the owning
+  HelmRelease (linked to the gs deployment details page, where the release's Flux
+  status already lives), and the agent's MCP-server and agent tool references.
+- **System prompt** — `spec.declarative.systemMessage`, copyable. An unset value
+  says so explicitly: the agent still has a prompt, just not one configured here.
+- **Skills** — each `spec.skills.gitRefs` entry with its repository, path and
+  `ref`. Unpinned refs are labelled "default branch (unpinned)", because that is
+  what makes an agent's behaviour change without its spec changing.
+- **Recent sessions** — see below.
+
+### The model is read directly, not from the fleet list
+
+The ModelConfig is fetched by name in the agent's own namespace, rather than
+reusing `ModelConfigsProvider`. That provider lists ModelConfigs **across all
+namespaces**, which is admin-only (see "Installation / ModelConfig querying"), so
+reusing it here would deny a non-admin the model name on a page they can otherwise
+read in full. When the read fails the bare reference name is shown — never an
+implication that the agent has no model.
+
+### GitOps provenance
+
+Provenance detection is now **one implementation** in `kubernetes-react`
+(`lib/k8s/provenance.ts`): `readProvenance` / `isGitOpsManaged` /
+`provenanceReleaseId` (previously in `muster`) alongside `isManagedByFlux` and the
+Kustomization label readers (previously in `flux-react`), plus new
+`getHelmReleaseName`/`getHelmReleaseNamespace`. `flux-react` and `muster` re-export
+from it, so their public APIs are unchanged.
+
+`isManagedByFlux` (Kustomization labels only) is **false for our Agents**: they are
+rendered by a Helm chart, so they carry `helm.toolkit.fluxcd.io/*` instead. The
+shared `GitOpsCard` therefore gained a hop — when a resource has no Kustomization
+label of its own it resolves the owning `HelmRelease` and follows _its_ labels to
+the Kustomization and GitRepository. It now takes any `KubeObject` as `resource`
+rather than an `App`/`HelmRelease` as `deployment`.
+
+Where that chain ends without a Kustomization, the card renders **without** a
+Source link rather than a dead one. That is exactly the case for an agent created
+by this plugin: the create flow applies its HelmRelease through the scaffolder, so
+the agent is Flux-reconciled but its desired state is not in Git.
+
+### Recent sessions are yours, not a usage metric
+
+The section reuses `SessionsTable` (with the agent and installation columns hidden
+— the page already fixes both) over a **single-installation** query that shares the
+Sessions tab's cache key, so no fleet fan-out happens and arriving from that tab
+renders instantly.
+
+kagent scopes its session list to the caller, so this can only ever show your own
+conversations with the agent, and the copy says so. On an installation running
+kagent in `unsecure` mode the list is everyone's, which the existing `/me` probe
+already detects — the copy switches rather than claiming ownership it cannot.
+
+### What it cannot show
+
+The prototype's stats strip — sessions all-time, sessions in the last 30 days, a
+success rate — has **no data behind it**. kagent keeps no per-agent counters and
+scopes sessions to the caller, so every one of those would be a number invented
+from one person's history, wrong by orders of magnitude on a shared agent. There is
+deliberately no stats strip; creation age moved into the header instead. Please
+don't add them speculatively.
+
 ## Configuration
 
 All under `agentPlatform` (see `plugins/agent-platform/config.d.ts` and
@@ -635,19 +729,21 @@ above). What remains is a separate, deeper concern:
   `spec.skills.gitAuthSecretRef` wired (the field exists in the CRD/chart but the
   create flow doesn't set it); (2) discovery reads a repo's **default branch** and
   doesn't expose per-skill version/`ref` selection in the UI.
-- **Agent management actions.** The agent list exists; management does not. A
-  delete action must respect the shared `OCIRepository/agent` (see "Shared
-  OCIRepository per namespace") — delete only the agent's `HelmRelease`, not the
-  shared source.
+- **Agent write actions.** The list and the detail page exist; every write path
+  does not. Editing an agent means changing the values its HelmRelease renders
+  from — so it needs the create flow's form driven from an existing agent, plus a
+  decision about whether that produces a live apply or a PR (GitOps-managed agents
+  are read-only, see "GitOps provenance"). A delete action must respect the shared
+  `OCIRepository/agent` (see "Shared OCIRepository per namespace") — delete only
+  the agent's `HelmRelease`, not the shared source. "Launch session" also has no
+  write path today.
 - **Session management + detail.** The Sessions tab is read-only. kagent supports
   deleting (soft) and renaming sessions, and exposes a session's events and A2A
   tasks — enough for a detail view. Deliberately deferred: rename in particular
   deviates from the prototype, where sessions are never user-named.
-- **Main menu entry + landing page.** The plugin is not yet surfaced in the main
-  sidebar menu. Adding it requires deciding **what page the entry leads to** —
-  there is no landing page yet (only the create flow and a minimal index). The
-  natural target is the agent list/management view above; until that exists the
-  entry could point straight at the create flow. Decision needed.
+- **Landing page.** The section still opens on the Agents tab. Whether the
+  platform wants a proper landing page above the tabs — fleet health, recent
+  activity — is an open product question, not a gap in the tabs themselves.
 
 ### UX
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -558,6 +558,18 @@ list's `AgentsDataProvider`, so a deep link works without the list having loaded
 It polls on the same two tiers as the list (`isAgentConverging` is now shared):
 5 s while an agent is converging, 60 s once it settles or stays durably broken.
 
+### Layout
+
+Two columns from `lg` (1024px) up, one below. The **status card takes a third of
+the width, beside the configuration**; everything under that row spans the full
+width.
+
+Status is the one section that does not want the whole page. A controller message
+is prose — a rejected spec carries several hundred words of admission-webhook
+output — and across a full-width card it runs to line lengths nobody can follow. A
+narrower column is the fix. The sections below it genuinely use the width: the
+skills grid fits three cards per row, and the sessions table has four columns.
+
 ### Sections
 
 - **Header** — avatar, display name, derived readiness, technical name,

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -567,8 +567,8 @@ It polls on the same two tiers as the list (`isAgentConverging` is now shared):
   reconciled Agent) and the `last-applied-configuration` annotation. That dialog is
   the escape hatch for everything the page does not surface — `deployment`,
   `sandbox`, `a2aConfig`, labels.
-- **GitOps** — the shared `GitOpsCard` from `flux-react`, shown whenever a
-  reconciler owns the agent. See "GitOps provenance" below.
+- **GitOps** — the shared `GitOpsCard` from `flux-react`, shown only when the
+  agent's desired state really is in Git. See "GitOps provenance" below.
 - **Status** — the readiness label, the controller's own explanation, an
   `UnsupportedFeatures` warning when present, a note naming both generations when
   the status is stale, and every condition verbatim through the new
@@ -580,8 +580,13 @@ It polls on the same two tiers as the list (`isAgentConverging` is now shared):
 - **System prompt** — `spec.declarative.systemMessage`, copyable. An unset value
   says so explicitly: the agent still has a prompt, just not one configured here.
 - **Skills** — each `spec.skills.gitRefs` entry with its repository, path and
-  `ref`. Unpinned refs are labelled "default branch (unpinned)", because that is
-  what makes an agent's behaviour change without its spec changing.
+  `ref`, in the **same card grid the create flow's skill picker uses**, so an
+  agent's skills look like the things that were picked. Read-only, via a new
+  `StaticCard` sharing the picker's card shell: deliberately not a `SelectableCard`
+  with the indicator hidden, since a `role="checkbox"` button that does nothing is
+  announced as operable and invites a click with no effect. Unpinned refs are
+  labelled "default branch (unpinned)", because that is what makes an agent's
+  behaviour change without its spec changing.
 - **Recent sessions** — see below.
 
 ### The model is read directly, not from the fleet list
@@ -609,10 +614,18 @@ label of its own it resolves the owning `HelmRelease` and follows _its_ labels t
 the Kustomization and GitRepository. It now takes any `KubeObject` as `resource`
 rather than an `App`/`HelmRelease` as `deployment`.
 
-Where that chain ends without a Kustomization, the card renders **without** a
-Source link rather than a dead one. That is exactly the case for an agent created
-by this plugin: the create flow applies its HelmRelease through the scaffolder, so
-the agent is Flux-reconciled but its desired state is not in Git.
+**Reconciled by Flux is not the same as GitOps-managed**, and the card now draws
+that line: where the chain ends without a Kustomization it renders **nothing**. An
+agent created through this plugin is exactly that case — the create flow applies its
+`HelmRelease` and `OCIRepository` through the scaffolder, so Flux reconciles the
+agent but no file in Git describes it. Claiming GitOps there is wrong in the way
+that matters, because it tells the reader to go and edit something that does not
+exist. The "Deployed by" row stays, and is the whole truth for such an agent.
+
+The page still pre-gates on `isGitOpsManaged`: with no Flux or Helm marker at all
+there is nothing to resolve, so the lookups are skipped entirely. The gs cluster and
+deployment pages gate on `isManagedByFlux` and therefore always have a Kustomization
+already, so their behaviour is unchanged.
 
 ### Recent sessions are yours, not a usage metric
 

--- a/packages/app/src/utils/telemetry.test.ts
+++ b/packages/app/src/utils/telemetry.test.ts
@@ -300,6 +300,31 @@ describe('getTelemetryPageViewPayload', () => {
     });
   });
 
+  it('should return correct payload for one agent', () => {
+    // No `view`: the path names an installation, a namespace and an agent, so
+    // echoing them would emit a page name per agent — and record which
+    // installations a user reads.
+    const result = getTelemetryPageViewPayload(
+      '/agent-platform/agents/gazelle/agentic-platform/pr-reviewer',
+    );
+    expect(result).toEqual({
+      page: 'Agent detail',
+      path: '/agent-platform/agents/gazelle/agentic-platform/pr-reviewer',
+    });
+  });
+
+  // The agent-detail pattern matches exactly three segments under `agents/`, so
+  // the create flow must keep reporting through the generic agent-platform case.
+  it('should not treat the create flow as an agent detail page', () => {
+    expect(
+      getTelemetryPageViewPayload('/agent-platform/agents/new/review'),
+    ).toEqual({
+      page: 'Agents',
+      view: 'agents/new/review',
+      path: '/agent-platform/agents/new/review',
+    });
+  });
+
   it('should return correct payload for metrics page', () => {
     const result = getTelemetryPageViewPayload('/metrics');
     expect(result).toEqual({
@@ -361,6 +386,7 @@ describe('getTelemetryPageViewPayload', () => {
       '/agent-platform/agents/new',
       '/agent-platform/agents/new/skills',
       '/agent-platform/agents/new/review',
+      '/agent-platform/agents/gazelle/agentic-platform/pr-reviewer',
       '/agent-platform/sessions',
       '/agent-platform/sessions/gazelle/abc123',
       '/metrics',

--- a/packages/app/src/utils/telemetry.ts
+++ b/packages/app/src/utils/telemetry.ts
@@ -154,6 +154,18 @@ export function getTelemetryPageViewPayload(pathname: string): {
       payload = { page: 'Session detail' };
       break;
 
+    // One agent: `/agent-platform/agents/<installation>/<namespace>/<name>`.
+    // Deliberately carries no `view`, for the same reason as Session detail: those
+    // segments name an installation and an agent, so including them would emit a
+    // distinct page name per agent and record which installations a user reads.
+    //
+    // Matched on exactly three segments so it cannot swallow the create flow's
+    // `agents/new`, `agents/new/skills` or `agents/new/review`, which keep
+    // reporting through the generic case below.
+    case /^\/agent-platform\/agents\/[^/]+\/[^/]+\/[^/]+$/.test(pathname):
+      payload = { page: 'Agent detail' };
+      break;
+
     case pathname === '/agent-platform':
       payload = { page: 'Agents index' };
       break;

--- a/plugins/agent-platform/package.json
+++ b/plugins/agent-platform/package.json
@@ -31,6 +31,7 @@
     "@backstage/plugin-kubernetes-react": "backstage:^",
     "@backstage/plugin-scaffolder-react": "backstage:^",
     "@backstage/ui": "backstage:^",
+    "@giantswarm/backstage-plugin-flux-react": "workspace:^",
     "@giantswarm/backstage-plugin-gs": "workspace:^",
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^",
     "@giantswarm/backstage-plugin-ui-react": "workspace:^",

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.test.tsx
@@ -1,0 +1,51 @@
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { crds } from '@giantswarm/k8s-types';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+import { AgentActionsMenu } from './AgentActionsMenu';
+
+type AgentInterface = crds.kagent.v1alpha2.Agent;
+
+function makeAgent(): Agent {
+  return new Agent(
+    {
+      apiVersion: 'kagent.dev/v1alpha2',
+      kind: 'Agent',
+      metadata: {
+        name: 'pr-reviewer',
+        namespace: 'agentic-platform',
+        managedFields: [{ manager: 'helm-controller', operation: 'Apply' }],
+      },
+      spec: {
+        type: 'Declarative',
+        declarative: { modelConfig: 'opus-4-7' },
+      },
+    } as AgentInterface,
+    'gazelle',
+  );
+}
+
+describe('AgentActionsMenu', () => {
+  it('opens the manifest dialog from the kebab menu', async () => {
+    await renderInTestApp(<AgentActionsMenu agent={makeAgent()} />);
+
+    // Nothing is shown until asked for — this is the rarely-needed escape hatch.
+    expect(screen.queryByText('Agent manifest')).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Agent actions' }),
+    );
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'View manifest' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Agent manifest')).toBeInTheDocument();
+    });
+    expect(screen.getByText('pr-reviewer.yaml')).toBeInTheDocument();
+    // Names the installation and namespace, so a manifest copied out of here can
+    // be traced back to where it came from.
+    expect(screen.getByText('gazelle · agentic-platform')).toBeInTheDocument();
+  });
+});

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { ButtonIcon, Menu, MenuItem, MenuTrigger } from '@backstage/ui';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+
+import { AgentManifestDialog } from './AgentManifestDialog';
+
+/**
+ * The agent details page's header actions.
+ *
+ * Owns the manifest dialog's open state itself, rather than the page doing so:
+ * the page hands this element to `useProvidePageHeaderActions`, which renders it
+ * in the shared plugin header — a different part of the tree — so keeping the
+ * state here is what makes the menu and its dialog one self-contained unit.
+ *
+ * Read-only for now. kagent supports deleting and re-deploying an agent, but a
+ * delete has to remove only the agent's own HelmRelease and never the
+ * `OCIRepository` a namespace's agents share, so it needs more than a menu item.
+ */
+export function AgentActionsMenu({ agent }: { agent: Agent }) {
+  const [isManifestOpen, setManifestOpen] = useState(false);
+
+  return (
+    <>
+      <MenuTrigger>
+        <ButtonIcon
+          icon={<MoreVertIcon />}
+          aria-label="Agent actions"
+          variant="tertiary"
+        />
+        <Menu>
+          <MenuItem onAction={() => setManifestOpen(true)}>
+            View manifest
+          </MenuItem>
+        </Menu>
+      </MenuTrigger>
+
+      <AgentManifestDialog
+        agent={agent}
+        isOpen={isManifestOpen}
+        onOpenChange={setManifestOpen}
+      />
+    </>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentConfigurationCard.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentConfigurationCard.tsx
@@ -136,9 +136,13 @@ function ToolsValue({ agent }: { agent: Agent }) {
 
   return (
     <Flex direction="column" gap="3">
-      {mcpServers.map(serverRef => (
+      {mcpServers.map((serverRef, index) => (
         <McpServerRow
-          key={mcpServerRefId(serverRef)}
+          // `namespace/name` is not unique: nothing stops two entries referencing
+          // the same server with different `toolNames`/`requireApproval`, which is
+          // how you express "these tools need approval, those don't" for one
+          // server. Same reasoning as the skill cards.
+          key={`${mcpServerRefId(serverRef)}#${index}`}
           server={serverRef}
           installation={agent.cluster}
         />

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentConfigurationCard.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentConfigurationCard.tsx
@@ -1,0 +1,265 @@
+import { ReactNode } from 'react';
+import { Box, Flex, Text } from '@backstage/ui';
+import { Link } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import {
+  Agent,
+  AgentMcpServerRef,
+  getHelmReleaseName,
+  getHelmReleaseNamespace,
+  ModelConfig,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+import {
+  DateComponent,
+  InfoCard,
+  NotAvailable,
+  StructuredMetadataList,
+} from '@giantswarm/backstage-plugin-ui-react';
+
+import {
+  agentDetailRouteRef,
+  deploymentDetailsExternalRouteRef,
+  musterToolExplorerExternalRouteRef,
+} from '../../routes';
+import {
+  describeToolScope,
+  isMusterServerRef,
+  mcpServerRefId,
+} from './helpers';
+
+/** Monospace for identifiers the reader may retype into `kubectl`. */
+const MONO: React.CSSProperties = { fontFamily: 'monospace' };
+
+/**
+ * How the model is described: the ModelConfig's friendly name, with the model id
+ * and provider underneath.
+ *
+ * Falls back to the bare reference when the ModelConfig cannot be read — which is
+ * normal for a non-admin, since ModelConfigs live in namespaces they may not have
+ * access to — rather than implying the agent has no model.
+ */
+function ModelValue({
+  modelConfigName,
+  modelConfig,
+  namespace,
+}: {
+  modelConfigName?: string;
+  modelConfig?: ModelConfig;
+  namespace?: string;
+}) {
+  if (!modelConfigName) {
+    return <NotAvailable />;
+  }
+
+  const modelId = modelConfig?.getModel();
+  const provider = modelConfig?.getProvider();
+
+  return (
+    <Flex direction="column" gap="1">
+      <Text variant="body-medium">
+        {modelConfig?.getDisplayName() ?? modelConfigName}
+      </Text>
+      {(modelId || provider) && (
+        <Text variant="body-small" color="secondary" style={MONO}>
+          {[modelId, provider].filter(Boolean).join(' · ')}
+        </Text>
+      )}
+      <Text variant="body-small" color="secondary">
+        ModelConfig{' '}
+        <span style={MONO}>
+          {namespace ? `${namespace}/${modelConfigName}` : modelConfigName}
+        </span>
+      </Text>
+    </Flex>
+  );
+}
+
+/**
+ * One MCP server the agent draws tools from.
+ *
+ * The prop is `server`, not `ref` — React intercepts a `ref` prop rather than
+ * passing it through.
+ */
+function McpServerRow({
+  server: serverRef,
+  installation,
+}: {
+  server: AgentMcpServerRef;
+  installation: string;
+}) {
+  const toolExplorerRoute = useRouteRef(musterToolExplorerExternalRouteRef);
+
+  // Preselect the installation the agent runs on, the way muster's own
+  // cross-links do. Only offered for the Muster gateway: the Tool Explorer talks
+  // to muster, so it can say nothing about any other MCP server.
+  const musterLink =
+    isMusterServerRef(serverRef) && toolExplorerRoute
+      ? `${toolExplorerRoute()}?installation=${encodeURIComponent(installation)}`
+      : undefined;
+
+  return (
+    <Flex direction="column" gap="1">
+      <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
+        <Text variant="body-medium" style={MONO}>
+          {serverRef.kind ?? 'RemoteMCPServer'} {mcpServerRefId(serverRef)}
+        </Text>
+        {musterLink && <Link to={musterLink}>Explore tools</Link>}
+      </Flex>
+      <Text variant="body-small" color="secondary">
+        {describeToolScope(serverRef)}
+      </Text>
+      {/* Rare, and the only per-tool setting that changes what a user will
+          experience mid-session, so it is worth naming. */}
+      {serverRef.requireApproval && serverRef.requireApproval.length > 0 && (
+        <Text variant="body-small" color="secondary">
+          Requires approval: {serverRef.requireApproval.join(', ')}
+        </Text>
+      )}
+    </Flex>
+  );
+}
+
+/** The tools block: MCP servers, then any agents invoked as tools. */
+function ToolsValue({ agent }: { agent: Agent }) {
+  const agentDetailRoute = useRouteRef(agentDetailRouteRef);
+  const mcpServers = agent.getMcpServerRefs();
+  const agentRefs = agent.getAgentRefs();
+
+  if (mcpServers.length === 0 && agentRefs.length === 0) {
+    return (
+      <Text variant="body-small" color="secondary">
+        This agent declares no tool servers, so it has no tools beyond its own
+        reasoning.
+      </Text>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="3">
+      {mcpServers.map(serverRef => (
+        <McpServerRow
+          key={mcpServerRefId(serverRef)}
+          server={serverRef}
+          installation={agent.cluster}
+        />
+      ))}
+
+      {agentRefs.map(ref => {
+        // Another agent invoked over A2A. Same installation by definition — a
+        // tool reference cannot cross clusters — and the namespace defaults to
+        // this agent's own when the reference omits it.
+        const namespace = ref.namespace ?? agent.getNamespace() ?? '';
+        const href = agentDetailRoute?.({
+          installation: agent.cluster,
+          namespace,
+          name: ref.name,
+        });
+
+        return (
+          <Flex
+            key={`agent/${namespace}/${ref.name}`}
+            direction="column"
+            gap="1"
+          >
+            <Text variant="body-medium">
+              Agent{' '}
+              {href ? (
+                <Link to={href}>{`${namespace}/${ref.name}`}</Link>
+              ) : (
+                <span style={MONO}>{`${namespace}/${ref.name}`}</span>
+              )}
+            </Text>
+            <Text variant="body-small" color="secondary">
+              Called as a tool over A2A
+            </Text>
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
+}
+
+/** The owning HelmRelease, linked to its deployment page when gs is enabled. */
+function DeployedByValue({ agent }: { agent: Agent }) {
+  const deploymentDetailsRoute = useRouteRef(deploymentDetailsExternalRouteRef);
+
+  const name = getHelmReleaseName(agent);
+  if (!name) {
+    // No Flux Helm labels: applied directly (kubectl, or a chart that doesn't
+    // stamp them). Saying "n/a" is honest here — we know of no owner.
+    return <NotAvailable />;
+  }
+
+  const namespace =
+    getHelmReleaseNamespace(agent) ?? agent.getNamespace() ?? '';
+  const label = namespace ? `${namespace}/${name}` : name;
+  const href = deploymentDetailsRoute?.({
+    installationName: agent.cluster,
+    kind: 'helmrelease',
+    namespace,
+    name,
+  });
+
+  return (
+    <Flex direction="column" gap="1">
+      {href ? (
+        <Link to={href}>{`HelmRelease ${label}`}</Link>
+      ) : (
+        <Text variant="body-medium" style={MONO}>{`HelmRelease ${label}`}</Text>
+      )}
+      <Text variant="body-small" color="secondary">
+        Reconciling this agent's chart
+      </Text>
+    </Flex>
+  );
+}
+
+export type AgentConfigurationCardProps = {
+  agent: Agent;
+  modelConfig?: ModelConfig;
+};
+
+/**
+ * What the agent *is*, as the Agent CR defines it.
+ *
+ * Read-only. Editing an agent means changing the Helm values its release renders
+ * from, which this plugin has no write path for yet.
+ */
+export function AgentConfigurationCard({
+  agent,
+  modelConfig,
+}: AgentConfigurationCardProps) {
+  const namespace = agent.getNamespace();
+  const created = agent.getCreatedTimestamp();
+
+  const metadata: Record<string, ReactNode> = {
+    Type: agent.getType() ?? <NotAvailable />,
+    Model: (
+      <ModelValue
+        modelConfigName={agent.getModelConfigName()}
+        modelConfig={modelConfig}
+        namespace={namespace}
+      />
+    ),
+    Installation: agent.cluster,
+    Namespace: namespace ?? <NotAvailable />,
+    Created: created ? (
+      <DateComponent value={created} relative />
+    ) : (
+      <NotAvailable />
+    ),
+    'Deployed by': <DeployedByValue agent={agent} />,
+    Tools: <ToolsValue agent={agent} />,
+  };
+
+  return (
+    <InfoCard title="Configuration">
+      <Box>
+        <StructuredMetadataList
+          metadata={metadata}
+          fixedKeyColumnWidth="160px"
+        />
+      </Box>
+    </InfoCard>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
@@ -513,6 +513,49 @@ describe('AgentDetailPage', () => {
       ).toBeInTheDocument();
     });
 
+    // Two entries may reference the same server with different scopes — that is
+    // how "these tools need approval, those don't" is expressed for one server —
+    // so `namespace/name` alone is not a usable React key.
+    it('renders two entries for the same server without a duplicate key', async () => {
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      stubResources({
+        resource: makeAgent({
+          spec: {
+            declarative: {
+              tools: [
+                { mcpServer: { name: 'muster', toolNames: ['list_tools'] } },
+                {
+                  mcpServer: {
+                    name: 'muster',
+                    toolNames: ['call_tool'],
+                    requireApproval: ['call_tool'],
+                  },
+                },
+              ],
+            },
+          },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('1 tool: list_tools')).toBeInTheDocument();
+      expect(screen.getByText('1 tool: call_tool')).toBeInTheDocument();
+      expect(
+        screen.getByText('Requires approval: call_tool'),
+      ).toBeInTheDocument();
+      expect(consoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining('same key'),
+        expect.anything(),
+        expect.anything(),
+      );
+
+      consoleError.mockRestore();
+    });
+
     // Must not imply Muster access the agent does not have.
     it('says so when the agent declares no tool servers', async () => {
       stubResources({
@@ -708,6 +751,58 @@ describe('AgentDetailPage', () => {
       expect(
         screen.getByRole('link', { name: 'Back to agents' }),
       ).toBeInTheDocument();
+    });
+
+    // The page polls every 5 s while an agent converges, and react-query keeps
+    // `data` while setting `error` on a failed refetch — so treating `error` as
+    // "we have nothing" would let one un-retried 503 blank an agent that is
+    // rendered and correct.
+    it('keeps the agent rendered when a background poll fails', async () => {
+      stubResources({
+        resource: makeAgent(),
+        error: Object.assign(new Error('service unavailable'), {
+          name: 'ServiceUnavailableError',
+        }),
+        errors: [
+          {
+            type: 'error',
+            cluster: 'gazelle',
+            error: Object.assign(new Error('service unavailable'), {
+              name: 'ServiceUnavailableError',
+            }),
+          },
+        ],
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('PR reviewer')).toBeInTheDocument();
+      expect(sectionTitle('Status')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Could not load this agent'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Same for a 404 mid-poll: it must not swap a rendered agent for "not found".
+    it('keeps the agent rendered when a background poll 404s', async () => {
+      stubResources({
+        resource: makeAgent(),
+        error: Object.assign(new Error('not found'), { name: 'NotFoundError' }),
+        errors: [
+          {
+            type: 'error',
+            cluster: 'gazelle',
+            error: Object.assign(new Error('not found'), {
+              name: 'NotFoundError',
+            }),
+          },
+        ],
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('PR reviewer')).toBeInTheDocument();
+      expect(screen.queryByText('Agent not found')).not.toBeInTheDocument();
     });
   });
 });

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
@@ -1,0 +1,565 @@
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { screen } from '@testing-library/react';
+import { crds } from '@giantswarm/k8s-types';
+import { agentsRouteRef } from '../../routes';
+import { AgentSessionsView } from '../../hooks/useAgentSessions';
+import { AgentDetailPage } from './AgentDetailPage';
+
+type AgentInterface = crds.kagent.v1alpha2.Agent;
+
+// The real Agent/ModelConfig classes are used to build fixtures — only the fetch
+// is mocked — so the page is exercised against the actual getters, readiness
+// derivation and provenance helpers rather than a duck-typed stand-in.
+const mockUseResource = jest.fn();
+
+jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
+  ...jest.requireActual('@giantswarm/backstage-plugin-kubernetes-react'),
+  useResource: (...args: unknown[]) => mockUseResource(...args),
+}));
+
+// The card resolves a chain of Flux resources; the page's own job is only to
+// decide whether it renders at all.
+jest.mock('@giantswarm/backstage-plugin-flux-react', () => ({
+  GitOpsCard: () => <div data-testid="gitops-card">Managed through GitOps</div>,
+}));
+
+jest.mock('../../hooks/useAgentAvatarUrl', () => ({
+  useAgentAvatarUrl: () => () =>
+    'https://avatars.example/v1/96/pr-reviewer.png',
+}));
+
+// Header actions land in the shared plugin header (supplied by GSPageLayout in the
+// real app), which is not part of this page's tree. The kebab menu and its manifest
+// dialog are covered by AgentActionsMenu.test.tsx instead.
+jest.mock('@giantswarm/backstage-plugin-ui-react', () => ({
+  ...jest.requireActual('@giantswarm/backstage-plugin-ui-react'),
+  useProvidePageHeaderActions: jest.fn(),
+}));
+
+const mockUseAgentSessions = jest.fn<AgentSessionsView, unknown[]>();
+
+jest.mock('../../hooks/useAgentSessions', () => ({
+  useAgentSessions: (...args: unknown[]) => mockUseAgentSessions(...args),
+}));
+
+const mockParams: {
+  installation: string;
+  namespace: string;
+  name: string;
+} = {
+  installation: 'gazelle',
+  namespace: 'agentic-platform',
+  name: 'pr-reviewer',
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => mockParams,
+}));
+
+const { Agent, ModelConfig } = jest.requireActual(
+  '@giantswarm/backstage-plugin-kubernetes-react',
+);
+
+const READY_CONDITIONS = [
+  {
+    type: 'Accepted',
+    status: 'True',
+    reason: 'Reconciled',
+    message: 'Agent configuration accepted',
+    lastTransitionTime: '2026-07-31T10:00:00Z',
+  },
+  {
+    type: 'Ready',
+    status: 'True',
+    reason: 'DeploymentReady',
+    message: 'Deployment is ready',
+    lastTransitionTime: '2026-07-31T10:02:00Z',
+  },
+];
+
+function makeAgent(overrides: Partial<AgentInterface> = {}) {
+  return new Agent(
+    {
+      apiVersion: 'kagent.dev/v1alpha2',
+      kind: 'Agent',
+      metadata: {
+        name: 'pr-reviewer',
+        namespace: 'agentic-platform',
+        generation: 1,
+        creationTimestamp: '2026-07-21T09:00:00Z',
+        annotations: { 'ui.giantswarm.io/display-name': 'PR reviewer' },
+        labels: {
+          'helm.toolkit.fluxcd.io/name': 'pr-reviewer',
+          'helm.toolkit.fluxcd.io/namespace': 'agentic-platform',
+        },
+        ...(overrides.metadata as object),
+      },
+      spec: {
+        type: 'Declarative',
+        description: 'Reviews pull requests in depth.',
+        declarative: {
+          modelConfig: 'opus-4-7',
+          systemMessage: 'You review pull requests.',
+          tools: [
+            {
+              type: 'McpServer',
+              mcpServer: { name: 'muster', namespace: 'agentic-platform' },
+            },
+          ],
+        },
+        skills: {
+          gitRefs: [
+            {
+              url: 'https://github.com/giantswarm/skills',
+              path: 'pr-review',
+              ref: 'v2.0.0',
+              name: 'PR review conventions',
+            },
+          ],
+        },
+        ...(overrides.spec as object),
+      },
+      status: {
+        observedGeneration: 1,
+        conditions: READY_CONDITIONS,
+        ...(overrides.status as object),
+      },
+    },
+    'gazelle',
+  );
+}
+
+function makeModelConfig() {
+  return new ModelConfig(
+    {
+      apiVersion: 'kagent.dev/v1alpha2',
+      kind: 'ModelConfig',
+      metadata: {
+        name: 'opus-4-7',
+        namespace: 'agentic-platform',
+        annotations: { 'ui.giantswarm.io/display-name': 'Claude Opus 4.7' },
+      },
+      spec: { model: 'claude-opus-4-7', provider: 'Anthropic' },
+    },
+    'gazelle',
+  );
+}
+
+const NO_SESSIONS: AgentSessionsView = {
+  rows: [],
+  isLoading: false,
+  isNotUserScoped: false,
+  isUnavailable: false,
+};
+
+/** Every `useResource` outcome the page can see, per resource class. */
+type ResourceOutcome = {
+  resource?: unknown;
+  isLoading?: boolean;
+  error?: Error | null;
+  errors?: unknown[];
+};
+
+function stubResources(agent?: ResourceOutcome, modelConfig?: ResourceOutcome) {
+  const fill = (outcome: ResourceOutcome = {}) => ({
+    resource: outcome.resource,
+    isLoading: outcome.isLoading ?? false,
+    error: outcome.error ?? null,
+    errors: outcome.errors ?? [],
+  });
+
+  mockUseResource.mockImplementation(
+    (_cluster: string, ResourceClass: unknown) =>
+      ResourceClass === Agent ? fill(agent) : fill(modelConfig),
+  );
+}
+
+// Only the parent RouteRef is mountable — `mountedRoutes` rejects a SubRouteRef —
+// and the detail sub-route resolves relative to it.
+const renderPage = () =>
+  renderInTestApp(<AgentDetailPage />, {
+    mountedRoutes: { '/agent-platform/agents': agentsRouteRef },
+  });
+
+/**
+ * Assert the *derived* readiness shown in the page header.
+ *
+ * Queried by test id rather than by text, because the conditions list labels its
+ * entries by condition type — so "Ready" legitimately appears twice on the page,
+ * once as the derived readiness and once as the condition it came from.
+ */
+function expectHeaderReadiness(label: string) {
+  expect(screen.getByTestId('agent-readiness')).toHaveTextContent(label);
+}
+
+/** An InfoCard title, which renders as a heading. */
+const sectionTitle = (name: string) => screen.getByRole('heading', { name });
+
+describe('AgentDetailPage', () => {
+  beforeEach(() => {
+    mockUseResource.mockReset();
+    mockUseAgentSessions.mockReset();
+    mockUseAgentSessions.mockReturnValue(NO_SESSIONS);
+  });
+
+  it('renders every section for a ready agent', async () => {
+    stubResources({ resource: makeAgent() }, { resource: makeModelConfig() });
+
+    await renderPage();
+
+    // Header
+    expect(screen.getByText('PR reviewer')).toBeInTheDocument();
+    expectHeaderReadiness('Ready');
+    expect(
+      screen.getByText('Reviews pull requests in depth.'),
+    ).toBeInTheDocument();
+
+    // Sections
+    expect(sectionTitle('Status')).toBeInTheDocument();
+    expect(sectionTitle('Configuration')).toBeInTheDocument();
+    expect(sectionTitle('System prompt')).toBeInTheDocument();
+    expect(sectionTitle('Skills (1)')).toBeInTheDocument();
+    expect(sectionTitle('Recent sessions')).toBeInTheDocument();
+
+    // Resolved model, from the targeted ModelConfig read
+    expect(screen.getByText('Claude Opus 4.7')).toBeInTheDocument();
+    expect(screen.getByText('claude-opus-4-7 · Anthropic')).toBeInTheDocument();
+
+    expect(screen.getByText('You review pull requests.')).toBeInTheDocument();
+    expect(screen.getByText('PR review conventions')).toBeInTheDocument();
+    expect(screen.getByText('at v2.0.0')).toBeInTheDocument();
+  });
+
+  it('falls back to the bare ModelConfig reference when it cannot be read', async () => {
+    // Normal for a non-admin: ModelConfigs live in namespaces they may not read.
+    stubResources({ resource: makeAgent() }, { resource: undefined });
+
+    await renderPage();
+
+    expect(screen.getByText('opus-4-7')).toBeInTheDocument();
+  });
+
+  describe('status', () => {
+    it('surfaces the Ready condition message for a not-ready agent, expanded', async () => {
+      stubResources({
+        resource: makeAgent({
+          status: {
+            observedGeneration: 1,
+            conditions: [
+              READY_CONDITIONS[0],
+              {
+                type: 'Ready',
+                status: 'False',
+                reason: 'DeploymentNotReady',
+                message: 'Deployment is not ready, 0/1 pods are ready',
+                lastTransitionTime: '2026-07-31T10:05:00Z',
+              },
+            ],
+          },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expectHeaderReadiness('Not ready');
+      // Visible without a click — the failing condition starts expanded.
+      expect(
+        screen.getAllByText('Deployment is not ready, 0/1 pods are ready')
+          .length,
+      ).toBeGreaterThan(0);
+      expect(screen.getByText('DeploymentNotReady')).toBeInTheDocument();
+    });
+
+    it('reports a rejected spec as not accepted, with the reconcile error', async () => {
+      stubResources({
+        resource: makeAgent({
+          status: {
+            observedGeneration: 1,
+            conditions: [
+              {
+                type: 'Accepted',
+                status: 'False',
+                reason: 'ReconcileFailed',
+                message: 'modelconfigs.kagent.dev "opus-4-7" not found',
+                lastTransitionTime: '2026-07-31T10:05:00Z',
+              },
+            ],
+          },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expectHeaderReadiness('Not accepted');
+      expect(
+        screen.getAllByText('modelconfigs.kagent.dev "opus-4-7" not found')
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    it('explains a stale status by naming both generations', async () => {
+      stubResources({
+        resource: makeAgent({
+          metadata: {
+            name: 'pr-reviewer',
+            namespace: 'agentic-platform',
+            generation: 5,
+          },
+          status: { observedGeneration: 4, conditions: READY_CONDITIONS },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expectHeaderReadiness('Pending');
+      expect(screen.getByText(/reconciled generation 4/)).toBeInTheDocument();
+      expect(screen.getByText(/generation 5/)).toBeInTheDocument();
+    });
+
+    it('explains an agent the controller has not reported on yet', async () => {
+      stubResources({
+        resource: makeAgent({
+          status: { conditions: [] },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expect(
+        screen.getByText(/kagent has not reported a status for this agent yet/),
+      ).toBeInTheDocument();
+    });
+
+    // Abnormal-true: independent of readiness, so a ready agent can carry it.
+    it('warns about unsupported features separately from readiness', async () => {
+      stubResources({
+        resource: makeAgent({
+          status: {
+            observedGeneration: 1,
+            conditions: [
+              ...READY_CONDITIONS,
+              {
+                type: 'UnsupportedFeatures',
+                status: 'True',
+                reason: 'UnsupportedFeatures',
+                message: 'memory is not supported by the go runtime',
+                lastTransitionTime: '2026-07-31T10:03:00Z',
+              },
+            ],
+          },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expectHeaderReadiness('Ready');
+      expect(
+        screen.getByText('Some configured features are unsupported'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('tools', () => {
+    it('links the muster gateway to the Tool Explorer, installation preselected', async () => {
+      stubResources({ resource: makeAgent() });
+
+      await renderPage();
+
+      // Unbound external route in the test app, so assert the reference is named
+      // and that a non-muster server gets no link (below) — the binding itself is
+      // muster's to provide.
+      expect(
+        screen.getByText('RemoteMCPServer agentic-platform/muster'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('All tools from this server'),
+      ).toBeInTheDocument();
+    });
+
+    it('describes a restricted server by its allowlist', async () => {
+      stubResources({
+        resource: makeAgent({
+          spec: {
+            declarative: {
+              tools: [
+                {
+                  mcpServer: {
+                    name: 'grafana',
+                    toolNames: ['query', 'dashboards'],
+                  },
+                },
+              ],
+            },
+          },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('RemoteMCPServer grafana')).toBeInTheDocument();
+      expect(
+        screen.getByText('2 tools: query, dashboards'),
+      ).toBeInTheDocument();
+    });
+
+    // Must not imply Muster access the agent does not have.
+    it('says so when the agent declares no tool servers', async () => {
+      stubResources({
+        resource: makeAgent({
+          spec: { declarative: { modelConfig: 'opus-4-7' } },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expect(screen.getByText(/declares no tool servers/)).toBeInTheDocument();
+    });
+  });
+
+  it('links the owning HelmRelease', async () => {
+    stubResources({ resource: makeAgent() });
+
+    await renderPage();
+
+    expect(
+      screen.getByText('HelmRelease agentic-platform/pr-reviewer'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the GitOps card for a reconciled agent', async () => {
+    stubResources({ resource: makeAgent() });
+
+    await renderPage();
+
+    expect(screen.getByTestId('gitops-card')).toBeInTheDocument();
+  });
+
+  it('omits the GitOps card for an agent no reconciler owns', async () => {
+    stubResources({
+      resource: makeAgent({
+        // Explicitly empty: applied directly, with no Flux or Helm markers.
+        metadata: {
+          name: 'pr-reviewer',
+          namespace: 'agentic-platform',
+          labels: {},
+        },
+      } as Partial<AgentInterface>),
+    });
+
+    await renderPage();
+
+    expect(screen.queryByTestId('gitops-card')).not.toBeInTheDocument();
+  });
+
+  it('says an unset system prompt is unset, not empty', async () => {
+    stubResources({
+      resource: makeAgent({
+        spec: { declarative: { modelConfig: 'opus-4-7' } },
+      } as Partial<AgentInterface>),
+    });
+
+    await renderPage();
+
+    expect(
+      screen.getByText('Not set on the Agent resource.'),
+    ).toBeInTheDocument();
+  });
+
+  describe('sessions', () => {
+    it('describes the list as the user’s own', async () => {
+      stubResources({ resource: makeAgent() });
+
+      await renderPage();
+
+      expect(
+        screen.getByText(/Your own sessions with this agent/),
+      ).toBeInTheDocument();
+    });
+
+    // An installation running kagent in `unsecure` mode returns everyone's
+    // sessions — calling those "yours" would be a lie in the other direction.
+    it('stops claiming the sessions are yours when kagent is not user-scoped', async () => {
+      stubResources({ resource: makeAgent() });
+      mockUseAgentSessions.mockReturnValue({
+        ...NO_SESSIONS,
+        isNotUserScoped: true,
+      });
+
+      await renderPage();
+
+      expect(
+        screen.getByText(/does not scope sessions to a user/),
+      ).toBeInTheDocument();
+    });
+
+    it('distinguishes unreadable sessions from no sessions', async () => {
+      stubResources({ resource: makeAgent() });
+      mockUseAgentSessions.mockReturnValue({
+        ...NO_SESSIONS,
+        isUnavailable: true,
+      });
+
+      await renderPage();
+
+      expect(
+        screen.getByText('Sessions could not be read from this installation.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('loading and failure', () => {
+    it('shows a progress bar while loading', async () => {
+      stubResources({ isLoading: true });
+
+      await renderPage();
+
+      expect(screen.getByTestId('progress')).toBeInTheDocument();
+    });
+
+    // Expected outcome — a stale bookmark or a deleted agent — so it gets an
+    // explanation rather than an error banner.
+    it('explains a missing agent instead of erroring', async () => {
+      stubResources({
+        error: new Error('not found'),
+        errors: [
+          {
+            type: 'error',
+            cluster: 'gazelle',
+            error: Object.assign(new Error('not found'), {
+              name: 'NotFoundError',
+            }),
+          },
+        ],
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('Agent not found')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Back to agents' }),
+      ).toBeInTheDocument();
+    });
+
+    it('reports any other failure as an error, keeping the way back', async () => {
+      stubResources({
+        error: new Error('the cluster is on fire'),
+        errors: [
+          {
+            type: 'error',
+            cluster: 'gazelle',
+            error: new Error('the cluster is on fire'),
+          },
+        ],
+      });
+
+      await renderPage();
+
+      expect(screen.getByText('Could not load this agent')).toBeInTheDocument();
+      expect(screen.getByText('the cluster is on fire')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Back to agents' }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
@@ -55,9 +55,8 @@ jest.mock('react-router-dom', () => ({
   useParams: () => mockParams,
 }));
 
-const { Agent, ModelConfig } = jest.requireActual(
-  '@giantswarm/backstage-plugin-kubernetes-react',
-);
+const { Agent, GitRepository, HelmRelease, Kustomization, ModelConfig } =
+  jest.requireActual('@giantswarm/backstage-plugin-kubernetes-react');
 
 const READY_CONDITIONS = [
   {
@@ -159,7 +158,22 @@ type ResourceOutcome = {
   errors?: unknown[];
 };
 
-function stubResources(agent?: ResourceOutcome, modelConfig?: ResourceOutcome) {
+/**
+ * The Flux chain `GitOpsCard` walks to decide whether the agent's desired state is
+ * in Git: Agent → HelmRelease → Kustomization → GitRepository. Left empty by
+ * default, which is the shape of an agent deployed by this plugin's own flow.
+ */
+type FluxChain = {
+  helmRelease?: unknown;
+  kustomization?: unknown;
+  gitRepository?: unknown;
+};
+
+function stubResources(
+  agent?: ResourceOutcome,
+  modelConfig?: ResourceOutcome,
+  flux: FluxChain = {},
+) {
   const fill = (outcome: ResourceOutcome = {}) => ({
     resource: outcome.resource,
     isLoading: outcome.isLoading ?? false,
@@ -171,19 +185,78 @@ function stubResources(agent?: ResourceOutcome, modelConfig?: ResourceOutcome) {
     clientOutdatedStates: [],
   });
 
-  // Matched per resource class, so the Flux chain GitOpsCard walks
-  // (HelmRelease → Kustomization → GitRepository) resolves to nothing rather than
-  // to whichever stub happened to be last.
+  // Matched per resource class, so each hop of the Flux chain resolves to its own
+  // fixture rather than to whichever stub happened to be last.
   mockUseResource.mockImplementation(
     (_cluster: string, ResourceClass: unknown) => {
-      if (ResourceClass === Agent) {
-        return fill(agent);
+      switch (ResourceClass) {
+        case Agent:
+          return fill(agent);
+        case ModelConfig:
+          return fill(modelConfig);
+        case HelmRelease:
+          return fill({ resource: flux.helmRelease });
+        case Kustomization:
+          return fill({ resource: flux.kustomization });
+        case GitRepository:
+          return fill({ resource: flux.gitRepository });
+        default:
+          return fill();
       }
-      if (ResourceClass === ModelConfig) {
-        return fill(modelConfig);
-      }
-      return fill();
     },
+  );
+}
+
+/** A HelmRelease, optionally carrying the Kustomization labels that put it in Git. */
+function makeHelmRelease(kustomization?: { name: string; namespace: string }) {
+  return new HelmRelease(
+    {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: {
+        name: 'pr-reviewer',
+        namespace: 'agentic-platform',
+        ...(kustomization
+          ? {
+              labels: {
+                'kustomize.toolkit.fluxcd.io/name': kustomization.name,
+                'kustomize.toolkit.fluxcd.io/namespace':
+                  kustomization.namespace,
+              },
+            }
+          : {}),
+      },
+      spec: {},
+    },
+    'gazelle',
+  );
+}
+
+function makeKustomization() {
+  return new Kustomization(
+    {
+      apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+      kind: 'Kustomization',
+      metadata: { name: 'agents', namespace: 'flux-giantswarm' },
+      spec: {
+        path: 'management-clusters/gazelle/extras',
+        sourceRef: { kind: 'GitRepository', name: 'management-clusters' },
+      },
+    },
+    'gazelle',
+  );
+}
+
+function makeGitRepository() {
+  return new GitRepository(
+    {
+      apiVersion: 'source.toolkit.fluxcd.io/v1',
+      kind: 'GitRepository',
+      metadata: { name: 'management-clusters', namespace: 'flux-giantswarm' },
+      spec: { url: 'https://github.com/giantswarm/management-clusters' },
+      status: { artifact: { revision: 'main@sha1:abc123' } },
+    },
+    'gazelle',
   );
 }
 
@@ -239,8 +312,33 @@ describe('AgentDetailPage', () => {
     expect(screen.getByText('claude-opus-4-7 · Anthropic')).toBeInTheDocument();
 
     expect(screen.getByText('You review pull requests.')).toBeInTheDocument();
+
+    // One skill card: the label, its repo as a link, and the ref it is pinned to.
     expect(screen.getByText('PR review conventions')).toBeInTheDocument();
-    expect(screen.getByText('at v2.0.0')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'giantswarm/skills' }),
+    ).toHaveAttribute('href', 'https://github.com/giantswarm/skills');
+    expect(screen.getByText('v2.0.0')).toBeInTheDocument();
+    // Read-only: the picker's checkbox affordance must not come along.
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('says when a skill is unpinned, since it then changes under the agent', async () => {
+    stubResources({
+      resource: makeAgent({
+        spec: {
+          skills: {
+            gitRefs: [
+              { url: 'https://github.com/giantswarm/skills', path: 'demo' },
+            ],
+          },
+        },
+      } as Partial<AgentInterface>),
+    });
+
+    await renderPage();
+
+    expect(screen.getByText('default branch (unpinned)')).toBeInTheDocument();
   });
 
   it('falls back to the bare ModelConfig reference when it cannot be read', async () => {
@@ -439,33 +537,67 @@ describe('AgentDetailPage', () => {
     ).toBeInTheDocument();
   });
 
-  // Renders the real card, so this also guards the ErrorsProvider it needs — the
-  // page crashed without one, and a stubbed card would not have noticed.
-  it('shows the GitOps card for a reconciled agent', async () => {
-    stubResources({ resource: makeAgent() });
+  describe('GitOps provenance', () => {
+    // Renders the real card, so this also guards the ErrorsProvider it needs — the
+    // page crashed without one, and a stubbed card would not have noticed.
+    it('claims GitOps, with a source link, when the chain reaches Git', async () => {
+      stubResources({ resource: makeAgent() }, undefined, {
+        helmRelease: makeHelmRelease({
+          name: 'agents',
+          namespace: 'flux-giantswarm',
+        }),
+        kustomization: makeKustomization(),
+        gitRepository: makeGitRepository(),
+      });
 
-    await renderPage();
+      await renderPage();
 
-    expect(screen.getByText('Managed through GitOps')).toBeInTheDocument();
-  });
-
-  it('omits the GitOps card for an agent no reconciler owns', async () => {
-    stubResources({
-      resource: makeAgent({
-        // Explicitly empty: applied directly, with no Flux or Helm markers.
-        metadata: {
-          name: 'pr-reviewer',
-          namespace: 'agentic-platform',
-          labels: {},
-        },
-      } as Partial<AgentInterface>),
+      expect(screen.getByText('Managed through GitOps')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /Source/ })).toHaveAttribute(
+        'href',
+        expect.stringContaining('management-clusters/gazelle/extras'),
+      );
     });
 
-    await renderPage();
+    // The case that matters: an agent created through this plugin is deployed by a
+    // HelmRelease the scaffolder applied, so it is Flux-reconciled but its desired
+    // state is not in Git. Claiming GitOps there sends the reader looking for a
+    // file that does not exist.
+    it('makes no GitOps claim when the owning HelmRelease is not in Git', async () => {
+      stubResources({ resource: makeAgent() }, undefined, {
+        // No Kustomization labels: applied directly, not from a Git source.
+        helmRelease: makeHelmRelease(),
+      });
 
-    expect(
-      screen.queryByText('Managed through GitOps'),
-    ).not.toBeInTheDocument();
+      await renderPage();
+
+      expect(
+        screen.queryByText('Managed through GitOps'),
+      ).not.toBeInTheDocument();
+      // The honest statement about where it came from stays.
+      expect(
+        screen.getByText('HelmRelease agentic-platform/pr-reviewer'),
+      ).toBeInTheDocument();
+    });
+
+    it('makes no GitOps claim for an agent no reconciler owns', async () => {
+      stubResources({
+        resource: makeAgent({
+          // Explicitly empty: applied directly, with no Flux or Helm markers.
+          metadata: {
+            name: 'pr-reviewer',
+            namespace: 'agentic-platform',
+            labels: {},
+          },
+        } as Partial<AgentInterface>),
+      });
+
+      await renderPage();
+
+      expect(
+        screen.queryByText('Managed through GitOps'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('says an unset system prompt is unset, not empty', async () => {

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
@@ -17,9 +17,9 @@ jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
   useResource: (...args: unknown[]) => mockUseResource(...args),
 }));
 
-// `GitOpsCard` is deliberately *not* mocked. It reports its Flux lookups through
-// `useShowErrors`, which throws without an `ErrorsProvider` — a real crash that a
-// stubbed card hid until the page was opened in the browser.
+// `GitOpsCard` is deliberately *not* mocked: it reports its Flux lookups through
+// `useShowErrors`, which throws without an `ErrorsProvider`, so a stub here would
+// hide whether the page actually provides one.
 
 jest.mock('../../hooks/useAgentAvatarUrl', () => ({
   useAgentAvatarUrl: () => () =>
@@ -538,8 +538,8 @@ describe('AgentDetailPage', () => {
   });
 
   describe('GitOps provenance', () => {
-    // Renders the real card, so this also guards the ErrorsProvider it needs — the
-    // page crashed without one, and a stubbed card would not have noticed.
+    // Renders the real card, so this also covers the ErrorsProvider it needs:
+    // without one the page throws rather than rendering anything at all.
     it('claims GitOps, with a source link, when the chain reaches Git', async () => {
       stubResources({ resource: makeAgent() }, undefined, {
         helmRelease: makeHelmRelease({

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
@@ -17,11 +17,9 @@ jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
   useResource: (...args: unknown[]) => mockUseResource(...args),
 }));
 
-// The card resolves a chain of Flux resources; the page's own job is only to
-// decide whether it renders at all.
-jest.mock('@giantswarm/backstage-plugin-flux-react', () => ({
-  GitOpsCard: () => <div data-testid="gitops-card">Managed through GitOps</div>,
-}));
+// `GitOpsCard` is deliberately *not* mocked. It reports its Flux lookups through
+// `useShowErrors`, which throws without an `ErrorsProvider` — a real crash that a
+// stubbed card hid until the page was opened in the browser.
 
 jest.mock('../../hooks/useAgentAvatarUrl', () => ({
   useAgentAvatarUrl: () => () =>
@@ -167,11 +165,25 @@ function stubResources(agent?: ResourceOutcome, modelConfig?: ResourceOutcome) {
     isLoading: outcome.isLoading ?? false,
     error: outcome.error ?? null,
     errors: outcome.errors ?? [],
+    // Part of `useResource`'s real shape, and read by GitOpsCard.
+    incompatibilities: [],
+    discoveryErrors: [],
+    clientOutdatedStates: [],
   });
 
+  // Matched per resource class, so the Flux chain GitOpsCard walks
+  // (HelmRelease → Kustomization → GitRepository) resolves to nothing rather than
+  // to whichever stub happened to be last.
   mockUseResource.mockImplementation(
-    (_cluster: string, ResourceClass: unknown) =>
-      ResourceClass === Agent ? fill(agent) : fill(modelConfig),
+    (_cluster: string, ResourceClass: unknown) => {
+      if (ResourceClass === Agent) {
+        return fill(agent);
+      }
+      if (ResourceClass === ModelConfig) {
+        return fill(modelConfig);
+      }
+      return fill();
+    },
   );
 }
 
@@ -427,12 +439,14 @@ describe('AgentDetailPage', () => {
     ).toBeInTheDocument();
   });
 
+  // Renders the real card, so this also guards the ErrorsProvider it needs — the
+  // page crashed without one, and a stubbed card would not have noticed.
   it('shows the GitOps card for a reconciled agent', async () => {
     stubResources({ resource: makeAgent() });
 
     await renderPage();
 
-    expect(screen.getByTestId('gitops-card')).toBeInTheDocument();
+    expect(screen.getByText('Managed through GitOps')).toBeInTheDocument();
   });
 
   it('omits the GitOps card for an agent no reconciler owns', async () => {
@@ -449,7 +463,9 @@ describe('AgentDetailPage', () => {
 
     await renderPage();
 
-    expect(screen.queryByTestId('gitops-card')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Managed through GitOps'),
+    ).not.toBeInTheDocument();
   });
 
   it('says an unset system prompt is unset, not empty', async () => {

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
@@ -7,7 +7,7 @@ import {
   Progress,
 } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/frontend-plugin-api';
-import { Alert, Avatar, Flex, Text } from '@backstage/ui';
+import { Alert, Avatar, Flex, Grid, Text } from '@backstage/ui';
 import {
   Agent,
   ErrorsProvider,
@@ -206,8 +206,33 @@ function AgentDetailPageContent() {
           <GitOpsCard resource={agent} installationName={installation} />
         )}
 
-        <AgentStatusCard agent={agent} />
-        <AgentConfigurationCard agent={agent} modelConfig={modelConfig} />
+        {/* Status sits in a third of the width, beside the configuration. A
+            controller message is prose — a rejected spec can carry several
+            hundred words of admission-webhook output — and across the full page
+            it runs to line lengths nobody can follow. A narrower column is the
+            fix, so the status card is the one thing that does not want the whole
+            width.
+
+            The sections below it do, and take it: a skills grid fits three cards
+            per row, and the sessions table has four columns to place. One column
+            below `lg`, where there is no width to divide. */}
+        <Grid.Root columns={{ initial: '1', lg: '3' }} gap="4">
+          {/* Status comes first in the DOM and is placed into the right-hand
+              column explicitly. Stacked into one column it is then the first
+              thing under the header, which is the right priority on a narrow
+              screen: someone opening a broken agent came for the status, not to
+              scroll past its configuration to reach it. */}
+          <Grid.Item colSpan="1" colStart={{ initial: '1', lg: '3' }}>
+            <AgentStatusCard agent={agent} />
+          </Grid.Item>
+          <Grid.Item
+            colSpan={{ initial: '1', lg: '2' }}
+            colStart={{ initial: '1', lg: '1' }}
+          >
+            <AgentConfigurationCard agent={agent} modelConfig={modelConfig} />
+          </Grid.Item>
+        </Grid.Root>
+
         <AgentSystemPromptCard agent={agent} />
         <AgentSkillsCard agent={agent} />
         <AgentSessionsCard sessions={sessions} />

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
@@ -216,20 +216,22 @@ function AgentDetailPageContent() {
             The sections below it do, and take it: a skills grid fits three cards
             per row, and the sessions table has four columns to place. One column
             below `lg`, where there is no width to divide. */}
+        {/* Document order is the layout order — no `colStart`. Grid's sparse
+            auto-placement moves the cursor to the next row whenever an item's
+            definite column-start is before the cursor's current column, so
+            placing the status in column 3 first and then pinning the
+            configuration to column 1 drops the configuration to a second row and
+            leaves the top-left of the page empty.
+
+            The consequence is that stacking below `lg` puts the configuration
+            above the status. Acceptable: the readiness label is already in the
+            page header, so the state is visible before either card. */}
         <Grid.Root columns={{ initial: '1', lg: '3' }} gap="4">
-          {/* Status comes first in the DOM and is placed into the right-hand
-              column explicitly. Stacked into one column it is then the first
-              thing under the header, which is the right priority on a narrow
-              screen: someone opening a broken agent came for the status, not to
-              scroll past its configuration to reach it. */}
-          <Grid.Item colSpan="1" colStart={{ initial: '1', lg: '3' }}>
-            <AgentStatusCard agent={agent} />
-          </Grid.Item>
-          <Grid.Item
-            colSpan={{ initial: '1', lg: '2' }}
-            colStart={{ initial: '1', lg: '1' }}
-          >
+          <Grid.Item colSpan={{ initial: '1', lg: '2' }}>
             <AgentConfigurationCard agent={agent} modelConfig={modelConfig} />
+          </Grid.Item>
+          <Grid.Item colSpan="1">
+            <AgentStatusCard agent={agent} />
           </Grid.Item>
         </Grid.Root>
 

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   isNotFoundError,
   ModelConfig,
   useResource,
+  useShowErrors,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { GitOpsCard } from '@giantswarm/backstage-plugin-flux-react';
 import {
@@ -103,6 +104,24 @@ function AgentDetailPageContent() {
   );
   useProvidePageHeaderActions(actions);
 
+  // A failed read while an agent is already in hand is reported through the
+  // ErrorsProvider notice, not by replacing the page.
+  //
+  // This page polls every 5 s while an agent converges, and the plugin's query
+  // client deliberately does not retry ServiceUnavailableError / Unauthorized /
+  // Forbidden. react-query keeps `data` and sets `error` on a failed *refetch*, so
+  // reading `error` as "we have nothing" would let one proxy hiccup blank a fully
+  // rendered agent until the next successful poll — up to a minute once polling has
+  // backed off. The rendered data is still correct; only its freshness is in doubt.
+  //
+  // Not-found is excluded because it has its own explanation below, and reporting
+  // it twice would be noise.
+  const reportableErrors = useMemo(
+    () => errors.filter(errorInfo => !isNotFoundError(errorInfo)),
+    [errors],
+  );
+  useShowErrors(reportableErrors);
+
   if (isLoading) {
     return (
       <Content>
@@ -111,25 +130,27 @@ function AgentDetailPageContent() {
     );
   }
 
-  // A 404 is an expected outcome here — a stale bookmark, a deleted or renamed
-  // agent — so it gets an explanation rather than an error banner. Also covers
-  // "kagent isn't installed on this installation", which answers 404 for the CRD.
-  if (errors.some(isNotFoundError)) {
-    return (
-      <Content>
-        <EmptyState
-          missing="data"
-          title="Agent not found"
-          description={`No agent named "${name}" exists in namespace "${namespace}" on ${
-            installation || 'that installation'
-          }. It may have been deleted or renamed, or kagent may not be installed there.`}
-          action={<BackToAgents>Back to agents</BackToAgents>}
-        />
-      </Content>
-    );
-  }
+  // Every branch below is gated on there being no agent to show. With one in hand
+  // the page renders, whatever the last read did.
+  if (!agent) {
+    // A 404 is an expected outcome here — a stale bookmark, a deleted or renamed
+    // agent — so it gets an explanation rather than an error banner. Also covers
+    // "kagent isn't installed on this installation", which answers 404 for the CRD.
+    if (errors.some(isNotFoundError)) {
+      return (
+        <Content>
+          <EmptyState
+            missing="data"
+            title="Agent not found"
+            description={`No agent named "${name}" exists in namespace "${namespace}" on ${
+              installation || 'that installation'
+            }. It may have been deleted or renamed, or kagent may not be installed there.`}
+            action={<BackToAgents>Back to agents</BackToAgents>}
+          />
+        </Content>
+      );
+    }
 
-  if (error || !agent) {
     return (
       <Content>
         <Flex direction="column" gap="3">

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
@@ -194,13 +194,14 @@ function AgentDetailPageContent() {
           {description && <Text variant="body-medium">{description}</Text>}
         </Flex>
 
-        {/* Shown whenever a reconciler owns the agent — which for anything created
-            through this plugin means a Flux HelmRelease. The card itself walks
-            Agent → HelmRelease → Kustomization → GitRepository for the source link
-            and omits it when there is no Kustomization, i.e. when the release was
-            applied directly rather than committed to Git. Nothing here is a health
-            signal: it is provenance, and it is why an agent will be read-only
-            wherever write actions are added later. */}
+        {/* A cheap pre-check only: no Flux or Helm marker at all means there is
+            nothing to resolve, so skip the lookups entirely. Whether the agent is
+            *actually* GitOps-managed is the card's own decision — it walks
+            Agent → HelmRelease → Kustomization → GitRepository and renders nothing
+            unless that ends in Git. An agent created by this plugin's own flow is
+            reconciled by a HelmRelease the scaffolder applied, which is not in Git,
+            so it correctly shows no card; the "Deployed by" row above is the whole
+            truth about where it came from. */}
         {isGitOpsManaged(agent) && (
           <GitOpsCard resource={agent} installationName={installation} />
         )}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
@@ -10,6 +10,7 @@ import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { Alert, Avatar, Flex, Text } from '@backstage/ui';
 import {
   Agent,
+  ErrorsProvider,
   isGitOpsManaged,
   isNotFoundError,
   ModelConfig,
@@ -54,20 +55,7 @@ function BackToAgents({ children }: { children: ReactNode }) {
   return <Link to={agentsRoute()}>{children}</Link>;
 }
 
-/**
- * One kagent agent: what it is, whether it works, and what it has been used for.
- *
- * Read-only. kagent agents are deployed from a Helm chart, so editing one means
- * changing the release's values — a write path this plugin does not have yet, and
- * one that has to respect the shared `OCIRepository` a namespace's agents share.
- *
- * What the APUI prototype shows and this deliberately does not, because there is
- * no data behind it: sessions all-time, sessions in the last 30 days, a success
- * rate, and "last activity" across the fleet. kagent keeps no per-agent counters
- * and scopes its session list to the calling user, so any of those would be a
- * number invented from one person's history. Please don't add them speculatively.
- */
-export function AgentDetailPage() {
+function AgentDetailPageContent() {
   const { installation = '', namespace = '', name = '' } = useParams();
   const buildAvatarUrl = useAgentAvatarUrl();
 
@@ -224,5 +212,31 @@ export function AgentDetailPage() {
         <AgentSessionsCard sessions={sessions} />
       </Flex>
     </Content>
+  );
+}
+
+/**
+ * One kagent agent: what it is, whether it works, and what it has been used for.
+ *
+ * Read-only. kagent agents are deployed from a Helm chart, so editing one means
+ * changing the release's values — a write path this plugin does not have yet, and
+ * one that has to respect the shared `OCIRepository` a namespace's agents share.
+ *
+ * What the APUI prototype shows and this deliberately does not, because there is
+ * no data behind it: sessions all-time, sessions in the last 30 days, a success
+ * rate, and "last activity" across the fleet. kagent keeps no per-agent counters
+ * and scopes its session list to the calling user, so any of those would be a
+ * number invented from one person's history. Please don't add them speculatively.
+ *
+ * `ErrorsProvider` is required, not decorative: the shared `GitOpsCard` reports
+ * the failures of its Flux lookups through `useShowErrors`, which throws without
+ * this context. Every gs details page wraps its content the same way, and it also
+ * gives this page the standard retry/dismiss notice for a failed read.
+ */
+export function AgentDetailPage() {
+  return (
+    <ErrorsProvider>
+      <AgentDetailPageContent />
+    </ErrorsProvider>
   );
 }

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
@@ -1,0 +1,228 @@
+import { ReactNode, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Content,
+  EmptyState,
+  Link,
+  Progress,
+} from '@backstage/core-components';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { Alert, Avatar, Flex, Text } from '@backstage/ui';
+import {
+  Agent,
+  isGitOpsManaged,
+  isNotFoundError,
+  ModelConfig,
+  useResource,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+import { GitOpsCard } from '@giantswarm/backstage-plugin-flux-react';
+import {
+  DateComponent,
+  StatusLabel,
+  useProvidePageHeaderActions,
+} from '@giantswarm/backstage-plugin-ui-react';
+
+import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
+import { useAgentSessions } from '../../hooks/useAgentSessions';
+import { AvatarSize } from '../../lib/agentAvatar';
+import { agentsRouteRef } from '../../routes';
+import { getAgentRefetchInterval, toAgentRow } from '../AgentsDataProvider';
+import { READINESS_PRESENTATION } from '../AgentsTable/readinessStatus';
+import { AgentActionsMenu } from './AgentActionsMenu';
+import { AgentConfigurationCard } from './AgentConfigurationCard';
+import { AgentSessionsCard } from './AgentSessionsCard';
+import { AgentSkillsCard } from './AgentSkillsCard';
+import { AgentStatusCard } from './AgentStatusCard';
+import { AgentSystemPromptCard } from './AgentSystemPromptCard';
+
+/** Matches the list's row avatar: two lines of text, 2× for hi-dpi. */
+const AVATAR_SIZE: AvatarSize = 96;
+
+/**
+ * Link back to the list.
+ *
+ * `useRouteRef` returns undefined when the route is not bound — which in practice
+ * means the Agent Platform extension is disabled, and then this page isn't
+ * rendering either. Rendering nothing is still better than hardcoding the path,
+ * which would silently rot if the route moved.
+ */
+function BackToAgents({ children }: { children: ReactNode }) {
+  const agentsRoute = useRouteRef(agentsRouteRef);
+  if (!agentsRoute) {
+    return null;
+  }
+  return <Link to={agentsRoute()}>{children}</Link>;
+}
+
+/**
+ * One kagent agent: what it is, whether it works, and what it has been used for.
+ *
+ * Read-only. kagent agents are deployed from a Helm chart, so editing one means
+ * changing the release's values — a write path this plugin does not have yet, and
+ * one that has to respect the shared `OCIRepository` a namespace's agents share.
+ *
+ * What the APUI prototype shows and this deliberately does not, because there is
+ * no data behind it: sessions all-time, sessions in the last 30 days, a success
+ * rate, and "last activity" across the fleet. kagent keeps no per-agent counters
+ * and scopes its session list to the calling user, so any of those would be a
+ * number invented from one person's history. Please don't add them speculatively.
+ */
+export function AgentDetailPage() {
+  const { installation = '', namespace = '', name = '' } = useParams();
+  const buildAvatarUrl = useAgentAvatarUrl();
+
+  const {
+    resource: agent,
+    isLoading,
+    error,
+    errors,
+  } = useResource(
+    installation,
+    Agent,
+    { name, namespace, enableDiscovery: false },
+    // Same two tiers as the list: tighten while the agent is converging, relax
+    // once it settles or stays broken. This page is where someone watches an
+    // agent come up, so the fast tier earns its keep here.
+    { refetchInterval: getAgentRefetchInterval },
+  );
+
+  // A targeted, namespaced read rather than ModelConfigsProvider's cluster-wide
+  // list — that list is admin-only, so reusing it here would deny a non-admin the
+  // model name on a page they can otherwise see in full.
+  const modelConfigName = agent?.getModelConfigName();
+  const { resource: modelConfig } = useResource(
+    installation,
+    ModelConfig,
+    { name: modelConfigName ?? '', namespace, enableDiscovery: false },
+    { enabled: Boolean(modelConfigName) },
+  );
+
+  // The row shape the sessions list uses, so this agent's name and avatar resolve
+  // identically in both places.
+  const agentRow = useMemo(
+    () =>
+      agent ? toAgentRow(agent, modelConfig ? [modelConfig] : []) : undefined,
+    [agent, modelConfig],
+  );
+  const sessions = useAgentSessions(installation, namespace, name, agentRow);
+
+  // `agent` is memoized on the fetched JSON, so this element's identity only
+  // changes when the agent actually does — which is what keeps the header slot
+  // from re-registering (and re-rendering) on every poll.
+  const actions = useMemo(
+    () => (agent ? <AgentActionsMenu agent={agent} /> : null),
+    [agent],
+  );
+  useProvidePageHeaderActions(actions);
+
+  if (isLoading) {
+    return (
+      <Content>
+        <Progress aria-label="Loading agent" />
+      </Content>
+    );
+  }
+
+  // A 404 is an expected outcome here — a stale bookmark, a deleted or renamed
+  // agent — so it gets an explanation rather than an error banner. Also covers
+  // "kagent isn't installed on this installation", which answers 404 for the CRD.
+  if (errors.some(isNotFoundError)) {
+    return (
+      <Content>
+        <EmptyState
+          missing="data"
+          title="Agent not found"
+          description={`No agent named "${name}" exists in namespace "${namespace}" on ${
+            installation || 'that installation'
+          }. It may have been deleted or renamed, or kagent may not be installed there.`}
+          action={<BackToAgents>Back to agents</BackToAgents>}
+        />
+      </Content>
+    );
+  }
+
+  if (error || !agent) {
+    return (
+      <Content>
+        <Flex direction="column" gap="3">
+          <Alert
+            status="danger"
+            title="Could not load this agent"
+            description={
+              (error as Error | null)?.message ??
+              'The installation returned a response we could not read. The agent may still exist.'
+            }
+          />
+          <BackToAgents>Back to agents</BackToAgents>
+        </Flex>
+      </Content>
+    );
+  }
+
+  const readiness = READINESS_PRESENTATION[agent.getReadiness()];
+  const description = agent.getDescription();
+  const created = agent.getCreatedTimestamp();
+  const avatarUrl = buildAvatarUrl(installation, name, { size: AVATAR_SIZE });
+
+  return (
+    <Content>
+      <Flex direction="column" gap="4">
+        <Flex direction="column" gap="2">
+          <BackToAgents>← Agents</BackToAgents>
+
+          <Flex align="center" gap="3" style={{ flexWrap: 'wrap' }}>
+            <Avatar
+              size="large"
+              purpose="decoration"
+              name={agent.getDisplayName()}
+              src={avatarUrl ?? ''}
+            />
+            <Flex direction="column" gap="1" style={{ minWidth: 0 }}>
+              <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
+                <Text variant="title-medium">{agent.getDisplayName()}</Text>
+                {/* Tagged because the derived readiness and the condition it came
+                    from share a label ("Ready", "Ready") — this is the derived
+                    one, distinct from the entries in the conditions list. */}
+                <span data-testid="agent-readiness">
+                  <StatusLabel
+                    label={readiness.label}
+                    intent={readiness.intent}
+                    icon={readiness.icon}
+                  />
+                </span>
+              </Flex>
+
+              <Text variant="body-small" color="secondary">
+                <span style={{ fontFamily: 'monospace' }}>{name}</span>
+                {' · '}
+                {installation}
+                {namespace ? ` / ${namespace}` : ''}
+                {created ? ' · created ' : ''}
+                {created ? <DateComponent value={created} relative /> : null}
+              </Text>
+            </Flex>
+          </Flex>
+
+          {description && <Text variant="body-medium">{description}</Text>}
+        </Flex>
+
+        {/* Shown whenever a reconciler owns the agent — which for anything created
+            through this plugin means a Flux HelmRelease. The card itself walks
+            Agent → HelmRelease → Kustomization → GitRepository for the source link
+            and omits it when there is no Kustomization, i.e. when the release was
+            applied directly rather than committed to Git. Nothing here is a health
+            signal: it is provenance, and it is why an agent will be read-only
+            wherever write actions are added later. */}
+        {isGitOpsManaged(agent) && (
+          <GitOpsCard resource={agent} installationName={installation} />
+        )}
+
+        <AgentStatusCard agent={agent} />
+        <AgentConfigurationCard agent={agent} modelConfig={modelConfig} />
+        <AgentSystemPromptCard agent={agent} />
+        <AgentSkillsCard agent={agent} />
+        <AgentSessionsCard sessions={sessions} />
+      </Flex>
+    </Content>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentManifestDialog.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentManifestDialog.tsx
@@ -1,0 +1,50 @@
+import { Dialog, DialogBody, DialogHeader, Text } from '@backstage/ui';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+
+import { CodeBlock } from '../CodeBlock';
+import { toAgentManifestYaml } from './helpers';
+
+export type AgentManifestDialogProps = {
+  agent: Agent;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+};
+
+/**
+ * The Agent CR as read-only YAML.
+ *
+ * A dialog rather than a section on the page: it is the escape hatch for the
+ * fields the page does not surface (`deployment`, `sandbox`, `a2aConfig`, labels),
+ * needed rarely and long enough to push everything else out of view.
+ *
+ * Controlled, because the trigger is a `MenuItem` in the page header's kebab —
+ * `DialogTrigger` would have to wrap the menu item, and react-aria closes the menu
+ * on selection, taking the trigger (and the dialog) with it.
+ */
+export function AgentManifestDialog({
+  agent,
+  isOpen,
+  onOpenChange,
+}: AgentManifestDialogProps) {
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      width="min(90vw, 860px)"
+    >
+      <DialogHeader>Agent manifest</DialogHeader>
+      <DialogBody>
+        <Text variant="body-small" color="secondary">
+          The resource as stored, minus server-side-apply bookkeeping. Read-only
+          — this view never writes.
+        </Text>
+        <CodeBlock
+          content={toAgentManifestYaml(agent)}
+          filename={`${agent.getName()}.yaml`}
+          path={`${agent.cluster} · ${agent.getNamespace() ?? ''}`}
+          language="yaml"
+        />
+      </DialogBody>
+    </Dialog>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentSessionsCard.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentSessionsCard.tsx
@@ -1,0 +1,75 @@
+import { Flex, Text } from '@backstage/ui';
+import { Link } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { InfoCard } from '@giantswarm/backstage-plugin-ui-react';
+
+import { AgentSessionsView } from '../../hooks/useAgentSessions';
+import { sessionsRouteRef } from '../../routes';
+import { SessionsTable } from '../SessionsTable';
+
+/**
+ * How many sessions to show inline. Enough to answer "has anyone used this
+ * agent, and did it just run"; the Sessions tab is there for the rest.
+ */
+const RECENT_SESSION_LIMIT = 5;
+
+/**
+ * The signed-in user's recent sessions with this agent.
+ *
+ * Explicitly *not* a usage metric. kagent scopes its session list to the caller,
+ * so this shows only your own conversations — the prototype's "2,104 sessions
+ * all-time" has no equivalent here, and inventing one from this list would be
+ * wrong by orders of magnitude on a shared agent.
+ */
+export function AgentSessionsCard({
+  sessions,
+}: {
+  sessions: AgentSessionsView;
+}) {
+  const sessionsRoute = useRouteRef(sessionsRouteRef);
+  const { rows, isLoading, isNotUserScoped, isUnavailable } = sessions;
+
+  const recent = rows.slice(0, RECENT_SESSION_LIMIT);
+
+  return (
+    <InfoCard
+      title="Recent sessions"
+      headerActions={
+        sessionsRoute && <Link to={sessionsRoute()}>View all sessions</Link>
+      }
+    >
+      <Flex direction="column" gap="3">
+        <Text variant="body-small" color="secondary">
+          {isNotUserScoped
+            ? // Not a caveat we can hide: on an installation running kagent in
+              // `unsecure` mode the list is everyone's, so calling it "yours"
+              // would be a lie in the other direction.
+              "This installation's kagent does not scope sessions to a user, so these are everyone's sessions with this agent."
+            : 'Your own sessions with this agent. kagent only lets you read sessions you started, so this is not a usage total.'}
+        </Text>
+
+        {isUnavailable ? (
+          <Text variant="body-medium" color="secondary">
+            Sessions could not be read from this installation.
+          </Text>
+        ) : (
+          <SessionsTable
+            rows={recent}
+            isLoading={isLoading}
+            hideColumns={['agentName', 'installation']}
+            showSearch={false}
+            showPagination={false}
+            emptyMessage="No sessions with this agent yet."
+          />
+        )}
+
+        {rows.length > recent.length && sessionsRoute && (
+          <Text variant="body-small" color="secondary">
+            Showing {recent.length} of {rows.length}.{' '}
+            <Link to={sessionsRoute()}>See all in Sessions</Link>
+          </Text>
+        )}
+      </Flex>
+    </InfoCard>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentSkillsCard.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentSkillsCard.tsx
@@ -1,0 +1,58 @@
+import { Flex, Text } from '@backstage/ui';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+import { ExternalLink, InfoCard } from '@giantswarm/backstage-plugin-ui-react';
+
+import { skillLabel } from './helpers';
+
+/**
+ * The skills mounted into the agent (`spec.skills.gitRefs`).
+ *
+ * Each is a path in a Git repository the agent pulls at startup. The `ref` is
+ * shown because it decides *which* version of a skill the agent actually runs —
+ * an unpinned skill changes under the agent whenever its repository does, which
+ * is the kind of thing you want to see while debugging changed behaviour.
+ */
+export function AgentSkillsCard({ agent }: { agent: Agent }) {
+  const skills = agent.getSkillRefs();
+
+  return (
+    <InfoCard title={`Skills${skills.length > 0 ? ` (${skills.length})` : ''}`}>
+      {skills.length === 0 ? (
+        <Text variant="body-medium" color="secondary">
+          No skills mounted. The agent works from its system prompt and tools
+          alone.
+        </Text>
+      ) : (
+        <Flex direction="column" gap="3">
+          {skills.map((skill, index) => (
+            <Flex
+              // Nothing in a gitRef is guaranteed unique — the same repository can
+              // be mounted at several paths, and both `name` and `path` are
+              // optional — so the index is part of the key.
+              key={`${skill.url}#${skill.path ?? ''}#${index}`}
+              direction="column"
+              gap="1"
+            >
+              <Text variant="body-medium">{skillLabel(skill)}</Text>
+              <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
+                <ExternalLink href={skill.url}>{skill.url}</ExternalLink>
+                {skill.path && (
+                  <Text
+                    variant="body-small"
+                    color="secondary"
+                    style={{ fontFamily: 'monospace' }}
+                  >
+                    {skill.path}
+                  </Text>
+                )}
+                <Text variant="body-small" color="secondary">
+                  {skill.ref ? `at ${skill.ref}` : 'default branch (unpinned)'}
+                </Text>
+              </Flex>
+            </Flex>
+          ))}
+        </Flex>
+      )}
+    </InfoCard>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentSkillsCard.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentSkillsCard.tsx
@@ -1,16 +1,66 @@
-import { Flex, Text } from '@backstage/ui';
+import { Text } from '@backstage/ui';
 import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
 import { ExternalLink, InfoCard } from '@giantswarm/backstage-plugin-ui-react';
 
+import { repoSlug } from '../../lib/skills';
+import {
+  SelectableCardGrid,
+  StaticCard,
+  useSelectableCardStyles,
+} from '../SelectableCard';
 import { skillLabel } from './helpers';
+
+type SkillRef = ReturnType<Agent['getSkillRefs']>[number];
+
+/**
+ * One mounted skill, in the same card the create flow's skill picker uses — just
+ * read-only, so there is no checkbox and nothing to press.
+ */
+function SkillCard({ skill }: { skill: SkillRef }) {
+  const classes = useSelectableCardStyles();
+  const label = skillLabel(skill);
+  const path = skill.path ?? '';
+
+  // Show the path only when it adds something the title doesn't already say —
+  // the same rule the picker applies.
+  const showPath = path !== '' && (path.includes('/') || path !== label);
+
+  return (
+    <StaticCard>
+      <Text weight="bold">{label}</Text>
+      <Text variant="body-x-small" color="secondary">
+        <ExternalLink href={skill.url}>{repoSlug(skill.url)}</ExternalLink>
+        {showPath && (
+          <>
+            {' · '}
+            <span className={classes.code}>{path}</span>
+          </>
+        )}
+      </Text>
+      {/* The ref decides *which* version of a skill the agent actually runs, and
+          an unpinned one changes under the agent whenever its repository does —
+          which is exactly what you want to see when behaviour changed and the
+          spec didn't. The picker has no equivalent: it always reads a repo's
+          default branch. */}
+      <Text variant="body-x-small" color="secondary">
+        {skill.ref ? (
+          <>
+            at <span className={classes.code}>{skill.ref}</span>
+          </>
+        ) : (
+          'default branch (unpinned)'
+        )}
+      </Text>
+    </StaticCard>
+  );
+}
 
 /**
  * The skills mounted into the agent (`spec.skills.gitRefs`).
  *
- * Each is a path in a Git repository the agent pulls at startup. The `ref` is
- * shown because it decides *which* version of a skill the agent actually runs —
- * an unpinned skill changes under the agent whenever its repository does, which
- * is the kind of thing you want to see while debugging changed behaviour.
+ * Each is a path in a Git repository the agent pulls at startup. Presented as the
+ * same grid of cards the create flow selects from, so an agent's skills look like
+ * the things that were picked.
  */
 export function AgentSkillsCard({ agent }: { agent: Agent }) {
   const skills = agent.getSkillRefs();
@@ -23,35 +73,21 @@ export function AgentSkillsCard({ agent }: { agent: Agent }) {
           alone.
         </Text>
       ) : (
-        <Flex direction="column" gap="3">
+        <SelectableCardGrid
+          role="list"
+          ariaLabel="Mounted skills"
+          minWidth={240}
+        >
           {skills.map((skill, index) => (
-            <Flex
+            <SkillCard
               // Nothing in a gitRef is guaranteed unique — the same repository can
               // be mounted at several paths, and both `name` and `path` are
               // optional — so the index is part of the key.
               key={`${skill.url}#${skill.path ?? ''}#${index}`}
-              direction="column"
-              gap="1"
-            >
-              <Text variant="body-medium">{skillLabel(skill)}</Text>
-              <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
-                <ExternalLink href={skill.url}>{skill.url}</ExternalLink>
-                {skill.path && (
-                  <Text
-                    variant="body-small"
-                    color="secondary"
-                    style={{ fontFamily: 'monospace' }}
-                  >
-                    {skill.path}
-                  </Text>
-                )}
-                <Text variant="body-small" color="secondary">
-                  {skill.ref ? `at ${skill.ref}` : 'default branch (unpinned)'}
-                </Text>
-              </Flex>
-            </Flex>
+              skill={skill}
+            />
           ))}
-        </Flex>
+        </SelectableCardGrid>
       )}
     </InfoCard>
   );

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentStatusCard.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentStatusCard.tsx
@@ -1,0 +1,85 @@
+import { Alert, Flex, Text } from '@backstage/ui';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+import {
+  ConditionLike,
+  ConditionsList,
+  InfoCard,
+  StatusLabel,
+} from '@giantswarm/backstage-plugin-ui-react';
+
+import { READINESS_PRESENTATION } from '../AgentsTable/readinessStatus';
+
+/**
+ * kagent's `UnsupportedFeatures` is abnormal-true: the controller only sets it
+ * when something *is* unsupported, and removes it once the warning clears. Every
+ * other Agent condition is positive-polarity.
+ */
+function isFailingAgentCondition(condition: ConditionLike): boolean {
+  if (condition.type === 'UnsupportedFeatures') {
+    return condition.status === 'True';
+  }
+
+  return condition.status !== 'True';
+}
+
+/**
+ * Why the agent is in the state the list shows: the readiness label, the
+ * controller's own explanation, and every status condition verbatim.
+ *
+ * This is the section that makes a broken agent debuggable without `kubectl`, so
+ * it leads the page rather than following the configuration.
+ */
+export function AgentStatusCard({ agent }: { agent: Agent }) {
+  const readiness = agent.getReadiness();
+  const { label, intent, icon } = READINESS_PRESENTATION[readiness];
+  const readinessMessage = agent.getReadinessMessage();
+  const unsupportedFeatures = agent.getUnsupportedFeaturesWarning();
+  const conditions = agent.getConditions() ?? [];
+
+  return (
+    <InfoCard title="Status">
+      <Flex direction="column" gap="4">
+        <Flex direction="column" gap="2">
+          <StatusLabel label={label} intent={intent} icon={icon} />
+          {readinessMessage && (
+            <Text variant="body-small" color="secondary">
+              {readinessMessage}
+            </Text>
+          )}
+          {/* The one explanation the conditions cannot give on their own: they
+              may all read healthy and still describe the *previous* spec. */}
+          {agent.isStale() && (
+            <Text variant="body-small" color="secondary">
+              The controller has reconciled generation{' '}
+              {agent.getObservedGeneration()}, but the stored spec is at
+              generation {agent.getGeneration()} — the conditions below describe
+              the previous version.
+            </Text>
+          )}
+        </Flex>
+
+        {/* Independent of readiness — a fully ready agent can carry this — so it
+            is reported separately rather than folded into the label above. */}
+        {unsupportedFeatures && (
+          <Alert
+            status="warning"
+            title="Some configured features are unsupported"
+            description={unsupportedFeatures}
+          />
+        )}
+
+        <ConditionsList
+          conditions={conditions}
+          isFailing={isFailingAgentCondition}
+          emptyContent={
+            <Text variant="body-small" color="secondary">
+              kagent has not reported a status for this agent yet. A newly
+              created agent shows this until the controller reconciles it for
+              the first time.
+            </Text>
+          }
+        />
+      </Flex>
+    </InfoCard>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentSystemPromptCard.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentSystemPromptCard.tsx
@@ -1,0 +1,33 @@
+import { Flex, Text } from '@backstage/ui';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+import { CodeBlock, InfoCard } from '@giantswarm/backstage-plugin-ui-react';
+
+/**
+ * The agent's system message (`spec.declarative.systemMessage`).
+ *
+ * Rendered as a copyable code block rather than prose: it is a configured value
+ * someone may want to lift verbatim into a review or a chart change, and the
+ * monospace framing makes clear where it starts and ends.
+ */
+export function AgentSystemPromptCard({ agent }: { agent: Agent }) {
+  const systemMessage = agent.getSystemMessage();
+
+  return (
+    <InfoCard title="System prompt">
+      {systemMessage ? (
+        <CodeBlock text={systemMessage} />
+      ) : (
+        <Flex direction="column" gap="1">
+          <Text variant="body-medium" color="secondary">
+            Not set on the Agent resource.
+          </Text>
+          {/* Worth spelling out: an empty field does not mean the agent has no
+              system prompt, only that it is not configured here. */}
+          <Text variant="body-small" color="secondary">
+            The agent runs with whatever default its chart or runtime provides.
+          </Text>
+        </Flex>
+      )}
+    </InfoCard>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/helpers.test.ts
+++ b/plugins/agent-platform/src/components/AgentDetailPage/helpers.test.ts
@@ -136,6 +136,30 @@ describe('toAgentManifestYaml', () => {
     expect(yaml).toContain('observedGeneration: 1');
   });
 
+  // The view exists to be compared against `kubectl get -o yaml`, so it prints the
+  // same key order.
+  it('orders keys apiVersion, kind, metadata, spec, status', () => {
+    const yaml = toAgentManifestYaml(
+      makeAgent({
+        spec: { type: 'Declarative' },
+        status: { observedGeneration: 1, conditions: [] },
+      } as Partial<AgentInterface>),
+    );
+
+    const topLevelKeys = yaml
+      .split('\n')
+      .filter(line => /^\S/.test(line))
+      .map(line => line.split(':')[0]);
+
+    expect(topLevelKeys).toEqual([
+      'apiVersion',
+      'kind',
+      'metadata',
+      'spec',
+      'status',
+    ]);
+  });
+
   // Server-side-apply bookkeeping is the bulk of a reconciled Agent and pushes
   // the spec off the screen; kubectl hides it too.
   it('drops managedFields', () => {

--- a/plugins/agent-platform/src/components/AgentDetailPage/helpers.test.ts
+++ b/plugins/agent-platform/src/components/AgentDetailPage/helpers.test.ts
@@ -1,0 +1,209 @@
+import { crds } from '@giantswarm/k8s-types';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+import {
+  describeToolScope,
+  isMusterServerRef,
+  mcpServerRefId,
+  skillLabel,
+  toAgentManifestYaml,
+} from './helpers';
+
+type AgentInterface = crds.kagent.v1alpha2.Agent;
+
+function makeAgent(overrides: Partial<AgentInterface> = {}): Agent {
+  return new Agent(
+    {
+      apiVersion: 'kagent.dev/v1alpha2',
+      kind: 'Agent',
+      metadata: { name: 'pr-reviewer', namespace: 'agentic-platform' },
+      ...overrides,
+    } as AgentInterface,
+    'gazelle',
+  );
+}
+
+describe('isMusterServerRef', () => {
+  // Matched on the name alone: the namespace is a chart value, so an installation
+  // may place the gateway somewhere other than agentic-platform.
+  it('recognises the muster gateway in any namespace', () => {
+    expect(isMusterServerRef({ name: 'muster' })).toBe(true);
+    expect(isMusterServerRef({ name: 'muster', namespace: 'mcp' })).toBe(true);
+  });
+
+  it('does not claim any other server is muster', () => {
+    expect(isMusterServerRef({ name: 'grafana' })).toBe(false);
+    expect(isMusterServerRef({ name: 'muster-staging' })).toBe(false);
+  });
+});
+
+describe('mcpServerRefId', () => {
+  it('qualifies the name with the namespace when there is one', () => {
+    expect(
+      mcpServerRefId({ name: 'muster', namespace: 'agentic-platform' }),
+    ).toBe('agentic-platform/muster');
+  });
+
+  it('falls back to the bare name', () => {
+    expect(mcpServerRefId({ name: 'muster' })).toBe('muster');
+  });
+});
+
+describe('describeToolScope', () => {
+  // An absent allowlist means "everything", which is worth stating rather than
+  // leaving to be inferred from a missing value.
+  it('says all tools when no allowlist is set', () => {
+    expect(describeToolScope({ name: 'muster' })).toBe(
+      'All tools from this server',
+    );
+    expect(describeToolScope({ name: 'muster', toolNames: [] })).toBe(
+      'All tools from this server',
+    );
+  });
+
+  it('lists an allowlist and counts it', () => {
+    expect(
+      describeToolScope({
+        name: 'grafana',
+        toolNames: ['query', 'dashboards'],
+      }),
+    ).toBe('2 tools: query, dashboards');
+  });
+
+  it('keeps the count singular for one tool', () => {
+    expect(describeToolScope({ name: 'grafana', toolNames: ['query'] })).toBe(
+      '1 tool: query',
+    );
+  });
+});
+
+describe('skillLabel', () => {
+  it('prefers the explicit name', () => {
+    expect(
+      skillLabel({
+        url: 'https://github.com/giantswarm/skills',
+        path: 'pr/review',
+        name: 'PR review conventions',
+      }),
+    ).toBe('PR review conventions');
+  });
+
+  it('falls back to the last path segment', () => {
+    expect(
+      skillLabel({
+        url: 'https://github.com/giantswarm/skills',
+        path: 'skills/idiomatic-go/',
+      }),
+    ).toBe('idiomatic-go');
+  });
+
+  it('falls back to the repository name, without the .git suffix', () => {
+    expect(
+      skillLabel({ url: 'https://github.com/giantswarm/skills.git' }),
+    ).toBe('skills');
+  });
+
+  // A row with no label is unusable, so there is always something.
+  it('falls back to the raw url when nothing else is available', () => {
+    expect(skillLabel({ url: 'weird' })).toBe('weird');
+  });
+});
+
+describe('toAgentManifestYaml', () => {
+  it('renders the resource as YAML, status included', () => {
+    const yaml = toAgentManifestYaml(
+      makeAgent({
+        spec: { type: 'Declarative', declarative: { modelConfig: 'opus' } },
+        status: {
+          observedGeneration: 1,
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'True',
+              reason: 'DeploymentReady',
+              message: 'Deployment is ready',
+              lastTransitionTime: '2026-07-31T10:00:00Z',
+            },
+          ],
+        },
+      } as Partial<AgentInterface>),
+    );
+
+    expect(yaml).toContain('kind: Agent');
+    expect(yaml).toContain('apiVersion: kagent.dev/v1alpha2');
+    expect(yaml).toContain('name: pr-reviewer');
+    expect(yaml).toContain('modelConfig: opus');
+    // The point of this view is to see what the page does not surface.
+    expect(yaml).toContain('observedGeneration: 1');
+  });
+
+  // Server-side-apply bookkeeping is the bulk of a reconciled Agent and pushes
+  // the spec off the screen; kubectl hides it too.
+  it('drops managedFields', () => {
+    const yaml = toAgentManifestYaml(
+      makeAgent({
+        metadata: {
+          name: 'pr-reviewer',
+          namespace: 'agentic-platform',
+          managedFields: [
+            {
+              manager: 'helm-controller',
+              operation: 'Apply',
+              apiVersion: 'kagent.dev/v1alpha2',
+            },
+          ],
+        },
+      } as Partial<AgentInterface>),
+    );
+
+    expect(yaml).not.toContain('managedFields');
+    expect(yaml).not.toContain('helm-controller');
+    expect(yaml).toContain('name: pr-reviewer');
+  });
+
+  it('drops the last-applied-configuration annotation but keeps the others', () => {
+    const yaml = toAgentManifestYaml(
+      makeAgent({
+        metadata: {
+          name: 'pr-reviewer',
+          namespace: 'agentic-platform',
+          annotations: {
+            'kubectl.kubernetes.io/last-applied-configuration': '{"a":1}',
+            'ui.giantswarm.io/display-name': 'PR reviewer',
+          },
+        },
+      } as Partial<AgentInterface>),
+    );
+
+    expect(yaml).not.toContain('last-applied-configuration');
+    expect(yaml).toContain('ui.giantswarm.io/display-name');
+  });
+
+  it('omits the annotations key entirely when nothing is left', () => {
+    const yaml = toAgentManifestYaml(
+      makeAgent({
+        metadata: {
+          name: 'pr-reviewer',
+          namespace: 'agentic-platform',
+          annotations: {
+            'kubectl.kubernetes.io/last-applied-configuration': '{"a":1}',
+          },
+        },
+      } as Partial<AgentInterface>),
+    );
+
+    expect(yaml).not.toContain('annotations');
+  });
+
+  // A long system message is a common reason to open this view, so it must not be
+  // folded across lines.
+  it('does not wrap long values', () => {
+    const systemMessage = 'You review pull requests. '.repeat(20).trim();
+    const yaml = toAgentManifestYaml(
+      makeAgent({
+        spec: { declarative: { systemMessage } },
+      } as Partial<AgentInterface>),
+    );
+
+    expect(yaml).toContain(systemMessage);
+  });
+});

--- a/plugins/agent-platform/src/components/AgentDetailPage/helpers.ts
+++ b/plugins/agent-platform/src/components/AgentDetailPage/helpers.ts
@@ -81,7 +81,7 @@ export function skillLabel(ref: SkillRef): string {
  * to see the fields the page does not surface.
  */
 export function toAgentManifestYaml(agent: Agent): string {
-  const { metadata, ...rest } = agent.jsonData;
+  const { apiVersion, kind, metadata, ...rest } = agent.jsonData;
   const {
     managedFields: _managedFields,
     annotations,
@@ -94,14 +94,20 @@ export function toAgentManifestYaml(agent: Agent): string {
   } = annotations ?? {};
 
   return dump(
+    // Key order is `apiVersion, kind, metadata, spec, status`, matching what
+    // `kubectl get -o yaml` prints — this view exists to be compared against that,
+    // and object spread order is what decides it (`sortKeys` is off deliberately:
+    // alphabetical would put `status` before `spec`).
     {
-      ...rest,
+      apiVersion,
+      kind,
       metadata: {
         ...restMetadata,
         ...(Object.keys(restAnnotations).length > 0
           ? { annotations: restAnnotations }
           : {}),
       },
+      ...rest,
     },
     // Long system messages and controller messages are the reason to open this,
     // so don't let js-yaml fold them at 80 columns.

--- a/plugins/agent-platform/src/components/AgentDetailPage/helpers.ts
+++ b/plugins/agent-platform/src/components/AgentDetailPage/helpers.ts
@@ -1,0 +1,110 @@
+import { dump } from 'js-yaml';
+import {
+  Agent,
+  AgentMcpServerRef,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+
+/**
+ * Name of the `RemoteMCPServer` the `agent` chart points every agent at for its
+ * tools (`muster.enabled: true` by default, referencing `muster` in
+ * `agentic-platform`). Matching on the name alone, not the namespace, because the
+ * namespace is a chart value and installations may place the gateway elsewhere.
+ *
+ * A name match is a heuristic, so it only ever *adds* a link to the Tool
+ * Explorer; a server we don't recognise is still listed, just without one.
+ */
+export const MUSTER_MCP_SERVER_NAME = 'muster';
+
+export function isMusterServerRef(ref: AgentMcpServerRef): boolean {
+  return ref.name === MUSTER_MCP_SERVER_NAME;
+}
+
+/** `<namespace>/<name>` for an MCP server reference, namespace omitted when unset. */
+export function mcpServerRefId(ref: AgentMcpServerRef): string {
+  return ref.namespace ? `${ref.namespace}/${ref.name}` : ref.name;
+}
+
+/**
+ * How the agent's access to a server is scoped, in words.
+ *
+ * `toolNames` is an allowlist; an absent or empty one means the agent may call
+ * everything the server exposes, which is worth stating rather than leaving to be
+ * inferred from a missing value.
+ */
+export function describeToolScope(ref: AgentMcpServerRef): string {
+  const toolNames = ref.toolNames ?? [];
+  if (toolNames.length === 0) {
+    return 'All tools from this server';
+  }
+
+  return `${toolNames.length} tool${toolNames.length === 1 ? '' : 's'}: ${toolNames.join(', ')}`;
+}
+
+type SkillRef = ReturnType<Agent['getSkillRefs']>[number];
+
+/**
+ * Display label for a mounted skill: the explicit `name` when the manifest sets
+ * one, else the last segment of the path it is mounted from, else the repository
+ * itself. Never empty, because a row with no label is unusable.
+ */
+export function skillLabel(ref: SkillRef): string {
+  if (ref.name) {
+    return ref.name;
+  }
+
+  const fromPath = (ref.path ?? '').split('/').filter(Boolean).pop();
+  if (fromPath) {
+    return fromPath;
+  }
+
+  const fromUrl = ref.url
+    .replace(/\.git$/, '')
+    .split('/')
+    .filter(Boolean)
+    .pop();
+
+  return fromUrl ?? ref.url;
+}
+
+/**
+ * The agent as the YAML a reader would compare against `kubectl get -o yaml`.
+ *
+ * Two fields are dropped first:
+ *
+ * - `metadata.managedFields`, which is server-side-apply bookkeeping and, on a
+ *   reconciled Agent, the bulk of the object. Nobody debugging an agent reads it,
+ *   and it pushes the spec off the screen. (`kubectl get` hides it too.)
+ * - the `last-applied-configuration` annotation, which is a JSON copy of the
+ *   whole object on one line — the same information, rendered unreadably.
+ *
+ * Everything else is shown verbatim, `status` included: the point of this view is
+ * to see the fields the page does not surface.
+ */
+export function toAgentManifestYaml(agent: Agent): string {
+  const { metadata, ...rest } = agent.jsonData;
+  const {
+    managedFields: _managedFields,
+    annotations,
+    ...restMetadata
+  } = metadata ?? {};
+
+  const {
+    'kubectl.kubernetes.io/last-applied-configuration': _lastApplied,
+    ...restAnnotations
+  } = annotations ?? {};
+
+  return dump(
+    {
+      ...rest,
+      metadata: {
+        ...restMetadata,
+        ...(Object.keys(restAnnotations).length > 0
+          ? { annotations: restAnnotations }
+          : {}),
+      },
+    },
+    // Long system messages and controller messages are the reason to open this,
+    // so don't let js-yaml fold them at 80 columns.
+    { lineWidth: -1, noRefs: true, sortKeys: false },
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/index.ts
+++ b/plugins/agent-platform/src/components/AgentDetailPage/index.ts
@@ -1,0 +1,1 @@
+export { AgentDetailPage } from './AgentDetailPage';

--- a/plugins/agent-platform/src/components/AgentsDataProvider/helpers.ts
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/helpers.ts
@@ -43,6 +43,50 @@ const TRANSITIONAL_REFETCH_INTERVAL_MS = 5_000;
 const TRANSITIONAL_MAX_AGE_MS = 3 * 60_000;
 
 /**
+ * Whether one agent is worth re-checking sooner than the rest: not settled into a
+ * healthy state, and its status still moving (or too new to tell).
+ *
+ * Shared by the fleet list and the single-agent detail page so both back off from
+ * a *permanently* broken agent on the same terms — see
+ * {@link TRANSITIONAL_MAX_AGE_MS} for why that bound exists.
+ */
+function isAgentConverging(
+  json: crds.kagent.v1alpha2.Agent,
+  now: number,
+): boolean {
+  if (!isAgentTransitional(deriveAgentReadiness(json))) {
+    return false;
+  }
+
+  const changedAt = getAgentStatusChangedAt(json);
+
+  // No usable timestamp: treat the agent as just-changed rather than as stuck,
+  // so a genuinely new agent is still picked up quickly.
+  return changedAt === undefined || now - changedAt < TRANSITIONAL_MAX_AGE_MS;
+}
+
+/**
+ * Refetch interval for a single agent, for the detail page.
+ *
+ * Same two tiers as the list below, decided from this one agent's own status: it
+ * tightens while the agent is converging and relaxes once it settles or stays
+ * broken. The detail page is exactly where someone watches an agent come up, so
+ * the fast tier matters more here than in the list.
+ */
+export function getAgentRefetchInterval(
+  query: Query<KubeObjectInterface>,
+): number {
+  const json = query.state.data as crds.kagent.v1alpha2.Agent | undefined;
+  if (!json) {
+    return BASELINE_REFETCH_INTERVAL_MS;
+  }
+
+  return isAgentConverging(json, Date.now())
+    ? TRANSITIONAL_REFETCH_INTERVAL_MS
+    : BASELINE_REFETCH_INTERVAL_MS;
+}
+
+/**
  * Per-installation refetch interval for the agent list.
  *
  * `useResources` applies this to each installation's list query separately, and
@@ -77,17 +121,9 @@ export function getAgentsRefetchInterval(
 
   // This query lists Agents, so its items are Agent JSON — narrow to read the
   // status conditions the shared derivation expects.
-  const isConverging = (items as crds.kagent.v1alpha2.Agent[]).some(json => {
-    if (!isAgentTransitional(deriveAgentReadiness(json))) {
-      return false;
-    }
-
-    const changedAt = getAgentStatusChangedAt(json);
-
-    // No usable timestamp: treat the agent as just-changed rather than as stuck,
-    // so a genuinely new agent is still picked up quickly.
-    return changedAt === undefined || now - changedAt < TRANSITIONAL_MAX_AGE_MS;
-  });
+  const isConverging = (items as crds.kagent.v1alpha2.Agent[]).some(json =>
+    isAgentConverging(json, now),
+  );
 
   return isConverging
     ? TRANSITIONAL_REFETCH_INTERVAL_MS

--- a/plugins/agent-platform/src/components/AgentsDataProvider/index.ts
+++ b/plugins/agent-platform/src/components/AgentsDataProvider/index.ts
@@ -1,4 +1,4 @@
 export { AgentsDataProvider, useAgents } from './AgentsDataProvider';
 export type { AgentsContextValue } from './AgentsDataProvider';
-export { sortAgentsBy } from './helpers';
+export { getAgentRefetchInterval, sortAgentsBy, toAgentRow } from './helpers';
 export type { AgentRow } from './helpers';

--- a/plugins/agent-platform/src/components/AgentsRouter/AgentsRouter.tsx
+++ b/plugins/agent-platform/src/components/AgentsRouter/AgentsRouter.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, useLocation } from 'react-router-dom';
 
 import { QueryClientProvider } from '../QueryClientProvider';
 import { NewAgentFormProvider } from '../NewAgentFormProvider';
+import { AgentDetailPage } from '../AgentDetailPage';
 import { AgentsIndexPage } from '../AgentsIndexPage';
 import { NewAgentPage } from '../NewAgentPage';
 import { NewAgentSkillsPage } from '../NewAgentSkillsPage';
@@ -19,13 +20,18 @@ function ScrollToTop() {
   return null;
 }
 
-// Content of the "Agents" tab. The index is a stub landing; the three create
-// steps share one NewAgentFormProvider so the composed agent survives
-// navigation across `/agent-platform/agents/new`, `.../new/skills` and
-// `.../new/review`.
+// Content of the "Agents" tab: the list, one agent's details, and the create
+// flow. The three create steps share one NewAgentFormProvider so the composed
+// agent survives navigation across `/agent-platform/agents/new`,
+// `.../new/skills` and `.../new/review`.
 //
 // This router is mounted as the tab's content (a descendant `<Routes>`), so the
 // paths here are relative — no leading slash — matching muster's WorkflowsRouter.
+//
+// The detail route is listed last, but order does not decide the match: react-
+// router ranks static segments above dynamic ones and matches on segment count,
+// so `new`/`new/skills`/`new/review` (one and two segments) can never be
+// swallowed by the three-segment detail path.
 export const AgentsRouter = () => {
   return (
     <QueryClientProvider>
@@ -36,6 +42,10 @@ export const AgentsRouter = () => {
           <Route path="new" element={<NewAgentPage />} />
           <Route path="new/skills" element={<NewAgentSkillsPage />} />
           <Route path="new/review" element={<NewAgentReviewPage />} />
+          <Route
+            path=":installation/:namespace/:name"
+            element={<AgentDetailPage />}
+          />
         </Routes>
       </NewAgentFormProvider>
     </QueryClientProvider>

--- a/plugins/agent-platform/src/components/AgentsTable/AgentsTable.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/AgentsTable.test.tsx
@@ -147,6 +147,21 @@ describe('AgentsTable', () => {
     );
   });
 
+  // The name is wrapped in a bui `Text` for its truncation, which sets its own
+  // colour — without an override the link renders in body text colour and stops
+  // looking like a link, diverging from the Sessions table.
+  it('lets the agent name inherit the link colour', async () => {
+    await renderTable(<AgentsTable rows={rows} />);
+
+    const anchor = screen.getByRole('link', { name: 'Incident triager' });
+    const label = anchor.querySelector('p')!;
+
+    // Asserted as "same colour as the anchor" rather than the literal `inherit`:
+    // that is the property that matters, and jsdom resolves `inherit` through the
+    // cascade anyway.
+    expect(getComputedStyle(label).color).toBe(getComputedStyle(anchor).color);
+  });
+
   it('navigates on a whole-row click', async () => {
     await renderTable(<AgentsTable rows={rows} />);
 

--- a/plugins/agent-platform/src/components/AgentsTable/AgentsTable.test.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/AgentsTable.test.tsx
@@ -1,6 +1,8 @@
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { AgentRow } from '../AgentsDataProvider';
+import { agentsRouteRef } from '../../routes';
 import { AgentsTable } from './AgentsTable';
 
 const mockBuildAvatarUrl = jest.fn(
@@ -11,6 +13,23 @@ const mockBuildAvatarUrl = jest.fn(
 jest.mock('../../hooks/useAgentAvatarUrl', () => ({
   useAgentAvatarUrl: () => mockBuildAvatarUrl,
 }));
+
+// The row's programmatic navigation, and *only* it: `Link` resolves `useNavigate`
+// internally within react-router-dom, so its own client-side navigation is
+// untouched by this mock. A call here therefore means the row handler ran.
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+// Only the parent RouteRef is mountable — `mountedRoutes` rejects a SubRouteRef —
+// and the detail sub-route resolves relative to it.
+const renderTable = (element: React.ReactElement) =>
+  renderInTestApp(element, {
+    mountedRoutes: { '/agent-platform/agents': agentsRouteRef },
+  });
 
 const rows: AgentRow[] = [
   {
@@ -41,9 +60,10 @@ const rows: AgentRow[] = [
 describe('AgentsTable', () => {
   beforeEach(() => {
     mockBuildAvatarUrl.mockClear();
+    mockNavigate.mockClear();
   });
   it('renders the column headers', async () => {
-    await renderInTestApp(<AgentsTable rows={rows} />);
+    await renderTable(<AgentsTable rows={rows} />);
 
     expect(screen.getByText('Agent')).toBeInTheDocument();
     expect(screen.getByText('Installation')).toBeInTheDocument();
@@ -54,7 +74,7 @@ describe('AgentsTable', () => {
   });
 
   it('renders each row readiness, explaining a non-ready one on hover', async () => {
-    await renderInTestApp(<AgentsTable rows={rows} />);
+    await renderTable(<AgentsTable rows={rows} />);
 
     expect(screen.getByText('Ready')).toBeInTheDocument();
     expect(screen.getByText('Not ready')).toBeInTheDocument();
@@ -64,7 +84,7 @@ describe('AgentsTable', () => {
   });
 
   it('labels a rejected agent distinctly from a not-ready one', async () => {
-    await renderInTestApp(
+    await renderTable(
       <AgentsTable
         rows={[
           {
@@ -81,7 +101,7 @@ describe('AgentsTable', () => {
   });
 
   it('shows an unreconciled agent as pending', async () => {
-    await renderInTestApp(
+    await renderTable(
       <AgentsTable rows={[{ ...rows[0], readiness: 'pending' }]} />,
     );
 
@@ -89,7 +109,7 @@ describe('AgentsTable', () => {
   });
 
   it('renders agent rows with resolved model and skill count', async () => {
-    await renderInTestApp(<AgentsTable rows={rows} />);
+    await renderTable(<AgentsTable rows={rows} />);
 
     expect(screen.getByText('Incident triager')).toBeInTheDocument();
     expect(screen.getByText('Triages incidents')).toBeInTheDocument();
@@ -98,20 +118,59 @@ describe('AgentsTable', () => {
   });
 
   it('shows a dash for agents without a resolved model', async () => {
-    await renderInTestApp(<AgentsTable rows={rows} />);
+    await renderTable(<AgentsTable rows={rows} />);
 
     expect(screen.getByText('BYO agent')).toBeInTheDocument();
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('shows the empty state when there are no agents', async () => {
-    await renderInTestApp(<AgentsTable rows={[]} />);
+    await renderTable(<AgentsTable rows={[]} />);
 
     expect(screen.getByText('No agents found.')).toBeInTheDocument();
   });
 
+  it('links each agent name to its details page, keyed on all three identity parts', async () => {
+    await renderTable(<AgentsTable rows={rows} />);
+
+    // Installation, namespace and the *technical* name — an Agent name is only
+    // unique within a namespace on one installation.
+    expect(
+      screen.getByRole('link', { name: 'Incident triager' }),
+    ).toHaveAttribute(
+      'href',
+      '/agent-platform/agents/inst-1/sre-team/incident-triager',
+    );
+    expect(screen.getByRole('link', { name: 'BYO agent' })).toHaveAttribute(
+      'href',
+      '/agent-platform/agents/inst-1/dev/byo-agent',
+    );
+  });
+
+  it('navigates on a whole-row click', async () => {
+    await renderTable(<AgentsTable rows={rows} />);
+
+    await userEvent.click(screen.getByText('Claude Sonnet 4.6'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/agent-platform/agents/inst-1/sre-team/incident-triager',
+    );
+  });
+
+  // Regression guard: the anchor and the row handler must not both fire, or a
+  // single click pushes the same path twice and Back needs two presses.
+  it('does not also fire the row handler when the name link is clicked', async () => {
+    await renderTable(<AgentsTable rows={rows} />);
+
+    await userEvent.click(
+      screen.getByRole('link', { name: 'Incident triager' }),
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('builds each avatar from the technical name at the list size', async () => {
-    await renderInTestApp(<AgentsTable rows={rows} />);
+    await renderTable(<AgentsTable rows={rows} />);
 
     // The avatar seeds from the technical (resource) name, not the display name.
     expect(mockBuildAvatarUrl).toHaveBeenCalledWith(

--- a/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   Avatar,
   Cell,
@@ -9,9 +9,14 @@ import {
   Text,
   useTable,
 } from '@backstage/ui';
+import { Link } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { useNavigate } from 'react-router-dom';
 import { AgentRow, sortAgentsBy } from '../AgentsDataProvider';
 import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
+import { agentDetailRouteRef } from '../../routes';
 import { AvatarSize } from '../../lib/agentAvatar';
+import { stopRowPress } from '../../lib/rowPress';
 import { AgentReadinessCell } from './readinessStatus';
 
 /**
@@ -22,6 +27,7 @@ const LIST_AVATAR_SIZE: AvatarSize = 96;
 
 function getColumnConfig(
   buildAvatarUrl: ReturnType<typeof useAgentAvatarUrl>,
+  hrefFor: (row: AgentRow) => string | undefined,
 ): ColumnConfig<AgentRow>[] {
   return [
     {
@@ -36,37 +42,65 @@ function getColumnConfig(
       // technical name, not the display name. The text mirrors CellText's
       // truncation (single-line, ellipsis, full text on hover) so this column
       // wraps/overflows consistently with the others.
-      cell: row => (
-        <Cell>
-          <Flex align="start" gap="3">
-            <Avatar
-              size="large"
-              purpose="decoration"
-              name={row.name}
-              src={
-                buildAvatarUrl(row.installation, row.technicalName, {
-                  size: LIST_AVATAR_SIZE,
-                }) ?? ''
-              }
-            />
-            <Flex direction="column" gap="1" style={{ minWidth: 0 }}>
-              <Text as="p" variant="body-medium" truncate title={row.name}>
-                {row.name}
-              </Text>
-              {row.description && (
-                <Text
-                  variant="body-medium"
-                  color="secondary"
-                  truncate
-                  title={row.description}
-                >
-                  {row.description}
-                </Text>
-              )}
+      cell: row => {
+        const href = hrefFor(row);
+
+        // A real anchor on the name, *as well as* the whole-row onClick below.
+        // The anchor is what makes cmd/middle-click open a new tab and what gives
+        // keyboard users something focusable; the row click is the convenience
+        // affordance. `Link` from core-components routes client-side, which
+        // `rowConfig.getHref` would not: BUIProvider is not mounted in this app,
+        // so react-aria's RouterProvider is inactive and a bui `href` would
+        // trigger a full page reload.
+        //
+        // The two affordances must not both fire for one click — see
+        // {@link stopRowPress}.
+        return (
+          <Cell>
+            <Flex align="start" gap="3">
+              <Avatar
+                size="large"
+                purpose="decoration"
+                name={row.name}
+                src={
+                  buildAvatarUrl(row.installation, row.technicalName, {
+                    size: LIST_AVATAR_SIZE,
+                  }) ?? ''
+                }
+              />
+              <Flex direction="column" gap="1" style={{ minWidth: 0 }}>
+                {href ? (
+                  <Link
+                    to={href}
+                    title={row.name}
+                    onPointerDown={stopRowPress}
+                    onPointerUp={stopRowPress}
+                    onClick={stopRowPress}
+                  >
+                    <Text as="p" variant="body-medium" truncate>
+                      {row.name}
+                    </Text>
+                  </Link>
+                ) : (
+                  <Text as="p" variant="body-medium" truncate title={row.name}>
+                    {row.name}
+                  </Text>
+                )}
+                {row.description && (
+                  <Text
+                    variant="body-medium"
+                    color="secondary"
+                    truncate
+                    title={row.description}
+                  >
+                    {row.description}
+                  </Text>
+                )}
+              </Flex>
             </Flex>
-          </Flex>
-        </Cell>
-      ),
+          </Cell>
+        );
+      },
     },
     {
       id: 'readiness',
@@ -120,9 +154,25 @@ export type AgentsTableProps = {
  */
 export function AgentsTable({ rows }: AgentsTableProps) {
   const buildAvatarUrl = useAgentAvatarUrl();
+  const navigate = useNavigate();
+  const agentDetailRoute = useRouteRef(agentDetailRouteRef);
+
+  // All three parameters are needed: an Agent name is only unique within a
+  // namespace on one installation. Undefined when the route isn't bound, in which
+  // case rows render as plain text rather than as links that go nowhere.
+  const hrefFor = useCallback(
+    (row: AgentRow) =>
+      agentDetailRoute?.({
+        installation: row.installation,
+        namespace: row.namespace,
+        name: row.technicalName,
+      }),
+    [agentDetailRoute],
+  );
+
   const columnConfig = useMemo(
-    () => getColumnConfig(buildAvatarUrl),
-    [buildAvatarUrl],
+    () => getColumnConfig(buildAvatarUrl, hrefFor),
+    [buildAvatarUrl, hrefFor],
   );
 
   // Client-side sorting. The initial sort is installation-then-name, which is the
@@ -149,6 +199,17 @@ export function AgentsTable({ rows }: AgentsTableProps) {
     <Table<AgentRow>
       {...tableProps}
       columnConfig={columnConfig}
+      rowConfig={{
+        // Whole-row click as a convenience, on top of the anchor on the name.
+        // `onClick` + navigate rather than `getHref`, because without BUIProvider
+        // a bui href does a full page reload (see the name cell).
+        onClick: row => {
+          const href = hrefFor(row);
+          if (href) {
+            navigate(href);
+          }
+        },
+      }}
       emptyState={
         <Text variant="body-medium" color="secondary">
           No agents found.

--- a/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/AgentsTable.tsx
@@ -77,7 +77,18 @@ function getColumnConfig(
                     onPointerUp={stopRowPress}
                     onClick={stopRowPress}
                   >
-                    <Text as="p" variant="body-medium" truncate>
+                    {/* `Text` is here for its truncation (single line, ellipsis,
+                        matching CellText), but it sets its own colour — which
+                        would silently strip the anchor's, leaving a link that
+                        doesn't look like one. `inherit` hands the colour back to
+                        the anchor, so this reads like the Sessions table's title
+                        link. bui `Text` has no `color="inherit"`. */}
+                    <Text
+                      as="p"
+                      variant="body-medium"
+                      truncate
+                      style={{ color: 'inherit' }}
+                    >
                       {row.name}
                     </Text>
                   </Link>

--- a/plugins/agent-platform/src/components/AgentsTable/readinessStatus.tsx
+++ b/plugins/agent-platform/src/components/AgentsTable/readinessStatus.tsx
@@ -23,7 +23,7 @@ import type { AgentRow } from '../AgentsDataProvider';
  * controller has not caught up with the current spec yet, which is "not known
  * yet", not "broken".
  */
-const READINESS_PRESENTATION: Record<
+export const READINESS_PRESENTATION: Record<
   AgentReadiness,
   { label: string; intent: StatusLabelIntent; icon: typeof CheckCircleIcon }
 > = {

--- a/plugins/agent-platform/src/components/SelectableCard/SelectableCard.tsx
+++ b/plugins/agent-platform/src/components/SelectableCard/SelectableCard.tsx
@@ -36,6 +36,20 @@ const useStyles = makeStyles(theme => ({
       outlineOffset: 1,
     },
   },
+  // Same shell as `card`, minus the affordances: nothing to click, so no pointer
+  // cursor and no hover feedback. Kept next to `card` so the two stay visually
+  // identical as that one evolves.
+  cardStatic: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    textAlign: 'left',
+    padding: theme.spacing(1.5),
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${theme.palette.divider}`,
+    background: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+  },
   selected: {
     borderColor: theme.palette.primary.main,
     outline: `1px solid ${theme.palette.primary.main}`,
@@ -59,8 +73,11 @@ const useStyles = makeStyles(theme => ({
 export const useSelectableCardStyles = useStyles;
 
 type SelectableCardGridProps = {
-  /** `radiogroup` for single-select, `group` for multi-select. */
-  role: 'radiogroup' | 'group';
+  /**
+   * `radiogroup` for single-select, `group` for multi-select, `list` for a
+   * read-only grid of {@link StaticCard}s.
+   */
+  role: 'radiogroup' | 'group' | 'list';
   ariaLabel: string;
   /** Minimum card width for the auto-fill grid. */
   minWidth?: number;
@@ -97,6 +114,27 @@ type SelectableCardProps = {
   onSelect: () => void;
   children: ReactNode;
 };
+
+/**
+ * The same card, read-only: no selection indicator, no press affordance.
+ *
+ * For displaying the things the pickers select — an agent's mounted skills, say —
+ * so the two surfaces look like one system. Deliberately a `<div>` with `role`
+ * `listitem` rather than a `SelectableCard` with the indicator hidden: a
+ * `role="checkbox"` button that does nothing is announced as an operable control
+ * and invites a click that has no effect.
+ */
+export function StaticCard({ children }: { children: ReactNode }) {
+  const classes = useStyles();
+
+  return (
+    <div role="listitem" className={classes.cardStatic}>
+      <Flex direction="column" gap="1">
+        {children}
+      </Flex>
+    </div>
+  );
+}
 
 /** A full-area selectable card with a selection indicator icon. */
 export function SelectableCard({

--- a/plugins/agent-platform/src/components/SelectableCard/index.ts
+++ b/plugins/agent-platform/src/components/SelectableCard/index.ts
@@ -1,5 +1,6 @@
 export {
   SelectableCard,
   SelectableCardGrid,
+  StaticCard,
   useSelectableCardStyles,
 } from './SelectableCard';

--- a/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
+++ b/plugins/agent-platform/src/components/SessionsTable/SessionsTable.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   Avatar,
   Cell,
@@ -17,6 +17,7 @@ import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
 import { sessionDetailRouteRef } from '../../routes';
 import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
 import { AvatarSize } from '../../lib/agentAvatar';
+import { stopRowPress } from '../../lib/rowPress';
 import {
   SessionRow,
   sessionSearchFn,
@@ -25,27 +26,6 @@ import {
 
 /** The avatar is one line of text tall; request 2× for hi-dpi crispness. */
 const ROW_AVATAR_SIZE: AvatarSize = 48;
-
-/**
- * Keep a press on the title anchor from also reaching the row.
- *
- * The row's `onClick` is react-aria's `onAction`, which fires for a press anywhere
- * inside the row — the anchor included, since `usePress` has no exemption for
- * interactive descendants. So a single click on the title used to navigate
- * *twice*: once through the anchor, once through the row. On a plain click that
- * pushed the same path onto the history stack twice, and Back needed two presses
- * to return to the list; with cmd held it was worse, because react-router leaves a
- * modified event to the browser, so the session opened in a new tab *and* the
- * current tab navigated away — defeating the reason the anchor exists.
- *
- * `usePress` works off pointer events rather than `click`, so `pointerdown` and
- * `pointerup` are the ones that have to be stopped; `click` is stopped too, for
- * the synthetic-click path. Stopping propagation does not set `defaultPrevented`,
- * so the anchor's own react-router navigation still happens.
- */
-function stopRowPress(event: SyntheticEvent) {
-  event.stopPropagation();
-}
 
 /** Dash shown where a value is genuinely unknown. */
 function Unknown() {
@@ -173,12 +153,30 @@ function getColumnConfig(
   ];
 }
 
+/** Columns an embedding page may drop because its context already implies them. */
+export type HideableSessionColumn = 'agentName' | 'installation';
+
 export type SessionsTableProps = {
   rows: SessionRow[];
   /** True only while no rows exist yet, so the skeleton replaces the table. */
   isLoading?: boolean;
   /** Search debounce; set to 0 in tests so typing takes effect immediately. */
   searchDebounceMs?: number;
+  /**
+   * Columns to leave out. For an agent's own sessions the agent and installation
+   * are fixed by the surrounding page, so repeating them in every row is noise.
+   */
+  hideColumns?: ReadonlyArray<HideableSessionColumn>;
+  /**
+   * Whether to render the search field. Off for a short embedded list, where
+   * there is nothing to search through and the field competes with the page's
+   * own controls.
+   */
+  showSearch?: boolean;
+  /** Whether to paginate. Off for a short embedded list. */
+  showPagination?: boolean;
+  /** Replaces the default "No sessions found." message. */
+  emptyMessage?: string;
 };
 
 /**
@@ -192,6 +190,10 @@ export function SessionsTable({
   rows,
   isLoading,
   searchDebounceMs = 150,
+  hideColumns,
+  showSearch = true,
+  showPagination = true,
+  emptyMessage = 'No sessions found.',
 }: SessionsTableProps) {
   const buildAvatarUrl = useAgentAvatarUrl();
   const navigate = useNavigate();
@@ -209,10 +211,14 @@ export function SessionsTable({
     [sessionDetailRoute],
   );
 
-  const columnConfig = useMemo(
-    () => getColumnConfig(buildAvatarUrl, hrefFor),
-    [buildAvatarUrl, hrefFor],
-  );
+  const hiddenKey = hideColumns?.join(',') ?? '';
+  const columnConfig = useMemo(() => {
+    const hidden = new Set<string>(hiddenKey ? hiddenKey.split(',') : []);
+
+    return getColumnConfig(buildAvatarUrl, hrefFor).filter(
+      column => !hidden.has(String(column.id)),
+    );
+  }, [buildAvatarUrl, hrefFor, hiddenKey]);
 
   const { tableProps, search } = useTable<SessionRow>({
     mode: 'complete',
@@ -224,17 +230,21 @@ export function SessionsTable({
     searchDebounceMs,
     sortFn: sortSessionsBy,
     initialSort: { column: 'updatedAt', direction: 'descending' },
-    paginationOptions: { pageSize: 25, pageSizeOptions: [25, 50, 100] },
+    paginationOptions: showPagination
+      ? { pageSize: 25, pageSizeOptions: [25, 50, 100] }
+      : { type: 'none' },
   });
 
   return (
     <Flex direction="column" gap="3">
-      <SearchField
-        aria-label="Search sessions"
-        placeholder="Search by session, agent, or installation"
-        value={search.value}
-        onChange={search.onChange}
-      />
+      {showSearch && (
+        <SearchField
+          aria-label="Search sessions"
+          placeholder="Search by session, agent, or installation"
+          value={search.value}
+          onChange={search.onChange}
+        />
+      )}
       <Table<SessionRow>
         {...tableProps}
         columnConfig={columnConfig}
@@ -251,7 +261,7 @@ export function SessionsTable({
         }}
         emptyState={
           <Text variant="body-medium" color="secondary">
-            No sessions found.
+            {emptyMessage}
           </Text>
         }
       />

--- a/plugins/agent-platform/src/hooks/useAgentSessions.test.tsx
+++ b/plugins/agent-platform/src/hooks/useAgentSessions.test.tsx
@@ -1,0 +1,101 @@
+import { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { kagentApiRef } from '../apis';
+import { KagentSession } from '../lib/kagentSessions';
+import { useAgentSessions } from './useAgentSessions';
+
+jest.mock('./useKagentCapabilities', () => ({
+  useKagentCapabilities: () => ({ isUserScoped: true }),
+}));
+
+const SESSIONS_KEY = ['agent-platform', 'kagent', 'sessions', 'gazelle'];
+
+/** kagent encodes an agent id as `namespace/name` with `-` → `_`, `/` → `__NS__`. */
+const AGENT_ID = 'agentic_platform__NS__pr_reviewer';
+
+function session(id: string): KagentSession {
+  return {
+    id: `gazelle/${id}`,
+    sessionId: id,
+    installation: 'gazelle',
+    title: 'Reviewing a PR',
+    agentId: AGENT_ID,
+    createdAt: '2026-07-31T10:00:00Z',
+    updatedAt: '2026-07-31T10:05:00Z',
+  };
+}
+
+function renderAgentSessions(listSessions: jest.Mock, seed?: KagentSession[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  // Seeding stands in for the Sessions tab having already populated this exact
+  // query key — the two share it deliberately.
+  if (seed) {
+    queryClient.setQueryData(SESSIONS_KEY, seed);
+  }
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TestApiProvider apis={[[kagentApiRef, { listSessions }]]}>
+        {children}
+      </TestApiProvider>
+    </QueryClientProvider>
+  );
+
+  return renderHook(
+    () => useAgentSessions('gazelle', 'agentic-platform', 'pr-reviewer'),
+    { wrapper },
+  );
+}
+
+describe('useAgentSessions', () => {
+  it('returns only the sessions belonging to this agent', async () => {
+    const listSessions = jest
+      .fn()
+      .mockResolvedValue([
+        session('a'),
+        { ...session('b'), agentId: 'kagent__NS__other_agent' },
+      ]);
+
+    const { result } = renderAgentSessions(listSessions);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.rows.map(row => row.sessionId)).toEqual(['a']);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+
+  it('reports unavailable when the first read fails', async () => {
+    const listSessions = jest.fn().mockRejectedValue(new Error('503'));
+
+    const { result } = renderAgentSessions(listSessions);
+
+    await waitFor(() => expect(result.current.isUnavailable).toBe(true));
+
+    expect(result.current.rows).toEqual([]);
+  });
+
+  // react-query keeps `data` and sets `error` on a failed *refetch*. Since this
+  // query is shared with the Sessions tab, arriving from that tab after its entry
+  // went stale triggers a background refetch whose failure must not hide sessions
+  // that were already read and are still correct.
+  it('keeps cached sessions when a background refetch fails', async () => {
+    const listSessions = jest.fn().mockRejectedValue(
+      Object.assign(new Error('service unavailable'), {
+        name: 'ServiceUnavailableError',
+      }),
+    );
+
+    const { result } = renderAgentSessions(listSessions, [session('a')]);
+
+    // The mount-time refetch fails while the seeded data is still held.
+    await waitFor(() => expect(listSessions).toHaveBeenCalled());
+
+    expect(result.current.rows.map(row => row.sessionId)).toEqual(['a']);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+});

--- a/plugins/agent-platform/src/hooks/useAgentSessions.ts
+++ b/plugins/agent-platform/src/hooks/useAgentSessions.ts
@@ -27,9 +27,9 @@ export type AgentSessionsView = {
    */
   isNotUserScoped: boolean;
   /**
-   * kagent could not be read on this installation. Distinguishes "no sessions"
-   * from "we don't know", without spelling out which failure it was — the
-   * sessions list already reports those in detail.
+   * kagent could not be read on this installation **and** nothing was read
+   * earlier. Distinguishes "no sessions" from "we don't know", without spelling
+   * out which failure it was — the sessions list already reports those in detail.
    */
   isUnavailable: boolean;
 };
@@ -97,6 +97,11 @@ export function useAgentSessions(
     rows,
     isLoading,
     isNotUserScoped: capabilities.isUserScoped === false,
-    isUnavailable: isError,
+    // Only unavailable when there is genuinely nothing to show. react-query keeps
+    // `data` and sets `error` on a failed *refetch*, and this query is shared with
+    // the Sessions tab — so arriving from that tab after its entry went stale
+    // triggers a background refetch whose failure would otherwise hide sessions
+    // that were already read and are still correct.
+    isUnavailable: isError && !sessions,
   };
 }

--- a/plugins/agent-platform/src/hooks/useAgentSessions.ts
+++ b/plugins/agent-platform/src/hooks/useAgentSessions.ts
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { useQuery } from '@tanstack/react-query';
+import { kagentApiRef } from '../apis';
+import { AgentRow } from '../components/AgentsDataProvider';
+import {
+  buildAgentIndex,
+  isListableSession,
+  SessionRow,
+  sortSessionRows,
+  toAgentIdentifier,
+  toSessionRow,
+} from '../components/SessionsDataProvider/helpers';
+import { useKagentCapabilities } from './useKagentCapabilities';
+
+export type AgentSessionsView = {
+  /** This agent's sessions, most recent activity first. */
+  rows: SessionRow[];
+  isLoading: boolean;
+  /**
+   * True when the installation's kagent runs in `unsecure` mode and so returns
+   * *everyone's* sessions. The UI must then stop calling these "yours".
+   *
+   * Strictly `false` from the probe means user-scoped; `undefined` (probe not
+   * resolved, or kagent reported no subject) is not an answer either way, so it
+   * does not set this.
+   */
+  isNotUserScoped: boolean;
+  /**
+   * kagent could not be read on this installation. Distinguishes "no sessions"
+   * from "we don't know", without spelling out which failure it was — the
+   * sessions list already reports those in detail.
+   */
+  isUnavailable: boolean;
+};
+
+/**
+ * The signed-in user's kagent sessions with one agent.
+ *
+ * Deliberately *not* built on `SessionsDataProvider`: that fans out across every
+ * reachable installation, and a details page only ever needs one. It reuses the
+ * provider's exact query key, so the two share a cache — arriving from the
+ * Sessions tab renders instantly, and this page's fetch warms that tab in turn.
+ *
+ * Note kagent only lists sessions belonging to the caller, so this can never be
+ * "all traffic through this agent" — see {@link AgentSessionsView.isNotUserScoped}
+ * for the one exception, which is a misconfiguration rather than a feature.
+ */
+export function useAgentSessions(
+  installation: string,
+  namespace: string,
+  name: string,
+  agentRow?: AgentRow,
+): AgentSessionsView {
+  const kagentApi = useApi(kagentApiRef);
+  const capabilities = useKagentCapabilities(installation);
+
+  const {
+    data: sessions,
+    isLoading,
+    isError,
+  } = useQuery({
+    // Same key as SessionsDataProvider, deliberately — see the note above.
+    queryKey: ['agent-platform', 'kagent', 'sessions', installation],
+    queryFn: () => kagentApi.listSessions(installation),
+    enabled: Boolean(installation),
+  });
+
+  // kagent identifies an agent by an encoded `namespace/name`. Match on the
+  // encode side rather than decoding kagent's id, because encoding is lossless
+  // and decoding is not.
+  const agentId = toAgentIdentifier(namespace, name);
+
+  // The join the sessions list uses, so the agent renders identically in both
+  // places. A single-entry index is enough here: we already know which agent this
+  // is, and reusing `toSessionRow` keeps the row shape (and the avatar seed) in
+  // one place.
+  const agentIndex = useMemo(
+    () => buildAgentIndex(agentRow ? [agentRow] : []),
+    [agentRow],
+  );
+
+  const rows = useMemo(() => {
+    if (!sessions) {
+      return [];
+    }
+
+    return sortSessionRows(
+      sessions
+        .filter(isListableSession)
+        .filter(session => session.agentId === agentId)
+        .map(session => toSessionRow(session, agentIndex)),
+    );
+  }, [sessions, agentId, agentIndex]);
+
+  return {
+    rows,
+    isLoading,
+    isNotUserScoped: capabilities.isUserScoped === false,
+    isUnavailable: isError,
+  };
+}

--- a/plugins/agent-platform/src/lib/rowPress.ts
+++ b/plugins/agent-platform/src/lib/rowPress.ts
@@ -1,0 +1,27 @@
+import { SyntheticEvent } from 'react';
+
+/**
+ * Keep a press on a link inside a table row from also reaching the row.
+ *
+ * Our tables give a row both an anchor in its row-header cell and a whole-row
+ * `onClick`. The row's `onClick` is react-aria's `onAction`, which fires for a
+ * press anywhere inside the row — the anchor included, since `usePress` has no
+ * exemption for interactive descendants. Without this, a single click on the
+ * link navigates *twice*: once through the anchor, once through the row. On a
+ * plain click that pushes the same path onto the history stack twice, so Back
+ * needs two presses to return to the list; with cmd held it is worse, because
+ * react-router leaves a modified event to the browser — the target opens in a
+ * new tab *and* the current tab navigates away, defeating the reason the anchor
+ * exists.
+ *
+ * `usePress` works off pointer events rather than `click`, so `pointerdown` and
+ * `pointerup` are the ones that have to be stopped; `click` is stopped too, for
+ * the synthetic-click path. Stopping propagation does not set
+ * `defaultPrevented`, so the anchor's own react-router navigation still happens.
+ *
+ * Attach to the anchor as
+ * `onPointerDown={stopRowPress} onPointerUp={stopRowPress} onClick={stopRowPress}`.
+ */
+export function stopRowPress(event: SyntheticEvent) {
+  event.stopPropagation();
+}

--- a/plugins/agent-platform/src/plugin.tsx
+++ b/plugins/agent-platform/src/plugin.tsx
@@ -14,7 +14,10 @@ import AndroidIcon from '@material-ui/icons/Android';
 
 import { KagentApiClient, kagentApiRef } from './apis';
 import {
+  agentDetailRouteRef,
   agentsRouteRef,
+  deploymentDetailsExternalRouteRef,
+  musterToolExplorerExternalRouteRef,
   newAgentReviewRouteRef,
   newAgentRouteRef,
   newAgentSkillsRouteRef,
@@ -42,9 +45,10 @@ const agentPlatformPage = PageBlueprint.make({
   },
 });
 
-// The "Agents" tab. Its content is a stub landing plus the create flow
-// (`/agent-platform/agents/new`, `.../new/skills` and `.../new/review`), driven
-// by an internal react-router in AgentsRouter.
+// The "Agents" tab. Its content is the agent list, one agent's details
+// (`/agent-platform/agents/<installation>/<namespace>/<name>`) and the create
+// flow (`/agent-platform/agents/new`, `.../new/skills` and `.../new/review`),
+// all driven by an internal react-router in AgentsRouter.
 const agentsSubPage = SubPageBlueprint.make({
   name: 'agents',
   params: {
@@ -100,10 +104,18 @@ export const agentPlatformPlugin = createFrontendPlugin({
   routes: {
     root: rootRouteRef,
     agents: agentsRouteRef,
+    agentDetail: agentDetailRouteRef,
     newAgent: newAgentRouteRef,
     newAgentSkills: newAgentSkillsRouteRef,
     newAgentReview: newAgentReviewRouteRef,
     sessions: sessionsRouteRef,
     sessionDetail: sessionDetailRouteRef,
+  },
+  // Both carry a `defaultTarget`, so they resolve without an app-config binding
+  // and are simply unbound when the target plugin is disabled. Every call site
+  // must handle `useRouteRef` returning undefined.
+  externalRoutes: {
+    musterToolExplorer: musterToolExplorerExternalRouteRef,
+    deploymentDetails: deploymentDetailsExternalRouteRef,
   },
 });

--- a/plugins/agent-platform/src/routes.ts
+++ b/plugins/agent-platform/src/routes.ts
@@ -1,4 +1,5 @@
 import {
+  createExternalRouteRef,
   createRouteRef,
   createSubRouteRef,
 } from '@backstage/frontend-plugin-api';
@@ -27,6 +28,19 @@ export const newAgentReviewRouteRef = createSubRouteRef({
   parent: agentsRouteRef,
 });
 
+// One agent (`/agent-platform/agents/<installation>/<namespace>/<name>`).
+//
+// All three segments are part of the path because all three are part of the
+// agent's identity: an `Agent` name is only unique within a namespace on one
+// installation. Same reasoning as `sessionDetailRouteRef` below.
+//
+// Three segments also keeps this clear of the create flow's `/new`,
+// `/new/skills` and `/new/review`, which are one and two segments deep.
+export const agentDetailRouteRef = createSubRouteRef({
+  path: '/:installation/:namespace/:name',
+  parent: agentsRouteRef,
+});
+
 // The "Sessions" tab (`/agent-platform/sessions`).
 export const sessionsRouteRef = createRouteRef();
 
@@ -39,4 +53,28 @@ export const sessionsRouteRef = createRouteRef();
 export const sessionDetailRouteRef = createSubRouteRef({
   path: '/:installation/:sessionId',
   parent: sessionsRouteRef,
+});
+
+/**
+ * muster's Tool Explorer, where an agent's Muster-provided tools can actually be
+ * inspected and tried.
+ *
+ * Resolves automatically when the muster plugin is enabled (it registers this
+ * target), and is unbound otherwise — in which case the agent details page names
+ * the MCP server without linking anywhere.
+ */
+export const musterToolExplorerExternalRouteRef = createExternalRouteRef({
+  defaultTarget: 'muster.toolExplorer',
+});
+
+/**
+ * The gs plugin's deployment details page.
+ *
+ * An agent created through this plugin is deployed as a Flux `HelmRelease`, and
+ * that page already carries the release's Flux status, conditions and GitOps
+ * source — so the agent page links to it rather than reproducing any of it.
+ */
+export const deploymentDetailsExternalRouteRef = createExternalRouteRef({
+  params: ['installationName', 'kind', 'namespace', 'name'],
+  defaultTarget: 'gs.deploymentDetails',
 });

--- a/plugins/agent-platform/src/setupTests.ts
+++ b/plugins/agent-platform/src/setupTests.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom';
+
+// jsdom does not implement ResizeObserver, which is used by some ui-react
+// components (e.g. StructuredMetadataList via useContainerDimensions). Provide a
+// no-op mock. Same shim as flux-react's setupTests.
+if (!('ResizeObserver' in globalThis)) {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver =
+    ResizeObserverMock;
+}

--- a/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.test.tsx
+++ b/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.test.tsx
@@ -1,0 +1,181 @@
+import { screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import {
+  ErrorsProvider,
+  GitRepository,
+  HelmRelease,
+  KubeObject,
+  Kustomization,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+import { GitOpsCard } from './GitOpsCard';
+
+const mockUseResource = jest.fn();
+
+jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
+  ...jest.requireActual('@giantswarm/backstage-plugin-kubernetes-react'),
+  useResource: (...args: unknown[]) => mockUseResource(...args),
+}));
+
+const KUSTOMIZE_LABELS = {
+  'kustomize.toolkit.fluxcd.io/name': 'agents',
+  'kustomize.toolkit.fluxcd.io/namespace': 'flux-giantswarm',
+};
+
+const HELM_LABELS = {
+  'helm.toolkit.fluxcd.io/name': 'pr-reviewer',
+  'helm.toolkit.fluxcd.io/namespace': 'agentic-platform',
+};
+
+/** Any reconciled object; only its labels matter to the card. */
+function makeResource(labels: Record<string, string>): KubeObject {
+  return new KubeObject(
+    {
+      apiVersion: 'kagent.dev/v1alpha2',
+      kind: 'Agent',
+      metadata: { name: 'pr-reviewer', namespace: 'agentic-platform', labels },
+    } as never,
+    'gazelle',
+  );
+}
+
+function makeHelmRelease(labels: Record<string, string> = {}) {
+  return new HelmRelease(
+    {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: 'pr-reviewer', namespace: 'agentic-platform', labels },
+      spec: {},
+    } as never,
+    'gazelle',
+  );
+}
+
+function makeKustomization() {
+  return new Kustomization(
+    {
+      apiVersion: 'kustomize.toolkit.fluxcd.io/v1',
+      kind: 'Kustomization',
+      metadata: { name: 'agents', namespace: 'flux-giantswarm' },
+      spec: {
+        path: 'management-clusters/gazelle/extras',
+        sourceRef: { kind: 'GitRepository', name: 'management-clusters' },
+      },
+    } as never,
+    'gazelle',
+  );
+}
+
+function makeGitRepository() {
+  return new GitRepository(
+    {
+      apiVersion: 'source.toolkit.fluxcd.io/v1',
+      kind: 'GitRepository',
+      metadata: { name: 'management-clusters', namespace: 'flux-giantswarm' },
+      spec: { url: 'https://github.com/giantswarm/management-clusters' },
+      status: { artifact: { revision: 'main@sha1:abc123' } },
+    } as never,
+    'gazelle',
+  );
+}
+
+type Chain = {
+  helmRelease?: unknown;
+  kustomization?: unknown;
+  gitRepository?: unknown;
+};
+
+function stubChain(chain: Chain) {
+  const outcome = (resource: unknown) => ({
+    resource,
+    isLoading: false,
+    error: null,
+    errors: [],
+    incompatibilities: [],
+    discoveryErrors: [],
+    clientOutdatedStates: [],
+  });
+
+  mockUseResource.mockImplementation(
+    (_cluster: string, ResourceClass: unknown) => {
+      switch (ResourceClass) {
+        case HelmRelease:
+          return outcome(chain.helmRelease);
+        case Kustomization:
+          return outcome(chain.kustomization);
+        case GitRepository:
+          return outcome(chain.gitRepository);
+        default:
+          return outcome(undefined);
+      }
+    },
+  );
+}
+
+const renderCard = (resource: KubeObject) =>
+  renderInTestApp(
+    <ErrorsProvider>
+      <GitOpsCard resource={resource} installationName="gazelle" />
+    </ErrorsProvider>,
+  );
+
+describe('GitOpsCard', () => {
+  beforeEach(() => {
+    mockUseResource.mockReset();
+  });
+
+  describe('when the resource is applied by a Kustomization', () => {
+    it('claims GitOps and links to the source', async () => {
+      stubChain({
+        kustomization: makeKustomization(),
+        gitRepository: makeGitRepository(),
+      });
+
+      await renderCard(makeResource(KUSTOMIZE_LABELS));
+
+      expect(screen.getByText('Managed through GitOps')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /Source/ })).toHaveAttribute(
+        'href',
+        expect.stringContaining('management-clusters/gazelle/extras'),
+      );
+    });
+  });
+
+  // An object rendered by a Helm chart carries only the release it came from, so
+  // the Kustomization has to be found on the HelmRelease one level up.
+  describe('when the resource is rendered by a HelmRelease', () => {
+    it('follows the release to the Kustomization and links to the source', async () => {
+      stubChain({
+        helmRelease: makeHelmRelease(KUSTOMIZE_LABELS),
+        kustomization: makeKustomization(),
+        gitRepository: makeGitRepository(),
+      });
+
+      await renderCard(makeResource(HELM_LABELS));
+
+      expect(screen.getByText('Managed through GitOps')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /Source/ })).toBeInTheDocument();
+    });
+
+    // Reconciled by Flux, but nothing in Git describes it — a release applied by
+    // hand or by a scaffolder action. Claiming GitOps here would send the reader
+    // looking for a file that does not exist.
+    it('renders nothing when the release itself is not in Git', async () => {
+      stubChain({ helmRelease: makeHelmRelease() });
+
+      const { container } = await renderCard(makeResource(HELM_LABELS));
+
+      expect(
+        screen.queryByText('Managed through GitOps'),
+      ).not.toBeInTheDocument();
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('renders nothing for a resource with no Flux labels at all', async () => {
+    stubChain({});
+
+    const { container } = await renderCard(makeResource({}));
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.test.tsx
+++ b/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.test.tsx
@@ -169,6 +169,36 @@ describe('GitOpsCard', () => {
       ).not.toBeInTheDocument();
       expect(container).toBeEmptyDOMElement();
     });
+
+    // A reader without RBAC on HelmReleases would otherwise get a global "Failed to
+    // load HelmRelease" notice on every agent they open — an error about a card
+    // they never see, on a page that is otherwise fine. The card asserts a Git
+    // source; a failed lookup is no basis for asserting one, so it stays silent.
+    it('reports nothing when the hop itself fails', async () => {
+      const helmReleaseError = new Error(
+        'helmreleases.helm.toolkit.fluxcd.io is forbidden',
+      );
+      mockUseResource.mockImplementation(
+        (_cluster: string, ResourceClass: unknown) => ({
+          resource: undefined,
+          isLoading: false,
+          error: ResourceClass === HelmRelease ? helmReleaseError : null,
+          errors:
+            ResourceClass === HelmRelease
+              ? [{ type: 'error', cluster: 'gazelle', error: helmReleaseError }]
+              : [],
+          incompatibilities: [],
+          discoveryErrors: [],
+          clientOutdatedStates: [],
+        }),
+      );
+
+      const { container } = await renderCard(makeResource(HELM_LABELS));
+
+      expect(container).toBeEmptyDOMElement();
+      // Nothing reached the ErrorsProvider notice either.
+      expect(screen.queryByText(/forbidden/)).not.toBeInTheDocument();
+    });
   });
 
   it('renders nothing for a resource with no Flux labels at all', async () => {

--- a/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.tsx
+++ b/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.tsx
@@ -34,6 +34,20 @@ type GitOpsCardProps = {
   installationName: string;
 };
 
+/**
+ * "Managed through GitOps", with a link to the resource's definition in Git.
+ *
+ * Renders **nothing** for a resource whose desired state is not actually in Git.
+ * Being reconciled by Flux is not the same as being GitOps-managed: a HelmRelease
+ * applied by hand — or by a scaffolder action, which is how the agent-platform
+ * create flow deploys an agent — produces a resource with Flux labels and no Git
+ * source at all. Claiming GitOps there is wrong in the way that matters, because
+ * it tells the reader to go and edit a file that does not exist.
+ *
+ * The test for "in Git" is a `Kustomization` somewhere up the chain, since that is
+ * what carries a source reference. Callers that have already established this (the
+ * gs cluster and deployment pages gate on `isManagedByFlux`) are unaffected.
+ */
 export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
   // A resource applied by a Kustomization carries the link to its source
   // directly. One rendered by a Helm chart does not — the helm-controller only
@@ -172,12 +186,13 @@ export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
   });
 
   // No Kustomization anywhere up the chain means the resource is reconciled but
-  // its desired state is not in Git — a HelmRelease applied by hand or by a
-  // scaffolder action, for instance. Rendering "Source · n/a" there implies a
-  // link we failed to load, so say nothing at all instead. While the HelmRelease
-  // hop is still resolving we don't know yet, so keep the slot.
-  const hasGitSource =
-    Boolean(kustomizationName) || (needsHelmReleaseHop && helmReleaseIsLoading);
+  // its desired state is not in Git, so there is no GitOps claim to make and no
+  // source to link — render nothing at all rather than a claim the reader cannot
+  // act on. Rendering nothing while the HelmRelease hop resolves, rather than a
+  // card that then disappears, keeps us from asserting it and taking it back.
+  if (!kustomizationName) {
+    return null;
+  }
 
   return (
     <InfoCard>
@@ -186,27 +201,25 @@ export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
           <GitOpsIcon />
         </Box>
         <Typography variant="inherit">Managed through GitOps</Typography>
-        {hasGitSource && (
-          <Box marginLeft={1.5} minWidth={75}>
-            <AsyncValue
-              isLoading={isLoading}
-              value={sourceUrl}
-              errorMessage={errorMessage}
-              renderError={message => (
-                <ErrorStatus errorMessage={message} notAvailable={false} />
-              )}
-            >
-              {value => (
-                <Box display="flex" alignItems="center">
-                  <Box marginLeft={-0.5} marginRight={1}>
-                    <Typography variant="inherit">·</Typography>
-                  </Box>
-                  <ExternalLink href={value}>Source</ExternalLink>
+        <Box marginLeft={1.5} minWidth={75}>
+          <AsyncValue
+            isLoading={isLoading}
+            value={sourceUrl}
+            errorMessage={errorMessage}
+            renderError={message => (
+              <ErrorStatus errorMessage={message} notAvailable={false} />
+            )}
+          >
+            {value => (
+              <Box display="flex" alignItems="center">
+                <Box marginLeft={-0.5} marginRight={1}>
+                  <Typography variant="inherit">·</Typography>
                 </Box>
-              )}
-            </AsyncValue>
-          </Box>
-        )}
+                <ExternalLink href={value}>Source</ExternalLink>
+              </Box>
+            )}
+          </AsyncValue>
+        </Box>
       </Box>
     </InfoCard>
   );

--- a/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.tsx
+++ b/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.tsx
@@ -58,21 +58,17 @@ export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
   const needsHelmReleaseHop =
     !getKustomizationName(resource) && Boolean(ownHelmReleaseName);
 
-  const {
-    resource: ownerHelmRelease,
-    errors: helmReleaseErrors,
-    isLoading: helmReleaseIsLoading,
-    error: helmReleaseError,
-    incompatibilities: helmReleaseIncompatibilities,
-  } = useResource(
-    installationName,
-    HelmRelease,
-    {
-      name: ownHelmReleaseName!,
-      namespace: ownHelmReleaseNamespace,
-    },
-    { enabled: needsHelmReleaseHop },
-  );
+  // The hop's failures are deliberately unread — see the note above `errors`.
+  const { resource: ownerHelmRelease, isLoading: helmReleaseIsLoading } =
+    useResource(
+      installationName,
+      HelmRelease,
+      {
+        name: ownHelmReleaseName!,
+        namespace: ownHelmReleaseNamespace,
+      },
+      { enabled: needsHelmReleaseHop },
+    );
 
   const kustomizationOwner = needsHelmReleaseHop ? ownerHelmRelease : resource;
   const kustomizationName = kustomizationOwner
@@ -134,25 +130,22 @@ export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
     (Boolean(kustomizationName) && kustomizationIsLoading) ||
     gitRepositoryIsLoading;
 
+  // The HelmRelease hop's failures are deliberately not reported. It is a lookup
+  // this card starts on its own initiative to find out *whether* there is a Git
+  // source, and if it fails the card renders nothing at all — so a global "Failed
+  // to load HelmRelease" notice would be an error about a card the reader never
+  // sees, on a page that is otherwise fine. A reader without RBAC on HelmReleases
+  // would get it on every agent they open.
+  //
+  // The other two are reported: they only fail once a Kustomization is known, which
+  // means the card *is* rendering and can show the failure in place of its link.
   const errors = useMemo(() => {
-    return [
-      ...helmReleaseErrors,
-      ...kustomizationErrors,
-      ...gitRepositoryErrors,
-    ];
-  }, [gitRepositoryErrors, helmReleaseErrors, kustomizationErrors]);
+    return [...kustomizationErrors, ...gitRepositoryErrors];
+  }, [gitRepositoryErrors, kustomizationErrors]);
 
   useShowErrors(errors);
 
   let errorMessage;
-  if (helmReleaseError) {
-    errorMessage = getErrorMessage({
-      error: helmReleaseError,
-      resourceKind: HelmRelease.kind,
-      resourceName: ownHelmReleaseName!,
-      resourceNamespace: ownHelmReleaseNamespace,
-    });
-  }
   if (kustomizationError) {
     errorMessage = getErrorMessage({
       error: kustomizationError,
@@ -168,9 +161,6 @@ export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
       resourceName: gitRepositoryName!,
       resourceNamespace: gitRepositoryNamespace,
     });
-  }
-  if (helmReleaseIncompatibilities[0]) {
-    errorMessage = getIncompatibilityMessage(helmReleaseIncompatibilities[0]);
   }
   if (kustomizationIncompatibilities[0]) {
     errorMessage = getIncompatibilityMessage(kustomizationIncompatibilities[0]);
@@ -190,6 +180,12 @@ export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
   // source to link — render nothing at all rather than a claim the reader cannot
   // act on. Rendering nothing while the HelmRelease hop resolves, rather than a
   // card that then disappears, keeps us from asserting it and taking it back.
+  //
+  // A *failed* hop lands here too, which means "we could not tell" renders
+  // identically to "definitely not in Git". That is the conservative side to err
+  // on: the card's only job is to assert a Git source, and a failed lookup is no
+  // basis for asserting one. Claiming GitOps off the Helm label alone would be
+  // wrong for every agent this plugin deploys.
   if (!kustomizationName) {
     return null;
   }

--- a/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.tsx
+++ b/plugins/flux-react/src/components/GitOpsCard/GitOpsCard.tsx
@@ -1,15 +1,15 @@
 import { Box, Typography } from '@material-ui/core';
 import { useMemo } from 'react';
 import {
+  getErrorMessage,
+  getHelmReleaseName,
+  getHelmReleaseNamespace,
+  getIncompatibilityMessage,
   getKustomizationName,
   getKustomizationNamespace,
-} from '../../utils/isManagedByFlux';
-import {
-  App,
-  getErrorMessage,
-  getIncompatibilityMessage,
   GitRepository,
   HelmRelease,
+  KubeObject,
   Kustomization,
   useResource,
   useShowErrors,
@@ -24,13 +24,49 @@ import { useGitSourceLink } from '../../hooks';
 import { GitOpsIcon } from '../../assets/icons';
 
 type GitOpsCardProps = {
-  deployment: App | HelmRelease;
+  /**
+   * Any reconciled resource. Only its Flux labels are read, so this serves an
+   * `App`/`HelmRelease` applied straight from a Kustomization as well as an
+   * object *rendered by* a HelmRelease (a kagent `Agent`, say), which needs the
+   * extra hop below.
+   */
+  resource: KubeObject;
   installationName: string;
 };
 
-export function GitOpsCard({ deployment, installationName }: GitOpsCardProps) {
-  const kustomizationName = getKustomizationName(deployment);
-  const kustomizationNamespace = getKustomizationNamespace(deployment);
+export function GitOpsCard({ resource, installationName }: GitOpsCardProps) {
+  // A resource applied by a Kustomization carries the link to its source
+  // directly. One rendered by a Helm chart does not — the helm-controller only
+  // stamps which HelmRelease produced it — so the Kustomization, and with it the
+  // Git source, has to be found one level up, on the HelmRelease itself.
+  const ownHelmReleaseName = getHelmReleaseName(resource);
+  const ownHelmReleaseNamespace = getHelmReleaseNamespace(resource);
+  const needsHelmReleaseHop =
+    !getKustomizationName(resource) && Boolean(ownHelmReleaseName);
+
+  const {
+    resource: ownerHelmRelease,
+    errors: helmReleaseErrors,
+    isLoading: helmReleaseIsLoading,
+    error: helmReleaseError,
+    incompatibilities: helmReleaseIncompatibilities,
+  } = useResource(
+    installationName,
+    HelmRelease,
+    {
+      name: ownHelmReleaseName!,
+      namespace: ownHelmReleaseNamespace,
+    },
+    { enabled: needsHelmReleaseHop },
+  );
+
+  const kustomizationOwner = needsHelmReleaseHop ? ownerHelmRelease : resource;
+  const kustomizationName = kustomizationOwner
+    ? getKustomizationName(kustomizationOwner)
+    : undefined;
+  const kustomizationNamespace = kustomizationOwner
+    ? getKustomizationNamespace(kustomizationOwner)
+    : undefined;
 
   const {
     resource: kustomization,
@@ -38,10 +74,15 @@ export function GitOpsCard({ deployment, installationName }: GitOpsCardProps) {
     isLoading: kustomizationIsLoading,
     error: kustomizationError,
     incompatibilities: kustomizationIncompatibilities,
-  } = useResource(installationName, Kustomization, {
-    name: kustomizationName!,
-    namespace: kustomizationNamespace,
-  });
+  } = useResource(
+    installationName,
+    Kustomization,
+    {
+      name: kustomizationName!,
+      namespace: kustomizationNamespace,
+    },
+    { enabled: Boolean(kustomizationName) },
+  );
 
   const kustomizationSourceRef = kustomization?.getSourceRef();
   const gitRepositoryName = kustomizationSourceRef?.name;
@@ -71,15 +112,33 @@ export function GitOpsCard({ deployment, installationName }: GitOpsCardProps) {
   const gitRepositoryUrl = gitRepository?.getURL();
   const gitRepositoryRevision = gitRepository?.getRevision();
 
-  const isLoading = kustomizationIsLoading || gitRepositoryIsLoading;
+  // Each stage's `isLoading` is only meaningful once that stage is enabled;
+  // a disabled query never resolves, so reading it unguarded would pin the
+  // skeleton on forever.
+  const isLoading =
+    (needsHelmReleaseHop && helmReleaseIsLoading) ||
+    (Boolean(kustomizationName) && kustomizationIsLoading) ||
+    gitRepositoryIsLoading;
 
   const errors = useMemo(() => {
-    return [...kustomizationErrors, ...gitRepositoryErrors];
-  }, [gitRepositoryErrors, kustomizationErrors]);
+    return [
+      ...helmReleaseErrors,
+      ...kustomizationErrors,
+      ...gitRepositoryErrors,
+    ];
+  }, [gitRepositoryErrors, helmReleaseErrors, kustomizationErrors]);
 
   useShowErrors(errors);
 
   let errorMessage;
+  if (helmReleaseError) {
+    errorMessage = getErrorMessage({
+      error: helmReleaseError,
+      resourceKind: HelmRelease.kind,
+      resourceName: ownHelmReleaseName!,
+      resourceNamespace: ownHelmReleaseNamespace,
+    });
+  }
   if (kustomizationError) {
     errorMessage = getErrorMessage({
       error: kustomizationError,
@@ -96,6 +155,9 @@ export function GitOpsCard({ deployment, installationName }: GitOpsCardProps) {
       resourceNamespace: gitRepositoryNamespace,
     });
   }
+  if (helmReleaseIncompatibilities[0]) {
+    errorMessage = getIncompatibilityMessage(helmReleaseIncompatibilities[0]);
+  }
   if (kustomizationIncompatibilities[0]) {
     errorMessage = getIncompatibilityMessage(kustomizationIncompatibilities[0]);
   }
@@ -109,6 +171,14 @@ export function GitOpsCard({ deployment, installationName }: GitOpsCardProps) {
     path: kustomizationPath,
   });
 
+  // No Kustomization anywhere up the chain means the resource is reconciled but
+  // its desired state is not in Git — a HelmRelease applied by hand or by a
+  // scaffolder action, for instance. Rendering "Source · n/a" there implies a
+  // link we failed to load, so say nothing at all instead. While the HelmRelease
+  // hop is still resolving we don't know yet, so keep the slot.
+  const hasGitSource =
+    Boolean(kustomizationName) || (needsHelmReleaseHop && helmReleaseIsLoading);
+
   return (
     <InfoCard>
       <Box display="flex" alignItems="center">
@@ -116,25 +186,27 @@ export function GitOpsCard({ deployment, installationName }: GitOpsCardProps) {
           <GitOpsIcon />
         </Box>
         <Typography variant="inherit">Managed through GitOps</Typography>
-        <Box marginLeft={1.5} minWidth={75}>
-          <AsyncValue
-            isLoading={isLoading}
-            value={sourceUrl}
-            errorMessage={errorMessage}
-            renderError={message => (
-              <ErrorStatus errorMessage={message} notAvailable={false} />
-            )}
-          >
-            {value => (
-              <Box display="flex" alignItems="center">
-                <Box marginLeft={-0.5} marginRight={1}>
-                  <Typography variant="inherit">·</Typography>
+        {hasGitSource && (
+          <Box marginLeft={1.5} minWidth={75}>
+            <AsyncValue
+              isLoading={isLoading}
+              value={sourceUrl}
+              errorMessage={errorMessage}
+              renderError={message => (
+                <ErrorStatus errorMessage={message} notAvailable={false} />
+              )}
+            >
+              {value => (
+                <Box display="flex" alignItems="center">
+                  <Box marginLeft={-0.5} marginRight={1}>
+                    <Typography variant="inherit">·</Typography>
+                  </Box>
+                  <ExternalLink href={value}>Source</ExternalLink>
                 </Box>
-                <ExternalLink href={value}>Source</ExternalLink>
-              </Box>
-            )}
-          </AsyncValue>
-        </Box>
+              )}
+            </AsyncValue>
+          </Box>
+        )}
       </Box>
     </InfoCard>
   );

--- a/plugins/flux-react/src/utils/isManagedByFlux.ts
+++ b/plugins/flux-react/src/utils/isManagedByFlux.ts
@@ -1,10 +1,9 @@
 /**
  * Flux provenance helpers.
  *
- * The implementation lives in `kubernetes-react` alongside `KubeObject`, next to
- * the broader Helm/Flux provenance helpers (`isGitOpsManaged`, `readProvenance`)
- * it used to be duplicated by. Re-exported here so the flux-react public API —
- * and its consumers in `gs` — stay unchanged.
+ * Implemented in `kubernetes-react`, alongside `KubeObject` and the broader
+ * Helm/Flux provenance helpers (`isGitOpsManaged`, `readProvenance`) that read the
+ * same labels. Re-exported here as part of the flux-react public API.
  */
 export {
   getKustomizationName,

--- a/plugins/flux-react/src/utils/isManagedByFlux.ts
+++ b/plugins/flux-react/src/utils/isManagedByFlux.ts
@@ -1,23 +1,13 @@
-import { KubeObject } from '@giantswarm/backstage-plugin-kubernetes-react';
-
-const LABEL_KUSTOMIZATION_NAME = 'kustomize.toolkit.fluxcd.io/name';
-const LABEL_KUSTOMIZATION_NAMESPACE = 'kustomize.toolkit.fluxcd.io/namespace';
-
-export function getKustomizationName(object: KubeObject) {
-  const labels = object.getLabels();
-
-  return labels?.[LABEL_KUSTOMIZATION_NAME];
-}
-
-export function getKustomizationNamespace(object: KubeObject) {
-  const labels = object.getLabels();
-
-  return labels?.[LABEL_KUSTOMIZATION_NAMESPACE];
-}
-
-export function isManagedByFlux(object: KubeObject) {
-  return (
-    Boolean(getKustomizationName(object)) &&
-    Boolean(getKustomizationNamespace(object))
-  );
-}
+/**
+ * Flux provenance helpers.
+ *
+ * The implementation lives in `kubernetes-react` alongside `KubeObject`, next to
+ * the broader Helm/Flux provenance helpers (`isGitOpsManaged`, `readProvenance`)
+ * it used to be duplicated by. Re-exported here so the flux-react public API —
+ * and its consumers in `gs` — stay unchanged.
+ */
+export {
+  getKustomizationName,
+  getKustomizationNamespace,
+  isManagedByFlux,
+} from '@giantswarm/backstage-plugin-kubernetes-react';

--- a/plugins/gs/src/components/UI/SimpleAccordion/SimpleAccordion.tsx
+++ b/plugins/gs/src/components/UI/SimpleAccordion/SimpleAccordion.tsx
@@ -1,23 +1,6 @@
-import { ReactNode } from 'react';
-import {
-  Accordion,
-  AccordionGroup,
-  AccordionPanel,
-  AccordionTrigger,
-} from '@backstage/ui';
-
-type SimpleAccordionProps = {
-  title: string;
-  children: ReactNode;
-};
-
-export const SimpleAccordion = ({ title, children }: SimpleAccordionProps) => {
-  return (
-    <AccordionGroup>
-      <Accordion id={title}>
-        <AccordionTrigger>{title}</AccordionTrigger>
-        <AccordionPanel>{children}</AccordionPanel>
-      </Accordion>
-    </AccordionGroup>
-  );
-};
+/**
+ * Re-exported from `ui-react`, which owns the implementation, so that the
+ * `components/UI` barrel offers it alongside the rest of the shared UI.
+ */
+export { SimpleAccordion } from '@giantswarm/backstage-plugin-ui-react';
+export type { SimpleAccordionProps } from '@giantswarm/backstage-plugin-ui-react';

--- a/plugins/gs/src/components/UI/SimpleAccordion/SimpleAccordion.tsx
+++ b/plugins/gs/src/components/UI/SimpleAccordion/SimpleAccordion.tsx
@@ -1,6 +1,0 @@
-/**
- * Re-exported from `ui-react`, which owns the implementation, so that the
- * `components/UI` barrel offers it alongside the rest of the shared UI.
- */
-export { SimpleAccordion } from '@giantswarm/backstage-plugin-ui-react';
-export type { SimpleAccordionProps } from '@giantswarm/backstage-plugin-ui-react';

--- a/plugins/gs/src/components/UI/SimpleAccordion/index.ts
+++ b/plugins/gs/src/components/UI/SimpleAccordion/index.ts
@@ -1,1 +1,0 @@
-export { SimpleAccordion } from './SimpleAccordion';

--- a/plugins/gs/src/components/UI/index.ts
+++ b/plugins/gs/src/components/UI/index.ts
@@ -15,7 +15,6 @@ export { JsonSchemaViewer } from './JsonSchemaViewer';
 export { KubernetesVersion } from './KubernetesVersion';
 export { NotAvailable } from './NotAvailable';
 export { ScrollContainer } from './ScrollContainer';
-export { SimpleAccordion } from './SimpleAccordion';
 export { StatusMessage } from './StatusMessage';
 export { StructuredMetadataList } from './StructuredMetadataList';
 export { Toolkit, type Tool } from './Toolkit';

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterAccessCard/ClusterAccessGS/ClusterAccessGS.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterAccessCard/ClusterAccessGS/ClusterAccessGS.tsx
@@ -5,7 +5,10 @@ import {
   TSH_LOGIN_COMMAND,
   getKubernetesAPIAccessCommand,
 } from './utils';
-import { CodeBlock, SimpleAccordion } from '../../../../../UI';
+import {
+  CodeBlock,
+  SimpleAccordion,
+} from '@giantswarm/backstage-plugin-ui-react';
 import { Cluster } from '@giantswarm/backstage-plugin-kubernetes-react';
 
 type ClusterAccessProps = {

--- a/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterGitOpsCard/ClusterGitOpsCard.tsx
+++ b/plugins/gs/src/components/clusters/cluster-details/ClusterOverview/ClusterGitOpsCard/ClusterGitOpsCard.tsx
@@ -13,6 +13,6 @@ export const ClusterGitOpsCard = () => {
   }
 
   return (
-    <GitOpsCard deployment={clusterApp} installationName={installationName} />
+    <GitOpsCard resource={clusterApp} installationName={installationName} />
   );
 };

--- a/plugins/gs/src/components/deployments/WorkloadDetailsPane/WorkloadDetailsPane.tsx
+++ b/plugins/gs/src/components/deployments/WorkloadDetailsPane/WorkloadDetailsPane.tsx
@@ -5,14 +5,10 @@ import {
   DetailsPane,
   InfoCard,
   JsonHighlight,
+  SimpleAccordion,
 } from '@giantswarm/backstage-plugin-ui-react';
 import { ErrorsProvider } from '@giantswarm/backstage-plugin-kubernetes-react';
-import {
-  ContentRow,
-  ClusterLink,
-  DateComponent,
-  SimpleAccordion,
-} from '../../UI';
+import { ContentRow, ClusterLink, DateComponent } from '../../UI';
 import { Labels } from '../../LabelsCard/Labels';
 import { ClusterTypes } from '../../clusters/utils';
 import { AIChatButton } from '@giantswarm/backstage-plugin-ai-chat-react';

--- a/plugins/gs/src/components/deployments/deployment-details/DeploymentOverview/DeploymentGitOpsCard/DeploymentGitOpsCard.tsx
+++ b/plugins/gs/src/components/deployments/deployment-details/DeploymentOverview/DeploymentGitOpsCard/DeploymentGitOpsCard.tsx
@@ -13,6 +13,6 @@ export const DeploymentGitOpsCard = () => {
   }
 
   return (
-    <GitOpsCard deployment={deployment} installationName={installationName} />
+    <GitOpsCard resource={deployment} installationName={installationName} />
   );
 };

--- a/plugins/gs/src/plugin.tsx
+++ b/plugins/gs/src/plugin.tsx
@@ -26,6 +26,7 @@ import ApartmentIcon from '@material-ui/icons/Apartment';
 import {
   appDeploymentTemplateRouteRef,
   clustersRouteRef,
+  deploymentDetailsRouteRef,
   deploymentsRouteRef,
   entityDeploymentsRouteRef,
   fluxOverviewExternalRouteRef,
@@ -647,6 +648,10 @@ export const gsPlugin = createFrontendPlugin({
     root: rootRouteRef,
     clustersPage: clustersRouteRef,
     deploymentsPage: deploymentsRouteRef,
+    // Exposed so other plugins can deep-link to one deployment — the
+    // agent-platform detail page links a kagent Agent to the HelmRelease that
+    // deployed it, where the Flux status and GitOps source already live.
+    deploymentDetails: deploymentDetailsRouteRef,
     entityContent: entityDeploymentsRouteRef,
   },
   externalRoutes: {

--- a/plugins/kubernetes-react/src/lib/k8s/Agent.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/Agent.test.ts
@@ -86,6 +86,94 @@ describe('Agent', () => {
     });
   });
 
+  describe('tool references', () => {
+    const agentWithTools = () =>
+      makeAgent({
+        spec: {
+          declarative: {
+            tools: [
+              // The chart's muster gateway entry: an MCP server, all its tools.
+              {
+                type: 'McpServer',
+                mcpServer: { name: 'muster', namespace: 'agentic-platform' },
+              },
+              // A restricted server, and one that omits `type` entirely — which
+              // the CRD allows and the controller infers.
+              {
+                mcpServer: {
+                  name: 'grafana',
+                  toolNames: ['query', 'dashboards'],
+                },
+              },
+              {
+                type: 'Agent',
+                agent: { name: 'sre-agent', namespace: 'kagent' },
+              },
+            ],
+          },
+        },
+      } as Partial<AgentInterface>);
+
+    it('returns every tool entry', () => {
+      expect(agentWithTools().getTools()).toHaveLength(3);
+    });
+
+    // Keyed on the presence of `mcpServer`, not on `type`, which is optional.
+    it('splits MCP server references out, including entries with no type', () => {
+      const refs = agentWithTools().getMcpServerRefs();
+
+      expect(refs.map(ref => ref.name)).toEqual(['muster', 'grafana']);
+      expect(refs[0].namespace).toBe('agentic-platform');
+      expect(refs[1].toolNames).toEqual(['query', 'dashboards']);
+    });
+
+    it('splits agent references out', () => {
+      const refs = agentWithTools().getAgentRefs();
+
+      expect(refs).toHaveLength(1);
+      expect(refs[0].name).toBe('sre-agent');
+    });
+
+    it('returns empty lists when the agent declares no tools', () => {
+      expect(makeAgent().getTools()).toEqual([]);
+      expect(makeAgent().getMcpServerRefs()).toEqual([]);
+      expect(makeAgent().getAgentRefs()).toEqual([]);
+    });
+  });
+
+  describe('generation tracking', () => {
+    it('reports the stored and observed generations', () => {
+      const agent = makeAgent({
+        metadata: { name: 'my-agent', namespace: 'team-a', generation: 4 },
+        status: { observedGeneration: 3, conditions: [] },
+      } as Partial<AgentInterface>);
+
+      expect(agent.getGeneration()).toBe(4);
+      expect(agent.getObservedGeneration()).toBe(3);
+      expect(agent.isStale()).toBe(true);
+    });
+
+    it('is not stale once the controller catches up', () => {
+      const agent = makeAgent({
+        metadata: { name: 'my-agent', namespace: 'team-a', generation: 4 },
+        status: { observedGeneration: 4, conditions: [] },
+      } as Partial<AgentInterface>);
+
+      expect(agent.isStale()).toBe(false);
+    });
+
+    // "Cannot tell" must not read as "stale" — see isAgentStatusStale.
+    it('is not stale when the controller records no observedGeneration', () => {
+      const agent = makeAgent({
+        metadata: { name: 'my-agent', namespace: 'team-a', generation: 4 },
+        status: { conditions: [] },
+      } as Partial<AgentInterface>);
+
+      expect(agent.getObservedGeneration()).toBeUndefined();
+      expect(agent.isStale()).toBe(false);
+    });
+  });
+
   describe('readiness', () => {
     const AT = '2026-07-31T10:00:00Z';
 

--- a/plugins/kubernetes-react/src/lib/k8s/Agent.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/Agent.ts
@@ -7,6 +7,21 @@ type AgentCondition = NonNullable<
 >[number];
 
 /**
+ * One entry of `spec.declarative.tools` — a reference to something the agent may
+ * call. The CRD models the list as a union of fixed-length tuples (its
+ * `maxItems: 20`), so it is indexed here to recover the element type.
+ */
+export type AgentTool = NonNullable<
+  NonNullable<NonNullable<AgentInterface['spec']>['declarative']>['tools']
+>[number];
+
+/** An `McpServer` tool reference: a `RemoteMCPServer`/`MCPServer` and, optionally, which of its tools to expose. */
+export type AgentMcpServerRef = NonNullable<AgentTool['mcpServer']>;
+
+/** An `Agent` tool reference: another agent invoked as a tool over A2A. */
+export type AgentToolAgentRef = NonNullable<AgentTool['agent']>;
+
+/**
  * Condition types the kagent controller sets on an Agent. `Accepted` reports
  * whether the spec reconciled, `Ready` whether the backing workload is up, and
  * `UnsupportedFeatures` is a soft warning that does not block reconciliation
@@ -67,6 +82,32 @@ function findAgentCondition(
  * callback, which sees `KubeObjectInterface[]` and not hydrated instances — can
  * reuse the exact same derivation instead of reimplementing it.
  */
+/**
+ * Whether the reported status describes an *older* spec than the one currently
+ * stored — the controller has seen the object but not yet caught up.
+ *
+ * Staleness is only claimed when observedGeneration is actually present and
+ * behind. The controller stamps it on every status write (including when
+ * reconciliation *fails*, so a rejected spec settles on `notAccepted` rather
+ * than sticking at `pending`), but the CRD marks it optional — whereas
+ * `metadata.generation` is always set by the apiserver. Treating "absent" as
+ * "stale" would therefore fail closed: against a build that writes conditions
+ * but not `status.observedGeneration`, *every* agent on that installation would
+ * read `pending`, hiding healthy and broken agents behind the same
+ * explanation-free label. Absent means "cannot tell", so this reports `false`
+ * and callers report what the conditions actually say.
+ */
+export function isAgentStatusStale(json: AgentInterface): boolean {
+  const { generation } = json.metadata ?? {};
+  const observedGeneration = json.status?.observedGeneration;
+
+  return (
+    typeof generation === 'number' &&
+    typeof observedGeneration === 'number' &&
+    observedGeneration < generation
+  );
+}
+
 export function deriveAgentReadiness(json: AgentInterface): AgentReadiness {
   const conditions = json.status?.conditions;
 
@@ -75,23 +116,7 @@ export function deriveAgentReadiness(json: AgentInterface): AgentReadiness {
     return 'pending';
   }
 
-  // Staleness is only claimed when observedGeneration is actually present and
-  // behind. The controller stamps it on every status write (including when
-  // reconciliation *fails*, so a rejected spec settles on `notAccepted` rather
-  // than sticking at `pending`), but the CRD marks it optional — whereas
-  // `metadata.generation` is always set by the apiserver. Treating "absent" as
-  // "stale" would therefore fail closed: against a build that writes conditions
-  // but not `status.observedGeneration`, *every* agent on that installation would
-  // read `pending`, hiding healthy and broken agents behind the same
-  // explanation-free label. Absent means "cannot tell", so fall through and
-  // report what the conditions actually say.
-  const { generation } = json.metadata ?? {};
-  const observedGeneration = json.status?.observedGeneration;
-  if (
-    typeof generation === 'number' &&
-    typeof observedGeneration === 'number' &&
-    observedGeneration < generation
-  ) {
+  if (isAgentStatusStale(json)) {
     return 'pending';
   }
 
@@ -199,8 +224,55 @@ export class Agent extends KubeObject<AgentInterface> {
     return this.getSkillRefs().length;
   }
 
+  /**
+   * Everything the agent may call: MCP servers and other agents. Spread into a
+   * plain array because the CRD types the field as a union of tuples.
+   */
+  getTools(): AgentTool[] {
+    return [...(this.jsonData.spec?.declarative?.tools ?? [])];
+  }
+
+  /**
+   * The MCP servers the agent draws tools from.
+   *
+   * Discriminated on the presence of `mcpServer` rather than on `type`, which is
+   * optional in the CRD — a hand-written or chart-rendered tool entry commonly
+   * omits it and lets the controller infer the kind.
+   */
+  getMcpServerRefs(): AgentMcpServerRef[] {
+    return this.getTools()
+      .map(tool => tool.mcpServer)
+      .filter((ref): ref is AgentMcpServerRef => Boolean(ref));
+  }
+
+  /** Other agents this agent invokes as tools (A2A). */
+  getAgentRefs(): AgentToolAgentRef[] {
+    return this.getTools()
+      .map(tool => tool.agent)
+      .filter((ref): ref is AgentToolAgentRef => Boolean(ref));
+  }
+
   getConditions() {
     return this.jsonData.status?.conditions;
+  }
+
+  /** Spec revision currently stored, bumped by the apiserver on every change. */
+  getGeneration(): number | undefined {
+    return this.jsonData.metadata?.generation;
+  }
+
+  /** Spec revision the reported status was computed from, when the controller records it. */
+  getObservedGeneration(): number | undefined {
+    return this.jsonData.status?.observedGeneration;
+  }
+
+  /**
+   * Whether the reported status is known to describe an older spec. See
+   * {@link isAgentStatusStale} — notably, this is `false` when the controller
+   * records no `observedGeneration` at all.
+   */
+  isStale(): boolean {
+    return isAgentStatusStale(this.jsonData);
   }
 
   getCondition(type: string) {

--- a/plugins/kubernetes-react/src/lib/k8s/index.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/index.ts
@@ -11,9 +11,15 @@ export {
   AgentConditionType,
   deriveAgentReadiness,
   getAgentStatusChangedAt,
+  isAgentStatusStale,
   isAgentTransitional,
 } from './Agent';
-export type { AgentReadiness } from './Agent';
+export type {
+  AgentMcpServerRef,
+  AgentReadiness,
+  AgentTool,
+  AgentToolAgentRef,
+} from './Agent';
 export { App } from './App';
 export { ClusterSecretStore } from './ClusterSecretStore';
 export { ConfigMap } from './ConfigMap';
@@ -35,6 +41,17 @@ export { Release, RELEASE_VERSION_PREFIXES } from './Release';
 export { Secret } from './Secret';
 export { SecretStore } from './SecretStore';
 export * from './KubeObject';
+export {
+  getHelmReleaseName,
+  getHelmReleaseNamespace,
+  getKustomizationName,
+  getKustomizationNamespace,
+  isGitOpsManaged,
+  isManagedByFlux,
+  provenanceReleaseId,
+  readProvenance,
+} from './provenance';
+export type { Provenance } from './provenance';
 export * from './FluxObject';
 export * from './FluxResourceStatusManager';
 export * from './FluxResourceMixin';

--- a/plugins/kubernetes-react/src/lib/k8s/provenance.test.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/provenance.test.ts
@@ -1,0 +1,187 @@
+import { KubeObject } from './KubeObject';
+import {
+  getHelmReleaseName,
+  getHelmReleaseNamespace,
+  getKustomizationName,
+  getKustomizationNamespace,
+  isGitOpsManaged,
+  isManagedByFlux,
+  provenanceReleaseId,
+  readProvenance,
+} from './provenance';
+
+function makeObject(
+  metadata: Record<string, unknown> = {},
+  cluster = 'gazelle',
+): KubeObject {
+  return new KubeObject(
+    {
+      apiVersion: 'kagent.dev/v1alpha2',
+      kind: 'Agent',
+      metadata: {
+        name: 'pr-reviewer',
+        namespace: 'agentic-platform',
+        ...metadata,
+      },
+    } as never,
+    cluster,
+  );
+}
+
+describe('provenance', () => {
+  describe('isManagedByFlux', () => {
+    it('is true only when both Kustomization labels are present', () => {
+      const object = makeObject({
+        labels: {
+          'kustomize.toolkit.fluxcd.io/name': 'agents',
+          'kustomize.toolkit.fluxcd.io/namespace': 'flux-giantswarm',
+        },
+      });
+
+      expect(isManagedByFlux(object)).toBe(true);
+      expect(getKustomizationName(object)).toBe('agents');
+      expect(getKustomizationNamespace(object)).toBe('flux-giantswarm');
+    });
+
+    it('is false when only the name label is present', () => {
+      const object = makeObject({
+        labels: { 'kustomize.toolkit.fluxcd.io/name': 'agents' },
+      });
+
+      expect(isManagedByFlux(object)).toBe(false);
+    });
+
+    // The distinction that matters for kagent Agents: they are rendered by a
+    // HelmRelease, so they are reconciled but carry no Kustomization link.
+    it('is false for an object rendered by a HelmRelease', () => {
+      const object = makeObject({
+        labels: {
+          'helm.toolkit.fluxcd.io/name': 'pr-reviewer',
+          'helm.toolkit.fluxcd.io/namespace': 'agentic-platform',
+        },
+      });
+
+      expect(isManagedByFlux(object)).toBe(false);
+      expect(isGitOpsManaged(object)).toBe(true);
+    });
+  });
+
+  describe('getHelmReleaseName / getHelmReleaseNamespace', () => {
+    it('reads the helm-controller labels', () => {
+      const object = makeObject({
+        labels: {
+          'helm.toolkit.fluxcd.io/name': 'pr-reviewer',
+          'helm.toolkit.fluxcd.io/namespace': 'agentic-platform',
+        },
+      });
+
+      expect(getHelmReleaseName(object)).toBe('pr-reviewer');
+      expect(getHelmReleaseNamespace(object)).toBe('agentic-platform');
+    });
+
+    it('returns undefined when the object carries no Helm labels', () => {
+      expect(getHelmReleaseName(makeObject())).toBeUndefined();
+      expect(getHelmReleaseNamespace(makeObject())).toBeUndefined();
+    });
+  });
+
+  describe('isGitOpsManaged', () => {
+    it('treats a Flux HelmRelease-labelled object as GitOps-managed', () => {
+      expect(
+        isGitOpsManaged(
+          makeObject({
+            labels: { 'helm.toolkit.fluxcd.io/name': 'agentic-platform' },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('treats a Kustomization-labelled object as GitOps-managed', () => {
+      expect(
+        isGitOpsManaged(
+          makeObject({
+            labels: { 'kustomize.toolkit.fluxcd.io/name': 'agents' },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('treats a plain Helm release as GitOps-managed', () => {
+      expect(
+        isGitOpsManaged(
+          makeObject({
+            annotations: { 'meta.helm.sh/release-name': 'muster' },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('recognises the managed-by label on its own', () => {
+      expect(
+        isGitOpsManaged(
+          makeObject({ labels: { 'app.kubernetes.io/managed-by': 'Helm' } }),
+        ),
+      ).toBe(true);
+      expect(
+        isGitOpsManaged(
+          makeObject({ labels: { 'app.kubernetes.io/managed-by': 'flux' } }),
+        ),
+      ).toBe(true);
+    });
+
+    it('treats an object with no Flux/Helm markers as ad-hoc (live CRUD)', () => {
+      expect(isGitOpsManaged(makeObject())).toBe(false);
+      expect(
+        isGitOpsManaged(
+          makeObject({ labels: { 'app.kubernetes.io/managed-by': 'kubectl' } }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('provenanceReleaseId', () => {
+    it('prefers the Helm annotations over the Flux labels', () => {
+      const provenance = readProvenance(
+        makeObject({
+          labels: {
+            'helm.toolkit.fluxcd.io/name': 'flux-name',
+            'helm.toolkit.fluxcd.io/namespace': 'flux-ns',
+          },
+          annotations: {
+            'meta.helm.sh/release-name': 'helm-name',
+            'meta.helm.sh/release-namespace': 'helm-ns',
+          },
+        }),
+      );
+
+      expect(provenanceReleaseId(provenance)).toBe('helm-ns/helm-name');
+    });
+
+    it('falls back to the Kustomization when there is no release', () => {
+      const provenance = readProvenance(
+        makeObject({
+          labels: {
+            'kustomize.toolkit.fluxcd.io/name': 'agents',
+            'kustomize.toolkit.fluxcd.io/namespace': 'flux-giantswarm',
+          },
+        }),
+      );
+
+      expect(provenanceReleaseId(provenance)).toBe('flux-giantswarm/agents');
+    });
+
+    it('omits the namespace when only a name is known', () => {
+      const provenance = readProvenance(
+        makeObject({
+          labels: { 'helm.toolkit.fluxcd.io/name': 'pr-reviewer' },
+        }),
+      );
+
+      expect(provenanceReleaseId(provenance)).toBe('pr-reviewer');
+    });
+
+    it('returns undefined for an ad-hoc object', () => {
+      expect(provenanceReleaseId(readProvenance(makeObject()))).toBeUndefined();
+    });
+  });
+});

--- a/plugins/kubernetes-react/src/lib/k8s/provenance.ts
+++ b/plugins/kubernetes-react/src/lib/k8s/provenance.ts
@@ -1,0 +1,124 @@
+import { KubeObject } from './KubeObject';
+
+const LABEL_KUSTOMIZATION_NAME = 'kustomize.toolkit.fluxcd.io/name';
+const LABEL_KUSTOMIZATION_NAMESPACE = 'kustomize.toolkit.fluxcd.io/namespace';
+const LABEL_HELMRELEASE_NAME = 'helm.toolkit.fluxcd.io/name';
+const LABEL_HELMRELEASE_NAMESPACE = 'helm.toolkit.fluxcd.io/namespace';
+const LABEL_MANAGED_BY = 'app.kubernetes.io/managed-by';
+const ANNOTATION_HELM_RELEASE_NAME = 'meta.helm.sh/release-name';
+const ANNOTATION_HELM_RELEASE_NAMESPACE = 'meta.helm.sh/release-namespace';
+
+/**
+ * Name of the Flux `Kustomization` that applied this object, from the labels
+ * Flux stamps on everything it applies.
+ */
+export function getKustomizationName(object: KubeObject) {
+  return object.getLabels()?.[LABEL_KUSTOMIZATION_NAME];
+}
+
+export function getKustomizationNamespace(object: KubeObject) {
+  return object.getLabels()?.[LABEL_KUSTOMIZATION_NAMESPACE];
+}
+
+/**
+ * Name of the Flux `HelmRelease` whose chart rendered this object. Set by the
+ * helm-controller on every object in a release, and the marker our kagent
+ * `Agent`s carry — they are rendered by the `agent` chart rather than applied
+ * from a Kustomization directly.
+ */
+export function getHelmReleaseName(object: KubeObject) {
+  return object.getLabels()?.[LABEL_HELMRELEASE_NAME];
+}
+
+export function getHelmReleaseNamespace(object: KubeObject) {
+  return object.getLabels()?.[LABEL_HELMRELEASE_NAMESPACE];
+}
+
+/**
+ * Whether the object was applied by a Flux `Kustomization`.
+ *
+ * Deliberately narrower than {@link isGitOpsManaged}: a Kustomization always has
+ * a source (a `GitRepository`/`OCIRepository`), so this is the marker that lets a
+ * caller resolve the object back to a path in Git. An object rendered by a
+ * HelmRelease carries no such link of its own — see {@link getHelmReleaseName}
+ * for the extra hop that needs.
+ */
+export function isManagedByFlux(object: KubeObject) {
+  return (
+    Boolean(getKustomizationName(object)) &&
+    Boolean(getKustomizationNamespace(object))
+  );
+}
+
+/**
+ * GitOps provenance recovered from a CR's labels/annotations. Both the Helm
+ * (`meta.helm.sh/*`) and Flux HelmRelease/Kustomization
+ * (`*.toolkit.fluxcd.io/*`) conventions are checked, so a resource deployed by
+ * either path shows where it comes from. Works for any CR carrying the standard
+ * markers (kagent `Agent`, muster `MCPServer`/`Workflow`, an `App`, …).
+ */
+export interface Provenance {
+  managedBy?: string;
+  helmRelease?: string;
+  helmNamespace?: string;
+  fluxHelmRelease?: string;
+  fluxHelmNamespace?: string;
+  fluxKustomization?: string;
+  fluxKustomizationNamespace?: string;
+}
+
+export function readProvenance(obj: KubeObject): Provenance {
+  const labels = obj.getLabels() ?? {};
+  const annotations = obj.getAnnotations() ?? {};
+  return {
+    managedBy: labels[LABEL_MANAGED_BY],
+    helmRelease: annotations[ANNOTATION_HELM_RELEASE_NAME],
+    helmNamespace: annotations[ANNOTATION_HELM_RELEASE_NAMESPACE],
+    fluxHelmRelease: labels[LABEL_HELMRELEASE_NAME],
+    fluxHelmNamespace: labels[LABEL_HELMRELEASE_NAMESPACE],
+    fluxKustomization: labels[LABEL_KUSTOMIZATION_NAME],
+    fluxKustomizationNamespace: labels[LABEL_KUSTOMIZATION_NAMESPACE],
+  };
+}
+
+/**
+ * Whether the resource is owned by GitOps (Flux/Helm) and therefore read-only
+ * in the app: editing it live would be reverted by the reconciler. Ad-hoc
+ * resources (created directly, no Flux/Helm/Helm-managed-by markers) return
+ * false and may be mutated live.
+ *
+ * Provenance is the only UI restriction: GitOps-managed resources produce a
+ * PR/manifest to commit; ad-hoc (manually added) resources allow live CRUD. See
+ * the provenance-only safety model ADR in klaus-lab.
+ *
+ * Note this answers "is a reconciler in charge of this object", *not* "is this
+ * object's desired state in Git". A HelmRelease applied by hand (or by our
+ * scaffolder) satisfies this while having no Git source at all. Callers that
+ * want to link to the source must resolve it and handle the absence — see
+ * {@link isManagedByFlux}.
+ */
+export function isGitOpsManaged(obj: KubeObject): boolean {
+  const p = readProvenance(obj);
+  return Boolean(
+    p.fluxHelmRelease ||
+    p.fluxKustomization ||
+    p.helmRelease ||
+    p.managedBy === 'Helm' ||
+    p.managedBy === 'flux',
+  );
+}
+
+/** The HelmRelease (or Kustomization) that owns the object, `ns/name` form. */
+export function provenanceReleaseId(p: Provenance): string | undefined {
+  const release = p.helmRelease ?? p.fluxHelmRelease;
+  const namespace = p.helmNamespace ?? p.fluxHelmNamespace;
+  if (release) {
+    return namespace ? `${namespace}/${release}` : release;
+  }
+  if (p.fluxKustomization) {
+    return p.fluxKustomizationNamespace
+      ? `${p.fluxKustomizationNamespace}/${p.fluxKustomization}`
+      : p.fluxKustomization;
+  }
+  return undefined;
+}

--- a/plugins/muster/src/lib/gitops.test.ts
+++ b/plugins/muster/src/lib/gitops.test.ts
@@ -1,9 +1,5 @@
 import { MusterWorkflow } from './k8s';
-import {
-  isGitOpsManaged,
-  toManifestYaml,
-  toWorkflowDefinition,
-} from './gitops';
+import { toManifestYaml, toWorkflowDefinition } from './gitops';
 
 function makeWorkflow(
   overrides: Record<string, unknown> = {},
@@ -28,21 +24,9 @@ function makeWorkflow(
   );
 }
 
-describe('workflow provenance (gitops.ts)', () => {
-  it('treats a Flux HelmRelease-labelled workflow as GitOps-managed', () => {
-    const managed = makeWorkflow({
-      metadata: {
-        name: 'deploy',
-        labels: { 'helm.toolkit.fluxcd.io/name': 'agentic-platform' },
-      },
-    });
-    expect(isGitOpsManaged(managed)).toBe(true);
-  });
-
-  it('treats a workflow with no Flux/Helm markers as ad-hoc (live CRUD)', () => {
-    expect(isGitOpsManaged(makeWorkflow())).toBe(false);
-  });
-
+// Provenance detection itself is tested where it lives, in
+// kubernetes-react's `provenance.test.ts`.
+describe('workflow definitions (gitops.ts)', () => {
   it('flattens the spec into the core_workflow_* argument shape', () => {
     const def = toWorkflowDefinition(makeWorkflow());
     expect(def).toEqual({

--- a/plugins/muster/src/lib/gitops.ts
+++ b/plugins/muster/src/lib/gitops.ts
@@ -1,15 +1,14 @@
 import { KubeObject } from '@giantswarm/backstage-plugin-kubernetes-react';
 
 /**
- * Provenance detection now lives in `kubernetes-react` (it only reads labels and
- * annotations off a `KubeObject`, and the agent-platform plugin needs the same
- * answers for kagent `Agent`s). Re-exported here so muster's own call sites keep
- * importing provenance and manifest helpers from one place.
+ * Provenance detection is implemented in `kubernetes-react`: it only reads labels
+ * and annotations off a `KubeObject`, and other plugins need the same answers for
+ * their own CRs. Re-exported here so muster's call sites get provenance and
+ * manifest helpers from one place.
  *
- * The safety model these encode is unchanged: GitOps-managed resources are
- * read-only in the app and produce a PR/manifest to commit; ad-hoc resources
- * (created through muster's own store) allow live
- * `core_*_create`/`_update`/`_delete` CRUD.
+ * The safety model these encode: GitOps-managed resources are read-only in the app
+ * and produce a PR/manifest to commit; ad-hoc resources (created through muster's
+ * own store) allow live `core_*_create`/`_update`/`_delete` CRUD.
  */
 export {
   isGitOpsManaged,

--- a/plugins/muster/src/lib/gitops.ts
+++ b/plugins/muster/src/lib/gitops.ts
@@ -1,72 +1,22 @@
 import { KubeObject } from '@giantswarm/backstage-plugin-kubernetes-react';
 
 /**
- * GitOps provenance recovered from a CR's labels/annotations. Both the Helm
- * (`meta.helm.sh/*`) and Flux HelmRelease/Kustomization
- * (`*.toolkit.fluxcd.io/*`) conventions are checked, so a resource deployed by
- * either path shows where it comes from. Works for any muster CR carrying the
- * standard markers (MCPServer, Workflow).
- */
-export interface Provenance {
-  managedBy?: string;
-  helmRelease?: string;
-  helmNamespace?: string;
-  fluxHelmRelease?: string;
-  fluxHelmNamespace?: string;
-  fluxKustomization?: string;
-  fluxKustomizationNamespace?: string;
-}
-
-export function readProvenance(obj: KubeObject): Provenance {
-  const labels = obj.getLabels() ?? {};
-  const annotations = obj.getAnnotations() ?? {};
-  return {
-    managedBy: labels['app.kubernetes.io/managed-by'],
-    helmRelease: annotations['meta.helm.sh/release-name'],
-    helmNamespace: annotations['meta.helm.sh/release-namespace'],
-    fluxHelmRelease: labels['helm.toolkit.fluxcd.io/name'],
-    fluxHelmNamespace: labels['helm.toolkit.fluxcd.io/namespace'],
-    fluxKustomization: labels['kustomize.toolkit.fluxcd.io/name'],
-    fluxKustomizationNamespace: labels['kustomize.toolkit.fluxcd.io/namespace'],
-  };
-}
-
-/**
- * Whether the resource is owned by GitOps (Flux/Helm) and therefore read-only
- * in the app: editing it live via the muster store would be reverted by the
- * reconciler. Ad-hoc resources (created through muster's own store, no
- * Flux/Helm/Helm-managed-by markers) return false and may be mutated live.
+ * Provenance detection now lives in `kubernetes-react` (it only reads labels and
+ * annotations off a `KubeObject`, and the agent-platform plugin needs the same
+ * answers for kagent `Agent`s). Re-exported here so muster's own call sites keep
+ * importing provenance and manifest helpers from one place.
  *
- * Provenance is the only UI restriction: GitOps-managed resources produce a
- * PR/manifest to commit; ad-hoc (manually added) resources allow live
- * core_*_create/_update/_delete CRUD. Applies identically to MCPServer and
- * Workflow CRs. See the provenance-only safety model ADR in klaus-lab.
+ * The safety model these encode is unchanged: GitOps-managed resources are
+ * read-only in the app and produce a PR/manifest to commit; ad-hoc resources
+ * (created through muster's own store) allow live
+ * `core_*_create`/`_update`/`_delete` CRUD.
  */
-export function isGitOpsManaged(obj: KubeObject): boolean {
-  const p = readProvenance(obj);
-  return Boolean(
-    p.fluxHelmRelease ||
-    p.fluxKustomization ||
-    p.helmRelease ||
-    p.managedBy === 'Helm' ||
-    p.managedBy === 'flux',
-  );
-}
-
-/** The HelmRelease (or Kustomization) that owns the server, `ns/name` form. */
-export function provenanceReleaseId(p: Provenance): string | undefined {
-  const release = p.helmRelease ?? p.fluxHelmRelease;
-  const namespace = p.helmNamespace ?? p.fluxHelmNamespace;
-  if (release) {
-    return namespace ? `${namespace}/${release}` : release;
-  }
-  if (p.fluxKustomization) {
-    return p.fluxKustomizationNamespace
-      ? `${p.fluxKustomizationNamespace}/${p.fluxKustomization}`
-      : p.fluxKustomization;
-  }
-  return undefined;
-}
+export {
+  isGitOpsManaged,
+  provenanceReleaseId,
+  readProvenance,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+export type { Provenance } from '@giantswarm/backstage-plugin-kubernetes-react';
 
 /**
  * Flatten an MCPServer CR's spec into the argument shape muster's

--- a/plugins/ui-react/package.json
+++ b/plugins/ui-react/package.json
@@ -64,6 +64,7 @@
     "@storybook/react": "^10.5.3",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/qs": "^6",
     "@types/semver": "^7",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"

--- a/plugins/ui-react/src/components/ConditionsList/ConditionsList.stories.tsx
+++ b/plugins/ui-react/src/components/ConditionsList/ConditionsList.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@backstage/ui';
+import { ConditionsList, ConditionLike } from './ConditionsList';
+import { componentDocs } from '../../storybook/docs';
+
+const meta = {
+  title: 'Components/ConditionsList',
+  component: ConditionsList,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: componentDocs({
+          summary:
+            "A resource's Kubernetes status conditions as a list of " +
+            'collapsible entries — the "why is this thing not working" view. ' +
+            'Each row shows the condition type, whether it is satisfied, and ' +
+            "when it last changed; expanding one reveals the controller's " +
+            '`reason` and `message`.',
+          whenToUse:
+            'On a resource details page, whenever the reader may need to debug ' +
+            'an unhealthy resource. Newest transition sorts first and the first ' +
+            'failing condition starts expanded, so the reason something just ' +
+            'broke is visible without a click. Pass `isFailing` for resources ' +
+            'with abnormal-true conditions (`Stalled`, `UnsupportedFeatures`), ' +
+            'where `status: True` is the bad news.',
+          migration: 'mixed',
+          extra:
+            'Presentation only — fetch the conditions yourself and pass them ' +
+            'in. The message body reuses `ConditionMessage`, so long ' +
+            'controller output scrolls inside the panel rather than stretching ' +
+            'the page.',
+        }),
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <Box style={{ maxWidth: 640 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof ConditionsList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const healthy: ConditionLike[] = [
+  {
+    type: 'Accepted',
+    status: 'True',
+    reason: 'Reconciled',
+    message: 'Agent configuration accepted',
+    lastTransitionTime: '2026-07-31T10:00:00Z',
+  },
+  {
+    type: 'Ready',
+    status: 'True',
+    reason: 'DeploymentReady',
+    message: 'Deployment is ready',
+    lastTransitionTime: '2026-07-31T10:02:00Z',
+  },
+];
+
+export const AllSatisfied: Story = {
+  args: { conditions: healthy },
+};
+
+export const WithFailure: Story = {
+  name: 'With a failure (auto-expanded)',
+  args: {
+    conditions: [
+      healthy[0],
+      {
+        type: 'Ready',
+        status: 'False',
+        reason: 'DeploymentNotReady',
+        message: 'Deployment is not ready, 0/1 pods are ready',
+        lastTransitionTime: '2026-07-31T10:05:00Z',
+      },
+    ],
+  },
+};
+
+export const UnknownStatus: Story = {
+  name: 'Unknown status (warning, not failure)',
+  args: {
+    conditions: [
+      healthy[0],
+      {
+        type: 'Ready',
+        status: 'Unknown',
+        reason: 'DeploymentNotFound',
+        message: 'deployments.apps "pr-reviewer" not found',
+        lastTransitionTime: '2026-07-31T10:05:00Z',
+      },
+    ],
+  },
+};
+
+export const AbnormalTrue: Story = {
+  name: 'Abnormal-true condition (custom isFailing)',
+  args: {
+    conditions: [
+      ...healthy,
+      {
+        type: 'UnsupportedFeatures',
+        status: 'True',
+        reason: 'UnsupportedFeatures',
+        message: 'memory is not supported by the go runtime',
+        lastTransitionTime: '2026-07-31T10:03:00Z',
+      },
+    ],
+    isFailing: condition =>
+      condition.type === 'UnsupportedFeatures'
+        ? condition.status === 'True'
+        : condition.status !== 'True',
+  },
+};
+
+export const LongMessage: Story = {
+  args: {
+    conditions: [
+      {
+        type: 'Accepted',
+        status: 'False',
+        reason: 'ReconcileFailed',
+        message: [
+          'failed to reconcile agent: admission webhook',
+          '"validation.kagent.dev" denied the request:',
+          'spec.declarative.modelConfig: modelconfigs.kagent.dev "opus-4-7"',
+          'not found in namespace "agentic-platform"',
+        ].join('\n'),
+        lastTransitionTime: '2026-07-31T10:05:00Z',
+      },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  name: 'No conditions yet',
+  args: {
+    conditions: [],
+    emptyContent: 'The controller has not reported a status yet.',
+  },
+};

--- a/plugins/ui-react/src/components/ConditionsList/ConditionsList.test.tsx
+++ b/plugins/ui-react/src/components/ConditionsList/ConditionsList.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react';
+import { ConditionsList, ConditionLike } from './ConditionsList';
+
+const accepted: ConditionLike = {
+  type: 'Accepted',
+  status: 'True',
+  reason: 'Reconciled',
+  message: 'Agent configuration accepted',
+  lastTransitionTime: '2026-07-31T10:00:00Z',
+};
+
+const notReady: ConditionLike = {
+  type: 'Ready',
+  status: 'False',
+  reason: 'DeploymentNotReady',
+  message: 'Deployment is not ready, 0/1 pods are ready',
+  lastTransitionTime: '2026-07-31T10:05:00Z',
+};
+
+/** The visible trigger buttons, in render order. */
+function triggers() {
+  return screen.getAllByRole('button');
+}
+
+describe('ConditionsList', () => {
+  it('renders one entry per condition, labelled by type', () => {
+    render(<ConditionsList conditions={[accepted, notReady]} />);
+
+    expect(screen.getByText('Accepted')).toBeInTheDocument();
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(triggers()).toHaveLength(2);
+  });
+
+  it('sorts the most recent transition first', () => {
+    render(<ConditionsList conditions={[accepted, notReady]} />);
+
+    expect(triggers()[0]).toHaveTextContent('Ready');
+    expect(triggers()[1]).toHaveTextContent('Accepted');
+  });
+
+  // Conditions with no timestamp sort last in either direction: "unknown" is not
+  // "oldest".
+  it('sorts conditions without a timestamp last', () => {
+    render(
+      <ConditionsList
+        conditions={[{ type: 'Orphan', status: 'True' }, accepted]}
+      />,
+    );
+
+    expect(triggers()[0]).toHaveTextContent('Accepted');
+    expect(triggers()[1]).toHaveTextContent('Orphan');
+  });
+
+  it('expands the first failing condition and leaves the rest collapsed', () => {
+    render(<ConditionsList conditions={[accepted, notReady]} />);
+
+    const [readyTrigger, acceptedTrigger] = triggers();
+    expect(readyTrigger).toHaveAttribute('aria-expanded', 'true');
+    expect(acceptedTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    // The message the reader came for is visible without a click.
+    expect(
+      screen.getByText('Deployment is not ready, 0/1 pods are ready'),
+    ).toBeInTheDocument();
+  });
+
+  it('expands nothing when every condition is satisfied', () => {
+    render(<ConditionsList conditions={[accepted]} />);
+
+    expect(triggers()[0]).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('shows the status and reason of the expanded condition', () => {
+    render(<ConditionsList conditions={[notReady]} />);
+
+    expect(screen.getByText('False')).toBeInTheDocument();
+    expect(screen.getByText('DeploymentNotReady')).toBeInTheDocument();
+  });
+
+  // A resource whose bad news is `status: True` (Stalled, UnsupportedFeatures)
+  // must be able to invert the test.
+  it('honours a custom isFailing for abnormal-true conditions', () => {
+    const unsupported: ConditionLike = {
+      type: 'UnsupportedFeatures',
+      status: 'True',
+      reason: 'UnsupportedFeatures',
+      message: 'memory is not supported by the go runtime',
+      lastTransitionTime: '2026-07-31T10:06:00Z',
+    };
+
+    render(
+      <ConditionsList
+        conditions={[accepted, unsupported]}
+        isFailing={condition =>
+          condition.type === 'UnsupportedFeatures'
+            ? condition.status === 'True'
+            : condition.status !== 'True'
+        }
+      />,
+    );
+
+    expect(triggers()[0]).toHaveTextContent('UnsupportedFeatures');
+    expect(triggers()[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(
+      screen.getByText('memory is not supported by the go runtime'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders per-condition actions when asked', () => {
+    render(
+      <ConditionsList
+        conditions={[notReady]}
+        renderActions={condition => <span>explain {condition.type}</span>}
+      />,
+    );
+
+    expect(screen.getByText('explain Ready')).toBeInTheDocument();
+  });
+
+  it('renders the empty content instead of a list when there are no conditions', () => {
+    render(
+      <ConditionsList conditions={[]} emptyContent="No status reported yet." />,
+    );
+
+    expect(screen.getByText('No status reported yet.')).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('renders nothing at all when empty with no empty content', () => {
+    const { container } = render(<ConditionsList conditions={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/plugins/ui-react/src/components/ConditionsList/ConditionsList.tsx
+++ b/plugins/ui-react/src/components/ConditionsList/ConditionsList.tsx
@@ -1,27 +1,9 @@
 import { ReactNode } from 'react';
-import {
-  Accordion,
-  AccordionPanel,
-  AccordionTrigger,
-  Box,
-  Flex,
-  Text,
-} from '@backstage/ui';
-import { makeStyles } from '@material-ui/core';
+import { Box, Flex, Text } from '@backstage/ui';
 import { ConditionMessage } from '../display/ConditionMessage';
 import { DateComponent } from '../DateComponent';
+import { SimpleAccordion } from '../SimpleAccordion';
 import { StatusLabel, StatusLabelIntent } from '../StatusLabel';
-
-const useStyles = makeStyles(theme => ({
-  // bui's AccordionTrigger has no bottom padding, so an expanded header sits
-  // flush against its panel and reads as top-heavy. Only add the gap when the
-  // panel is actually open, or collapsed rows in a list drift apart.
-  trigger: {
-    '&[aria-expanded="true"]': {
-      paddingBottom: theme.spacing(1),
-    },
-  },
-}));
 
 /**
  * The subset of a Kubernetes status condition this renders. Structurally typed
@@ -127,8 +109,6 @@ export const ConditionsList = ({
   renderActions,
   emptyContent,
 }: ConditionsListProps) => {
-  const classes = useStyles();
-
   if (conditions.length === 0) {
     return <>{emptyContent}</>;
   }
@@ -143,11 +123,12 @@ export const ConditionsList = ({
         const actions = renderActions?.(condition);
 
         return (
-          <Accordion
+          <SimpleAccordion
+            // Keyed on the transition time as well as the type, so a condition
+            // that flips re-mounts and `defaultExpanded` is re-seeded.
             key={`${condition.type}-${condition.lastTransitionTime ?? ''}`}
             defaultExpanded={condition === firstFailing}
-          >
-            <AccordionTrigger className={classes.trigger}>
+            title={
               <Box grow>
                 <Flex align="center" justify="between" gap="2">
                   <StatusLabel
@@ -164,34 +145,33 @@ export const ConditionsList = ({
                   )}
                 </Flex>
               </Box>
-            </AccordionTrigger>
-            <AccordionPanel>
-              <Flex direction="column" gap="2" pb="2">
-                <Flex align="center" gap="2">
-                  <Text variant="body-small" color="secondary">
-                    Status
-                  </Text>
-                  <Text variant="body-small">{condition.status}</Text>
-                  {condition.reason && (
-                    <>
-                      <Text variant="body-small" color="secondary">
-                        Reason
-                      </Text>
-                      <Text variant="body-small">{condition.reason}</Text>
-                    </>
-                  )}
-                </Flex>
-
-                {condition.message && (
-                  <Box>
-                    <ConditionMessage message={condition.message} />
-                  </Box>
+            }
+          >
+            <Flex direction="column" gap="2" pb="2">
+              <Flex align="center" gap="2">
+                <Text variant="body-small" color="secondary">
+                  Status
+                </Text>
+                <Text variant="body-small">{condition.status}</Text>
+                {condition.reason && (
+                  <>
+                    <Text variant="body-small" color="secondary">
+                      Reason
+                    </Text>
+                    <Text variant="body-small">{condition.reason}</Text>
+                  </>
                 )}
-
-                {actions && <Box>{actions}</Box>}
               </Flex>
-            </AccordionPanel>
-          </Accordion>
+
+              {condition.message && (
+                <Box>
+                  <ConditionMessage message={condition.message} />
+                </Box>
+              )}
+
+              {actions && <Box>{actions}</Box>}
+            </Flex>
+          </SimpleAccordion>
         );
       })}
     </Flex>

--- a/plugins/ui-react/src/components/ConditionsList/ConditionsList.tsx
+++ b/plugins/ui-react/src/components/ConditionsList/ConditionsList.tsx
@@ -1,0 +1,199 @@
+import { ReactNode } from 'react';
+import {
+  Accordion,
+  AccordionPanel,
+  AccordionTrigger,
+  Box,
+  Flex,
+  Text,
+} from '@backstage/ui';
+import { makeStyles } from '@material-ui/core';
+import { ConditionMessage } from '../display/ConditionMessage';
+import { DateComponent } from '../DateComponent';
+import { StatusLabel, StatusLabelIntent } from '../StatusLabel';
+
+const useStyles = makeStyles(theme => ({
+  // bui's AccordionTrigger has no bottom padding, so an expanded header sits
+  // flush against its panel and reads as top-heavy. Only add the gap when the
+  // panel is actually open, or collapsed rows in a list drift apart.
+  trigger: {
+    '&[aria-expanded="true"]': {
+      paddingBottom: theme.spacing(1),
+    },
+  },
+}));
+
+/**
+ * The subset of a Kubernetes status condition this renders. Structurally typed
+ * rather than tied to one CRD's generated type, so any resource's conditions fit
+ * — they all follow the `metav1.Condition` shape.
+ *
+ * `status` is a plain string rather than the `'True' | 'False' | 'Unknown'`
+ * union: some generated CRD types widen it, and a value outside the union should
+ * still render as itself instead of failing to compile.
+ */
+export type ConditionLike = {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+  observedGeneration?: number;
+};
+
+export type ConditionsListProps = {
+  conditions: ConditionLike[];
+  /**
+   * Whether a condition represents a problem — it drives the icon, the colour,
+   * and which condition starts expanded.
+   *
+   * Defaults to "anything that is not `True`", which is right for the common
+   * positive-polarity conditions (`Ready`, `Accepted`). Pass your own for
+   * resources with abnormal-true conditions, where `True` is the bad news:
+   *
+   * ```ts
+   * isFailing={c => (c.type === 'Stalled' ? c.status === 'True' : c.status === 'False')}
+   * ```
+   */
+  isFailing?: (condition: ConditionLike) => boolean;
+  /** Extra controls for a condition's panel, e.g. an "explain this error" button. */
+  renderActions?: (condition: ConditionLike) => ReactNode;
+  /** Shown instead of the list when there are no conditions at all. */
+  emptyContent?: ReactNode;
+};
+
+function defaultIsFailing(condition: ConditionLike): boolean {
+  return condition.status !== 'True';
+}
+
+function conditionIntent(
+  condition: ConditionLike,
+  isFailing: boolean,
+): StatusLabelIntent {
+  if (!isFailing) {
+    return 'positive';
+  }
+
+  // `Unknown` is "the controller cannot tell yet", which is a weaker claim than
+  // an outright failure and shouldn't look identical to one.
+  return condition.status === 'Unknown' ? 'warning' : 'negative';
+}
+
+function transitionTime(condition: ConditionLike): number | undefined {
+  if (!condition.lastTransitionTime) {
+    return undefined;
+  }
+  const parsed = Date.parse(condition.lastTransitionTime);
+
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Sort the most recently changed condition first, so the reason a resource just
+ * became unhealthy is at the top. Conditions with no usable timestamp sort last
+ * — "unknown" is not "oldest" — and ties fall back to the type for a stable
+ * order.
+ */
+function sortConditions(conditions: ConditionLike[]): ConditionLike[] {
+  return [...conditions].sort((a, b) => {
+    const aTime = transitionTime(a);
+    const bTime = transitionTime(b);
+
+    if (aTime !== bTime) {
+      if (aTime === undefined) return 1;
+      if (bTime === undefined) return -1;
+      return bTime - aTime;
+    }
+
+    return a.type.localeCompare(b.type);
+  });
+}
+
+/**
+ * A resource's status conditions, verbatim, as a list of collapsible entries —
+ * the "why is this thing not working" view.
+ *
+ * Each condition shows its type, whether it is satisfied, and when it last
+ * changed; expanding one reveals the controller's `reason` and `message`. The
+ * first failing condition starts expanded, because that is the one the reader
+ * came for; everything else is collapsed so a long list stays scannable.
+ *
+ * Presentation only — pass already-fetched conditions in. Deliberately agnostic
+ * about the resource kind: pass `isFailing` for abnormal-true conditions.
+ */
+export const ConditionsList = ({
+  conditions,
+  isFailing = defaultIsFailing,
+  renderActions,
+  emptyContent,
+}: ConditionsListProps) => {
+  const classes = useStyles();
+
+  if (conditions.length === 0) {
+    return <>{emptyContent}</>;
+  }
+
+  const sorted = sortConditions(conditions);
+  const firstFailing = sorted.find(condition => isFailing(condition));
+
+  return (
+    <Flex direction="column" gap="1">
+      {sorted.map(condition => {
+        const failing = isFailing(condition);
+        const actions = renderActions?.(condition);
+
+        return (
+          <Accordion
+            key={`${condition.type}-${condition.lastTransitionTime ?? ''}`}
+            defaultExpanded={condition === firstFailing}
+          >
+            <AccordionTrigger className={classes.trigger}>
+              <Box grow>
+                <Flex align="center" justify="between" gap="2">
+                  <StatusLabel
+                    label={condition.type}
+                    intent={conditionIntent(condition, failing)}
+                  />
+                  {condition.lastTransitionTime && (
+                    <Text variant="body-small" color="secondary">
+                      <DateComponent
+                        value={condition.lastTransitionTime}
+                        relative
+                      />
+                    </Text>
+                  )}
+                </Flex>
+              </Box>
+            </AccordionTrigger>
+            <AccordionPanel>
+              <Flex direction="column" gap="2" pb="2">
+                <Flex align="center" gap="2">
+                  <Text variant="body-small" color="secondary">
+                    Status
+                  </Text>
+                  <Text variant="body-small">{condition.status}</Text>
+                  {condition.reason && (
+                    <>
+                      <Text variant="body-small" color="secondary">
+                        Reason
+                      </Text>
+                      <Text variant="body-small">{condition.reason}</Text>
+                    </>
+                  )}
+                </Flex>
+
+                {condition.message && (
+                  <Box>
+                    <ConditionMessage message={condition.message} />
+                  </Box>
+                )}
+
+                {actions && <Box>{actions}</Box>}
+              </Flex>
+            </AccordionPanel>
+          </Accordion>
+        );
+      })}
+    </Flex>
+  );
+};

--- a/plugins/ui-react/src/components/ConditionsList/index.ts
+++ b/plugins/ui-react/src/components/ConditionsList/index.ts
@@ -1,0 +1,2 @@
+export { ConditionsList } from './ConditionsList';
+export type { ConditionLike, ConditionsListProps } from './ConditionsList';

--- a/plugins/ui-react/src/components/SimpleAccordion/SimpleAccordion.stories.tsx
+++ b/plugins/ui-react/src/components/SimpleAccordion/SimpleAccordion.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, Flex, Text } from '@backstage/ui';
+import { SimpleAccordion } from './SimpleAccordion';
+import { componentDocs } from '../../storybook/docs';
+
+const meta = {
+  title: 'Components/SimpleAccordion',
+  component: SimpleAccordion,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: componentDocs({
+          summary:
+            'A single collapsible section — a header that reveals its content ' +
+            'when triggered.',
+          whenToUse:
+            'Any time content should start hidden: a "how to" aside, a raw-data ' +
+            'dump, one entry in a list of details. Prefer it over composing ' +
+            "bui's `Accordion`/`AccordionTrigger`/`AccordionPanel` yourself — a " +
+            'hand-composed accordion has no bottom padding on an expanded ' +
+            'header, so the header sits flush against its content, and the CSS ' +
+            'selector that fixes it is easy to get wrong in a way that fails ' +
+            'silently. For an exclusive set (only one open at a time) or ' +
+            "controlled expansion, use bui's primitives with " +
+            '`useSimpleAccordionStyles` to keep the spacing.',
+          migration: 'mixed',
+          extra:
+            'Each instance is its own `AccordionGroup`, so sections expand ' +
+            'independently. `defaultExpanded` is read on mount only — give the ' +
+            'element a React `key` that changes with its content to re-seed it.',
+        }),
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <Box style={{ maxWidth: 560 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof SimpleAccordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'How to set up tsh',
+    children: (
+      <Text>
+        Install the Teleport client, then log in with your Giant Swarm account.
+      </Text>
+    ),
+  },
+};
+
+export const Expanded: Story = {
+  name: 'Open by default',
+  args: {
+    title: 'Raw data',
+    children: <Text>Everything the API returned for this workload.</Text>,
+  },
+  render: args => <SimpleAccordion {...args} defaultExpanded />,
+};
+
+export const NodeTitle: Story = {
+  name: 'Header carrying more than a label',
+  args: {
+    title: (
+      <Box grow>
+        <Flex align="center" justify="between" gap="2">
+          <Text>Ready</Text>
+          <Text variant="body-small" color="secondary">
+            9 days ago
+          </Text>
+        </Flex>
+      </Box>
+    ),
+    children: <Text>Deployment is not ready, 0/1 pods are ready.</Text>,
+  },
+};
+
+export const Stacked: Story = {
+  name: 'Several, expanding independently',
+  args: { title: 'Accepted', children: null },
+  render: () => (
+    <Flex direction="column" gap="1">
+      <SimpleAccordion title="Accepted">
+        <Text>Agent configuration accepted.</Text>
+      </SimpleAccordion>
+      <SimpleAccordion title="Ready" defaultExpanded>
+        <Text>Deployment is ready.</Text>
+      </SimpleAccordion>
+      <SimpleAccordion title="UnsupportedFeatures">
+        <Text>memory is not supported by the go runtime.</Text>
+      </SimpleAccordion>
+    </Flex>
+  ),
+};

--- a/plugins/ui-react/src/components/SimpleAccordion/SimpleAccordion.test.tsx
+++ b/plugins/ui-react/src/components/SimpleAccordion/SimpleAccordion.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SimpleAccordion } from './SimpleAccordion';
+
+/** The trigger button — the element bui puts `aria-expanded` on. */
+const trigger = (name: string) => screen.getByRole('button', { name });
+
+describe('SimpleAccordion', () => {
+  it('starts collapsed and reveals its content when triggered', async () => {
+    render(
+      <SimpleAccordion title="How to set up tsh">
+        <p>Install the client.</p>
+      </SimpleAccordion>,
+    );
+
+    expect(trigger('How to set up tsh')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+
+    await userEvent.click(trigger('How to set up tsh'));
+
+    expect(trigger('How to set up tsh')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByText('Install the client.')).toBeInTheDocument();
+  });
+
+  it('honours defaultExpanded', () => {
+    render(
+      <SimpleAccordion title="Raw data" defaultExpanded>
+        <p>Payload.</p>
+      </SimpleAccordion>,
+    );
+
+    expect(trigger('Raw data')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Payload.')).toBeInTheDocument();
+  });
+
+  it('accepts a node as the title, for a header carrying more than a label', () => {
+    render(
+      <SimpleAccordion
+        title={
+          <span>
+            Ready <em>9 days ago</em>
+          </span>
+        }
+      >
+        <p>Detail.</p>
+      </SimpleAccordion>,
+    );
+
+    expect(screen.getByText('9 days ago')).toBeInTheDocument();
+  });
+
+  // The reason this component exists. The rule has to target the trigger *button*
+  // — `aria-expanded` lives there, not on the `<h3>` wrapping it — and a selector
+  // scoped to the wrong element fails silently, which is exactly what a rendering
+  // test cannot see. Assert the class is scoped to something that actually
+  // matches the button in the rendered markup.
+  it('scopes the trigger-spacing rule to the element that carries aria-expanded', () => {
+    const { container } = render(
+      <SimpleAccordion title="Conditions" defaultExpanded>
+        <p>Detail.</p>
+      </SimpleAccordion>,
+    );
+
+    const button = trigger('Conditions');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).toHaveClass('bui-AccordionTriggerButton');
+
+    // The generated class sits on an ancestor of the button, so a descendant
+    // selector from it can reach the button. Were it applied to the trigger
+    // element itself with `&[aria-expanded]`, nothing would ever match.
+    const styled = container.querySelector('[class*="makeStyles-group"]');
+    expect(styled).not.toBeNull();
+    expect(styled).toContainElement(button);
+    expect(styled).not.toBe(button);
+  });
+});

--- a/plugins/ui-react/src/components/SimpleAccordion/SimpleAccordion.tsx
+++ b/plugins/ui-react/src/components/SimpleAccordion/SimpleAccordion.tsx
@@ -1,0 +1,83 @@
+import { ReactNode, useId } from 'react';
+import {
+  Accordion,
+  AccordionGroup,
+  AccordionPanel,
+  AccordionTrigger,
+} from '@backstage/ui';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  group: {
+    // bui's accordion trigger has no bottom padding, so an expanded header sits
+    // flush against its panel and the whole thing reads top-heavy. Added only
+    // when expanded — a collapsed header would otherwise look padded on one side.
+    //
+    // The selector must reach the *button*. `AccordionTrigger` renders an
+    // `<h3 class="bui-AccordionTrigger">` wrapping a
+    // `<button class="bui-AccordionTriggerButton" aria-expanded>`, so
+    // `&[aria-expanded="true"]` on the trigger's own element matches nothing.
+    '& .bui-AccordionTriggerButton[aria-expanded="true"]': {
+      paddingBottom: theme.spacing(1),
+    },
+  },
+}));
+
+export type SimpleAccordionProps = {
+  /**
+   * The clickable header. A plain string for the common case; any node when the
+   * header carries more than a label (a status, a timestamp, a badge).
+   */
+  title: ReactNode;
+  children: ReactNode;
+  /** Open on first render. Only applies on mount — see the note below. */
+  defaultExpanded?: boolean;
+};
+
+/**
+ * A single collapsible section, with the spacing bui leaves out.
+ *
+ * Prefer this over composing `Accordion`/`AccordionTrigger`/`AccordionPanel`
+ * directly — a hand-composed accordion needs the trigger-padding fix above, and
+ * the selector it requires is easy to get wrong in a way that fails silently.
+ *
+ * Each instance is its own `AccordionGroup`, so sections expand independently.
+ * For a set where only one may be open at a time, or where expansion is
+ * controlled, compose bui's primitives directly and apply
+ * {@link useSimpleAccordionStyles} to keep the spacing.
+ *
+ * `defaultExpanded` maps to the group's `defaultExpandedKeys`, which bui reads
+ * only on mount: to re-seed it when the content changes, give the element a
+ * React `key` that changes with it.
+ */
+export const SimpleAccordion = ({
+  title,
+  children,
+  defaultExpanded,
+}: SimpleAccordionProps) => {
+  const classes = useStyles();
+  // bui identifies an accordion within its group by id, and this component owns
+  // the group — so generate one rather than making every caller invent a unique
+  // string. A title-derived id would not work for a node title anyway.
+  const id = useId();
+
+  return (
+    <AccordionGroup
+      className={classes.group}
+      defaultExpandedKeys={defaultExpanded ? new Set([id]) : undefined}
+    >
+      <Accordion id={id}>
+        <AccordionTrigger>{title}</AccordionTrigger>
+        <AccordionPanel>{children}</AccordionPanel>
+      </Accordion>
+    </AccordionGroup>
+  );
+};
+
+/**
+ * The trigger-spacing fix on its own, for the cases {@link SimpleAccordion}
+ * cannot serve (controlled expansion, exclusive groups). Apply the returned
+ * `group` class to the `AccordionGroup` — or to any element wrapping the
+ * accordions.
+ */
+export const useSimpleAccordionStyles = useStyles;

--- a/plugins/ui-react/src/components/SimpleAccordion/index.ts
+++ b/plugins/ui-react/src/components/SimpleAccordion/index.ts
@@ -1,0 +1,2 @@
+export { SimpleAccordion, useSimpleAccordionStyles } from './SimpleAccordion';
+export type { SimpleAccordionProps } from './SimpleAccordion';

--- a/plugins/ui-react/src/components/index.ts
+++ b/plugins/ui-react/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './display/FiltersLayout';
 export * from './AsyncValue';
 export * from './Autocomplete';
 export * from './CodeBlock';
+export * from './ConditionsList';
 export * from './ContentRow';
 export * from './DateComponent';
 export * from './DetailsPane';

--- a/plugins/ui-react/src/components/index.ts
+++ b/plugins/ui-react/src/components/index.ts
@@ -17,6 +17,7 @@ export * from './MultipleSelect';
 export * from './NotAvailable';
 export * from './PageHeaderActions';
 export * from './SectionHeader';
+export * from './SimpleAccordion';
 export * from './SingleSelect';
 export * from './StackedBarChart';
 export * from './StatusLabel';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10910,6 +10910,7 @@ __metadata:
     "@backstage/plugin-scaffolder-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@backstage/ui": "backstage:^"
+    "@giantswarm/backstage-plugin-flux-react": "workspace:^"
     "@giantswarm/backstage-plugin-gs": "workspace:^"
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^"
     "@giantswarm/backstage-plugin-ui-react": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11509,6 +11509,7 @@ __metadata:
     "@storybook/react": "npm:^10.5.3"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
+    "@testing-library/user-event": "npm:^14.5.2"
     "@types/lodash": "npm:^4.17.5"
     "@types/qs": "npm:^6"
     "@types/semver": "npm:^7"


### PR DESCRIPTION
### What does this PR do?

Adds an agent details page to the Agent Platform plugin. Clicking an agent in the
list opens `/agent-platform/agents/<installation>/<namespace>/<name>` — all three
segments, because an `Agent` name is only unique within a namespace on one
installation.

Seven sections:

- **Header** — avatar, display name, derived readiness, technical name,
  installation/namespace, creation age, description. A kebab in the shared plugin
  header opens a **manifest dialog** with the Agent CR as read-only YAML, minus
  `metadata.managedFields` and the `last-applied-configuration` annotation. That
  dialog is the escape hatch for what the page does not surface (`deployment`,
  `sandbox`, `a2aConfig`, labels).
- **GitOps** — the shared `GitOpsCard`, when the agent's desired state really is in
  Git (see below).
- **Status** — readiness, the controller's own explanation, an `UnsupportedFeatures`
  warning, a note naming both generations when the status is stale, and every
  condition verbatim. This is what makes a broken agent debuggable without
  `kubectl`, so it leads the page.
- **Configuration** — type, model, installation, namespace, created, the owning
  HelmRelease (linked to its deployment page), and the MCP-server / agent tool
  references. A Muster gateway reference links to muster's Tool Explorer with the
  installation preselected.
- **System prompt** — copyable.
- **Skills** — the same card grid the create flow's picker uses, read-only, plus the
  `ref` each skill is pinned to.
- **Recent sessions** — the newest few, over a single-installation query that shares
  the Sessions tab's cache key.

**Read-only.** Editing an agent means changing the values its HelmRelease renders
from, and a delete must remove only that release and never the `OCIRepository` a
namespace's agents share — so neither is a menu item yet, and neither is "Launch
session". `docs/agent-platform.md` records what is still needed for the write path.

### What is the effect of this change to users?

Agents in the list become clickable, and one agent now has a page showing what it
is, whether it works, and what it has been used for. The main gain is
debuggability: a rejected spec's admission-webhook output and every status
condition are readable in the UI instead of requiring `kubectl get agent -o yaml`.

Deliberately **not** shown, because there is no data behind it: sessions all-time,
sessions in the last 30 days, and a success rate. kagent keeps no per-agent counters
and scopes its session list to the caller, so each would be a number invented from
one person's history — wrong by orders of magnitude on a shared agent. The sessions
section says whose sessions it is showing, and changes wording on an installation
whose kagent is not user-scoped rather than claiming ownership it cannot.

Two smaller user-visible fixes come along:

- The `SimpleAccordion` used by the cluster access card and the workload details
  pane gains the bottom padding bui's accordion trigger omits, so an expanded header
  no longer sits flush against its content.
- `GitOpsCard` stops claiming GitOps for resources that are reconciled but not in
  Git — see below.

### How does it look like?

<img width="1252" height="800" alt="image" src="https://github.com/user-attachments/assets/1247bb02-cb43-4c75-a26d-5a539af8fb33" />

<img width="1249" height="515" alt="image" src="https://github.com/user-attachments/assets/2509c8d5-493a-4076-a8d8-8fade9903419" />


### Any background context you can provide?

Three pieces of shared work were needed, and each removes a duplicate:

**GitOps provenance is de-duplicated.** `readProvenance` / `isGitOpsManaged` /
`provenanceReleaseId` (from `muster`) and `isManagedByFlux` with the Kustomization
label readers (from `flux-react`) now live in one module in `kubernetes-react`,
alongside new `getHelmReleaseName`/`getHelmReleaseNamespace`. `flux-react` and
`muster` re-export from it, so their public APIs are unchanged.

The distinction mattered: `isManagedByFlux` is **false** for a kagent `Agent`, which
is rendered by a Helm chart and so carries `helm.toolkit.fluxcd.io/*` rather than
Kustomization labels. `GitOpsCard` therefore gained a hop — with no Kustomization
label of its own it resolves the owning `HelmRelease` and follows _its_ labels to
the Kustomization and GitRepository — and now takes any `KubeObject` as `resource`
instead of an `App`/`HelmRelease` as `deployment`.

It also stops equating "reconciled by Flux" with "GitOps-managed": where that chain
ends without a Kustomization it renders **nothing**. An agent created through this
plugin is exactly that case — the create flow applies its `HelmRelease` and
`OCIRepository` through the scaffolder, so Flux reconciles the agent but no file in
Git describes it, and saying otherwise sends the reader looking for something that
does not exist. The gs cluster and deployment pages gate on `isManagedByFlux` and so
always have a Kustomization already; their behaviour is unchanged. `GitOpsCard` had
no tests and now has them for both provenance paths.

**New in `ui-react`: `SimpleAccordion`.** One collapsible section, carrying the
bottom padding bui's accordion trigger lacks. Four places had composed bui's
accordion primitives directly and fixed that locally in three different ways — one
with a selector scoped to the trigger element rather than the button that actually
carries `aria-expanded`, so it matched nothing. gs's own `SimpleAccordion` is
removed in favour of this one and its two call sites import from `ui-react`
directly. `plans`' `MergedTab`, agent-platform's `TimelineEntry` and muster's
`DisclosureAccordion` still carry their own copies and could adopt it.

**New in `ui-react`: `ConditionsList`.** A bui renderer for a resource's status
conditions: one collapsible entry per condition with its type, satisfaction,
relative transition time, reason and message; newest transition first, and the first
failing condition expanded. Takes an `isFailing` override for abnormal-true
conditions (`Stalled`, `UnsupportedFeatures`). gs's MUI v4 `HelmReleaseConditions`
is a candidate to adopt it later; that migration is not in this PR.

Also worth knowing:

- The agent is fetched with a single targeted `useResource`, not read out of the
  list's provider, so a deep link works without the list having loaded. It polls on
  the same two tiers as the list (`isAgentConverging` is now shared): 5 s while
  converging, 60 s once settled or durably broken.
- The model is read by name in the agent's **own namespace**, not through the
  cluster-wide `ModelConfigsProvider` list, which is admin-only — reusing it would
  deny a non-admin the model name on a page they can otherwise read in full. A
  failed read falls back to the bare reference, never to "no model".
- `getTelemetryPageViewPayload` gained an `Agent detail` case, deliberately with no
  `view`: the path segments name an installation and an agent, so echoing them would
  emit a page name per agent and record which installations a user reads.

Verified against real agents on `gazelle` and `graveler`, including a genuinely
_Not accepted_ agent, the manifest dialog, the Muster link, back-navigation, and the
telemetry payload.

### Do the docs need to be updated?

Yes — done in this PR. `docs/agent-platform.md` gains an "agent detail page"
section covering the layout, the sections, the targeted model read, the GitOps
semantics and what the page cannot show, and its open-TODO list is narrowed to the
write path that is still missing.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
