### PR TITLE
feat(agent-platform): delete an agent from the details page

### DIFF
--- a/.changeset/agent-platform-delete-agent.md
+++ b/.changeset/agent-platform-delete-agent.md
@@ -1,0 +1,69 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+'@giantswarm/backstage-plugin-kubernetes-react': minor
+'@giantswarm/backstage-plugin-ui-react': minor
+---
+
+Add the companion delete to agent creation. The agent detail page's kebab menu
+gains **Delete agent…**, which removes the agent's `HelmRelease` — the object that
+owns its existence, since an `Agent` rendered by a chart would just be rendered
+again. Deleting it makes helm-controller uninstall the release and take the `Agent`
+CR with it. The owner is resolved through the Flux provenance labels rather than by
+assuming the release is named after the agent, so it also works for agents created
+outside the wizard.
+
+**The delete is offered only to users who may perform it.** A
+`SelfSubjectAccessReview` for `delete` on that named `HelmRelease` in its namespace
+runs first, and the menu item is withheld while the checks are still in flight, so
+it never appears and then disappears. The review decides what is _shown_;
+authorization stays the apiserver's, since the proxy forwards the user's own OIDC
+token — a bypassed menu item still gets a real 403. Two further conditions hide it:
+no resolvable owner (an `Agent` applied by hand has no release to delete), and a
+release applied by a Kustomization, whose desired state is in Git and which would
+be recreated on the next reconciliation.
+
+**The shared `OCIRepository` goes only when it is provably unused.** Every agent in
+a namespace shares one `agent` chart source, so the `HelmRelease`es in the source's
+namespace are listed first and any other release referencing the same object keeps
+it. A failed list read keeps it too — an empty list because the read failed is not
+the same answer as an empty list because nothing references it. A failure to delete
+the source is swallowed: the agent is gone, which is what was asked for, and a
+chart source nobody references is inert and re-applied identically by the next
+agent creation. This is also why the permission gate does not require `delete` on
+`ocirepositories`.
+
+**The confirmation modal says one thing**: that this ends any session currently
+running with the agent, including ones started by other people that are not shown.
+That is the only thing the person clicking cannot work out for themselves, since
+kagent scopes its session list to the caller and a quiet list is therefore not
+evidence that an agent is idle. Nothing mechanical appears in it — not the
+`HelmRelease`, not the shared chart source, not the fact that a suspended release is
+not uninstalled at all. True, and all of it noise at the moment of deciding; it is
+documented in `docs/agent-platform.md` instead.
+
+On success the user returns to the agents list with a toast that says "Deleting",
+not "Deleted": the `HelmRelease` has a finalizer, so all that is certain is that the
+apiserver accepted the request, and the agent can still be in the list for a few
+seconds. On failure the dialog stays open with the message inline — no toast, since
+the user is still looking at the modal they pressed Delete in.
+
+**New in `ui-react`: `ConfirmDialog`** — the repo's first reusable modal, for asking
+before doing something that cannot be taken back. Controlled rather than wrapping a
+`DialogTrigger`, which is the only thing that works when the trigger is a `MenuItem`
+(react-aria unmounts the menu on selection, taking any trigger inside it along).
+Confirming deliberately does not close it: an action that can fail needs somewhere
+to report that, and a dialog that dismisses itself on confirm has thrown away the
+only place the user was still looking. So the caller runs the action, passes
+`isBusy` while it is in flight and `error` if it fails, and closes on success. While
+busy the dialog is undismissable, so a stray click or Escape cannot orphan a request
+already on its way to a server.
+
+**New in `kubernetes-react`: `deleteResource`** — the package's first mutating verb
+besides `patchResource`, and the first Kubernetes `DELETE` in the app. It goes
+through the same proxy, with the same trailing-slash stripping and the same
+`ForbiddenError`/`NotFoundError` naming, so an idempotent caller can treat a 404 as
+success. The details both verbs need moved into a shared `k8sMutation` module;
+`BACKSTAGE_FIELD_MANAGER` keeps its existing import path.
+
+Toasts here use `toastApiRef` from `@backstage/frontend-plugin-api` rather than the
+deprecated `alertApi`, which upstream has scheduled for removal.

--- a/.changeset/agent-platform-delete-agent.md
+++ b/.changeset/agent-platform-delete-agent.md
@@ -18,19 +18,40 @@ runs first, and the menu item is withheld while the checks are still in flight, 
 it never appears and then disappears. The review decides what is _shown_;
 authorization stays the apiserver's, since the proxy forwards the user's own OIDC
 token — a bypassed menu item still gets a real 403. Two further conditions hide it:
-no resolvable owner (an `Agent` applied by hand has no release to delete), and a
-release applied by a Kustomization, whose desired state is in Git and which would
-be recreated on the next reconciliation.
+the owning release not being **in hand** (the object, not merely a label naming it —
+a release that could not be read is "cannot decide", not "no owner"), and a release
+applied by a Kustomization, whose desired state is in Git and which would be
+recreated on the next reconciliation.
+
+**A suspended release is refused rather than deleted.** Flux drops the finalizer on
+a suspended `HelmRelease` without running the uninstall, so deleting it would remove
+the release and leave the agent and the rest of the chart's objects behind, with no
+owner left to clean them up. The mutation explains that instead of reporting an
+uninstall that will not happen.
 
 **The shared `OCIRepository` goes only when it is provably unused.** Every agent in
 a namespace shares one `agent` chart source, so the `HelmRelease`es in the source's
 namespace are listed first and any other release referencing the same object keeps
-it. A failed list read keeps it too — an empty list because the read failed is not
-the same answer as an empty list because nothing references it. A failure to delete
-the source is swallowed: the agent is gone, which is what was asked for, and a
-chart source nobody references is inert and re-applied identically by the next
-agent creation. This is also why the permission gate does not require `delete` on
-`ocirepositories`.
+it. That list is read fresh at mutation time via the new `fetchResourceList`, not
+from the query cache: a cached list is up to `staleTime` (60s) old, so a sibling
+created moments ago in another tab would be invisible while looking perfectly
+certain. Every failure resolves to keeping the source — a failed list read means
+"cannot tell", never "nothing found", and a failed delete is swallowed, since the
+agent is gone by then and an unreferenced chart source is inert and re-applied
+identically by the next agent creation. This is also why the permission gate does
+not require `delete` on `ocirepositories`.
+
+**Bug fix in `kubernetes-react`: `useListResources` keyed its query without the
+namespace**, while the namespace lived in the request path. Two lists of the same
+kind on one cluster differing only by namespace were therefore _one_ query, and the
+second caller was served the first one's items with no request made at all — silent,
+because `staleTime` is 60s in several plugins and the cache is persisted to
+localStorage. `useGetResource` has always keyed on its namespace; lists now match.
+Found while reviewing this PR's own use of it, where the collision could have
+answered "nothing else references this chart source" from a different namespace and
+deleted a source other agents still needed. Also latent for
+`useNodePoolsForAWSCluster` and `SecretStoreSelector`. The scope is appended last so
+the existing 6-segment prefix still matches for invalidation.
 
 **The confirmation modal says one thing**: that this ends any session currently
 running with the agent, including ones started by other people that are not shown.

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -189,10 +189,11 @@ range, so the shared source is uniform.
 
 Two consequences to keep in mind:
 
-- **Deletion must not remove the shared OCIRepository.** A future "delete agent"
-  flow should only delete that agent's `HelmRelease`; `OCIRepository/agent` is
-  still referenced by any other agents in the namespace. Remove it only when the
-  last agent in the namespace is gone (or leave it).
+- **Deletion must not remove the shared OCIRepository** while others still use it.
+  Deleting an agent removes only that agent's `HelmRelease`, and takes
+  `OCIRepository/agent` with it only after confirming no other `HelmRelease` in
+  the source's namespace references it (see "Deleting an agent"). Every
+  uncertainty resolves to keeping it.
 - **Per-agent chart versions aren't expressible.** The sharing relies on every
   agent tracking the same range. If a specific agent ever needed a different
   chart version, it would need its own OCIRepository (e.g. named after the slug).
@@ -548,10 +549,9 @@ agent in the list. All three segments are in the path because all three are part
 the agent's identity — an `Agent` name is only unique within a namespace on one
 installation.
 
-Read-only. Editing an agent means changing the values its HelmRelease renders from,
-and deleting one must remove only that release and never the `OCIRepository` a
-namespace's agents share (see "Shared OCIRepository per namespace"), so neither is
-a menu item yet.
+An agent can be **deleted** from the kebab menu (see "Deleting an agent"), but not
+edited: editing means changing the values its HelmRelease renders from, so it needs
+a re-release rather than a menu item.
 
 The agent is fetched with a **single targeted `useResource`**, not read out of the
 list's `AgentsDataProvider`, so a deep link works without the list having loaded.
@@ -600,6 +600,71 @@ skills grid fits three cards per row, and the sessions table has four columns.
   labelled "default branch (unpinned)", because that is what makes an agent's
   behaviour change without its spec changing.
 - **Recent sessions** — see below.
