### PR TITLE
fix(deps): update dependency @giantswarm/k8s-types to v0.7.0

### DIFF
--- a/plugins/agent-platform/package.json
+++ b/plugins/agent-platform/package.json
@@ -55,7 +55,7 @@
     "@backstage/dev-utils": "backstage:^",
     "@backstage/frontend-test-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.6.3",
+    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.7.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.0.0",

--- a/plugins/kubernetes-react/package.json
+++ b/plugins/kubernetes-react/package.json
@@ -31,7 +31,7 @@
     "@backstage/plugin-kubernetes-react": "backstage:^",
     "@giantswarm/backstage-plugin-error-reporter-react": "workspace:^",
     "@giantswarm/backstage-plugin-ui-react": "workspace:^",
-    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.6.3",
+    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.7.0",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@types/lodash": "^4.17.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10914,7 +10914,7 @@ __metadata:
     "@giantswarm/backstage-plugin-gs": "workspace:^"
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^"
     "@giantswarm/backstage-plugin-ui-react": "workspace:^"
-    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.6.3"
+    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.7.0"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
     "@tanstack/query-async-storage-persister": "npm:^5.86.0"
@@ -11290,7 +11290,7 @@ __metadata:
     "@backstage/plugin-kubernetes-react": "backstage:^"
     "@giantswarm/backstage-plugin-error-reporter-react": "workspace:^"
     "@giantswarm/backstage-plugin-ui-react": "workspace:^"
-    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.6.3"
+    "@giantswarm/k8s-types": "github:giantswarm/k8s-typescript-types#v0.7.0"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.11.3"
     "@testing-library/jest-dom": "npm:^6.0.0"
@@ -11532,10 +11532,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@giantswarm/k8s-types@github:giantswarm/k8s-typescript-types#v0.6.3":
+"@giantswarm/k8s-types@github:giantswarm/k8s-typescript-types#v0.7.0":
   version: 0.1.0
-  resolution: "@giantswarm/k8s-types@https://github.com/giantswarm/k8s-typescript-types.git#commit=927f4ecc1354511b0431e6547fad244617d04a47"
-  checksum: 10c0/d2d68304da8d51cce3f2cd5d4b18ca286aecd9252cd6f51a6dd4e386ac123c6e8fd88a7fedbf5cd50711fb984914d90276005c563c3514c3bbba55612bb48906
+  resolution: "@giantswarm/k8s-types@https://github.com/giantswarm/k8s-typescript-types.git#commit=b14293a78c820c64f7d50186df13888400a63414"
+  checksum: 10c0/fe7a8936e3118e435ee90a9f77e7c0c3153978ea37a0fbff5daf46689af716b768ce0855b76c620712660dbf82e7ee9bf10a0132f117def70840ee8b38b605cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Updates `@giantswarm/k8s-types` from `v0.6.3` to `v0.7.0` in
`plugins/kubernetes-react` and `plugins/agent-platform`.

v0.7.0 ([release notes](https://github.com/giantswarm/k8s-typescript-types/releases/tag/v0.7.0))
is the follow-up to the `v1beta2` breakage that #1986 worked around:

- Every Flux CRD source is now pinned to a release tag, with one source per API
  version — the newest release that still serves it
  ([#74](https://github.com/giantswarm/k8s-typescript-types/pull/74)). `HelmRelease`
  and `Kustomization` were the last two tracking a controller's `main` branch,
  which is how 0.6.1 silently dropped the `v1beta2` image types.
- The `capi` CRD URLs are pinned to cluster-api `v1.13.4`
  ([#76](https://github.com/giantswarm/k8s-typescript-types/pull/76)). They pointed
  at `main`, where the CRDs have moved to `core/config/crd/bases/`, so all five
  404'd and any regeneration would have deleted the `Cluster`, `Machine`,
  `MachineDeployment` and `MachinePool` types we depend on.
- New API versions are now available: `crds.fluxcd.v1beta1`,
  `crds.fluxcd.v2beta1`, `crds.fluxcd.v2beta2` and
  `crds.fluxcd.v1beta2.Kustomization`.

Nothing in this repo has to change to consume it — the update is additive for the
versions our resource classes declare. The new `v1beta1` / `v2beta1` / `v2beta2`
types are available if we ever want to widen `supportedVersions`; the Flux
release deployed by flux-app (2.6.4) does still serve them.

### What is the effect of this change to users?

None. No behaviour changes; this only widens and stabilises the generated
Kubernetes types available to the frontend.

### Any background context you can provide?

Follow-on from #1986. The underlying cause there was that k8s-types generated
several CRDs from upstream `main` branches, so a regeneration picked up API
versions that upstream had already removed but our clusters still serve. That
class of failure is now closed upstream: no CRD URL points at a moving branch,
and a URL that 404s is reported as an error instead of silently dropping types.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

No changeset, consistent with the preceding `@giantswarm/k8s-types` bumps
(#1986 and earlier) — happy to add one if you'd prefer this to appear in the
plugin release notes.

### Verification

Run locally against the published `v0.7.0`:

- `yarn tsc --noEmit` (with `*.tsbuildinfo` cleared) → 0 errors
- `yarn test:all` → 181 suites, 1797 tests passed
- `yarn lint:all` → clean
- `yarn prettier:check` → clean