### PR TITLE
fix(catalog): make entity page tab links work from non-Overview tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "storybook:build": "storybook build -o storybook-static",
     "storybook:coverage": "tsx scripts/check-story-coverage.mts",
     "typecheck:storybook": "tsc -p tsconfig.storybook.json",
-    "postinstall": "yarn patch-package",
+    "postinstall": "yarn patch-package --error-on-fail",
     "prepare": "husky"
   },
   "workspaces": {

--- a/patches/@backstage+plugin-catalog+2.0.7.patch
+++ b/patches/@backstage+plugin-catalog+2.0.7.patch
@@ -7,7 +7,7 @@ index f3fb7e0..1abb9fa 100644
 +import { useRouteRefParams } from '@backstage/core-plugin-api';
 +import { entityRouteRef, useEntityRefLink } from '@backstage/plugin-catalog-react';
  import { useSelectedSubRoute } from './EntityTabs.esm.js';
- 
+
 +// GIANT SWARM PATCH -- see patches/README.md.
 +//
 +// buildHeaderTabs below builds *relative* tab hrefs ("", "deployments", ...).

--- a/patches/@backstage+plugin-catalog+2.0.7.patch
+++ b/patches/@backstage+plugin-catalog+2.0.7.patch
@@ -1,0 +1,68 @@
+diff --git a/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js b/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js
+index f3fb7e0..75438d4 100644
+--- a/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js
++++ b/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js
+@@ -1,6 +1,47 @@
+ import { useMemo } from 'react';
++import { useLocation, useParams } from 'react-router-dom';
+ import { useSelectedSubRoute } from './EntityTabs.esm.js';
+ 
++// GIANT SWARM PATCH -- see patches/README.md.
++//
++// buildHeaderTabs below builds *relative* tab hrefs ("", "deployments", ...).
++// The bui Header renders them through react-aria's RouterProvider, which resolves
++// them with react-router's useHref -- and react-router 7 resolves a relative link
++// inside a splat route (the entity page is mounted at
++// "/catalog/:namespace/:kind/:name/*") against the full current pathname rather
++// than the route's base. So on any tab other than Overview every tab href gets
++// the active tab segment prefixed (".../my-component/circleci/deployments"), and
++// Overview's "" resolves to the current URL -- clicking it does nothing.
++//
++// Resolve the hrefs against the entity's own base path instead. Drop this patch
++// once upstream emits absolute tab hrefs.
++function useEntityBasePath() {
++  const { pathname } = useLocation();
++  const params = useParams();
++  // Compare by segment count: pathname stays percent-encoded while the splat
++  // param is decoded, so lengths would differ on encoded characters -- the "/"
++  // count does not.
++  const splatSegments = (params["*"] ?? "").split("/").filter(Boolean).length;
++  const segments = pathname.split("/").filter(Boolean);
++  return `/${segments.slice(0, Math.max(0, segments.length - splatSegments)).join("/")}`;
++}
++function absoluteTabHref(basePath, href) {
++  if (!href) return basePath;
++  if (href.startsWith("/")) return href;
++  return `${basePath}/${href}`;
++}
++function withAbsoluteTabHrefs(tabs, basePath) {
++  return tabs.map(
++    (tab) => "items" in tab ? {
++      ...tab,
++      items: tab.items.map((item) => ({
++        ...item,
++        href: absoluteTabHref(basePath, item.href)
++      }))
++    } : { ...tab, href: absoluteTabHref(basePath, tab.href) }
++  );
++}
++
+ function tabHrefFromPath(path) {
+   return path.replace(/\/\*$/, "").replace(/^\//, "");
+ }
+@@ -47,9 +88,13 @@ function buildHeaderTabs(routes, groupDefinitions, defaultContentOrder) {
+ function useEntityTabs(props) {
+   const { routes, groupDefinitions, defaultContentOrder } = props;
+   const { route, element } = useSelectedSubRoute(routes);
++  const basePath = useEntityBasePath();
+   const tabs = useMemo(
+-    () => buildHeaderTabs(routes, groupDefinitions, defaultContentOrder),
+-    [routes, groupDefinitions, defaultContentOrder]
++    () => withAbsoluteTabHrefs(
++      buildHeaderTabs(routes, groupDefinitions, defaultContentOrder),
++      basePath
++    ),
++    [routes, groupDefinitions, defaultContentOrder, basePath]
+   );
+   return {
+     tabs,

--- a/patches/@backstage+plugin-catalog+2.0.7.patch
+++ b/patches/@backstage+plugin-catalog+2.0.7.patch
@@ -1,10 +1,11 @@
 diff --git a/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js b/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js
-index f3fb7e0..75438d4 100644
+index f3fb7e0..1abb9fa 100644
 --- a/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js
 +++ b/node_modules/@backstage/plugin-catalog/dist/alpha/components/EntityTabs/useEntityTabs.esm.js
-@@ -1,6 +1,47 @@
+@@ -1,6 +1,45 @@
  import { useMemo } from 'react';
-+import { useLocation, useParams } from 'react-router-dom';
++import { useRouteRefParams } from '@backstage/core-plugin-api';
++import { entityRouteRef, useEntityRefLink } from '@backstage/plugin-catalog-react';
  import { useSelectedSubRoute } from './EntityTabs.esm.js';
  
 +// GIANT SWARM PATCH -- see patches/README.md.
@@ -18,17 +19,14 @@ index f3fb7e0..75438d4 100644
 +// the active tab segment prefixed (".../my-component/circleci/deployments"), and
 +// Overview's "" resolves to the current URL -- clicking it does nothing.
 +//
-+// Resolve the hrefs against the entity's own base path instead. Drop this patch
-+// once upstream emits absolute tab hrefs.
++// Resolve the hrefs against the entity's own base path instead, built from the
++// entity route ref so the params are encoded the same way every other entity link
++// in the catalog is (entityRouteParams -> encodeParams). Drop this patch once
++// upstream emits absolute tab hrefs.
 +function useEntityBasePath() {
-+  const { pathname } = useLocation();
-+  const params = useParams();
-+  // Compare by segment count: pathname stays percent-encoded while the splat
-+  // param is decoded, so lengths would differ on encoded characters -- the "/"
-+  // count does not.
-+  const splatSegments = (params["*"] ?? "").split("/").filter(Boolean).length;
-+  const segments = pathname.split("/").filter(Boolean);
-+  return `/${segments.slice(0, Math.max(0, segments.length - splatSegments)).join("/")}`;
++  const routeParams = useRouteRefParams(entityRouteRef);
++  const entityLink = useEntityRefLink();
++  return entityLink(routeParams);
 +}
 +function absoluteTabHref(basePath, href) {
 +  if (!href) return basePath;
@@ -50,7 +48,7 @@ index f3fb7e0..75438d4 100644
  function tabHrefFromPath(path) {
    return path.replace(/\/\*$/, "").replace(/^\//, "");
  }
-@@ -47,9 +88,13 @@ function buildHeaderTabs(routes, groupDefinitions, defaultContentOrder) {
+@@ -47,9 +86,13 @@ function buildHeaderTabs(routes, groupDefinitions, defaultContentOrder) {
  function useEntityTabs(props) {
    const { routes, groupDefinitions, defaultContentOrder } = props;
    const { route, element } = useSelectedSubRoute(routes);

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,50 @@
+# Dependency patches
+
+Patches in this directory are applied to `node_modules` by
+[`patch-package`](https://github.com/ds300/patch-package) from the root
+`postinstall` script. A patch that no longer applies **fails the install**, so a
+dependency bump that touches patched code surfaces immediately rather than
+silently dropping the fix.
+
+The version in a patch filename is informational — `patch-package` warns (but
+still applies the patch) when the installed version differs. Re-check the patches
+below whenever the Backstage or CodeMirror dependencies are bumped, and delete a
+patch as soon as its upstream fix lands.
+
+> `yarn patch-package --create <pkg>` does not work in this repo: it does a
+> pristine temp install with yarn classic, which cannot resolve our `backstage:^`
+> specifiers. Edit the file under `node_modules/`, then produce the diff by hand
+> in the same format (paths prefixed `a/node_modules/…` and `b/node_modules/…`)
+> and verify it with a `yarn patch-package` run against a restored, unpatched
+> copy of the file.
+
+## `@backstage/plugin-catalog+2.0.7.patch`
+
+Makes the entity page's header tab hrefs absolute.
+
+`useEntityTabs`/`buildHeaderTabs` build them relative (`''`, `'deployments'`, …).
+The bui `Header` renders them through react-aria's `RouterProvider`, which
+resolves them with react-router's `useHref` — and react-router 7 resolves a
+relative link inside a splat route (the entity page is mounted at
+`/catalog/:namespace/:kind/:name/*`) against the **full current pathname**, not
+the route's base. So on any tab other than Overview, every tab href gains the
+active tab segment (`…/my-component/circleci/deployments`), and Overview's `''`
+resolves to the current URL — clicking it does nothing.
+
+The patch resolves each href against the entity's own base path (current pathname
+minus the matched splat remainder). Upstream still emits relative hrefs on
+`master`, so this cannot be dropped until that changes. Our own plugin pages
+avoid the same trap in `packages/app/src/modules/app/GSPageLayout.tsx`, which
+absolutizes `SubPageBlueprint` tab hrefs via `useSplatBasePath()`.
+
+## `codemirror-json-schema+0.8.1.patch`
+
+Adds a YAML block-style fallback to schema completion: when typing the first
+property name in a block mapping (`ingress:\n  enabl`), the parser sees a literal
+value rather than a key, so no completions were offered. Falls back to property
+name completions when the schema expects an object at that position.
+
+## `react-vtree+3.0.0.patch`
+
+Adds `require`/`default` conditions to the package's `exports` map so the package
+can be consumed outside a pure-ESM import path.

--- a/patches/README.md
+++ b/patches/README.md
@@ -2,9 +2,11 @@
 
 Patches in this directory are applied to `node_modules` by
 [`patch-package`](https://github.com/ds300/patch-package) from the root
-`postinstall` script. A patch that no longer applies **fails the install**, so a
-dependency bump that touches patched code surfaces immediately rather than
-silently dropping the fix.
+`postinstall` script. It runs with `--error-on-fail`, so a patch that no longer
+applies **fails the install** — a dependency bump that touches patched code
+surfaces immediately instead of silently dropping the fix. (Without that flag
+`patch-package` only exits non-zero in CI, so a local `yarn install` would print a
+red line and carry on, leaving a developer running without the fix.)
 
 The version in a patch filename is informational — `patch-package` warns (but
 still applies the patch) when the installed version differs. Re-check the patches
@@ -31,10 +33,12 @@ the route's base. So on any tab other than Overview, every tab href gains the
 active tab segment (`…/my-component/circleci/deployments`), and Overview's `''`
 resolves to the current URL — clicking it does nothing.
 
-The patch resolves each href against the entity's own base path (current pathname
-minus the matched splat remainder). Upstream still emits relative hrefs on
-`master`, so this cannot be dropped until that changes. Our own plugin pages
-avoid the same trap in `packages/app/src/modules/app/GSPageLayout.tsx`, which
+The patch resolves each href against the entity's own base path, built from
+`entityRouteRef` via `useEntityRefLink()` — the same helper every other entity
+link in the catalog goes through, so the params are encoded identically and no
+pathname/splat arithmetic is involved. Upstream still emits relative hrefs on
+`master`, so this cannot be dropped until that changes. Our own plugin pages avoid
+the same trap in `packages/app/src/modules/app/GSPageLayout.tsx`, which
 absolutizes `SubPageBlueprint` tab hrefs via `useSplatBasePath()`.
 
 ## `codemirror-json-schema+0.8.1.patch`

--- a/plugins/ui-react/src/hooks/useSplatBasePath.test.tsx
+++ b/plugins/ui-react/src/hooks/useSplatBasePath.test.tsx
@@ -1,0 +1,52 @@
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { useSplatBasePath } from './useSplatBasePath';
+
+const Probe = () => <div data-testid="base">{useSplatBasePath()}</div>;
+
+function renderAt(routePath: string, url: string) {
+  const { unmount } = render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path={routePath} element={<Probe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  const basePath = screen.getByTestId('base').textContent;
+  // Several cases per test, so tear down between renders instead of relying on
+  // the per-test cleanup.
+  unmount();
+  return basePath;
+}
+
+describe('useSplatBasePath', () => {
+  it('strips the matched splat remainder', () => {
+    expect(renderAt('/flux/*', '/flux/list')).toBe('/flux');
+    expect(
+      renderAt('/agent-platform/muster/*', '/agent-platform/muster/tools'),
+    ).toBe('/agent-platform/muster');
+  });
+
+  it('handles a multi-segment and an empty remainder', () => {
+    expect(renderAt('/flux/*', '/flux/tree/kustomization/foo')).toBe('/flux');
+    expect(renderAt('/flux/*', '/flux')).toBe('/flux');
+  });
+
+  // A pathname segment holding an encoded slash decodes into two parts of the
+  // splat param, so counting the param's segments would strip one segment too
+  // many and return a path above the mount point.
+  it('does not over-strip when a splat segment contains an encoded slash', () => {
+    expect(renderAt('/flux/*', '/flux/workflows/a%2Fb')).toBe('/flux');
+    expect(renderAt('/flux/*', '/flux/a%2Fb%2Fc')).toBe('/flux');
+  });
+
+  it('keeps a base path for deeply encoded remainders instead of escaping to the root', () => {
+    // Segment-counting would yield '/' here, which callers turn into the
+    // protocol-relative '//sub'.
+    expect(renderAt('/x/*', '/x/a%2Fb%2Fc%2Fd')).toBe('/x');
+  });
+
+  it('returns an empty string when the whole path is the splat', () => {
+    expect(renderAt('/*', '/list/tree')).toBe('');
+  });
+});

--- a/plugins/ui-react/src/hooks/useSplatBasePath.ts
+++ b/plugins/ui-react/src/hooks/useSplatBasePath.ts
@@ -1,22 +1,55 @@
 import { useLocation, useParams } from 'react-router-dom';
 
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Malformed escape sequence — compare the raw segment rather than throw.
+    return segment;
+  }
+}
+
 /**
  * Returns the base path of a component mounted at a splat route (e.g. a page
  * mounted at `/flux/*` or a section at `/agent-platform/muster/*`): the current
  * pathname with the matched `*` remainder removed.
  *
- * Works by path *segment* count rather than string length: `location.pathname`
- * stays percent-encoded while `useParams()['*']` is decoded, so comparing
- * lengths would break on encoded characters — but the `/` separator count is
- * unaffected. Must be called from within the routed subtree so `useParams` sees
- * the splat.
+ * `location.pathname` stays percent-encoded while `useParams()['*']` arrives
+ * decoded, so the two cannot be compared directly — and their `/`-separated parts
+ * do not even correspond one-to-one, because a single pathname segment containing
+ * `%2F` decodes into two parts of the splat. Counting segments would then strip
+ * too many and return a base path *above* the mount point (at the extreme, `/`,
+ * which turns a joined href into the protocol-relative `//sub`). So this consumes
+ * pathname segments from the end only while their decoded value still matches the
+ * tail of the splat, stopping at the first mismatch — erring towards too long a
+ * base path rather than too short a one.
+ *
+ * The result never has a trailing slash, so callers can join with
+ * `` `${basePath}/${sub}` ``; for a component mounted at the root (the whole
+ * pathname is the splat) that means an empty string.
+ *
+ * Must be called from within the routed subtree so `useParams` sees the splat.
  */
 export function useSplatBasePath(): string {
   const { pathname } = useLocation();
   const params = useParams();
-  const splatSegments = (params['*'] ?? '').split('/').filter(Boolean).length;
+
   const segments = pathname.split('/').filter(Boolean);
-  return `/${segments
-    .slice(0, Math.max(0, segments.length - splatSegments))
-    .join('/')}`;
+  let remaining = (params['*'] ?? '').replace(/^\/+|\/+$/g, '');
+  let consumed = 0;
+
+  while (remaining.length > 0 && consumed < segments.length) {
+    const decoded = safeDecode(segments[segments.length - 1 - consumed]);
+    if (!remaining.endsWith(decoded)) {
+      break;
+    }
+    remaining = remaining
+      .slice(0, remaining.length - decoded.length)
+      .replace(/\/+$/, '');
+    consumed += 1;
+  }
+
+  const basePath = segments.slice(0, segments.length - consumed).join('/');
+
+  return basePath ? `/${basePath}` : '';
 }


### PR DESCRIPTION
### What does this PR do?

Fixes entity page header tabs: from any tab other than **Overview**, every tab link was wrong.

| on `…/component/backstage/circleci` | link before | link after |
| --- | --- | --- |
| Overview | `…/backstage/circleci` (the current URL → click does nothing) | `…/backstage` |
| Deployments | `…/backstage/circleci/deployments` | `…/backstage/deployments` |
| Dependencies | `…/backstage/circleci/dependencies` | `…/backstage/dependencies` |

Clicking one of the others didn't just misnavigate — `…/circleci/dependencies` still matches the `circleci/*` content route, so you land on a bogus URL showing the *previous* tab's content.

**Cause (upstream):** `useEntityTabs`/`buildHeaderTabs` in `@backstage/plugin-catalog` build the tab hrefs relative (`''`, `'deployments'`, …). The bui `Header` renders them through react-aria's `RouterProvider` (mounted by `@backstage/plugin-app`'s `AppRoot`), which resolves them with react-router's `useHref` — and react-router 7 resolves a relative link inside a splat route against the **full current pathname**, not the route's base. The entity page is mounted at `/catalog/:namespace/:kind/:name/*`, so the active tab segment gets prefixed onto every link. Verified on production `v0.179.5` by reading the rendered hrefs and the React props (`tabs` carries `href: 'deployments'`; the anchor gets `…/circleci/deployments`).

**Why a patch and not an override:** the supported override point, `EntityHeaderLayoutBlueprint`, only receives `{ tabs, activeTabId }`, and supplying a `HeaderComponent` makes `EntityLayoutBui` skip `EntityHeaderBui` altogether — we'd re-implement title/tags/lifecycle/owner/part-of metadata and the favourite button, and lose the entity context menu (`contextMenuItems` never reach a custom header, and `EntityContextMenu` isn't exported). The patch is ~40 lines in one dist file, keeps the upstream header intact, and `postinstall` fails loudly if a Backstage bump changes that code.

Upstream `master` still emits relative hrefs, so there is no version to bump to yet. `patches/README.md` (new) records what each of our three patches does and when it can be dropped, plus the note that `patch-package --create` cannot be used in this repo (its pristine temp install uses yarn classic, which can't resolve our `backstage:^` specifiers — patches have to be hand-diffed and verified with an apply run).

### What is the effect of this change to users?

Entity page tabs navigate correctly from any tab. In particular "Overview" works instead of appearing dead.

### How does it look like?

Verified against a local dev server on this branch, walking tab → tab without passing through Overview:

```
Overview        -> /catalog/default/component/backstage           (Overview active)
Dependencies    -> /catalog/default/component/backstage/dependencies
Version History -> /catalog/default/component/backstage/version-history
Overview        -> /catalog/default/component/backstage
GitHub Actions  -> /catalog/default/component/backstage/github-actions
Deployments     -> /catalog/default/component/backstage/deployments
```

Also checked from a deep nested sub-route (`…/circleci/12345/step/1`): all tab hrefs still resolve to the entity base and CircleCI stays the active tab.

### Any background context you can provide?

Second of two tab-navigation bugs reported together; the first (muster's MCP Servers section landing on a blank view) was #2017 and is unrelated.

### Do the docs need to be updated?

No — `patches/README.md` is added as part of this change.

### Should this change be mentioned in the release notes?

- [ ] No changeset: no published `@giantswarm/backstage-plugin-*` package changes, only a dependency patch consumed by the app.