+
+### Deleting an agent
+
+`useDeleteAgent` + `AgentDeleteDialog`, offered as a `Delete agent…` item in the
+kebab. It deletes the agent's **`HelmRelease`**, which is what makes
+helm-controller uninstall the release and take the `Agent` CR with it — an `Agent`
+rendered by a chart cannot meaningfully be deleted on its own, since the release
+would just render it again.
+
+The owner is resolved through `getHelmReleaseName`/`getHelmReleaseNamespace`
+(provenance labels), not by assuming the release is named after the agent, so this
+also works for agents created outside the wizard.
+
+**The delete is only offered when three things hold**, and is withheld while any of
+them is still being established, so it never appears and then disappears:
+
+1. A `SelfSubjectAccessReview` says the signed-in user may `delete` `helmreleases`
+   by that name in that namespace. `useSelfSubjectAccessReview` fails closed, does
+   not retry, and is never persisted, so a verdict cannot be rehydrated for a
+   different user. The review decides what is _shown_; authorization itself is the
+   apiserver's, since the proxy forwards the user's own OIDC token — a bypassed
+   menu item still gets a real 403.
+2. The owning `HelmRelease` was found (an `Agent` applied by hand has no labels and
+   nothing to delete).
+3. The release is **not** applied by a Kustomization. Those have their desired state
+   in Git and would be recreated on the next reconciliation, so they stay read-only
+   (see "GitOps provenance").
+
+The shared `OCIRepository` goes only when it is provably unused: the
+`HelmRelease`es in the source's namespace are listed, and any _other_ release whose
+`chartRef` resolves to the same object keeps it. A failed list read keeps it too —
+an empty list because the read failed is not the same answer as an empty list
+because nothing references it. The check does not cover cross-namespace
+`chartRef`s, which would need a cluster-wide list a tenant user does not have; the
+cost of being wrong is a chart source that the next agent creation re-applies. A
+failure to delete the source is swallowed for the same reason: the agent is gone,
+which is what was asked for, and this is why the permission gate does not require
+`delete` on `ocirepositories`.
+
+**The dialog says one thing:** that this ends any session currently running with the
+agent, including ones started by other people that are not shown. That is the only
+thing the person clicking cannot work out for themselves — kagent scopes its session
+list to the caller, so a quiet sessions list is not evidence that an agent is idle.
+
+Everything mechanical is deliberately kept out of it: which `HelmRelease` goes, what
+happens to the shared chart source, and the fact that a **suspended** release is not
+uninstalled at all (Flux drops the finalizer without running the uninstall, leaving
+the agent's resources behind). All true, all noise at the moment of deciding, and all
+documented here instead.
+
+Note what the dialog does _not_ claim, because an earlier draft got it wrong in both
+directions: session history is **not** lost. Sessions live in kagent's own store
+keyed by `user_id`, not in the `Agent` CR, and both the list and a session's detail
+are fetched by session id — see `toSessionRow`'s `decodeAgentIdLabel` fallback, which
+labels a session from its `agent_id` precisely when no `Agent` matches. Nor is a
+re-created agent a clean slate: `toAgentIdentifier` derives `agent_id` from
+`namespace/name` alone, so re-creating under the same name in the same namespace
+re-associates it with those very sessions.
+
+On success the user lands back on the agents list with a toast (`toastApiRef`, not
+the deprecated `alertApi`) that says "Deleting", not "Deleted": the `HelmRelease`
+has a finalizer, so all that is certain is that the apiserver accepted the request.
+The agent can still be in the list for a few seconds. On failure the dialog stays
+open and shows the message — there is no toast, because the user is still looking
+at the modal.
 
 ### The model is read directly, not from the fleet list
 
@@ -754,14 +819,11 @@ above). What remains is a separate, deeper concern:
   `spec.skills.gitAuthSecretRef` wired (the field exists in the CRD/chart but the
   create flow doesn't set it); (2) discovery reads a repo's **default branch** and
   doesn't expose per-skill version/`ref` selection in the UI.
-- **Agent write actions.** The list and the detail page exist; every write path
-  does not. Editing an agent means changing the values its HelmRelease renders
-  from — so it needs the create flow's form driven from an existing agent, plus a
-  decision about whether that produces a live apply or a PR (GitOps-managed agents
-  are read-only, see "GitOps provenance"). A delete action must respect the shared
-  `OCIRepository/agent` (see "Shared OCIRepository per namespace") — delete only
-  the agent's `HelmRelease`, not the shared source. "Launch session" also has no
-  write path today.
+- **Editing an agent.** Create and delete exist; edit does not. Editing means
+  changing the values its HelmRelease renders from — so it needs the create flow's
+  form driven from an existing agent, plus a decision about whether that produces
+  a live apply or a PR (GitOps-managed agents are read-only, see "GitOps
+  provenance"). "Launch session" also has no write path today.
 - **Session management + detail.** The Sessions tab is read-only. kagent supports
   deleting (soft) and renaming sessions, and exposes a session's events and A2A
   tasks — enough for a detail view. Deliberately deferred: rename in particular

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -622,22 +622,43 @@ them is still being established, so it never appears and then disappears:
    different user. The review decides what is _shown_; authorization itself is the
    apiserver's, since the proxy forwards the user's own OIDC token — a bypassed
    menu item still gets a real 403.
-2. The owning `HelmRelease` was found (an `Agent` applied by hand has no labels and
-   nothing to delete).
+2. The owning `HelmRelease` is **in hand** — the object, not just the label naming
+   it. Keying on the label would treat a release that could not be _read_ as "no
+   owner": the affordance would appear and then fail, and because an unreadable
+   release also reads as not-Kustomization-owned, it would quietly switch off the
+   guard below. Reachable via a proxy 5xx (`ServiceUnavailableError` is not retried
+   and this read does not poll) or RBAC granting `delete` without `get`.
 3. The release is **not** applied by a Kustomization. Those have their desired state
    in Git and would be recreated on the next reconciliation, so they stay read-only
    (see "GitOps provenance").
 
+**A suspended release is refused, not deleted.** Flux drops the finalizer on a
+suspended `HelmRelease` without running the uninstall, so deleting it would remove
+the release and leave the `Agent` and everything else the chart rendered behind —
+with no owner, so this path could not clean them up afterwards either. The mutation
+throws with an explanation instead of reporting an uninstall that will not happen.
+
 The shared `OCIRepository` goes only when it is provably unused: the
 `HelmRelease`es in the source's namespace are listed, and any _other_ release whose
-`chartRef` resolves to the same object keeps it. A failed list read keeps it too —
-an empty list because the read failed is not the same answer as an empty list
-because nothing references it. The check does not cover cross-namespace
-`chartRef`s, which would need a cluster-wide list a tenant user does not have; the
-cost of being wrong is a chart source that the next agent creation re-applies. A
-failure to delete the source is swallowed for the same reason: the agent is gone,
-which is what was asked for, and this is why the permission gate does not require
-`delete` on `ocirepositories`.
+`chartRef` resolves to the same object keeps it.
+
+That list is read **fresh, at mutation time**, through `fetchResourceList` rather
+than `useResources` — deliberately bypassing the query cache. Two reasons, both
+learned the hard way in review. A cached list is up to `staleTime` (60s here) old,
+so a sibling agent created moments ago in another tab would be invisible; and
+`useListResources` used to key its query without the namespace, which meant a list
+for a _different_ namespace could answer the question while looking perfectly
+certain. The second is now fixed at the source (the namespace is part of the key),
+but a destructive decision should not rest on a cache either way.
+
+Every failure resolves to keeping the source: a failed list read means "cannot
+tell", never "nothing found", and a failed delete is swallowed. The agent is gone
+by then, which is what was asked for, and an unreferenced chart source is inert and
+re-applied identically by the next agent creation. This is also why the permission
+gate does not require `delete` on `ocirepositories`. The check does not cover
+cross-namespace `chartRef`s, which would need a cluster-wide list a tenant user does
+not have; the cost of being wrong that way is a chart source the next agent creation
+re-applies.
 
 **The dialog says one thing:** that this ends any session currently running with the
 agent, including ones started by other people that are not shown. That is the only

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.test.tsx
@@ -1,11 +1,39 @@
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { crds } from '@giantswarm/k8s-types';
 import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+import { agentsRouteRef } from '../../routes';
+import type { UseDeleteAgentResult } from '../../hooks/useDeleteAgent';
 import { AgentActionsMenu } from './AgentActionsMenu';
 
 type AgentInterface = crds.kagent.v1alpha2.Agent;
+
+// The delete state arrives as a prop — the menu renders in the shared plugin
+// header, outside the plugin's QueryClientProvider, so it cannot call the hook
+// itself. This test is therefore about what the menu offers and what it does with
+// the outcome; the checks behind `isDeletable` are covered by
+// useDeleteAgent.test.tsx.
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockToastPost = jest.fn();
+
+// Only the toast API is swapped out — everything else the test app looks up
+// (themes, route resolution) has to keep working.
+jest.mock('@backstage/frontend-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/frontend-plugin-api');
+
+  return {
+    ...actual,
+    useApi: (ref: unknown) =>
+      ref === actual.toastApiRef ? { post: mockToastPost } : actual.useApi(ref),
+  };
+});
 
 function makeAgent(): Agent {
   return new Agent(
@@ -26,16 +54,63 @@ function makeAgent(): Agent {
   );
 }
 
+const deleteAgent = jest.fn();
+const reset = jest.fn();
+
+let deletion: UseDeleteAgentResult;
+
+function setDeleteState(overrides: Partial<UseDeleteAgentResult> = {}) {
+  deletion = {
+    isDeletable: true,
+    isCheckingDeletable: false,
+    deleteAgent,
+    isDeleting: false,
+    error: null,
+    reset,
+    ...overrides,
+  } as UseDeleteAgentResult;
+}
+
+const renderMenu = () =>
+  renderInTestApp(
+    <AgentActionsMenu agent={makeAgent()} deletion={deletion} />,
+    { mountedRoutes: { '/agent-platform/agents': agentsRouteRef } },
+  );
+
+async function openMenu() {
+  await userEvent.click(screen.getByRole('button', { name: 'Agent actions' }));
+}
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  mockToastPost.mockReset();
+  deleteAgent.mockReset();
+  deleteAgent.mockResolvedValue(undefined);
+  reset.mockReset();
+  setDeleteState();
+});
+
 describe('AgentActionsMenu', () => {
+  it('renders without a QueryClient in scope', async () => {
+    // The regression this file exists to prevent. The menu is rendered into the
+    // shared plugin header, which is outside the plugin's QueryClientProvider, so
+    // a react-query hook called here throws "No QueryClient set" and takes the
+    // whole page down with it — the delete state has to arrive as a prop.
+    // `renderInTestApp` deliberately provides no client, so this asserts it.
+    await renderMenu();
+
+    expect(
+      screen.getByRole('button', { name: 'Agent actions' }),
+    ).toBeInTheDocument();
+  });
+
   it('opens the manifest dialog from the kebab menu', async () => {
-    await renderInTestApp(<AgentActionsMenu agent={makeAgent()} />);
+    await renderMenu();
 
     // Nothing is shown until asked for — this is the rarely-needed escape hatch.
     expect(screen.queryByText('Agent manifest')).not.toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Agent actions' }),
-    );
+    await openMenu();
     await userEvent.click(
       screen.getByRole('menuitem', { name: 'View manifest' }),
     );
@@ -47,5 +122,117 @@ describe('AgentActionsMenu', () => {
     // Names the installation and namespace, so a manifest copied out of here can
     // be traced back to where it came from.
     expect(screen.getByText('gazelle · agentic-platform')).toBeInTheDocument();
+  });
+
+  it('hides the deletion from someone who may not perform it', async () => {
+    setDeleteState({ isDeletable: false });
+    await renderMenu();
+    await openMenu();
+
+    expect(
+      screen.queryByRole('menuitem', { name: /Delete agent/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'View manifest' }),
+    ).toBeInTheDocument();
+  });
+
+  it('withholds the deletion while the checks are still running', async () => {
+    // Rather than offering it and taking it away again once the access review
+    // comes back.
+    setDeleteState({ isDeletable: true, isCheckingDeletable: true });
+    await renderMenu();
+    await openMenu();
+
+    expect(
+      screen.queryByRole('menuitem', { name: /Delete agent/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('warns about invisible sessions before deleting', async () => {
+    await renderMenu();
+    await openMenu();
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /Delete agent/ }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Delete agent "pr-reviewer"?'),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/including sessions started by other people/),
+    ).toBeInTheDocument();
+    // Opening the dialog does not delete anything.
+    expect(deleteAgent).not.toHaveBeenCalled();
+  });
+
+  it('confirms, reports and returns to the list on success', async () => {
+    await renderMenu();
+    await openMenu();
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /Delete agent/ }),
+    );
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Delete agent' }),
+    );
+
+    await waitFor(() => {
+      expect(deleteAgent).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockToastPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'success',
+        // Permanent unless a timeout is given, and this is an acknowledgement.
+        timeout: expect.any(Number),
+      }),
+    );
+    // Not "deleted": the release has a finalizer, so the agent can still be in
+    // the list for a few seconds.
+    expect(mockToastPost.mock.calls[0][0].title).toMatch(
+      /Deleting agent "pr-reviewer"/,
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/agent-platform/agents');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Delete agent "pr-reviewer"?'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the dialog open and says nothing succeeded when the delete fails', async () => {
+    deleteAgent.mockRejectedValue(new Error('helmreleases is forbidden'));
+    setDeleteState({ error: new Error('helmreleases is forbidden') });
+
+    await renderMenu();
+    await openMenu();
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /Delete agent/ }),
+    );
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Delete agent' }),
+    );
+
+    await waitFor(() => {
+      expect(deleteAgent).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByText('Delete agent "pr-reviewer"?')).toBeInTheDocument();
+    expect(screen.getByText('helmreleases is forbidden')).toBeInTheDocument();
+    expect(mockToastPost).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('clears a previous failure when the dialog is reopened', async () => {
+    await renderMenu();
+    await openMenu();
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /Delete agent/ }),
+    );
+
+    expect(reset).toHaveBeenCalled();
   });
 });

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentActionsMenu.tsx
@@ -1,24 +1,103 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  toastApiRef,
+  useApi,
+  useRouteRef,
+} from '@backstage/frontend-plugin-api';
 import { ButtonIcon, Menu, MenuItem, MenuTrigger } from '@backstage/ui';
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
 
+import type { UseDeleteAgentResult } from '../../hooks/useDeleteAgent';
+import { agentsRouteRef } from '../../routes';
+import { AgentDeleteDialog } from './AgentDeleteDialog';
 import { AgentManifestDialog } from './AgentManifestDialog';
+
+/** Long enough to read two lines, short enough not to follow you to the next page. */
+const TOAST_TIMEOUT_MS = 6000;
 
 /**
  * The agent details page's header actions.
  *
- * Owns the manifest dialog's open state itself, rather than the page doing so:
- * the page hands this element to `useProvidePageHeaderActions`, which renders it
- * in the shared plugin header — a different part of the tree — so keeping the
- * state here is what makes the menu and its dialog one self-contained unit.
+ * Owns its dialogs' open state itself, rather than the page doing so: the page
+ * hands this element to `useProvidePageHeaderActions`, which renders it in the
+ * shared plugin header — a different part of the tree — so keeping the state here
+ * is what makes the menu and its dialogs one self-contained unit.
  *
- * Read-only for now. kagent supports deleting and re-deploying an agent, but a
- * delete has to remove only the agent's own HelmRelease and never the
- * `OCIRepository` a namespace's agents share, so it needs more than a menu item.
+ * The deletion arrives as a prop for the same reason, and this is the constraint
+ * to respect when adding an action: rendering in the shared header means rendering
+ * **outside the plugin's `QueryClientProvider`**, so anything backed by react-query
+ * — every `useResource`, access review or mutation — has to be called by the page
+ * and passed down. Calling `useDeleteAgent` here throws "No QueryClient set".
  */
