### PR TITLE
chore(renovate): hold @assistant-ui/react-ai-sdk below 1.3.41

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -34,9 +34,11 @@
       // The ai@6 -> ai@7 migration is now PARTIAL: the backend
       // (ai-chat-backend + its @ai-sdk/* providers, gs-node, muster-backend)
       // moved to ai@7 / provider@4 / @ai-sdk/mcp@2, but the FRONTEND
-      // (plugins/ai-chat) is still on ai@6 because @assistant-ui/react-ai-sdk
-      // has no ai@7 release yet (its latest still peer-requires ai@^6 /
-      // @ai-sdk/react@^3). The two `ai` majors coexist because root
+      // (plugins/ai-chat) is still on ai@6, held there deliberately by root
+      // package.json's `resolutions` pin of @assistant-ui/core to 0.2.21 (see
+      // the @assistant-ui/react-ai-sdk hold below -- assistant-ui itself
+      // shipped ai@7 support starting at react-ai-sdk@1.3.41, but bumping it
+      // alone breaks the build). The two `ai` majors coexist because root
       // package.json pins ONLY the backend to 7.x via a scoped `resolutions`
       // override (`.../ai-chat-backend/ai`); there is deliberately no unscoped
       // `ai` resolution, since an unscoped pin overrides scoped ones in Yarn 4
@@ -50,8 +52,9 @@
       // while the stack is split across two majors would let Renovate propose
       // exactly the uncoordinated major bump #1926 hit. Do the next major
       // (ai@7 -> ai@8, providers@4 -> @5) deliberately in one reviewed PR --
-      // ideally once assistant-ui ships ai@7 support so the frontend can move
-      // too -- then revisit lifting this rule. Minor/patch updates still flow.
+      // together with the deferred frontend ai@6 -> ai@7 move (see the
+      // @assistant-ui/react-ai-sdk hold below) -- then revisit lifting this
+      // rule. Minor/patch updates still flow.
       matchPackageNames: ['ai', '@ai-sdk{/,}**'],
       matchUpdateTypes: ['major'],
       enabled: false,
@@ -59,6 +62,22 @@
     {
       groupName: 'assistant-ui packages',
       matchPackageNames: ['@assistant-ui{/,}**'],
+    },
+    {
+      // Hold @assistant-ui/react-ai-sdk below 1.3.41: starting at that
+      // version it switched its own `ai` dependency from ^6 to ^7 (and by
+      // 1.4.x requires @assistant-ui/core@^0.3.4), while root package.json's
+      // `resolutions` pins @assistant-ui/core to exact 0.2.21 to keep the
+      // frontend (plugins/ai-chat, which itself pins `ai@^6.0.176`) on the
+      // ai@6-compatible line. A caret range let Renovate's PR #2021 resolve
+      // this to 1.4.4 and break the app build with "'createRuntimeExtras' is
+      // not exported from '@assistant-ui/core/react'" (node-build job).
+      //
+      // Lift this together with the `ai`/`@ai-sdk` major-hold above, in one
+      // deliberate PR that also bumps @assistant-ui/core, @assistant-ui/store,
+      // ai, @ai-sdk/react, and @ai-sdk/mcp for the frontend to ai@7.
+      matchPackageNames: ['@assistant-ui/react-ai-sdk'],
+      allowedVersions: '<1.3.41',
     },
     {
       groupName: 'backstage packages',


### PR DESCRIPTION
### What does this PR do?

Adds a Renovate hold on `@assistant-ui/react-ai-sdk`, capping it below `1.3.41`.

Starting at `1.3.41`, `react-ai-sdk` switched its own `ai` dependency from `^6` to `^7` (and by `1.4.x` requires `@assistant-ui/core@^0.3.4`), while root `package.json`'s `resolutions` field pins `@assistant-ui/core` to exact `0.2.21` to keep the frontend (`plugins/ai-chat`, pinned to `ai@^6.0.176`) on the ai@6-compatible assistant-ui line.

Because `plugins/ai-chat/package.json` pins `@assistant-ui/react-ai-sdk` with a caret range (`^1.3.1`), Renovate's #2021 (nominally "1.3.40 → 1.3.41") resolved the lockfile to `1.4.4` and broke the app build:

```
Attempted import error: 'createRuntimeExtras' is not exported from '@assistant-ui/core/react'
```

(`ci/circleci: node-build` on #2021). Also refreshes the stale comment on the neighboring `ai`/`@ai-sdk` major-hold, which said assistant-ui had no ai@7 release yet — it now does, starting at this same version.

### What is the effect of this change to users?

None — this only changes which dependency bumps Renovate is allowed to propose. No app code changes.

### How does it look like?

N/A (Renovate config only).

### Any background context you can provide?

Closes/supersedes #2021, which fails CI for the reason described above. The deferred frontend ai@6 → ai@7 migration (see the `ai`/`@ai-sdk` hold's comment) should bump `ai`, `@ai-sdk/react`, `@ai-sdk/mcp`, `@assistant-ui/core`, `@assistant-ui/store`, and `@assistant-ui/react-ai-sdk` together in one deliberate, reviewed PR — that's when this hold should be lifted.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.