### PR TITLE
fix(muster): keep the MCP Servers index redirect from being clobbered

### DIFF
--- a/.changeset/muster-index-redirect-clobber.md
+++ b/.changeset/muster-index-redirect-clobber.md
@@ -14,4 +14,7 @@ cached), it replaced `/muster/dashboard` back with `/muster`.
 
 The index redirect and the legacy `workflows/:name/run` redirect are now mounted
 as siblings of the views, outside `MusterProviders`, so they can no longer be
-overwritten by the installation-param write.
+overwritten by the installation-param write. The index redirect also keeps the
+query string, so a deep link like `/agent-platform/muster?installation=alpha` no
+longer loses the requested installation to the default on the way to the
+dashboard.

--- a/.changeset/muster-index-redirect-clobber.md
+++ b/.changeset/muster-index-redirect-clobber.md
@@ -1,0 +1,17 @@
+---
+'@giantswarm/backstage-plugin-muster': patch
+---
+
+Fix the MCP Servers section landing on a blank view with no tab selected.
+
+Opening the Agent Platform "MCP Servers" tab a second time within a session left
+the URL on `/agent-platform/muster` with no view rendered and no second-level tab
+highlighted. `MusterInstanceProvider` writes the active installation into
+`?installation=` from an effect, and that search-only navigation resolves against
+the pathname of the render that created it — so when it ran in the same commit as
+the section's index redirect (which it does once the installations query is
+cached), it replaced `/muster/dashboard` back with `/muster`.
+
+The index redirect and the legacy `workflows/:name/run` redirect are now mounted
+as siblings of the views, outside `MusterProviders`, so they can no longer be
+overwritten by the installation-param write.

--- a/plugins/muster/package.json
+++ b/plugins/muster/package.json
@@ -48,6 +48,7 @@
     "@backstage/cli": "backstage:^",
     "@backstage/core-app-api": "backstage:^",
     "@backstage/dev-utils": "backstage:^",
+    "@backstage/frontend-test-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",