-export function AgentActionsMenu({ agent }: { agent: Agent }) {
+export function AgentActionsMenu({
+  agent,
+  deletion,
+}: {
+  agent: Agent;
+  deletion: UseDeleteAgentResult;
+}) {
   const [isManifestOpen, setManifestOpen] = useState(false);
+  const [isDeleteOpen, setDeleteOpen] = useState(false);
+  const toastApi = useApi(toastApiRef);
+  const navigate = useNavigate();
+  const agentsRoute = useRouteRef(agentsRouteRef);
+
+  const {
+    isDeletable,
+    isCheckingDeletable,
+    deleteAgent,
+    isDeleting,
+    error,
+    reset,
+  } = deletion;
+
+  // Withheld while the checks are still running, not only when they come back
+  // negative, so the item never appears and then disappears under the pointer of
+  // someone who was never allowed to use it.
+  const canOfferDelete = isDeletable && !isCheckingDeletable;
+
+  const openDeleteDialog = () => {
+    // Clear a previous attempt's error, so the dialog does not open still
+    // showing it.
+    reset();
+    setDeleteOpen(true);
+  };
+
+  const confirmDelete = async () => {
+    try {
+      await deleteAgent();
+    } catch {
+      // Left to the dialog, which stays open and renders the hook's `error`. No
+      // toast: the user is still looking at the modal they pressed Delete in.
+      return;
+    }
+
+    setDeleteOpen(false);
+    toastApi.post({
+      // Deliberately not "Agent deleted": the HelmRelease has a finalizer, so all
+      // that is certain here is that the apiserver accepted the request and
+      // helm-controller has started uninstalling. The agent can still be in the
+      // list for a few seconds, and a toast claiming otherwise would read as a
+      // bug in the list.
+      title: `Deleting agent "${agent.getDisplayName()}"`,
+      description:
+        'Flux is uninstalling its Helm release, so it may take a moment to disappear from the list.',
+      status: 'success',
+      // A ToastApi toast without a timeout is permanent, and this is an
+      // acknowledgement, not something to dismiss by hand.
+      timeout: TOAST_TIMEOUT_MS,
+    });
+
+    // An unbound route means the Agent Platform extension is disabled — in which
+    // case this page is not rendering either. Staying put beats hardcoding a
+    // path that would silently rot if the route moved.
+    if (agentsRoute) {
+      navigate(agentsRoute());
+    }
+  };
 
   return (
     <>
@@ -32,6 +111,15 @@ export function AgentActionsMenu({ agent }: { agent: Agent }) {
           <MenuItem onAction={() => setManifestOpen(true)}>
             View manifest
           </MenuItem>
+          {canOfferDelete ? (
+            <MenuItem
+              color="danger"
+              iconStart={<DeleteOutlineIcon />}
+              onAction={openDeleteDialog}
+            >
+              Delete agent…
+            </MenuItem>
+          ) : null}
         </Menu>
       </MenuTrigger>
 
@@ -39,6 +127,15 @@ export function AgentActionsMenu({ agent }: { agent: Agent }) {
         agent={agent}
         isOpen={isManifestOpen}
         onOpenChange={setManifestOpen}
+      />
+
+      <AgentDeleteDialog
+        agent={agent}
+        isOpen={isDeleteOpen}
+        onOpenChange={setDeleteOpen}
+        isDeleting={isDeleting}
+        error={error?.message}
+        onConfirm={confirmDelete}
       />
     </>
   );

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDeleteDialog.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDeleteDialog.tsx
@@ -1,0 +1,53 @@
+import { Text } from '@backstage/ui';
+import { Agent } from '@giantswarm/backstage-plugin-kubernetes-react';
+import { ConfirmDialog } from '@giantswarm/backstage-plugin-ui-react';
+
+export type AgentDeleteDialogProps = {
+  agent: Agent;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  isDeleting: boolean;
+  error?: string;
+  onConfirm: () => void;
+};
+
+/**
+ * Asks before deleting an agent.
+ *
+ * Says one thing, because it is the only thing the person clicking cannot work
+ * out for themselves: sessions may be running, and not all of them are on screen.
+ * kagent scopes its session list to the caller, so a quiet sessions list is not
+ * evidence that an agent is idle — someone else's conversation ends just the same.
+ *
+ * Everything mechanical is deliberately left out: which `HelmRelease` goes, what
+ * happens to the namespace's shared chart source, what a suspended release does to
+ * the uninstall. Correct, and all of it noise at the moment of deciding. It lives
+ * in `useDeleteAgent` and in docs/agent-platform.md instead.
+ */
+export function AgentDeleteDialog({
+  agent,
+  isOpen,
+  onOpenChange,
+  isDeleting,
+  error,
+  onConfirm,
+}: AgentDeleteDialogProps) {
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      title={`Delete agent "${agent.getDisplayName()}"?`}
+      destructive
+      confirmLabel="Delete agent"
+      busyLabel="Deleting…"
+      isBusy={isDeleting}
+      error={error}
+      onConfirm={onConfirm}
+    >
+      <Text variant="body-medium">
+        This ends any session currently running with this agent — including
+        sessions started by other people, which are not shown to you.
+      </Text>
+    </ConfirmDialog>
+  );
+}

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.test.tsx
@@ -40,6 +40,21 @@ jest.mock('../../hooks/useAgentSessions', () => ({
   useAgentSessions: (...args: unknown[]) => mockUseAgentSessions(...args),
 }));
 
+// The page calls this on the menu's behalf, because the menu renders in the shared
+// header — outside the plugin's QueryClientProvider — and so cannot call it itself.
+// Stubbed for the same reason `useAgentSessions` is: this page's react-query client
+// is not part of the test, and the menu is not rendered here anyway.
+jest.mock('../../hooks/useDeleteAgent', () => ({
+  useDeleteAgent: () => ({
+    isDeletable: false,
+    isCheckingDeletable: false,
+    deleteAgent: jest.fn(),
+    isDeleting: false,
+    error: null,
+    reset: jest.fn(),
+  }),
+}));
+
 const mockParams: {
   installation: string;
   namespace: string;

--- a/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
+++ b/plugins/agent-platform/src/components/AgentDetailPage/AgentDetailPage.tsx
@@ -26,6 +26,7 @@ import {
 
 import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
 import { useAgentSessions } from '../../hooks/useAgentSessions';
+import { useDeleteAgent } from '../../hooks/useDeleteAgent';
 import { AvatarSize } from '../../lib/agentAvatar';
 import { agentsRouteRef } from '../../routes';
 import { getAgentRefetchInterval, toAgentRow } from '../AgentsDataProvider';
@@ -95,12 +96,19 @@ function AgentDetailPageContent() {
   );
   const sessions = useAgentSessions(installation, namespace, name, agentRow);
 
-  // `agent` is memoized on the fetched JSON, so this element's identity only
-  // changes when the agent actually does — which is what keeps the header slot
-  // from re-registering (and re-rendering) on every poll.
+  // Called here rather than inside the menu: the menu is rendered in the shared
+  // plugin header, which is outside this plugin's `QueryClientProvider`, so its
+  // react-query reads and mutation would have no client there.
+  const deletion = useDeleteAgent(agent);
+
+  // `agent` is memoized on the fetched JSON and `deletion` is memoized on its own
+  // contents, so this element's identity only changes when one of them actually
+  // does — which is what keeps the header slot from re-registering (and
+  // re-rendering) on every poll.
   const actions = useMemo(
-    () => (agent ? <AgentActionsMenu agent={agent} /> : null),
-    [agent],
+    () =>
+      agent ? <AgentActionsMenu agent={agent} deletion={deletion} /> : null,
+    [agent, deletion],
   );
   useProvidePageHeaderActions(actions);
 
@@ -267,9 +275,9 @@ function AgentDetailPageContent() {
 /**
  * One kagent agent: what it is, whether it works, and what it has been used for.
  *
- * Read-only. kagent agents are deployed from a Helm chart, so editing one means
- * changing the release's values — a write path this plugin does not have yet, and
- * one that has to respect the shared `OCIRepository` a namespace's agents share.
+ * The agent can be deleted from the header's actions menu. It cannot be edited:
+ * an agent's settings are its Helm release's values, so changing one means
+ * re-releasing the chart, which this plugin has no write path for yet.
  *
  * What the APUI prototype shows and this deliberately does not, because there is
  * no data behind it: sessions all-time, sessions in the last 30 days, a success

--- a/plugins/agent-platform/src/hooks/useDeleteAgent.test.tsx
+++ b/plugins/agent-platform/src/hooks/useDeleteAgent.test.tsx
@@ -15,17 +15,17 @@ import { useDeleteAgent } from './useDeleteAgent';
 // classes are the real ones, so the label reading and GVK resolution under test
 // are the real thing.
 const mockUseResource = jest.fn();
-const mockUseResources = jest.fn();
 const mockUseSelfSubjectAccessReview = jest.fn();
 const mockDeleteResource = jest.fn();
+const mockFetchResourceList = jest.fn();
 
 jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
   ...jest.requireActual('@giantswarm/backstage-plugin-kubernetes-react'),
   useResource: (...args: unknown[]) => mockUseResource(...args),
-  useResources: (...args: unknown[]) => mockUseResources(...args),
   useSelfSubjectAccessReview: (...args: unknown[]) =>
     mockUseSelfSubjectAccessReview(...args),
   deleteResource: (...args: unknown[]) => mockDeleteResource(...args),
+  fetchResourceList: (...args: unknown[]) => mockFetchResourceList(...args),
 }));
 
 const CLUSTER = 'gazelle';
@@ -95,8 +95,8 @@ function makeChartSource(): OCIRepository {
 /**
  * @param helmRelease the agent's owning release, or undefined if it was not read
  * @param allowed the SelfSubjectAccessReview verdict for deleting it
- * @param namespaceReleases every release in the chart source's namespace
- * @param didReadNamespaceReleases whether that list read succeeded at all
+ * @param namespaceReleases every release the fresh sibling list returns
+ * @param didReadNamespaceReleases whether that list read succeeds at all
  */
 function setup({
   agent = makeAgent(),
@@ -107,7 +107,8 @@ function setup({
   chartSource = makeChartSource(),
 }: {
   agent?: Agent;
-  helmRelease?: HelmRelease;
+  /** `null` means the read returned nothing (undefined re-triggers the default). */
+  helmRelease?: HelmRelease | null;
   allowed?: boolean;
   namespaceReleases?: HelmRelease[];
   didReadNamespaceReleases?: boolean;
@@ -127,32 +128,25 @@ function setup({
 
       return {
         resource:
-          ResourceClass.kind === 'HelmRelease' ? helmRelease : chartSource,
+          ResourceClass.kind === 'HelmRelease'
+            ? (helmRelease ?? undefined)
+            : chartSource,
         isLoading: false,
       };
     },
   );
 
-  mockUseResources.mockImplementation(
-    (
-      _clusters: string,
-      _ResourceClass: unknown,
-      _options: unknown,
-      queryOptions?: { enabled?: boolean },
-    ) => {
-      if (queryOptions?.enabled === false) {
-        return { resources: [], clustersData: [], isLoading: false };
-      }
+  // The sibling list is fetched fresh at mutation time, so it is a promise here
+  // rather than a hook return. A failure means "cannot tell".
+  mockFetchResourceList.mockImplementation(async () => {
+    if (!didReadNamespaceReleases) {
+      const error = new Error('helmreleases is forbidden');
+      error.name = 'ForbiddenError';
+      throw error;
+    }
 
-      return {
-        resources: namespaceReleases,
-        clustersData: didReadNamespaceReleases
-          ? [{ cluster: CLUSTER, data: [] }]
-          : [],
-        isLoading: false,
-      };
-    },
-  );
+    return namespaceReleases.map(release => release.jsonData);
+  });
 
   mockUseSelfSubjectAccessReview.mockReturnValue({
     allowed,
@@ -176,10 +170,10 @@ function setup({
 
 beforeEach(() => {
   mockUseResource.mockReset();
-  mockUseResources.mockReset();
   mockUseSelfSubjectAccessReview.mockReset();
   mockDeleteResource.mockReset();
   mockDeleteResource.mockResolvedValue(undefined);
+  mockFetchResourceList.mockReset();
 });
 
 describe('useDeleteAgent', () => {
@@ -221,6 +215,18 @@ describe('useDeleteAgent', () => {
     expect(result.current.isCheckingDeletable).toBe(false);
   });
 
+  it('refuses when the owning release could not be read', () => {
+    // Regression: `isDeletable` used to key on the provenance *label*, so an
+    // unreadable release (a proxy 5xx that is not retried, or RBAC granting
+    // `delete` without `get`) still offered the action — which then failed, and
+    // silently switched off the Kustomization guard, since a release that cannot
+    // be read also reads as not-GitOps-owned.
+    const { result } = setup({ helmRelease: null });
+
+    expect(result.current.isDeletable).toBe(false);
+    expect(result.current.isCheckingDeletable).toBe(false);
+  });
+
   it('refuses when the release is applied by a Kustomization', () => {
     // Its desired state is in Git, so Flux would put it straight back.
     const { result } = setup({
@@ -233,6 +239,21 @@ describe('useDeleteAgent', () => {
     });
 
     expect(result.current.isDeletable).toBe(false);
+  });
+
+  it('refuses to delete a suspended release rather than claim an uninstall', async () => {
+    // Flux drops the finalizer on a suspended release without running the
+    // uninstall, so the HelmRelease would go and the Agent would stay — with no
+    // owner left, and no way back through this path.
+    const { result } = setup({
+      helmRelease: makeHelmRelease({ suspend: true }),
+    });
+
+    await act(async () => {
+      await expect(result.current.deleteAgent()).rejects.toThrow(/suspended/);
+    });
+
+    expect(mockDeleteResource).not.toHaveBeenCalled();
   });
 
   it('deletes the release and the chart source when nothing else uses it', async () => {
@@ -317,6 +338,25 @@ describe('useDeleteAgent', () => {
     expect(mockDeleteResource).toHaveBeenCalledTimes(1);
   });
 
+  it('reads the sibling list fresh, scoped to the chart source namespace', async () => {
+    // Regression: this used to come from `useResources`, whose cache key omitted
+    // the namespace — so another namespace's list could answer the question, and
+    // a <=60s cache could miss a sibling created moments ago in another tab. The
+    // destructive decision must rest on a request made now, for this namespace.
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.deleteAgent();
+    });
+
+    expect(mockFetchResourceList).toHaveBeenCalledTimes(1);
+    expect(mockFetchResourceList.mock.calls[0][0]).toMatchObject({
+      cluster: CLUSTER,
+      namespace: NAMESPACE,
+      gvk: expect.objectContaining({ plural: 'helmreleases' }),
+    });
+  });
+
   it('treats an already-deleted release as success', async () => {
     const notFound = new Error('helmreleases "pr-reviewer" not found');
     notFound.name = 'NotFoundError';
@@ -366,12 +406,15 @@ describe('useDeleteAgent', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('fails when there is no release to delete', async () => {
-    const { result } = setup({ agent: makeAgent({}), helmRelease: undefined });
+  it('fails with an accurate message when the release is not in hand', async () => {
+    // Not "it was applied directly": the agent carries the provenance label, so
+    // the release exists — we just could not read it. Pointing the user at
+    // deleting it by hand would be wrong.
+    const { result } = setup({ helmRelease: null });
 
     await act(async () => {
       await expect(result.current.deleteAgent()).rejects.toThrow(
-        /no HelmRelease to delete/,
+        /could not be read/,
       );
     });
 

--- a/plugins/agent-platform/src/hooks/useDeleteAgent.test.tsx
+++ b/plugins/agent-platform/src/hooks/useDeleteAgent.test.tsx
@@ -1,0 +1,380 @@
+import { PropsWithChildren } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { crds } from '@giantswarm/k8s-types';
+import {
+  Agent,
+  HelmRelease,
+  OCIRepository,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+import { useDeleteAgent } from './useDeleteAgent';
+
+// The reads and the write are mocked; the provenance helpers and the resource
+// classes are the real ones, so the label reading and GVK resolution under test
+// are the real thing.
+const mockUseResource = jest.fn();
+const mockUseResources = jest.fn();
+const mockUseSelfSubjectAccessReview = jest.fn();
+const mockDeleteResource = jest.fn();
+
+jest.mock('@giantswarm/backstage-plugin-kubernetes-react', () => ({
+  ...jest.requireActual('@giantswarm/backstage-plugin-kubernetes-react'),
+  useResource: (...args: unknown[]) => mockUseResource(...args),
+  useResources: (...args: unknown[]) => mockUseResources(...args),
+  useSelfSubjectAccessReview: (...args: unknown[]) =>
+    mockUseSelfSubjectAccessReview(...args),
+  deleteResource: (...args: unknown[]) => mockDeleteResource(...args),
+}));
+
+const CLUSTER = 'gazelle';
+const NAMESPACE = 'agentic-platform';
+
+function makeAgent(labels?: Record<string, string>): Agent {
+  return new Agent(
+    {
+      apiVersion: 'kagent.dev/v1alpha2',
+      kind: 'Agent',
+      metadata: {
+        name: 'pr-reviewer',
+        namespace: NAMESPACE,
+        labels: labels ?? {
+          'helm.toolkit.fluxcd.io/name': 'pr-reviewer',
+          'helm.toolkit.fluxcd.io/namespace': NAMESPACE,
+        },
+      },
+      spec: { type: 'Declarative', declarative: { modelConfig: 'opus-4-7' } },
+    } as crds.kagent.v1alpha2.Agent,
+    CLUSTER,
+  );
+}
+
+function makeHelmRelease({
+  name = 'pr-reviewer',
+  chartSourceName = 'agent',
+  labels,
+  suspend,
+}: {
+  name?: string;
+  chartSourceName?: string;
+  labels?: Record<string, string>;
+  suspend?: boolean;
+} = {}): HelmRelease {
+  return new HelmRelease(
+    {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name, namespace: NAMESPACE, labels },
+      spec: {
+        interval: '10m',
+        ...(suspend === undefined ? {} : { suspend }),
+        chartRef: {
+          kind: 'OCIRepository',
+          name: chartSourceName,
+          namespace: NAMESPACE,
+        },
+      },
+    } as crds.fluxcd.v2.HelmRelease,
+    CLUSTER,
+  );
+}
+
+function makeChartSource(): OCIRepository {
+  return new OCIRepository(
+    {
+      apiVersion: 'source.toolkit.fluxcd.io/v1',
+      kind: 'OCIRepository',
+      metadata: { name: 'agent', namespace: NAMESPACE },
+      spec: { interval: '30m', url: 'oci://example.test/charts/agent' },
+    } as crds.fluxcd.v1.OCIRepository,
+    CLUSTER,
+  );
+}
+
+/**
+ * @param helmRelease the agent's owning release, or undefined if it was not read
+ * @param allowed the SelfSubjectAccessReview verdict for deleting it
+ * @param namespaceReleases every release in the chart source's namespace
+ * @param didReadNamespaceReleases whether that list read succeeded at all
+ */
+function setup({
+  agent = makeAgent(),
+  helmRelease = makeHelmRelease(),
+  allowed = true,
+  namespaceReleases = [makeHelmRelease()],
+  didReadNamespaceReleases = true,
+  chartSource = makeChartSource(),
+}: {
+  agent?: Agent;
+  helmRelease?: HelmRelease;
+  allowed?: boolean;
+  namespaceReleases?: HelmRelease[];
+  didReadNamespaceReleases?: boolean;
+  chartSource?: OCIRepository;
+} = {}) {
+  mockUseResource.mockImplementation(
+    (
+      _cluster: string,
+      ResourceClass: { kind: string },
+      _options: unknown,
+      queryOptions?: { enabled?: boolean },
+    ) => {
+      // A disabled query has no data, exactly as react-query would report it.
+      if (queryOptions?.enabled === false) {
+        return { resource: undefined, isLoading: false };
+      }
+
+      return {
+        resource:
+          ResourceClass.kind === 'HelmRelease' ? helmRelease : chartSource,
+        isLoading: false,
+      };
+    },
+  );
+
+  mockUseResources.mockImplementation(
+    (
+      _clusters: string,
+      _ResourceClass: unknown,
+      _options: unknown,
+      queryOptions?: { enabled?: boolean },
+    ) => {
+      if (queryOptions?.enabled === false) {
+        return { resources: [], clustersData: [], isLoading: false };
+      }
+
+      return {
+        resources: namespaceReleases,
+        clustersData: didReadNamespaceReleases
+          ? [{ cluster: CLUSTER, data: [] }]
+          : [],
+        isLoading: false,
+      };
+    },
+  );
+
+  mockUseSelfSubjectAccessReview.mockReturnValue({
+    allowed,
+    isLoading: false,
+  });
+
+  const wrapper = ({ children }: PropsWithChildren<{}>) => (
+    <TestApiProvider apis={[[kubernetesApiRef, { proxy: jest.fn() }]]}>
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+        }
+      >
+        {children}
+      </QueryClientProvider>
+    </TestApiProvider>
+  );
+
+  return renderHook(() => useDeleteAgent(agent), { wrapper });
+}
+
+beforeEach(() => {
+  mockUseResource.mockReset();
+  mockUseResources.mockReset();
+  mockUseSelfSubjectAccessReview.mockReset();
+  mockDeleteResource.mockReset();
+  mockDeleteResource.mockResolvedValue(undefined);
+});
+
+describe('useDeleteAgent', () => {
+  it('offers the deletion for an agent owned by a HelmRelease we may delete', () => {
+    const { result } = setup();
+
+    expect(result.current.isDeletable).toBe(true);
+    expect(result.current.isCheckingDeletable).toBe(false);
+  });
+
+  it('checks the permission against the owning release, by name', () => {
+    setup();
+
+    expect(mockUseSelfSubjectAccessReview).toHaveBeenCalledWith(
+      CLUSTER,
+      {
+        group: 'helm.toolkit.fluxcd.io',
+        resource: 'helmreleases',
+        namespace: NAMESPACE,
+        name: 'pr-reviewer',
+        verb: 'delete',
+      },
+      { enabled: true },
+    );
+  });
+
+  it('refuses when the access review says no', () => {
+    const { result } = setup({ allowed: false });
+
+    expect(result.current.isDeletable).toBe(false);
+  });
+
+  it('refuses when the agent carries no Flux Helm labels', () => {
+    // Applied directly rather than released, so there is no HelmRelease whose
+    // removal would take it away.
+    const { result } = setup({ agent: makeAgent({}) });
+
+    expect(result.current.isDeletable).toBe(false);
+    expect(result.current.isCheckingDeletable).toBe(false);
+  });
+
+  it('refuses when the release is applied by a Kustomization', () => {
+    // Its desired state is in Git, so Flux would put it straight back.
+    const { result } = setup({
+      helmRelease: makeHelmRelease({
+        labels: {
+          'kustomize.toolkit.fluxcd.io/name': 'agents',
+          'kustomize.toolkit.fluxcd.io/namespace': 'flux-system',
+        },
+      }),
+    });
+
+    expect(result.current.isDeletable).toBe(false);
+  });
+
+  it('deletes the release and the chart source when nothing else uses it', async () => {
+    const { result } = setup({ namespaceReleases: [makeHelmRelease()] });
+
+    await act(async () => {
+      await result.current.deleteAgent();
+    });
+
+    expect(mockDeleteResource).toHaveBeenCalledTimes(2);
+    expect(mockDeleteResource.mock.calls[0][0]).toMatchObject({
+      cluster: CLUSTER,
+      name: 'pr-reviewer',
+      namespace: NAMESPACE,
+      gvk: expect.objectContaining({
+        plural: 'helmreleases',
+        apiVersion: 'v2',
+      }),
+    });
+    expect(mockDeleteResource.mock.calls[1][0]).toMatchObject({
+      cluster: CLUSTER,
+      name: 'agent',
+      namespace: NAMESPACE,
+      gvk: expect.objectContaining({
+        plural: 'ocirepositories',
+        apiVersion: 'v1',
+      }),
+    });
+  });
+
+  it('keeps the chart source when another release still references it', async () => {
+    const { result } = setup({
+      namespaceReleases: [
+        makeHelmRelease(),
+        makeHelmRelease({ name: 'triage' }),
+      ],
+    });
+
+    await act(async () => {
+      await result.current.deleteAgent();
+    });
+
+    expect(mockDeleteResource).toHaveBeenCalledTimes(1);
+    expect(mockDeleteResource.mock.calls[0][0]).toMatchObject({
+      gvk: expect.objectContaining({ plural: 'helmreleases' }),
+    });
+  });
+
+  it('ignores releases pointing at a different chart source', async () => {
+    const { result } = setup({
+      namespaceReleases: [
+        makeHelmRelease(),
+        makeHelmRelease({ name: 'muster', chartSourceName: 'muster' }),
+      ],
+    });
+
+    await act(async () => {
+      await result.current.deleteAgent();
+    });
+
+    // The muster release holds a different OCIRepository, so it does not keep
+    // this agent's chart source alive.
+    expect(mockDeleteResource).toHaveBeenCalledTimes(2);
+    expect(mockDeleteResource.mock.calls[1][0]).toMatchObject({
+      name: 'agent',
+      gvk: expect.objectContaining({ plural: 'ocirepositories' }),
+    });
+  });
+
+  it('keeps the chart source when the sibling list could not be read', async () => {
+    // An empty list because the read failed is not the same answer as an empty
+    // list because nothing references it.
+    const { result } = setup({
+      namespaceReleases: [],
+      didReadNamespaceReleases: false,
+    });
+
+    await act(async () => {
+      await result.current.deleteAgent();
+    });
+
+    expect(mockDeleteResource).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an already-deleted release as success', async () => {
+    const notFound = new Error('helmreleases "pr-reviewer" not found');
+    notFound.name = 'NotFoundError';
+    mockDeleteResource.mockRejectedValueOnce(notFound);
+
+    const { result } = setup();
+
+    await act(async () => {
+      await expect(result.current.deleteAgent()).resolves.toBeUndefined();
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it('reports a refused deletion', async () => {
+    const forbidden = new Error('helmreleases is forbidden');
+    forbidden.name = 'ForbiddenError';
+    mockDeleteResource.mockRejectedValueOnce(forbidden);
+
+    const { result } = setup();
+
+    await act(async () => {
+      await expect(result.current.deleteAgent()).rejects.toThrow(
+        'helmreleases is forbidden',
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.error?.name).toBe('ForbiddenError');
+    });
+  });
+
+  it('succeeds even when the chart source cleanup fails', async () => {
+    // The agent is gone, which is what was asked for, and a chart source nobody
+    // references does nothing on its own.
+    mockDeleteResource
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('ocirepositories is forbidden'));
+
+    const { result } = setup();
+
+    await act(async () => {
+      await expect(result.current.deleteAgent()).resolves.toBeUndefined();
+    });
+
+    expect(mockDeleteResource).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fails when there is no release to delete', async () => {
+    const { result } = setup({ agent: makeAgent({}), helmRelease: undefined });
+
+    await act(async () => {
+      await expect(result.current.deleteAgent()).rejects.toThrow(
+        /no HelmRelease to delete/,
+      );
+    });
+
+    expect(mockDeleteResource).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/agent-platform/src/hooks/useDeleteAgent.ts
+++ b/plugins/agent-platform/src/hooks/useDeleteAgent.ts
@@ -1,0 +1,280 @@
+import { useCallback, useMemo } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  Agent,
+  CustomResourceMatcher,
+  deleteResource,
+  HelmRelease,
+  getHelmReleaseName,
+  getHelmReleaseNamespace,
+  isManagedByFlux,
+  OCIRepository,
+  useResource,
+  useResources,
+  useSelfSubjectAccessReview,
+} from '@giantswarm/backstage-plugin-kubernetes-react';
+
+/** A `spec.chartRef` pointing at the chart source a release renders from. */
+type ChartSourceRef = {
+  name: string;
+  namespace: string;
+};
+
+function isSameObject(
+  a: { name?: string; namespace?: string },
+  b: { name?: string; namespace?: string },
+) {
+  return a.name === b.name && a.namespace === b.namespace;
+}
+
+/**
+ * Deleting one agent, and the checks that decide whether to offer it at all.
+ *
+ * An agent is not a thing we can delete directly: it is rendered by the `agent`
+ * chart, so the object that owns its existence is the `HelmRelease`, and removing
+ * that is what makes helm-controller uninstall the release and take the `Agent`
+ * CR with it. The owner is found through the Flux provenance labels rather than
+ * by assuming the release is named after the agent, so this also works for agents
+ * created outside this plugin's wizard.
+ *
+ * The `OCIRepository` the release points at is a different matter: every agent in
+ * a namespace shares one `agent` chart source, so it may only be removed once
+ * nothing else references it. The check is a list of the `HelmRelease`s in the
+ * source's namespace, and every uncertainty resolves to keeping it — an orphaned
+ * chart source is inert and the next agent created in the namespace re-applies an
+ * identical one, while a wrongly deleted one breaks every remaining agent's next
+ * reconciliation.
+ *
+ * Call this from inside the plugin's `QueryClientProvider` — i.e. from the page,
+ * not from the actions element the page hands to `useProvidePageHeaderActions`,
+ * which renders in the shared header outside that provider. `agent` is therefore
+ * optional: the page has none while it is still loading, and a hook cannot be
+ * called conditionally.
+ */
+export function useDeleteAgent(agent: Agent | undefined) {
+  const kubernetesApi = useApi(kubernetesApiRef);
+  const queryClient = useQueryClient();
+
+  const cluster = agent?.cluster ?? '';
+  const helmReleaseName = agent ? getHelmReleaseName(agent) : undefined;
+  const helmReleaseNamespace = agent
+    ? (getHelmReleaseNamespace(agent) ?? agent.getNamespace())
+    : undefined;
+  const hasOwner = Boolean(helmReleaseName);
+
+  // The owning release, for three things: whether Flux owns it declaratively,
+  // which chart source it uses, and the API version to address it at.
+  const { resource: helmRelease, isLoading: isLoadingHelmRelease } =
+    useResource(
+      cluster,
+      HelmRelease,
+      {
+        name: helmReleaseName ?? '',
+        namespace: helmReleaseNamespace,
+        enableDiscovery: false,
+      },
+      { enabled: hasOwner },
+    );
+
+  // A release applied by a Kustomization has its desired state in Git, so
+  // deleting it here would be undone on the next reconciliation — a confusing
+  // no-op dressed up as a deletion. Those agents stay read-only.
+  const isGitOpsOwned = helmRelease ? isManagedByFlux(helmRelease) : false;
+
+  const { allowed: isAllowed, isLoading: isCheckingPermission } =
+    useSelfSubjectAccessReview(
+      cluster,
+      {
+        group: HelmRelease.group,
+        resource: HelmRelease.plural,
+        namespace: helmReleaseNamespace,
+        // Named, so a grant restricted via `resourceNames` answers accurately.
+        name: helmReleaseName,
+        verb: 'delete',
+      },
+      { enabled: hasOwner },
+    );
+
+  const chartRef = helmRelease?.getChartRef();
+  const chartSource: ChartSourceRef | undefined =
+    chartRef?.kind === 'OCIRepository'
+      ? { name: chartRef.name, namespace: chartRef.namespace }
+      : undefined;
+
+  // Everything else in the source's namespace that could be holding on to it.
+  const { resources: namespaceReleases, clustersData } = useResources(
+    cluster,
+    HelmRelease,
+    { [cluster]: { namespace: chartSource?.namespace ?? '' } },
+    { enableDiscovery: false, enabled: Boolean(chartSource) },
+  );
+
+  // `clustersData` only carries clusters whose read succeeded, which is the
+  // distinction that matters here: an empty list because nothing else references
+  // the source is not the same answer as an empty list because the read failed.
+  const hasReadNamespaceReleases = clustersData.some(
+    entry => entry.cluster === cluster,
+  );
+
+  const isChartSourceShared =
+    chartSource !== undefined &&
+    namespaceReleases.some(release => {
+      // Our own release does not count as another user of the source.
+      if (
+        isSameObject(
+          { name: release.getName(), namespace: release.getNamespace() },
+          { name: helmReleaseName, namespace: helmReleaseNamespace },
+        )
+      ) {
+        return false;
+      }
+
+      const ref = release.getChartRef();
+
+      return ref?.kind === 'OCIRepository' && isSameObject(ref, chartSource);
+    });
+
+  // Deliberately not a check on the whole cluster: `HelmRelease`s in other
+  // namespaces can reference this source cross-namespace, but listing them needs
+  // a cluster-wide read a tenant user does not have. Getting this wrong costs a
+  // chart source that the next agent creation re-applies.
+  const willRemoveChartSource =
+    Boolean(chartSource) && hasReadNamespaceReleases && !isChartSourceShared;
+
+  // Read at its served version so the delete addresses a version the cluster
+  // actually has — `OCIRepository` exists as both v1beta2 and v1, so discovery
+  // stays on here. No object means there is nothing left to remove.
+  const { resource: chartSourceResource } = useResource(
+    cluster,
+    OCIRepository,
+    {
+      name: chartSource?.name ?? '',
+      namespace: chartSource?.namespace ?? '',
+    },
+    { enabled: willRemoveChartSource },
+  );
+
+  const invalidateReads = async (gvks: CustomResourceMatcher[]) => {
+    // Prefixes of the keys the read hooks register (see `useListResources` /
+    // `useGetResource`), so one entry per kind covers every list and instance of
+    // it on this cluster. Invalidate rather than editing the cache: the
+    // QueryClient is persisted to localStorage, so a stale pre-deletion object
+    // could otherwise be rehydrated on reload.
+    await Promise.all(
+      gvks.flatMap(gvk =>
+        ['list', 'get'].map(operation =>
+          queryClient.invalidateQueries({
+            queryKey: [
+              'cluster',
+              cluster,
+              operation,
+              gvk.group,
+              gvk.apiVersion,
+              gvk.plural,
+            ].filter(Boolean),
+          }),
+        ),
+      ),
+    );
+  };
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!agent || !helmRelease || !helmReleaseName) {
+        throw new Error(
+          'This agent has no HelmRelease to delete. It was applied directly, so it has to be removed the same way.',
+        );
+      }
+
+      const helmReleaseGVK = helmRelease.getResolvedGVK();
+
+      try {
+        await deleteResource({
+          kubernetesApi,
+          cluster,
+          gvk: helmReleaseGVK,
+          name: helmReleaseName,
+          namespace: helmReleaseNamespace,
+        });
+      } catch (error) {
+        // Already gone — someone else deleted it, or an earlier attempt got
+        // further than its error suggested. Either way the goal is met.
+        if ((error as Error).name !== 'NotFoundError') {
+          throw error;
+        }
+      }
+
+      const invalidated: CustomResourceMatcher[] = [
+        helmReleaseGVK,
+        agent.getResolvedGVK(),
+      ];
+
+      if (willRemoveChartSource && chartSourceResource) {
+        const chartSourceGVK = chartSourceResource.getResolvedGVK();
+
+        try {
+          await deleteResource({
+            kubernetesApi,
+            cluster,
+            gvk: chartSourceGVK,
+            name: chartSourceResource.getName(),
+            namespace: chartSourceResource.getNamespace(),
+          });
+          invalidated.push(chartSourceGVK);
+        } catch {
+          // Swallowed on purpose. The agent is gone, which is what was asked
+          // for, and a chart source nobody references does nothing on its own —
+          // failing the whole operation over its cleanup would report a
+          // successful deletion as an error. This is also why the permission
+          // gate does not require `delete` on `ocirepositories`.
+        }
+      }
+
+      await invalidateReads(invalidated);
+    },
+  });
+
+  const { mutateAsync, reset } = mutation;
+  const deleteAgent = useCallback(async () => {
+    await mutateAsync();
+  }, [mutateAsync]);
+
+  // Memoized as a whole because the page passes this straight into the element it
+  // registers as the header's actions: a fresh object every render would
+  // re-register (and re-render) that slot on every poll.
+  return useMemo(
+    () => ({
+      /**
+       * Whether to offer the deletion: an owner we can act on, not declaratively
+       * owned by Flux, and the cluster says this user may delete it.
+       */
+      isDeletable: hasOwner && !isGitOpsOwned && isAllowed,
+      /** Still establishing the above. Withhold the affordance rather than guess. */
+      isCheckingDeletable:
+        hasOwner && (isLoadingHelmRelease || isCheckingPermission),
+      deleteAgent,
+      isDeleting: mutation.isPending,
+      error: mutation.error as Error | null,
+      reset,
+    }),
+    // `helmRelease` and `willRemoveChartSource` are deliberately not returned:
+    // the confirmation dialog says nothing mechanical, so they are internal to the
+    // mutation now. Both still decide what actually gets deleted.
+    [
+      hasOwner,
+      isGitOpsOwned,
+      isAllowed,
+      isLoadingHelmRelease,
+      isCheckingPermission,
+      deleteAgent,
+      mutation.isPending,
+      mutation.error,
+      reset,
+    ],
+  );
+}
+
+/** What {@link useDeleteAgent} hands to the confirmation UI. */
+export type UseDeleteAgentResult = ReturnType<typeof useDeleteAgent>;

--- a/plugins/agent-platform/src/hooks/useDeleteAgent.ts
+++ b/plugins/agent-platform/src/hooks/useDeleteAgent.ts
@@ -6,13 +6,13 @@ import {
   Agent,
   CustomResourceMatcher,
   deleteResource,
+  fetchResourceList,
   HelmRelease,
   getHelmReleaseName,
   getHelmReleaseNamespace,
   isManagedByFlux,
   OCIRepository,
   useResource,
-  useResources,
   useSelfSubjectAccessReview,
 } from '@giantswarm/backstage-plugin-kubernetes-react';
 
@@ -103,49 +103,9 @@ export function useDeleteAgent(agent: Agent | undefined) {
       ? { name: chartRef.name, namespace: chartRef.namespace }
       : undefined;
 
-  // Everything else in the source's namespace that could be holding on to it.
-  const { resources: namespaceReleases, clustersData } = useResources(
-    cluster,
-    HelmRelease,
-    { [cluster]: { namespace: chartSource?.namespace ?? '' } },
-    { enableDiscovery: false, enabled: Boolean(chartSource) },
-  );
-
-  // `clustersData` only carries clusters whose read succeeded, which is the
-  // distinction that matters here: an empty list because nothing else references
-  // the source is not the same answer as an empty list because the read failed.
-  const hasReadNamespaceReleases = clustersData.some(
-    entry => entry.cluster === cluster,
-  );
-
-  const isChartSourceShared =
-    chartSource !== undefined &&
-    namespaceReleases.some(release => {
-      // Our own release does not count as another user of the source.
-      if (
-        isSameObject(
-          { name: release.getName(), namespace: release.getNamespace() },
-          { name: helmReleaseName, namespace: helmReleaseNamespace },
-        )
-      ) {
-        return false;
-      }
-
-      const ref = release.getChartRef();
-
-      return ref?.kind === 'OCIRepository' && isSameObject(ref, chartSource);
-    });
-
-  // Deliberately not a check on the whole cluster: `HelmRelease`s in other
-  // namespaces can reference this source cross-namespace, but listing them needs
-  // a cluster-wide read a tenant user does not have. Getting this wrong costs a
-  // chart source that the next agent creation re-applies.
-  const willRemoveChartSource =
-    Boolean(chartSource) && hasReadNamespaceReleases && !isChartSourceShared;
-
-  // Read at its served version so the delete addresses a version the cluster
+  // Read at its served version so a delete addresses a version the cluster
   // actually has — `OCIRepository` exists as both v1beta2 and v1, so discovery
-  // stays on here. No object means there is nothing left to remove.
+  // stays on here. No object means there is nothing to remove.
   const { resource: chartSourceResource } = useResource(
     cluster,
     OCIRepository,
@@ -153,8 +113,56 @@ export function useDeleteAgent(agent: Agent | undefined) {
       name: chartSource?.name ?? '',
       namespace: chartSource?.namespace ?? '',
     },
-    { enabled: willRemoveChartSource },
+    { enabled: Boolean(chartSource) },
   );
+
+  /**
+   * Whether anything other than this agent's own release still renders from the
+   * chart source — answered from a **fresh** list, not the query cache.
+   *
+   * Deliberately not `useResources`: this decides whether to destroy a shared
+   * object, and a cached list is the wrong basis for that. `staleTime` is 60s
+   * here and the cache is persisted, so a sibling agent created moments ago in
+   * another tab would be invisible — and the answer would look certain.
+   *
+   * Throws if the list cannot be read, which the caller turns into "keep the
+   * source". An empty list because the read failed is not the same answer as an
+   * empty list because nothing references it.
+   *
+   * Scoped to the source's own namespace. A cross-namespace `chartRef` from
+   * elsewhere would not be seen, but listing cluster-wide needs a read a tenant
+   * user does not have, and the cost of being wrong that way is a chart source
+   * the next agent creation re-applies.
+   */
+  const isChartSourceShared = async (
+    source: ChartSourceRef,
+    releaseGVK: CustomResourceMatcher,
+  ) => {
+    const items = await fetchResourceList<HelmRelease['jsonData']>({
+      kubernetesApi,
+      cluster,
+      gvk: releaseGVK,
+      namespace: source.namespace,
+    });
+
+    return items
+      .map(item => new HelmRelease(item, cluster))
+      .some(release => {
+        // Our own release does not count as another user of the source.
+        if (
+          isSameObject(
+            { name: release.getName(), namespace: release.getNamespace() },
+            { name: helmReleaseName, namespace: helmReleaseNamespace },
+          )
+        ) {
+          return false;
+        }
+
+        const ref = release.getChartRef();
+
+        return ref?.kind === 'OCIRepository' && isSameObject(ref, source);
+      });
+  };
 
   const invalidateReads = async (gvks: CustomResourceMatcher[]) => {
     // Prefixes of the keys the read hooks register (see `useListResources` /
@@ -184,7 +192,18 @@ export function useDeleteAgent(agent: Agent | undefined) {
     mutationFn: async () => {
       if (!agent || !helmRelease || !helmReleaseName) {
         throw new Error(
-          'This agent has no HelmRelease to delete. It was applied directly, so it has to be removed the same way.',
+          'The HelmRelease that reconciles this agent could not be read, so it cannot be deleted from here. Try reloading the page.',
+        );
+      }
+
+      // Deleting a suspended release removes the release and nothing else: Flux
+      // drops its finalizer without running the uninstall, leaving the Agent and
+      // the rest of the chart's objects behind — and with no owner, so this path
+      // could not clean them up afterwards either. Refuse rather than report an
+      // uninstall that will not happen.
+      if (helmRelease.isSuspended()) {
+        throw new Error(
+          `HelmRelease ${helmReleaseNamespace}/${helmReleaseName} is suspended. Flux would remove it without uninstalling the agent, leaving its resources behind. Resume the release first, then delete the agent.`,
         );
       }
 
@@ -211,24 +230,29 @@ export function useDeleteAgent(agent: Agent | undefined) {
         agent.getResolvedGVK(),
       ];
 
-      if (willRemoveChartSource && chartSourceResource) {
-        const chartSourceGVK = chartSourceResource.getResolvedGVK();
-
+      // Everything from here is best-effort cleanup of the shared chart source,
+      // after the point where the agent is already gone. Every failure — an
+      // unreadable sibling list, a denied delete — leaves the source in place,
+      // which is always the safe outcome: it is inert on its own, and the next
+      // agent created in the namespace re-applies an identical one. That is also
+      // why the permission gate does not require `delete` on `ocirepositories`.
+      if (chartSource && chartSourceResource) {
         try {
-          await deleteResource({
-            kubernetesApi,
-            cluster,
-            gvk: chartSourceGVK,
-            name: chartSourceResource.getName(),
-            namespace: chartSourceResource.getNamespace(),
-          });
-          invalidated.push(chartSourceGVK);
+          if (!(await isChartSourceShared(chartSource, helmReleaseGVK))) {
+            const chartSourceGVK = chartSourceResource.getResolvedGVK();
+
+            await deleteResource({
+              kubernetesApi,
+              cluster,
+              gvk: chartSourceGVK,
+              name: chartSourceResource.getName(),
+              namespace: chartSourceResource.getNamespace(),
+            });
+            invalidated.push(chartSourceGVK);
+          }
         } catch {
-          // Swallowed on purpose. The agent is gone, which is what was asked
-          // for, and a chart source nobody references does nothing on its own —
-          // failing the whole operation over its cleanup would report a
-          // successful deletion as an error. This is also why the permission
-          // gate does not require `delete` on `ocirepositories`.
+          // Keep the source. Failing the whole operation here would report a
+          // successful deletion as an error.
         }
       }
 
@@ -247,10 +271,20 @@ export function useDeleteAgent(agent: Agent | undefined) {
   return useMemo(
     () => ({
       /**
-       * Whether to offer the deletion: an owner we can act on, not declaratively
-       * owned by Flux, and the cluster says this user may delete it.
+       * Whether to offer the deletion: the owning release is **in hand** (not
+       * merely named by a label), it is not declaratively owned by Flux, and the
+       * cluster says this user may delete it.
+       *
+       * Keyed on the object rather than on `hasOwner`, so that a release we could
+       * not read is "cannot decide" instead of "no owner". Those differ: an
+       * unreadable release also reads as not-GitOps-owned, which would quietly
+       * switch off the Kustomization guard, and the mutation needs the object
+       * anyway — offering an action that is certain to fail is worse than not
+       * offering it. Reachable via a proxy 5xx (not retried for
+       * `ServiceUnavailableError`, and this read does not poll) or RBAC granting
+       * `delete` without `get`.
        */
-      isDeletable: hasOwner && !isGitOpsOwned && isAllowed,
+      isDeletable: Boolean(helmRelease) && !isGitOpsOwned && isAllowed,
       /** Still establishing the above. Withhold the affordance rather than guess. */
       isCheckingDeletable:
         hasOwner && (isLoadingHelmRelease || isCheckingPermission),
@@ -259,11 +293,11 @@ export function useDeleteAgent(agent: Agent | undefined) {
       error: mutation.error as Error | null,
       reset,
     }),
-    // `helmRelease` and `willRemoveChartSource` are deliberately not returned:
-    // the confirmation dialog says nothing mechanical, so they are internal to the
-    // mutation now. Both still decide what actually gets deleted.
+    // `helmRelease` itself is deliberately not returned: the confirmation dialog
+    // says nothing mechanical, so it is internal to the mutation now.
     [
       hasOwner,
+      helmRelease,
       isGitOpsOwned,
       isAllowed,
       isLoadingHelmRelease,

--- a/plugins/kubernetes-react/src/hooks/index.ts
+++ b/plugins/kubernetes-react/src/hooks/index.ts
@@ -5,6 +5,7 @@ export * from './useResource';
 export * from './useResources';
 export * from './useApiDiscovery';
 export * from './useSelfSubjectAccessReview';
+export * from './utils/deleteResource';
 export * from './utils/patchResource';
 export * from './utils/queries';
 export * from './utils/queryPersistence';

--- a/plugins/kubernetes-react/src/hooks/index.ts
+++ b/plugins/kubernetes-react/src/hooks/index.ts
@@ -6,6 +6,7 @@ export * from './useResources';
 export * from './useApiDiscovery';
 export * from './useSelfSubjectAccessReview';
 export * from './utils/deleteResource';
+export * from './utils/fetchResourceList';
 export * from './utils/patchResource';
 export * from './utils/queries';
 export * from './utils/queryPersistence';

--- a/plugins/kubernetes-react/src/hooks/useListResources.test.tsx
+++ b/plugins/kubernetes-react/src/hooks/useListResources.test.tsx
@@ -1,0 +1,104 @@
+import { PropsWithChildren } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/frontend-test-utils';
+import { kubernetesApiRef } from '@backstage/plugin-kubernetes-react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CustomResourceMatcher } from '../lib/k8s/CustomResourceMatcher';
+import { useListResources } from './useListResources';
+
+const CLUSTER = 'gazelle';
+
+const gvk: CustomResourceMatcher = {
+  group: 'helm.toolkit.fluxcd.io',
+  apiVersion: 'v2',
+  plural: 'helmreleases',
+  isCore: false,
+};
+
+function createKubernetesApi() {
+  const proxy = jest.fn(async ({ path }: { path: string }) => {
+    // Echo the requested path back as an item name, so a response can be traced
+    // to the request that produced it.
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [{ metadata: { name: path } }] }),
+    } as unknown as Response;
+  });
+
+  return { api: { proxy } as any, proxy };
+}
+
+/**
+ * One QueryClient shared across renders, with a non-zero `staleTime` — the
+ * condition under which a cache collision is silent, because a hit issues no
+ * request at all. Mirrors the plugin clients (60s).
+ */
+function renderWithSharedCache() {
+  const { api, proxy } = createKubernetesApi();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 60_000, retry: false } },
+  });
+
+  const wrapper = ({ children }: PropsWithChildren<{}>) => (
+    <TestApiProvider apis={[[kubernetesApiRef, api]]}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </TestApiProvider>
+  );
+
+  const list = (namespace: string) =>
+    renderHook(
+      () =>
+        useListResources<{ metadata: { name: string } }>(
+          [CLUSTER],
+          { [CLUSTER]: gvk },
+          { [CLUSTER]: { namespace } },
+        ),
+      { wrapper },
+    );
+
+  return { list, proxy };
+}
+
+describe('useListResources', () => {
+  it('does not serve one namespace’s list from another namespace’s cache entry', async () => {
+    // Regression. The key omitted the namespace while the *path* carried it, so
+    // two lists of the same kind on one cluster were a single query: the second
+    // caller got the first one's items and no request was made. That is
+    // dangerous well beyond a display glitch — a caller deciding "nothing else
+    // references this, so it is safe to delete" could be answered from an
+    // entirely different namespace.
+    const { list, proxy } = renderWithSharedCache();
+
+    const teamA = list('team-a');
+    await waitFor(() => expect(teamA.result.current.isLoading).toBe(false));
+
+    const teamB = list('team-b');
+    await waitFor(() => expect(teamB.result.current.isLoading).toBe(false));
+
+    expect(proxy).toHaveBeenCalledTimes(2);
+
+    const paths = proxy.mock.calls.map(call => call[0].path);
+    expect(paths[0]).toContain('/namespaces/team-a/');
+    expect(paths[1]).toContain('/namespaces/team-b/');
+
+    // Each hook holds its own namespace's items.
+    const nameFor = (r: ReturnType<typeof list>) =>
+      r.result.current.clustersData[0]?.data[0]?.metadata.name ?? '';
+    expect(nameFor(teamA)).toContain('/namespaces/team-a/');
+    expect(nameFor(teamB)).toContain('/namespaces/team-b/');
+  });
+
+  it('still shares a cache entry for the same namespace', async () => {
+    // The caching this exists for is unaffected: an identical scope is one query.
+    const { list, proxy } = renderWithSharedCache();
+
+    const first = list('team-a');
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+
+    const second = list('team-a');
+    await waitFor(() => expect(second.result.current.isLoading).toBe(false));
+
+    expect(proxy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/kubernetes-react/src/hooks/useListResources.ts
+++ b/plugins/kubernetes-react/src/hooks/useListResources.ts
@@ -38,6 +38,17 @@ export function useListResources<T>(
           gvk.group,
           gvk.apiVersion,
           gvk.plural,
+          // The scope — namespace and label selector — lives in the path, not in
+          // the segments above, so it has to be part of the key too. Without it,
+          // two lists of the same kind on one cluster differing only by namespace
+          // are *one* query, and the second caller is served the first one's
+          // items with no request made at all (`staleTime` is 60s in several
+          // plugins, and the cache is persisted to localStorage). `useGetResource`
+          // has always keyed on its namespace and name; this brings lists in line.
+          //
+          // Appended last so the existing 6-segment prefix still matches, which
+          // is how both invalidation call sites use this key.
+          path,
         ].filter(Boolean),
         queryFn: async () => {
           const response = await kubernetesApi.proxy({

--- a/plugins/kubernetes-react/src/hooks/utils/deleteResource.test.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/deleteResource.test.ts
@@ -1,0 +1,158 @@
+import { KubernetesApi } from '@backstage/plugin-kubernetes-react';
+import { CustomResourceMatcher } from '../../lib/k8s/CustomResourceMatcher';
+import { deleteResource } from './deleteResource';
+
+const gvk: CustomResourceMatcher = {
+  group: 'helm.toolkit.fluxcd.io',
+  apiVersion: 'v2',
+  plural: 'helmreleases',
+  isCore: false,
+};
+
+type ProxyArgs = {
+  clusterName: string;
+  path: string;
+  init: { method: string };
+};
+
+function createKubernetesApi(response: Partial<Response>) {
+  const proxy = jest.fn(async (_args: ProxyArgs) => response as Response);
+
+  return { api: { proxy } as unknown as KubernetesApi, proxy };
+}
+
+describe('deleteResource', () => {
+  it('sends a DELETE to the resource path', async () => {
+    const { api, proxy } = createKubernetesApi({ ok: true, status: 200 });
+
+    await deleteResource({
+      kubernetesApi: api,
+      cluster: 'test-installation',
+      gvk,
+      name: 'pr-reviewer',
+      namespace: 'agentic-platform',
+    });
+
+    expect(proxy).toHaveBeenCalledTimes(1);
+    expect(proxy).toHaveBeenCalledWith({
+      clusterName: 'test-installation',
+      // No trailing slash: `getK8sGetPath` appends one, which we do not want to
+      // rely on the apiserver tolerating for a mutating verb.
+      path: '/apis/helm.toolkit.fluxcd.io/v2/namespaces/agentic-platform/helmreleases/pr-reviewer',
+      init: { method: 'DELETE' },
+    });
+  });
+
+  it('sends no body and no headers', async () => {
+    // Nothing needs either, and a DELETE with a body is the more awkward path
+    // through fetch and any proxy in between.
+    const { api, proxy } = createKubernetesApi({ ok: true, status: 200 });
+
+    await deleteResource({
+      kubernetesApi: api,
+      cluster: 'test-installation',
+      gvk,
+      name: 'pr-reviewer',
+      namespace: 'agentic-platform',
+    });
+
+    expect(proxy.mock.calls[0][0].init).toEqual({ method: 'DELETE' });
+  });
+
+  it('passes a propagation policy as a query parameter', async () => {
+    const { api, proxy } = createKubernetesApi({ ok: true, status: 200 });
+
+    await deleteResource({
+      kubernetesApi: api,
+      cluster: 'test-installation',
+      gvk,
+      name: 'pr-reviewer',
+      namespace: 'agentic-platform',
+      propagationPolicy: 'Foreground',
+    });
+
+    expect(proxy.mock.calls[0][0].path).toBe(
+      '/apis/helm.toolkit.fluxcd.io/v2/namespaces/agentic-platform/helmreleases/pr-reviewer?propagationPolicy=Foreground',
+    );
+  });
+
+  it('omits the namespace segment for a cluster-scoped resource', async () => {
+    const { api, proxy } = createKubernetesApi({ ok: true, status: 200 });
+
+    await deleteResource({
+      kubernetesApi: api,
+      cluster: 'test-installation',
+      gvk,
+      name: 'pr-reviewer',
+    });
+
+    expect(proxy.mock.calls[0][0].path).toBe(
+      '/apis/helm.toolkit.fluxcd.io/v2/helmreleases/pr-reviewer',
+    );
+  });
+
+  it('throws a ForbiddenError on 403', async () => {
+    const { api } = createKubernetesApi({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({
+        message: 'helmreleases.helm.toolkit.fluxcd.io is forbidden',
+      }),
+    });
+
+    await expect(
+      deleteResource({
+        kubernetesApi: api,
+        cluster: 'test-installation',
+        gvk,
+        name: 'pr-reviewer',
+        namespace: 'agentic-platform',
+      }),
+    ).rejects.toMatchObject({
+      name: 'ForbiddenError',
+      message: expect.stringContaining(
+        'helmreleases.helm.toolkit.fluxcd.io is forbidden',
+      ),
+    });
+  });
+
+  it('throws a NotFoundError on 404, so an idempotent caller can shrug it off', async () => {
+    const { api } = createKubernetesApi({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({ message: 'helmreleases "pr-reviewer" not found' }),
+    });
+
+    await expect(
+      deleteResource({
+        kubernetesApi: api,
+        cluster: 'test-installation',
+        gvk,
+        name: 'pr-reviewer',
+        namespace: 'agentic-platform',
+      }),
+    ).rejects.toMatchObject({ name: 'NotFoundError' });
+  });
+
+  it('falls back to the status text when the body is not a Status object', async () => {
+    const { api } = createKubernetesApi({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => {
+        throw new Error('not json');
+      },
+    });
+
+    await expect(
+      deleteResource({
+        kubernetesApi: api,
+        cluster: 'test-installation',
+        gvk,
+        name: 'pr-reviewer',
+      }),
+    ).rejects.toThrow(/Internal Server Error/);
+  });
+});

--- a/plugins/kubernetes-react/src/hooks/utils/deleteResource.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/deleteResource.ts
@@ -1,0 +1,65 @@
+import { KubernetesApi } from '@backstage/plugin-kubernetes-react';
+import { CustomResourceMatcher } from '../../lib/k8s/CustomResourceMatcher';
+import { k8sMutationError, stripTrailingSlash } from './k8sMutation';
+import { getK8sGetPath } from './k8sPath';
+
+/**
+ * How the apiserver treats dependents of the deleted object. Omitted by default,
+ * which leaves the choice to the object's own
+ * `metadata.deletionPropagation`/apiserver default (`Background` for the CRs we
+ * delete) — the right answer whenever a controller, not us, owns the cascade.
+ */
+export type PropagationPolicy = 'Foreground' | 'Background' | 'Orphan';
+
+/**
+ * Deletes a single Kubernetes resource through the Kubernetes proxy.
+ *
+ * Authorization is the signed-in user's own RBAC on the target cluster: the
+ * backend proxy forwards their OIDC token, so a rejected delete surfaces as a
+ * 403 (`ForbiddenError`) from the apiserver. A 404 is a `NotFoundError`, which an
+ * idempotent caller may want to treat as success.
+ *
+ * Returning without throwing means the apiserver accepted the request, not that
+ * the object is gone: anything with a finalizer (every Flux resource, for one)
+ * only gets its `deletionTimestamp` set here, and disappears once its controller
+ * has finished cleaning up.
+ */
+export async function deleteResource(options: {
+  kubernetesApi: KubernetesApi;
+  cluster: string;
+  gvk: CustomResourceMatcher;
+  name: string;
+  namespace?: string;
+  propagationPolicy?: PropagationPolicy;
+}): Promise<void> {
+  const { kubernetesApi, cluster, gvk, name, namespace, propagationPolicy } =
+    options;
+
+  // As a query parameter rather than a `DeleteOptions` body: DELETE with a body
+  // is the more awkward path through fetch and any proxy in between, and the two
+  // are equivalent to the apiserver.
+  const query = propagationPolicy
+    ? `?propagationPolicy=${encodeURIComponent(propagationPolicy)}`
+    : '';
+  const path = `${stripTrailingSlash(
+    getK8sGetPath(gvk, name, namespace),
+  )}${query}`;
+
+  const response = await kubernetesApi.proxy({
+    clusterName: cluster,
+    path,
+    // No body, so no `Content-Type` — note that if one is ever added it must be a
+    // plain object, since `KubernetesClient.getKubernetesHeaders` object-spreads
+    // the headers and a `Headers` instance spreads to `{}`.
+    init: {
+      method: 'DELETE',
+    },
+  });
+
+  if (!response.ok) {
+    throw await k8sMutationError(
+      response,
+      `Failed to delete ${gvk.plural} ${name} on ${cluster}`,
+    );
+  }
+}

--- a/plugins/kubernetes-react/src/hooks/utils/fetchResourceList.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/fetchResourceList.ts
@@ -1,0 +1,51 @@
+import { KubernetesApi } from '@backstage/plugin-kubernetes-react';
+import { CustomResourceMatcher } from '../../lib/k8s/CustomResourceMatcher';
+import { KubeObjectInterface } from '../../lib/k8s/KubeObject';
+import { k8sMutationError } from './k8sMutation';
+import { getK8sListPath } from './k8sPath';
+
+/**
+ * Lists a kind in one namespace, right now, bypassing the react-query cache
+ * entirely.
+ *
+ * The counterpart to `useResources` for the case where a *decision* depends on
+ * the answer rather than a render: a mutation that is about to delete something
+ * on the strength of "nothing else references it" must not act on a list that
+ * `staleTime` merely considers fresh. A sibling created seconds ago in another
+ * tab would be invisible, and the destructive step is not repeatable.
+ *
+ * Prefer `useResources` for anything displayed. Reach for this only where
+ * staleness changes the outcome.
+ *
+ * Errors follow the mutation convention: 403 is `ForbiddenError`, 404 is
+ * `NotFoundError`. Callers deciding whether to destroy something must treat a
+ * failure here as "cannot tell", never as "nothing found".
+ */
+export async function fetchResourceList<
+  T extends KubeObjectInterface = KubeObjectInterface,
+>(options: {
+  kubernetesApi: KubernetesApi;
+  cluster: string;
+  gvk: CustomResourceMatcher;
+  namespace?: string;
+}): Promise<T[]> {
+  const { kubernetesApi, cluster, gvk, namespace } = options;
+
+  const response = await kubernetesApi.proxy({
+    clusterName: cluster,
+    path: getK8sListPath(gvk, { namespace }),
+  });
+
+  if (!response.ok) {
+    throw await k8sMutationError(
+      response,
+      `Failed to list ${gvk.plural}${
+        namespace ? ` in namespace ${namespace}` : ''
+      } on ${cluster}`,
+    );
+  }
+
+  const list: { items?: T[] } = await response.json();
+
+  return list.items ?? [];
+}

--- a/plugins/kubernetes-react/src/hooks/utils/k8sMutation.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/k8sMutation.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared plumbing for mutating verbs against the Kubernetes proxy.
+ *
+ * Reads tolerate things a write should not, so the handful of details that make a
+ * proxied mutation behave live here rather than being rediscovered per verb.
+ */
+
+/**
+ * The `metadata.managedFields` manager name recorded for writes made from here.
+ *
+ * Set explicitly because the apiserver otherwise derives the manager from the
+ * request's User-Agent — which, for a write proxied through the Backstage
+ * backend, is both unpredictable and useless in an audit trail. A deliberate name
+ * makes our writes attributable in `kubectl get ... --show-managed-fields`, and
+ * gives cluster operators a value they can pass to a controller's
+ * `--override-manager` if they want these changes force-reverted.
+ *
+ * Note we deliberately do *not* masquerade as `flux`. Nothing in Flux keys off
+ * that name — the CLI never sets a field manager at all, and
+ * kustomize-controller's disallowed-manager list does not mention it — so
+ * impersonating it would buy nothing and destroy attribution.
+ */
+export const BACKSTAGE_FIELD_MANAGER = 'giantswarm-backstage';
+
+/**
+ * Reads succeed with the trailing slash `k8sUrl.create` appends, but we do not
+ * want to rely on the apiserver tolerating it for a mutating verb.
+ */
+export function stripTrailingSlash(path: string): string {
+  return path.replace(/\/$/, '');
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = await response.json();
+
+    if (typeof body?.message === 'string') {
+      return body.message;
+    }
+  } catch {
+    // Not a Kubernetes Status object — fall back to the status text.
+  }
+
+  return response.statusText;
+}
+
+/**
+ * An `Error` for a failed mutation, named so callers can branch on the two
+ * outcomes that mean something other than "it broke": `ForbiddenError` (the
+ * user's RBAC says no) and `NotFoundError` (nothing there to act on, which an
+ * idempotent caller may treat as success).
+ */
+export async function k8sMutationError(
+  response: Response,
+  description: string,
+): Promise<Error> {
+  const message = await readErrorMessage(response);
+  const error = new Error(`${description}. Reason: ${message}.`);
+
+  if (response.status === 403) {
+    error.name = 'ForbiddenError';
+  } else if (response.status === 404) {
+    error.name = 'NotFoundError';
+  }
+
+  return error;
+}

--- a/plugins/kubernetes-react/src/hooks/utils/patchResource.ts
+++ b/plugins/kubernetes-react/src/hooks/utils/patchResource.ts
@@ -1,45 +1,15 @@
 import { KubernetesApi } from '@backstage/plugin-kubernetes-react';
 import { CustomResourceMatcher } from '../../lib/k8s/CustomResourceMatcher';
+import {
+  BACKSTAGE_FIELD_MANAGER,
+  k8sMutationError,
+  stripTrailingSlash,
+} from './k8sMutation';
 import { getK8sGetPath } from './k8sPath';
 
-/**
- * The `metadata.managedFields` manager name recorded for writes made from here.
- *
- * Set explicitly because the apiserver otherwise derives the manager from the
- * request's User-Agent — which, for a write proxied through the Backstage
- * backend, is both unpredictable and useless in an audit trail. A deliberate name
- * makes our writes attributable in `kubectl get ... --show-managed-fields`, and
- * gives cluster operators a value they can pass to a controller's
- * `--override-manager` if they want these changes force-reverted.
- *
- * Note we deliberately do *not* masquerade as `flux`. Nothing in Flux keys off
- * that name — the CLI never sets a field manager at all, and
- * kustomize-controller's disallowed-manager list does not mention it — so
- * impersonating it would buy nothing and destroy attribution.
- */
-export const BACKSTAGE_FIELD_MANAGER = 'giantswarm-backstage';
-
-/**
- * Reads succeed with the trailing slash `k8sUrl.create` appends, but we do not
- * want to rely on the apiserver tolerating it for a mutating verb.
- */
-function stripTrailingSlash(path: string): string {
-  return path.replace(/\/$/, '');
-}
-
-async function readErrorMessage(response: Response): Promise<string> {
-  try {
-    const body = await response.json();
-
-    if (typeof body?.message === 'string') {
-      return body.message;
-    }
-  } catch {
-    // Not a Kubernetes Status object — fall back to the status text.
-  }
-
-  return response.statusText;
-}
+// Re-exported because this used to be its definition site, and it is part of the
+// package's public surface.
+export { BACKSTAGE_FIELD_MANAGER };
 
 /**
  * Applies a JSON merge patch to a single Kubernetes resource through the
@@ -78,13 +48,9 @@ export async function patchResource(options: {
   });
 
   if (!response.ok) {
-    const message = await readErrorMessage(response);
-    const error = new Error(
-      `Failed to patch ${gvk.plural} ${name} on ${cluster}. Reason: ${message}.`,
+    throw await k8sMutationError(
+      response,
+      `Failed to patch ${gvk.plural} ${name} on ${cluster}`,
     );
-    error.name = response.status === 403 ? 'ForbiddenError' : error.name;
-    error.name = response.status === 404 ? 'NotFoundError' : error.name;
-
-    throw error;
   }
 }

--- a/plugins/ui-react/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/plugins/ui-react/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button, Flex, Text } from '@backstage/ui';
+import { ConfirmDialog, type ConfirmDialogProps } from './ConfirmDialog';
+import { componentDocs } from '../../storybook/docs';
+
+const meta = {
+  title: 'Components/ConfirmDialog',
+  component: ConfirmDialog,
+  tags: ['autodocs'],
+  args: {
+    // The three required props live here so every story inherits them: a story
+    // that only sets `render` would otherwise have to repeat them to satisfy
+    // `StoryObj`'s required-args check. The interactive stories override all
+    // three with their own state.
+    isOpen: true,
+    onOpenChange: () => {},
+    onConfirm: () => {},
+    title: 'Delete agent "Issue Tracker"?',
+    destructive: true,
+    confirmLabel: 'Delete agent',
+    busyLabel: 'Deleting…',
+    children: (
+      <Text variant="body-medium">
+        This ends any session currently running with this agent — including
+        sessions started by other people, which are not shown to you.
+      </Text>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: componentDocs({
+          summary:
+            'A modal that asks before doing something the user cannot take ' +
+            'back. Controlled via `isOpen`/`onOpenChange`, with a `destructive` ' +
+            'confirm button, a busy state for the action in flight, and a slot ' +
+            'for the error if it fails.',
+          whenToUse:
+            'Before any irreversible action — deleting a resource, discarding ' +
+            'work. Put only what the reader cannot work out for themselves in ' +
+            'the body: the consequence they would not have predicted, not a ' +
+            'recap of the mechanics. Keep it to a sentence or two; a modal is ' +
+            'read at the moment of deciding, not studied.',
+          migration: 'bui',
+          extra:
+            'Two behaviours worth knowing before extending it.\n\n' +
+            '**Confirming does not close it.** The caller closes it, once it ' +
+            'knows the action succeeded — so run the action, pass `isBusy` ' +
+            'while it is in flight and `error` if it fails. A dialog that ' +
+            'dismissed itself on confirm would throw away the only place a ' +
+            'failure could be reported.\n\n' +
+            '**It is controlled, not a `DialogTrigger` wrapper.** That is the ' +
+            'only thing that works when the trigger is a `MenuItem`: ' +
+            'react-aria unmounts the menu on selection, taking any trigger ' +
+            'inside it along. While `isBusy` it is also undismissable, so a ' +
+            'stray click or Escape cannot orphan a request already on its way ' +
+            'to a server.',
+        }),
+      },
+    },
+  },
+} satisfies Meta<typeof ConfirmDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// A small component so the interactive stories can own the open/busy state
+// (hooks belong in a component, not a bare `render` callback).
+const ConfirmDialogExample = ({
+  outcome = 'success',
+  ...args
+}: ConfirmDialogProps & { outcome?: 'success' | 'failure' }) => {
+  const [isOpen, setOpen] = useState(false);
+  const [isBusy, setBusy] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const confirm = () => {
+    setError(undefined);
+    setBusy(true);
+
+    // Stands in for the request the caller would make.
+    window.setTimeout(() => {
+      setBusy(false);
+      if (outcome === 'failure') {
+        setError(
+          'helmreleases.helm.toolkit.fluxcd.io "issue-tracker" is forbidden',
+        );
+        return;
+      }
+      setOpen(false);
+    }, 1200);
+  };
+
+  return (
+    <Flex direction="column" gap="3" style={{ alignItems: 'flex-start' }}>
+      <Button
+        variant="secondary"
+        destructive
+        onClick={() => {
+          setError(undefined);
+          setOpen(true);
+        }}
+      >
+        Delete agent…
+      </Button>
+      <ConfirmDialog
+        {...args}
+        isOpen={isOpen}
+        onOpenChange={setOpen}
+        isBusy={isBusy}
+        error={error}
+        onConfirm={confirm}
+      />
+    </Flex>
+  );
+};
+
+/** The whole flow: open, confirm, watch it work, and close on success. */
+export const Interactive: Story = {
+  render: args => <ConfirmDialogExample {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Confirming starts a fake request that takes a moment and then ' +
+          'succeeds, at which point the caller closes the dialog.',
+      },
+    },
+  },
+};
+
+/** The same flow when the action is refused — the dialog stays put and explains. */
+export const ConfirmFails: Story = {
+  render: args => <ConfirmDialogExample {...args} outcome="failure" />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The action fails, so the dialog stays open and renders `error` ' +
+          'above the buttons. This is why confirming does not close it.',
+      },
+    },
+  },
+};
+
+/** Open, at rest — the state the docs page is most useful showing. */
+export const Open: Story = {};
+
+/** Mid-flight: both buttons locked, confirm reporting progress. */
+export const Busy: Story = {
+  args: { isBusy: true },
+};
+
+/** A non-destructive confirmation, with its own labels. */
+export const NonDestructive: Story = {
+  args: {
+    destructive: false,
+    title: 'Discard your changes?',
+    confirmLabel: 'Discard',
+    cancelLabel: 'Keep editing',
+    children: (
+      <Text variant="body-medium">
+        The values you entered will not be saved.
+      </Text>
+    ),
+  },
+};

--- a/plugins/ui-react/src/components/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/plugins/ui-react/src/components/ConfirmDialog/ConfirmDialog.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfirmDialog } from './ConfirmDialog';
+
+function renderDialog(
+  props: Partial<Parameters<typeof ConfirmDialog>[0]> = {},
+) {
+  const onConfirm = jest.fn();
+  const onOpenChange = jest.fn();
+
+  render(
+    <ConfirmDialog
+      isOpen
+      onOpenChange={onOpenChange}
+      title="Delete the thing?"
+      onConfirm={onConfirm}
+      {...props}
+    >
+      <span>It will not come back.</span>
+    </ConfirmDialog>,
+  );
+
+  return { onConfirm, onOpenChange };
+}
+
+describe('ConfirmDialog', () => {
+  it('shows the title and the body', () => {
+    renderDialog();
+
+    expect(screen.getByText('Delete the thing?')).toBeInTheDocument();
+    expect(screen.getByText('It will not come back.')).toBeInTheDocument();
+  });
+
+  it('renders nothing while closed', () => {
+    renderDialog({ isOpen: false });
+
+    expect(screen.queryByText('Delete the thing?')).not.toBeInTheDocument();
+  });
+
+  it('asks to close on cancel', async () => {
+    const { onOpenChange, onConfirm } = renderDialog();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('confirms without closing itself', async () => {
+    // The caller closes it, once it knows the action succeeded. A dialog that
+    // dismissed itself here would have thrown away the only place a failure
+    // could be reported.
+    const { onConfirm, onOpenChange } = renderDialog();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('uses the given labels', () => {
+    renderDialog({ confirmLabel: 'Delete agent', cancelLabel: 'Keep it' });
+
+    expect(
+      screen.getByRole('button', { name: 'Delete agent' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Keep it' })).toBeInTheDocument();
+  });
+
+  it('locks both buttons while the action is in flight', async () => {
+    const { onConfirm, onOpenChange } = renderDialog({
+      isBusy: true,
+      confirmLabel: 'Delete',
+      busyLabel: 'Deleting…',
+    });
+
+    // The confirm button reports the progress rather than inviting a second press.
+    const confirm = screen.getByRole('button', { name: 'Deleting…' });
+    expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+
+    await userEvent.click(confirm);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps the confirm label while busy when no busy label is given', () => {
+    renderDialog({ isBusy: true, confirmLabel: 'Delete' });
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('shows a failed attempt without closing', () => {
+    renderDialog({ error: 'helmreleases is forbidden' });
+
+    expect(screen.getByText('helmreleases is forbidden')).toBeInTheDocument();
+    expect(screen.getByText('Delete the thing?')).toBeInTheDocument();
+  });
+
+  it('cannot be dismissed with Escape while busy', async () => {
+    // A stray keypress must not orphan a request already on its way to a server.
+    const { onOpenChange } = renderDialog({ isBusy: true });
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/ui-react/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/plugins/ui-react/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,0 +1,100 @@
+import { ReactNode } from 'react';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+  Flex,
+} from '@backstage/ui';
+
+export type ConfirmDialogProps = {
+  isOpen: boolean;
+  /**
+   * Called with `false` when the dialog wants to close (Cancel, Escape, a click
+   * outside). Never called as a result of confirming — see {@link onConfirm}.
+   */
+  onOpenChange: (isOpen: boolean) => void;
+  title: string;
+  /** What is about to happen, and anything the user should weigh before saying yes. */
+  children: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Confirm button label while `isBusy`. Defaults to `confirmLabel`. */
+  busyLabel?: string;
+  /** Renders the confirm button in the destructive (red) treatment. */
+  destructive?: boolean;
+  /** The confirmed action is in flight: both buttons lock and the dialog stays put. */
+  isBusy?: boolean;
+  /** Shown as a danger alert above the buttons. Typically a failed attempt's message. */
+  error?: ReactNode;
+  onConfirm: () => void;
+  width?: number | string;
+};
+
+/**
+ * A modal that asks before doing something the user cannot take back.
+ *
+ * Controlled rather than wrapping a `DialogTrigger`, for two reasons. It is the
+ * only thing that works when the trigger is a `MenuItem` — react-aria unmounts
+ * the menu on selection, taking any trigger inside it along. And it is what lets
+ * the caller decide when the dialog goes away.
+ *
+ * Which matters, because confirming deliberately does *not* close it: an action
+ * that can fail needs somewhere to say so, and a dialog that dismisses itself on
+ * confirm has thrown away the only place the user was still looking. So the
+ * caller runs the action, passes `isBusy` while it is in flight and `error` if it
+ * fails, and closes the dialog when it succeeds. While busy the dialog is also
+ * undismissable — a stray click outside must not orphan a request that is already
+ * on its way to a server.
+ */
+export function ConfirmDialog({
+  isOpen,
+  onOpenChange,
+  title,
+  children,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  busyLabel,
+  destructive,
+  isBusy = false,
+  error,
+  onConfirm,
+  width = 'min(90vw, 520px)',
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      isDismissable={!isBusy}
+      isKeyboardDismissDisabled={isBusy}
+      width={width}
+    >
+      <DialogHeader>{title}</DialogHeader>
+      <DialogBody>
+        <Flex direction="column" gap="3">
+          {children}
+          {error ? <Alert status="danger" description={error} /> : null}
+        </Flex>
+      </DialogBody>
+      <DialogFooter>
+        <Button
+          variant="secondary"
+          isDisabled={isBusy}
+          onClick={() => onOpenChange(false)}
+        >
+          {cancelLabel}
+        </Button>
+        <Button
+          variant="primary"
+          destructive={destructive}
+          isPending={isBusy}
+          onClick={onConfirm}
+        >
+          {isBusy ? (busyLabel ?? confirmLabel) : confirmLabel}
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/plugins/ui-react/src/components/ConfirmDialog/index.ts
+++ b/plugins/ui-react/src/components/ConfirmDialog/index.ts
@@ -1,0 +1,2 @@
+export { ConfirmDialog } from './ConfirmDialog';
+export type { ConfirmDialogProps } from './ConfirmDialog';

--- a/plugins/ui-react/src/components/index.ts
+++ b/plugins/ui-react/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './AsyncValue';
 export * from './Autocomplete';
 export * from './CodeBlock';
 export * from './ConditionsList';
+export * from './ConfirmDialog';
 export * from './ContentRow';
 export * from './DateComponent';
 export * from './DetailsPane';


### PR DESCRIPTION
### What does this PR do?

Adds the companion delete to agent creation. The agent details page's kebab menu
gains **Delete agent…**, which removes the agent's `HelmRelease` — the object that
owns its existence, since helm-controller would otherwise just re-render the `Agent`
CR. Deleting it makes helm-controller uninstall the release and take the agent with
it. The owner is resolved from the Flux provenance labels rather than by assuming the
release is named after the agent, so this also works for agents created outside the
wizard.

**The delete is only offered to users who may perform it.** A
`SelfSubjectAccessReview` for `delete` on that named `HelmRelease` in its namespace
runs before the menu item renders, and the item is withheld while the review is still
in flight, so it never appears and then disappears. The review decides what is
_shown_; authorization stays the apiserver's, since the Kubernetes proxy forwards the
user's own OIDC token — a bypassed menu item still gets a real 403, surfaced in the
dialog. Two further conditions hide it: no resolvable owner (an `Agent` applied by
hand has no release to delete), and a release applied by a Kustomization, whose
desired state is in Git and which would be recreated on the next reconciliation.

**The namespace's shared `OCIRepository` is removed only when provably unused.**
Every agent in a namespace shares one `agent` chart source, so the `HelmRelease`s in
the source's namespace are listed first, and any other release referencing the same
object keeps it. A failed list read keeps it too — an empty list because the read
failed is not the same answer as an empty list because nothing references it. A
failure to delete the source is swallowed: the agent is gone, which is what was asked
for, and an unreferenced chart source is inert and re-applied identically by the next
agent creation. That is also why the permission gate does not require `delete` on
`ocirepositories` — requiring it would hide the action from users whose real deletion
would succeed.

Two new shared primitives, both firsts for this repo:

- **`ConfirmDialog` in `ui-react`** — the first reusable modal. Controlled rather than
  wrapping a `DialogTrigger`, which is the only thing that works when the trigger is a
  `MenuItem` (react-aria unmounts the menu on selection, taking any trigger inside it
  along). Confirming deliberately does **not** close it: an action that can fail needs
  somewhere to report that, and a dialog that dismisses itself on confirm has thrown
  away the only place the user was still looking. While busy it is undismissable, so a
  stray click or Escape cannot orphan an in-flight request.
- **`deleteResource` in `kubernetes-react`** — the first Kubernetes `DELETE` in the
  app. Same proxy, same trailing-slash stripping, same `ForbiddenError`/`NotFoundError`
  naming as `patchResource`, so an idempotent caller can treat a 404 as success. The
  details both verbs need moved into a shared `k8sMutation` module;
  `BACKSTAGE_FIELD_MANAGER` keeps its existing import path.

### What is the effect of this change to users?

An agent can be deleted from its details page, by users whose cluster RBAC allows it.
On success they land back on the agents list with a toast that says "Deleting", not
"Deleted": the `HelmRelease` has a finalizer, so all that is certain is that the
apiserver accepted the request, and the agent can still be in the list for a few
seconds. On failure the dialog stays open with the message inline, and no toast —
the user is still looking at the modal they pressed Delete in.

The confirmation modal says exactly one thing, because it is the only thing the
person clicking cannot work out for themselves:

> This ends any session currently running with this agent — including sessions started
> by other people, which are not shown to you.

kagent scopes its session list to the caller, so a quiet sessions list is not evidence
that an agent is idle. Everything mechanical is deliberately kept out of the modal
(which `HelmRelease` goes, what happens to the shared chart source, that a _suspended_
release is not uninstalled at all) — true, and all of it noise at the moment of
deciding. It is documented in `docs/agent-platform.md` instead.

Toasts use `toastApiRef` from `@backstage/frontend-plugin-api` rather than the
deprecated `alertApi`, which now emits a runtime deprecation warning and is scheduled
for removal upstream.

### How does it look like?

The kebab on the agent details page, and the confirmation:

```
Delete agent "Issue Tracker"?

This ends any session currently running with this agent — including sessions
started by other people, which are not shown to you.

                                          [ Cancel ]  [ Delete agent ]
```

### Any background context you can provide?

The constraint that shaped this is documented in `docs/agent-platform.md` under
"Shared OCIRepository per namespace": one shared `OCIRepository/agent` per namespace,
many `HelmRelease`s. `AgentActionsMenu`'s docstring previously named this as the
reason no delete existed yet.

Two things worth knowing for review:

- **A bug only the running app caught.** `AgentActionsMenu` is rendered into the shared
  plugin header via `useProvidePageHeaderActions`, which is **outside** the plugin's
  `QueryClientProvider` — so calling a react-query hook there throws "No QueryClient
  set" and takes the page down. The page now calls `useDeleteAgent` and passes the
  result down as a prop. Deliberately _not_ fixed by wrapping the actions element in a
  second provider: that component builds a `new QueryClient` per mount, so the delete
  would have got a private cache and its invalidations would never have reached the
  page's reads. There is now a regression test that renders the menu with no client in
  scope.
- **Sessions survive.** An earlier draft of the modal claimed deleting an agent made
  its session history unreachable. It does not: sessions live in kagent's own store
  keyed by `user_id`, not in the `Agent` CR, and both the list and a session's detail
  are fetched by session id — `toSessionRow`'s `decodeAgentIdLabel` fallback exists
  precisely to label a session whose `Agent` is gone. Nor is a re-created agent a clean
  slate, since `agent_id` is derived from `namespace/name` alone. Both claims were
  removed.

Verified end-to-end against a real installation, including that the shared
`OCIRepository` is correctly kept when other agents in the namespace still use it.

### Do the docs need to be updated?

Yes, done in this PR — `docs/agent-platform.md` gains a "Deleting an agent" section,
and the passages that described deletion as future work were rewritten.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