--- a/plugins/muster/src/components/MusterInstanceProvider/MusterInstanceProvider.tsx
+++ b/plugins/muster/src/components/MusterInstanceProvider/MusterInstanceProvider.tsx
@@ -163,6 +163,13 @@ export const MusterInstanceProvider = ({
 
   // Once installations resolve, write the chosen default back to the URL +
   // localStorage so the picker reflects it and deep links stay stable.
+  //
+  // NOTE: keep route-level redirects OUT of this provider's subtree. This is a
+  // search-only navigation, so react-router resolves it against the pathname of
+  // the render that created it; if a redirect below fires in the same commit,
+  // this write lands on the pre-redirect path and silently undoes it. See the
+  // note in MusterSection, which mounts its redirects as siblings for that
+  // reason.
   useEffect(() => {
     if (!activeInstallation) {
       return;

--- a/plugins/muster/src/components/MusterSection/MusterSection.test.tsx
+++ b/plugins/muster/src/components/MusterSection/MusterSection.test.tsx
@@ -37,9 +37,11 @@ jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
   useShowErrors: () => jest.fn(),
 }));
 
+// Two installations, so a redirect that drops `?installation=` is visible as the
+// default (`gazelle`, the first entry) replacing an explicitly requested one.
 const musterApi = {
   listInstallations: jest.fn(async () => ({
-    installations: [{ name: 'gazelle' }],
+    installations: [{ name: 'gazelle' }, { name: 'alpha' }],
   })),
 } as unknown as MusterApi;
 
@@ -70,6 +72,10 @@ function renderSection(path: string) {
 }
 
 describe('MusterSection', () => {
+  // The active installation is persisted, so each case has to start from a clean
+  // slate to exercise the default resolution rather than the previous test's pick.
+  beforeEach(() => window.localStorage.clear());
+
   it('redirects the section index to the dashboard view', async () => {
     renderSection('/agent-platform/muster');
 
@@ -100,6 +106,17 @@ describe('MusterSection', () => {
     await waitFor(() => {
       expect(screen.getByTestId('path')).toHaveTextContent(
         '/agent-platform/muster/dashboard?installation=gazelle',
+      );
+    });
+  });
+
+  it('keeps an explicit installation across the index redirect', async () => {
+    renderSection('/agent-platform/muster?installation=alpha');
+
+    expect(await screen.findByText('dashboard-view')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('path')).toHaveTextContent(
+        '/agent-platform/muster/dashboard?installation=alpha',
       );
     });
   });

--- a/plugins/muster/src/components/MusterSection/MusterSection.test.tsx
+++ b/plugins/muster/src/components/MusterSection/MusterSection.test.tsx
@@ -1,0 +1,117 @@
+import { Route, Routes, useLocation } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+// The NFS test app: `useRouteRef` from `@backstage/frontend-plugin-api` (used by
+// the legacy-run redirect) resolves against the new route-resolution API, which
+// the classic `@backstage/test-utils` app does not provide.
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { MusterApi, musterApiRef } from '../../apis';
+import { rootRouteRef } from '../../routes';
+import { MusterSection } from './MusterSection';
+
+// The views are irrelevant here -- this is about the section's routing -- and
+// stubbing them keeps the tree free of the kubernetes/muster reads they do.
+jest.mock('../DashboardPage', () => ({
+  DashboardPage: () => <div>dashboard-view</div>,
+}));
+jest.mock('../McpServersPage', () => ({
+  McpServersPage: () => <div>servers-view</div>,
+}));
+jest.mock('../WorkflowsRouter', () => ({
+  WorkflowsRouter: () => <div>workflows-view</div>,
+}));
+jest.mock('../ToolExplorerPage', () => ({
+  ToolExplorerPage: () => <div>tools-view</div>,
+}));
+
+// MusterInstanceProvider is deliberately NOT stubbed: its `?installation=` write
+// is what used to clobber the index redirect. Only its data sources are.
+jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
+  ...jest.requireActual('@giantswarm/backstage-plugin-kubernetes-react'),
+  useResources: () => ({
+    resources: [],
+    errors: [],
+    queries: [],
+    isLoading: false,
+    retry: jest.fn(),
+  }),
+  useShowErrors: () => jest.fn(),
+}));
+
+const musterApi = {
+  listInstallations: jest.fn(async () => ({
+    installations: [{ name: 'gazelle' }],
+  })),
+} as unknown as MusterApi;
+
+const CurrentPath = () => {
+  const { pathname, search } = useLocation();
+  return <div data-testid="path">{`${pathname}${search}`}</div>;
+};
+
+function renderSection(path: string) {
+  return renderInTestApp(
+    <Routes>
+      <Route
+        path="/agent-platform/muster/*"
+        element={
+          <>
+            <MusterSection />
+            <CurrentPath />
+          </>
+        }
+      />
+    </Routes>,
+    {
+      initialRouteEntries: [path],
+      mountedRoutes: { '/agent-platform/muster': rootRouteRef },
+      apis: [[musterApiRef, musterApi]],
+    },
+  );
+}
+
+describe('MusterSection', () => {
+  it('redirects the section index to the dashboard view', async () => {
+    renderSection('/agent-platform/muster');
+
+    expect(await screen.findByText('dashboard-view')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('path')).toHaveTextContent(
+        '/agent-platform/muster/dashboard',
+      );
+    });
+  });
+
+  // The section's QueryClient is a module-level singleton, so a second visit
+  // within a session has the installations list already cached. That used to
+  // make MusterInstanceProvider's `?installation=` effect run in the same commit
+  // as the index redirect and overwrite it with the pre-redirect path, leaving
+  // the section on `/muster` with no view and no selected tab.
+  it('keeps the redirect when the installations query is already cached', async () => {
+    const first = renderSection('/agent-platform/muster/dashboard');
+    expect(await screen.findByText('dashboard-view')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('path')).toHaveTextContent('installation=');
+    });
+    first.unmount();
+
+    renderSection('/agent-platform/muster');
+
+    expect(await screen.findByText('dashboard-view')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('path')).toHaveTextContent(
+        '/agent-platform/muster/dashboard?installation=gazelle',
+      );
+    });
+  });
+
+  it('redirects the legacy workflow run deep link to the workflow detail', async () => {
+    renderSection('/agent-platform/muster/workflows/my-flow/run');
+
+    expect(await screen.findByText('workflows-view')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('path')).toHaveTextContent(
+        '/agent-platform/muster/workflows/my-flow',
+      );
+    });
+  });
+});

--- a/plugins/muster/src/components/MusterSection/MusterSection.tsx
+++ b/plugins/muster/src/components/MusterSection/MusterSection.tsx
@@ -1,7 +1,15 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import {
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useParams,
+} from 'react-router-dom';
 import { Box, Tab, TabList, Tabs } from '@backstage/ui';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { useSplatBasePath } from '@giantswarm/backstage-plugin-ui-react';
 
+import { workflowDetailRouteRef } from '../../routes';
 import { MusterProviders } from '../MusterProviders';
 import { DashboardPage } from '../DashboardPage';
 import { McpServersPage } from '../McpServersPage';
@@ -19,14 +27,27 @@ const VIEWS = [
   { path: 'tools', title: 'Tool explorer' },
 ] as const;
 
-// The "MCP Servers" tab of the Agent Platform page. Renders its own second-level
-// tab row (a plain bui Tabs strip — the section title comes from the Agent
-// Platform header above, so no PluginHeader here) plus the routed view. The tabs
-// are navigation links whose active state follows the route (`matchStrategy`);
-// the content is driven by the router below, not by TabPanels. Wrapped once in
-// MusterProviders so all views share one muster instance + session, and the
-// providers don't remount as the user switches views.
-export const MusterSection = () => {
+/**
+ * The bespoke `/workflows/:name/run` route was removed when Run was unified with
+ * the tool explorer; a lingering deep link used to silently resolve to the full
+ * workflows list. Redirect it to the workflow detail (preserving the query
+ * string, e.g. `?installation=`) so the named workflow is not dropped.
+ */
+const LegacyRunRedirect = () => {
+  const { name = '' } = useParams();
+  const { search } = useLocation();
+  const detailLink = useRouteRef(workflowDetailRouteRef);
+  const to = detailLink ? detailLink({ name }) : '..';
+  return <Navigate to={`${to}${search}`} replace />;
+};
+
+// The second-level tab row (a plain bui Tabs strip — the section title comes from
+// the Agent Platform header above, so no PluginHeader here) plus the routed view.
+// The tabs are navigation links whose active state follows the route
+// (`matchStrategy`); the content is driven by the router below, not by TabPanels.
+// Wrapped once in MusterProviders so all views share one muster instance +
+// session, and the providers don't remount as the user switches views.
+const MusterViews = () => {
   const basePath = useSplatBasePath();
 
   return (
@@ -54,7 +75,6 @@ export const MusterSection = () => {
         </Tabs>
       </Box>
       <Routes>
-        <Route index element={<Navigate to="dashboard" replace />} />
         <Route path="dashboard" element={<DashboardPage />} />
         <Route path="servers" element={<McpServersPage />} />
         <Route path="workflows/*" element={<WorkflowsRouter />} />
@@ -63,3 +83,24 @@ export const MusterSection = () => {
     </MusterProviders>
   );
 };
+
+// The "MCP Servers" tab of the Agent Platform page.
+//
+// The index redirect is a sibling of the views, NOT a route inside
+// MusterViews/MusterProviders, and it has to stay that way: MusterInstanceProvider
+// writes the active installation into `?installation=` from an effect, and a
+// search-only navigation resolves against the pathname of the render it was
+// created in. Mounted alongside the redirect, that write lands on the
+// pre-redirect path and silently replaces `/muster/dashboard` back with
+// `/muster`, leaving the section with no view and no selected tab. It only shows
+// once the installations query is cached (i.e. from the second visit in a
+// session), because a pending query makes the effect bail out and lose the race.
+// Redirecting before the providers mount keeps the two writes in separate
+// commits. Same reason the legacy `workflows/:name/run` redirect lives here.
+export const MusterSection = () => (
+  <Routes>
+    <Route index element={<Navigate to="dashboard" replace />} />
+    <Route path="workflows/:name/run" element={<LegacyRunRedirect />} />
+    <Route path="*" element={<MusterViews />} />
+  </Routes>
+);

--- a/plugins/muster/src/components/MusterSection/MusterSection.tsx
+++ b/plugins/muster/src/components/MusterSection/MusterSection.tsx
@@ -28,16 +28,31 @@ const VIEWS = [
 ] as const;
 
 /**
+ * Sends the section index to the first view. Keeps the query string: an explicit
+ * `?installation=` in a deep link to the section root has to survive the
+ * redirect, or MusterInstanceProvider mounts on a location without the param and
+ * falls back to localStorage / the first installation.
+ */
+const IndexRedirect = () => {
+  const { search } = useLocation();
+  return <Navigate to={{ pathname: 'dashboard', search }} replace />;
+};
+
+/**
  * The bespoke `/workflows/:name/run` route was removed when Run was unified with
  * the tool explorer; a lingering deep link used to silently resolve to the full
  * workflows list. Redirect it to the workflow detail (preserving the query
  * string, e.g. `?installation=`) so the named workflow is not dropped.
+ *
+ * The fallback is spelled `../workflows` rather than `..`: this route is matched
+ * relative to the section root, so a bare `..` would land on the index (and from
+ * there on the Dashboard) instead of the workflows list.
  */
 const LegacyRunRedirect = () => {
   const { name = '' } = useParams();
   const { search } = useLocation();
   const detailLink = useRouteRef(workflowDetailRouteRef);
-  const to = detailLink ? detailLink({ name }) : '..';
+  const to = detailLink ? detailLink({ name }) : '../workflows';
   return <Navigate to={`${to}${search}`} replace />;
 };
 
@@ -99,7 +114,7 @@ const MusterViews = () => {
 // commits. Same reason the legacy `workflows/:name/run` redirect lives here.
 export const MusterSection = () => (
   <Routes>
-    <Route index element={<Navigate to="dashboard" replace />} />
+    <Route index element={<IndexRedirect />} />
     <Route path="workflows/:name/run" element={<LegacyRunRedirect />} />
     <Route path="*" element={<MusterViews />} />
   </Routes>

--- a/plugins/muster/src/components/WorkflowsRouter/WorkflowsRouter.tsx
+++ b/plugins/muster/src/components/WorkflowsRouter/WorkflowsRouter.tsx
@@ -1,40 +1,20 @@
-import {
-  Navigate,
-  Routes,
-  Route,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
-import { useRouteRef } from '@backstage/frontend-plugin-api';
-import { workflowDetailRouteRef } from '../../routes';
+import { Routes, Route } from 'react-router-dom';
 import { WorkflowsListPage } from '../WorkflowsListPage';
 import { WorkflowDetailPage } from '../WorkflowDetailPage';
-
-/**
- * The bespoke `/workflows/:name/run` route was removed when Run was unified with
- * the tool explorer; a lingering deep link used to silently resolve to the full
- * workflows list. Redirect it to the workflow detail (preserving the query
- * string, e.g. `?installation=`) so the named workflow is not dropped.
- */
-const LegacyRunRedirect = () => {
-  const { name = '' } = useParams();
-  const { search } = useLocation();
-  const detailLink = useRouteRef(workflowDetailRouteRef);
-  const to = detailLink ? detailLink({ name }) : '..';
-  return <Navigate to={`${to}${search}`} replace />;
-};
 
 /**
  * Routing within the Workflows tab: the list and the per-workflow detail share
  * the tab (the detail keeps the Workflows tab selected). Mounted inside
  * MusterProviders by the workflows sub-page, so both views share one muster
  * instance.
+ *
+ * The legacy `workflows/:name/run` deep link is redirected one level up in
+ * MusterSection, outside MusterProviders — see the note there.
  */
 export const WorkflowsRouter = () => {
   return (
     <Routes>
       <Route index element={<WorkflowsListPage />} />
-      <Route path=":name/run" element={<LegacyRunRedirect />} />
       <Route path=":name" element={<WorkflowDetailPage />} />
     </Routes>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -11342,6 +11342,7 @@ __metadata:
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/dev-utils": "backstage:^"
     "@backstage/frontend-plugin-api": "backstage:^"
+    "@backstage/frontend-test-utils": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@backstage/ui": "backstage:^"
     "@giantswarm/backstage-plugin-kubernetes-react": "workspace:^"


### PR DESCRIPTION
### What does this PR do?

Fixes the Agent Platform → **MCP Servers** section landing on a blank view with no second-level tab selected.

`MusterInstanceProvider` writes the active installation into `?installation=` from an effect. That is a *search-only* navigation, so react-router resolves it against the pathname of the render that created it. Once the muster installations query is cached (i.e. from the second visit to the tab within a session), the effect runs in the same commit as the section's index redirect, and its write lands on the pre-redirect path — replacing `/agent-platform/muster/dashboard` back with `/agent-platform/muster`, where no view route matches.

The index redirect and the legacy `workflows/:name/run` redirect are now mounted as siblings of the views, outside `MusterProviders`, so the installation-param write happens in a later commit and can no longer overwrite them. `MusterInstanceProvider` carries a note about the constraint so a redirect isn't re-introduced under it.

Reproduced against production (`v0.179.5`); the history trace on a tab click was:

```
push    /agent-platform/muster
replace /agent-platform/muster/dashboard          <- the index redirect
replace /agent-platform/muster?installation=gazelle  <- clobbers it
```

### What is the effect of this change to users?

Clicking the "MCP Servers" tab always lands on the muster Dashboard view with the Dashboard tab highlighted, not on an empty page.

### Any background context you can provide?

Found while investigating two separate tab-navigation reports. The other one — every entity-page tab href getting the active tab segment prefixed, so "Overview" looks dead — is an upstream bug in `@backstage/plugin-catalog`'s bui entity header (relative tab hrefs + react-router 7 relative-splat resolution) and is not addressed here.

New `MusterSection.test.tsx` covers both redirects; the warm-cache case fails on `main` and passes with this change.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))