### PR TITLE
docs(skills): add MUI v4 icon name + synonym reference to ui skill

### DIFF
--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -21,6 +21,15 @@ between releases and it is **not** a full replacement for core-components yet.
 When unsure whether a bui component exists or what props it takes, check the
 Storybook source (see below) rather than guessing.
 
+### Picking an MUI v4 icon
+
+`references/mui-v4-icons.md` lists all 1,120 `@material-ui/icons` base names
+with search synonyms (e.g. `AccountBalance — bank building court money payment
+structure temple transaction`), generated from the installed package version
+merged with MUI's own docs-search synonym data. Grep it by concept when you
+need an icon name but don't know it (e.g. `grep -i wallet` finds
+`AccountBalanceWallet`) instead of guessing or opening the MUI v4 docs site.
+
 ## bui setup (already done)
 
 - The plugin's `package.json` must declare `"@backstage/ui": "backstage:^"`

--- a/.claude/skills/ui/references/mui-v4-icons.md
+++ b/.claude/skills/ui/references/mui-v4-icons.md
@@ -1,0 +1,1145 @@
+# MUI v4 icon reference (`@material-ui/icons` 4.11.3)
+
+Generated from the locally installed `@material-ui/icons` package (base icon
+names — the canonical import identifiers) merged with MUI's own search-synonym
+data (`docs/src/pages/components/material-icons/synonyms.js` on the
+`mui/material-ui` `v4.x` branch — only about 74% of icons have a synonyms
+entry; the rest are only searchable by name).
+
+Regenerate if `@material-ui/icons` is bumped: list
+`node_modules/@material-ui/icons/*.js` for the current base names, fetch
+https://raw.githubusercontent.com/mui/material-ui/v4.x/docs/src/pages/components/material-icons/synonyms.js,
+merge (strip the `Outlined|Rounded|Sharp|TwoTone` suffix to get the base name).
+
+Each base name ships up to 5 style variants (suffix the import name): `Filled`
+(no suffix), `Outlined`, `Rounded`, `Sharp`, `TwoTone` — e.g. `Delete`,
+`DeleteOutlined`, `DeleteRounded`. Not every icon has all 5; check
+`node_modules/@material-ui/icons/<Name><Suffix>.js` exists before importing a
+variant. Import as:
+```ts
+import DeleteIcon from '@material-ui/icons/Delete';
+```
+
+1120 base icons, 831 with synonyms.
+
+---
+AcUnit — freeze snowflake
+AccessAlarm — clock time
+AccessAlarms — clock time
+AccessTime — clock time
+Accessibility — accessible body help human person user
+AccessibilityNew — accessible arms body help human person user
+Accessible — accessibility body help human person user wheelchair
+AccessibleForward — accessibility body help human person wheelchair
+AccountBalance — bank building court money payment structure temple transaction
+AccountBalanceWallet — money payment transaction
+AccountBox — avatar person profile square thumbnail user
+AccountCircle — avatar person profile thumbnail user
+AccountTree — sitemap project
+Adb
+Add — create item new plus
+AddAPhoto — camera
+AddAlarm — clock plus time
+AddAlert — announcement bell callout information notification plus reminder
+AddBox — create new plus square
+AddCircle — create new plus
+AddCircleOutline — create new plus
+AddComment
+AddIcCall
+AddLocation — gps
+AddPhotoAlternate
+AddShoppingCart — checkout plus
+AddToHomeScreen
+AddToPhotos — plus
+AddToQueue — backlog display lineup monitor plus television watch
+Adjust — circle
+AirlineSeatFlat — bed sleep
+AirlineSeatFlatAngled — bed sleep
+AirlineSeatIndividualSuite — bed sleep
+AirlineSeatLegroomExtra
+AirlineSeatLegroomNormal
+AirlineSeatLegroomReduced
+AirlineSeatReclineExtra
+AirlineSeatReclineNormal
+AirplanemodeActive — flying
+AirplanemodeInactive — flying
+Airplay — apple arrow connect control device monitor screen signal television
+AirportShuttle — bus car vehicle
+Alarm — clock countdown time
+AlarmAdd — clock plus time
+AlarmOff — clock disabled stop time
+AlarmOn — checkmark clock enabled ready start time
+Album — artist cd music play record track vinyl
+AllInbox — delivery email letter post send
+AllInclusive — infinite
+AllOut — arrows circle directional expand shape
+AlternateEmail
+AmpStories
+Android — brand character logo mascot operating system toy
+Announcement — alert balloon bubble chat comment exclamation message news speech
+Apartment — building
+Apple — brand logo
+Apps — grid homescreen icons
+Archive
+ArrowBack — left
+ArrowBackIos — left
+ArrowDownward
+ArrowDropDown
+ArrowDropDownCircle
+ArrowDropUp
+ArrowForward
+ArrowForwardIos
+ArrowLeft
+ArrowRight
+ArrowRightAlt — pointing shape
+ArrowUpward — submit
+ArtTrack — display format insert
+AspectRatio — expand image monitor resolution scale screen size square
+Assessment — analytics bars chart graph measure metrics tracking report
+Assignment — article clipboard document task text writing
+AssignmentInd — clipboard document person profile task user
+AssignmentLate — alert announcement clipboard exclamation task
+AssignmentReturn — arrow clipboard left point task
+AssignmentReturned — arrow clipboard down point task
+AssignmentTurnedIn — checkmark clipboard complete done finished task
+Assistant — chat comment star
+AssistantPhoto
+Atm
+AttachFile — item paperclip
+AttachMoney — cash currency dollar finance price profit sale
+Attachment — file item paperclip
+Audiotrack — note
+Autorenew — arrows cached inprogress loader loading refresh rotate
+AvTimer — clock countdown minutes seconds stopwatch
+Backspace — clear delete remove
+Backup — arrow cloud point submit upload
+Ballot
+BarChart — anlytics graph
+Bathtub — clean shower
+Battery20
+Battery30
+Battery50
+Battery60
+Battery80
+Battery90
+BatteryAlert — exclamation
+BatteryCharging20
+BatteryCharging30
+BatteryCharging50
+BatteryCharging60
+BatteryCharging80
+BatteryCharging90
+BatteryChargingFull — lightning
+BatteryFull
+BatteryStd
+BatteryUnknown — question
+BeachAccess — parasol sun umbrella
+Beenhere — checkmark
+Block — allowed banned cancel disable not
+Bluetooth — network wireless
+BluetoothAudio
+BluetoothConnected — network wireless
+BluetoothDisabled — network wireless
+BluetoothSearching — network wireless
+BlurCircular — circle
+BlurLinear
+BlurOff
+BlurOn
+Book — bookmark reading blog
+Bookmark — favorite remember save
+BookmarkBorder — favorite outline remember save
+Bookmarks — remember save
+BorderAll
+BorderBottom
+BorderClear
+BorderColor — create marker pencil
+BorderHorizontal
+BorderInner
+BorderLeft
+BorderOuter
+BorderRight
+BorderStyle
+BorderTop
+BorderVertical
+BrandingWatermark — emblem format identity logo stamp
+Brightness1
+Brightness2 — moon night
+Brightness3 — moon night
+Brightness4 — dark moon night sun
+Brightness5 — sun
+Brightness6 — sun
+Brightness7 — sun light
+BrightnessAuto
+BrightnessHigh
+BrightnessLow
+BrightnessMedium
+BrokenImage — picture
+Brush — paint
+BubbleChart — analytics graph
+BugReport — animal file insect issue ticket
+Build — spanner tool wrench
+BurstMode — image picture
+Business — address apartment building company flat office structure
+BusinessCenter — briefcase suitcase
+Cached — arrows inprogress loader loading refresh reload renew rotate
+Cake — birthday pie
+CalendarToday — date event month remember reminder week
+CalendarViewDay — month remember reminder today week
+Call — device mobile phone talk
+CallEnd — device mobile phone talk
+CallMade — arrow device mobile
+CallMerge — arrow device mobile
+CallMissed — arrow device mobile
+CallMissedOutgoing — arrow device mobile
+CallReceived — arrow device mobile
+CallSplit — arrow device mobile
+CallToAction — alert bar cta information message notification
+Camera
+CameraAlt
+CameraEnhance — lens photo picture quality
+CameraFront
+CameraRear
+CameraRoll
+Cancel — close cross disable
+CancelPresentation — close device screen share x
+CancelScheduleSend
+CardGiftcard — certificate creditcard present
+CardMembership — certificate creditcard subscription
+CardTravel — creditcard membership miles trip
+Casino — dice
+Cast — chromecast
+CastConnected — chromecast
+CastForEducation
+Category
+CellWifi
+CenterFocusStrong
+CenterFocusWeak
+ChangeHistory — shape triangle
+Chat — bubble comment message speech talk text
+ChatBubble — comment message speech talk text
+ChatBubbleOutline — comment message speech talk text
+Check — checkmark success tick
+CheckBox — checkmark square success tick
+CheckBoxOutlineBlank — checkmark square tick
+CheckCircle — checkmark complete done finished success tick
+CheckCircleOutline — checkmark complete done finished success tick
+ChevronLeft — arrow
+ChevronRight — arrow
+ChildCare — baby
+ChildFriendly — baby
+ChromeReaderMode — text
+Class — category item
+Clear — allowed cancel cross disable not times x
+ClearAll — delete document erase format lines list notifications wipe
+Close — allowed cancel cross disable not times x
+ClosedCaption — accessible decoder language subtitles
+Cloud — weather
+CloudCircle
+CloudDone — checkmark
+CloudDownload
+CloudOff
+CloudQueue
+CloudUpload
+Code — brackets css developer engineering html parenthesis platform
+Collections
+CollectionsBookmark
+ColorLens
+Colorize — color picker pipette
+Comment — bubble chat document message note
+Commute — car train transportation vehicle
+Compare
+CompareArrows — directional facing pointing
+CompassCalibration
+Computer — laptop monitor pc
+ConfirmationNumber — ticket
+ContactMail — address information person profile user
+ContactPhone — information number person profile user
+ContactSupport — alert announcement bubble help information mark question speech
+Contactless — applepay tap wifi
+Contacts — address information number person phone profile user
+ControlCamera — adjust arrows direction left move right
+ControlPoint — circle plus
+ControlPointDuplicate — circle plus
+Copyright — emblem symbol
+Create — item new pencil write
+CreateNewFolder — directory
+CreditCard — charge creditcard finance information money payment price
+Crop
+Crop169 — image picture square
+Crop32 — image picture square
+Crop54 — image picture square
+Crop75 — image picture square
+CropDin — image picture square
+CropFree — barcode qrcode square
+CropLandscape — image picture square
+CropOriginal — image picture square
+CropPortrait — image picture square
+CropRotate
+CropSquare
+Dashboard — cards rectangle shapes square
+DataUsage — circle
+DateRange — agenda calendar event month remember reminder today week
+Deck — furniture garden patio
+Dehaze
+Delete — bin garbage junk recycle remove trashcan
+DeleteForever — bin garbage junk recycle remove trashcan x
+DeleteOutline — can garbage remove trash
+DeleteSweep — bin junk recycle trashcan
+DepartureBoard
+Description — article bill document file invoice item text writing
+DesktopAccessDisabled — apple device monitor off pc screen
+DesktopMac — apple monitor pc
+DesktopWindows — monitor pc
+Details — triangle
+DeveloperBoard — devkit
+DeveloperMode — code
+DeviceHub
+DeviceUnknown
+Devices — laptop mobile phone
+DevicesOther — smartwatch
+DialerSip — call internet phone protocol routing
+Dialpad — call device dots numbers phone
+Directions — arrow naviate
+DirectionsBike — bicycle
+DirectionsBoat
+DirectionsBus
+DirectionsCar
+DirectionsRailway
+DirectionsRun — health person
+DirectionsSubway
+DirectionsTransit — metro subway
+DirectionsWalk — person
+DiscFull — cd exclamation vinyl
+Dns — address bars domain information ip list lookup name network server
+Dock — charger
+Domain — building
+DomainDisabled — building internet off website
+Done — checkmark complete finished success tick
+DoneAll — checkmark complete finished multiple success tick
+DoneOutline — checkmark complete finished success tick
+DonutLarge — chart circle complete graph inprogress,
+DonutSmall — chart circle
+DoubleArrow — chevron right
+Drafts — email envelope letter
+DragHandle — lines
+DragIndicator — circle dots drop move shape shift
+DriveEta — car transport vehicle
+Duo — call chat conference device video
+Dvr — laptop monitor
+DynamicFeed — live refresh update
+Eco — environment green leaf
+Edit
+EditAttributes
+EditLocation — gps map pin write
+Eject — arrow player remove triangle up
+Email — envelope letter message note post receive send write
+EmojiEmotions — emoticon face happy like smiley
+EmojiEvents
+EmojiFlags
+EmojiFoodBeverage — cup dring mug tea
+EmojiNature — bee flower honey
+EmojiObjects — lamp lightbulb
+EmojiPeople — man person wave waving
+EmojiSymbols — ampersand music note percent
+EmojiTransportation — building car commute company office vehicle
+EnhancedEncryption — lock security
+Equalizer — adjustment chart graph noise sound static volume
+Error — alert announcement circle danger exclamation feedback problem warning
+ErrorOutline — alert announcement circle danger exclamation feedback problem warning
+Euro — cash currency finance money price profit
+EuroSymbol — cash currency dollar finance money price profit
+EvStation — car charge filling fuel gasoline power station vehicle
+Event — agenda calendar date item mark month range remember reminder today week
+EventAvailable — agenda calendar date item
+EventBusy — agenda calendar date item
+EventNote — agenda calendar date item
+EventSeat — assigned bench chair reservation row section sit
+ExitToApp — arrow back leave login logout pointing quit right signin signup register signout
+ExpandLess — arrow up
+ExpandMore — arrow down
+Explicit — adult content language
+Explore — compass destination location map needle travel
+ExploreOff — compass destination disabled location map needle travel
+Exposure — minus plus
+ExposureNeg1 — minus
+ExposureNeg2 — minus
+ExposurePlus1 — like plus
+ExposurePlus2 — plus
+ExposureZero
+Extension — extended item jigsaw piece puzzle shape add-ons
+Face — avatar eyes human person profile thumbnail user
+Facebook — brand logo social
+FastForward — control music speed time video
+FastRewind — control music speed time video
+Fastfood — burger drink
+Favorite — health heart like love remember save shape success
+FavoriteBorder — health heart like love remember save shape success
+FeaturedPlayList — audio collection highlighted item music playlist recommended
+FeaturedVideo — highlighted item play recommended watch,advertised
+Feedback — alert announcement bubble chat comment exclamation message speech
+FiberDvr — digital electronics network recorder tv video
+FiberManualRecord — circle dot play watch
+FiberNew — network
+FiberPin — network
+FiberSmartRecord — play watch
+FileCopy — bill invoice item page duplicate clone
+Filter
+Filter1
+Filter2
+Filter3
+Filter4
+Filter5
+Filter6
+Filter7
+Filter8
+Filter9
+Filter9Plus
+FilterBAndW
+FilterCenterFocus
+FilterDrama — cloud
+FilterFrames
+FilterHdr — mountains
+FilterList — lines
+FilterNone
+FilterTiltShift
+FilterVintage — flower
+FindInPage — document glass look magnifying paper search see
+FindReplace — arrows glass inprogress look magnifying refresh rotate search see
+Fingerprint — biometrics identification identity reader thumbprint touchid
+Fireplace — flame
+FirstPage — arrow
+FitnessCenter — health weights workout
+Flag
+Flare — bright lensflare light shine sparkle star sun
+FlashAuto — lightning
+FlashOff — lightning
+FlashOn — lightning
+Flight — airplane flying
+FlightLand — airplane arrival arriving flying landing transportation travel
+FlightTakeoff — airplane departed departing flying landing transportation travel
+Flip
+FlipCameraAndroid — front rear reverse
+FlipCameraIos — front rear reverse
+FlipToBack — arrangement front move order sort
+FlipToFront — arrangement back move order sort
+Folder — directory
+FolderOpen — directory
+FolderShared — directory
+FolderSpecial — directory
+FontDownload — letter square
+FormatAlignCenter — lines
+FormatAlignJustify — lines
+FormatAlignLeft — lines
+FormatAlignRight — lines
+FormatBold
+FormatClear
+FormatColorFill — bucket
+FormatColorReset — drop liquid water
+FormatColorText
+FormatIndentDecrease
+FormatIndentIncrease
+FormatItalic
+FormatLineSpacing
+FormatListBulleted — task todo
+FormatListNumbered — task todo
+FormatListNumberedRtl — task todo
+FormatPaint — paintroller
+FormatQuote — quotation
+FormatShapes
+FormatSize
+FormatStrikethrough
+FormatTextdirectionLToR — paragraph
+FormatTextdirectionRToL — paragraph
+FormatUnderlined
+Forum — bubble chat community conversation hub messages speech talk
+Forward — arrow
+Forward10 — arrow circle control fast music rotate speed time video
+Forward30 — arrow circle control fast music rotate speed time video
+Forward5 — arrow circle control fast music rotate speed time video
+FourK — 4000 display pixels resolution
+FreeBreakfast — coffee drink tea
+Fullscreen
+FullscreenExit
+Functions — math sigma
+GTranslate — emblem google language logo mark speaking speech translator words
+Gamepad
+Games — adjust arrows controller direction dpad left move nintendo playstation right xbox
+Gavel — court document government hammer judge law mallet official police rules
+Gesture — drawing line
+GetApp — arrow download pointing retrieve
+Gif — animated animation bitmap format graphics interchange
+GitHub — brand code
+GolfCourse — flag
+GpsFixed — location
+GpsNotFixed
+GpsOff
+Grade — likes rated rating shape star
+Gradient
+Grain
+GraphicEq — audio equalizer
+GridOff
+GridOn — sheet
+Group — people person team users
+GroupAdd — people person users
+GroupWork — alliance circle collaboration film partnership reel teamwork together
+Hd — definition high movies resolution tv
+HdrOff
+HdrOn
+HdrStrong
+HdrWeak
+Headset — earmuffs headphones
+HeadsetMic — headphones
+Healing — bandaid health
+Hearing — accessibility accessible impaired listen sound
+Height — arrows down resize stretch up
+Help — alert announcement information mark question support
+HelpOutline — alert announcement information mark question support
+HighQuality — definition hq movies resolution tv
+Highlight — flashlight marker
+HighlightOff — circle clear click close delete disable focus remove stop target times x
+History — arrow backwards clock refresh reverse revert rotate time undo
+Home — address building house place residence structure unit
+HomeWork — building house office
+HorizontalSplit — bars stacked
+HotTub — jacuzzi
+Hotel — bed sleep
+HourglassEmpty — countdown loading minutes start time waiting
+HourglassFull — countdown loading minutes time waiting
+House
+HowToReg
+HowToVote
+Http — internet network transfer url website
+Https — connection encrypt internet key locked network secure security ssl web
+Image — picture
+ImageAspectRatio
+ImageSearch
+ImportContacts — address book friends information magazine open
+ImportExport — arrows direction down explort up
+ImportantDevices — cell computer monitor phone star
+Inbox
+IndeterminateCheckBox — minus square
+Info — about alert announcement bubble circle information
+Input — arrow box right
+InsertChart — barchart graph
+InsertChartOutlined
+InsertComment — chat message
+InsertDriveFile — bill document invoice item
+InsertEmoticon — emoji face happy like smiley
+InsertInvitation — agenda calendar
+InsertLink — anchor
+InsertPhoto — image wallpaper
+Instagram — brand logo social
+InvertColors — droplet hue inverted liquid palette tone water
+InvertColorsOff — droplet hue inverted liquid opacity palette tone water
+Iso
+Keyboard
+KeyboardArrowDown — chevron open
+KeyboardArrowLeft — chevron
+KeyboardArrowRight — chevron open start
+KeyboardArrowUp — chevron submit
+KeyboardBackspace — left
+KeyboardCapslock — arrow
+KeyboardHide
+KeyboardReturn — arrow
+KeyboardTab — arrow
+KeyboardVoice
+KingBed — double hotel sleep
+Kitchen — cabinet food freezer refrigerator
+Label — badge indent item stamp sticker tag
+LabelImportant — badge important. indent item mail stamp sticker tag wing
+LabelOff — indent stamp sticker tag
+Landscape
+Language — earth globe i18n l10n planet website world www country
+Laptop
+LaptopChromebook
+LaptopMac — apple
+LaptopWindows
+LastPage — arrow
+Launch — arrow box new open window
+Layers
+LayersClear
+LeakAdd
+LeakRemove
+Lens
+LibraryAdd — collection plus
+LibraryAddCheck
+LibraryBooks — add collection
+LibraryMusic — add collection song
+LineStyle — dash dotted editor rule spacing
+LineWeight — editor height spacing style thickness
+LinearScale
+Link — anchor
+LinkOff — anchor
+LinkedCamera
+LinkedIn — brand logo social
+List — editor file format index menu task todo
+ListAlt — box contained editor format lines reorder stacked task title todo sheet
+LiveHelp — alert announcement bubble comment faq information mark question support
+LiveTv — monitor television
+LocalActivity — star
+LocalAirport — airplane flying
+LocalAtm — cash currency dollar financial money price profit
+LocalBar — alcohol drink martini
+LocalCafe — coffee cup drink mug
+LocalCarWash
+LocalConvenienceStore — building
+LocalDining — cutlery knife spoon
+LocalDrink — glass water
+LocalFlorist — flower
+LocalGasStation — car filling fuel gasoline station vehicle
+LocalGroceryStore
+LocalHospital — aid doctor first health medical plus
+LocalHotel — bed sleep
+LocalLaundryService — clean
+LocalLibrary — book person
+LocalMall — bag shopping
+LocalMovies
+LocalOffer — price tag
+LocalParking
+LocalPharmacy — food
+LocalPhone
+LocalPizza
+LocalPlay
+LocalPostOffice
+LocalPrintshop
+LocalSee
+LocalShipping — car semi truck vehicle
+LocalTaxi — car vehicle
+LocationCity — building company
+LocationDisabled
+LocationOff — gps
+LocationOn — gps
+LocationSearching
+Lock — connection key locked logout padlock password secure security signout
+LockOpen — connection key login padlock password secure security signin signup register unlocked
+Looks — rainbow
+Looks3
+Looks4
+Looks5
+Looks6
+LooksOne
+LooksTwo
+Loop — arrows loader loading music refresh repeat rotate
+Loupe
+LowPriority — arrow list task todo
+Loyalty — badge card credit heart love membership miles points program sale tag travel trip
+Mail — envelope letter
+MailOutline — email envelope letter message note post receive send write
+Map
+Markunread — envelope letter
+MarkunreadMailbox — deliver envelop letter postal postbox receive send
+Maximize — line shape
+MeetingRoom — door logout signout
+Memory — chip
+Menu — hamburger
+MenuBook — page
+MenuOpen — chevron hamburger left
+MergeType — arrow
+Message — bubble chat comment speech talk text
+Mic — hearing microphone noise record sound voice
+MicNone — hearing microphone noise record sound voice
+MicOff — hearing microphone noise record sound voice
+Minimize — line shape
+MissedVideoCall — arrow record
+Mms — chat comment message
+MobileFriendly
+MobileOff
+MobileScreenShare — arrow device mirror monitor phone tv
+ModeComment — chat message
+MonetizationOn — cash currency dollar finance money price profit sale
+Money — cash currency finance price profit
+MoneyOff — cash currency dollar finance money price profit
+MonochromePhotos
+Mood — emoji emoticon face smiley
+MoodBad — emoji emoticon face smiley
+More — badge tag
+MoreHoriz — dots
+MoreVert — dots
+Motorcycle — bicycle moped motorbike ride riding transportation vehicle wheels
+Mouse
+MoveToInbox
+Movie — film screen show tv video watch
+MovieCreation — film video
+MovieFilter — film video
+MultilineChart — analytics graph line
+Museum
+MusicNote
+MusicOff
+MusicVideo — band recording screen tv watch
+MyLocation
+Nature — forest tree
+NaturePeople — forest person tree
+NavigateBefore — arrow
+NavigateNext — arrow
+Navigation — arrow
+NearMe — arrow
+NetworkCell
+NetworkCheck — wifi
+NetworkLocked — wifi
+NetworkWifi
+NewReleases — alert announcement burst exclamation star
+NextWeek — briefcase suitcase
+Nfc
+NightsStay — cloud moon
+NoEncryption — disabled lock security
+NoMeetingRoom — door
+NoSim — camera card device eject insert memory phone storage
+NotInterested — allowed banned circle disabled dislike interested not off prohibited x
+NotListedLocation — map pin questionmark
+Note — bookmark message paper
+NoteAdd — create document
+Notes
+NotificationImportant — alert announcement bell feedback problem
+Notifications — alert bell ring
+NotificationsActive — alert bell ring
+NotificationsNone — alert bell ring
+NotificationsOff — alert bell ring
+NotificationsPaused — aleet bell ring
+OfflineBolt — circle flash lightning spark
+OfflinePin — checkmark circle
+OndemandVideo — monitor television
+Opacity — color droplet hue inverted liquid palette tone water
+OpenInBrowser — arrow box new window
+OpenInNew — arrow box window
+OpenWith — arrows directional expand move
+OutdoorGrill — barbeque bbq
+OutlinedFlag
+Pages
+Pageview — document find glass magnifying paper search
+Palette — color
+PanTool — drag hand human move scan stop touch wait
+Panorama — image picture
+PanoramaFishEye
+PanoramaHorizontal
+PanoramaVertical
+PanoramaWideAngle
+PartyMode
+Pause — controls music video wait
+PauseCircleFilled — controls music video wait
+PauseCircleOutline — controls music video wait
+PausePresentation — device screen share wait
+Payment — charge creditcard financial information money price
+People — group person team users
+PeopleAlt — group person users
+PeopleOutline — group person team users
+PermCameraMic — microphone photo speaker
+PermContactCalendar — agenda human person profile user
+PermDataSetting — cellular configure information network settings wifi wireless
+PermDeviceInformation — alert announcement cell important mobile phone
+PermIdentity — human information person profile save, user
+PermMedia — collection directories folders images mountain save
+PermPhoneMsg — bubble chat message mobile recording save speech voice
+PermScanWifi — alert announcement information internet network service wireless
+Person — avatar profile user
+PersonAdd — user
+PersonAddDisabled — profile user
+PersonOutline — avatar profile user
+PersonPin — gps location
+PersonPinCircle — gps location
+PersonalVideo — monitor television
+Pets — animal cat claw dog hand paw
+Phone — call chat device mobile text
+PhoneAndroid — mobile
+PhoneBluetoothSpeaker
+PhoneCallback
+PhoneDisabled
+PhoneEnabled
+PhoneForwarded
+PhoneInTalk
+PhoneIphone — apple mobile
+PhoneLocked — security
+PhoneMissed
+PhonePaused — wait
+Phonelink
+PhonelinkErase — device mobile
+PhonelinkLock — device mobile security
+PhonelinkOff
+PhonelinkRing — device mobile
+PhonelinkSetup — device information mobile settings
+Photo
+PhotoAlbum — image picture
+PhotoCamera — image picture
+PhotoFilter
+PhotoLibrary — image picture
+PhotoSizeSelectActual
+PhotoSizeSelectLarge
+PhotoSizeSelectSmall
+PictureAsPdf
+PictureInPicture — cropped overlap photo shape
+PictureInPictureAlt — cropped overlap photo shape
+PieChart — analytics graph
+PinDrop — gps location
+Pinterest — brand logo social
+Place
+PlayArrow — controls music start video
+PlayCircleFilled — arrow controls music start video
+PlayCircleFilledWhite — start
+PlayCircleOutline — arrow controls music start video
+PlayForWork — arrow circle down google half
+PlaylistAdd — collection music plus task todo
+PlaylistAddCheck — checkmark collection music task tick todo
+PlaylistPlay — collection music
+PlusOne — add
+Policy — glass magnifying shield
+Poll — analytics barchart graph
+Polymer — emblem logo mark
+Pool — swimming water
+PortableWifiOff — connected connection device internet network service usage
+Portrait
+PostAdd — document item page plus
+Power — plug socket
+PowerInput — dc
+PowerOff
+PowerSettingsNew — information off save shutdown
+PregnantWoman — baby birth female human lady maternity person user
+PresentToAll — arrow
+Print — draft ink paper printer send
+PrintDisabled
+PriorityHigh — exclamation
+Public — earth globe world country language
+Publish — arrow submit upload
+QueryBuilder — clock hour minute save time
+QuestionAnswer — bubble chat comment conversation converse message speech talk
+Queue — add collection music playlist stream video
+QueueMusic — add collection playlist stream
+QueuePlayNext — add arrow collection device monitor music playlist plus screen video
+Radio — antenna device listen music player tune
+RadioButtonChecked — circle
+RadioButtonUnchecked — circle
+RateReview — chat comment message
+Receipt — bill credit invoice paper payment sale transaction
+RecentActors — cards carousel contacts human profile user
+RecordVoiceOver — human person profile recording sound speaking speech transcript user
+Reddit — brand logo social
+Redeem — certificate credit giftcard present
+Redo — arrow
+Refresh
+Remove — line minus subtract
+RemoveCircle — allowed banned disable not
+RemoveCircleOutline — allowed banned disable not
+RemoveFromQueue — collection device list monitor screen television
+RemoveRedEye
+RemoveShoppingCart — checkout
+Reorder — format lines list stacked
+Repeat — arrows controls music video
+RepeatOne — 1 arrows controls music video
+Replay — arrows controls music refresh reload repeat rewind undo video retry
+Replay10 — arrows controls music repeat rewind video
+Replay30 — arrows controls music repeat rewind video
+Replay5 — arrows controls music repeat rewind video
+Reply — arrow
+ReplyAll — arrows
+Report — exclamation
+ReportOff
+ReportProblem — alert announcement danger exclamation feedback triangle warning
+Restaurant — cutlery fork knife
+RestaurantMenu
+Restore — arrow backwards clock history refresh reverse rotate time undo
+RestoreFromTrash — arrow can delete garbage remove up
+RestorePage — arrow history paper refresh rotate undo web
+RingVolume — mobile phone
+Room — gps location map marker pin place spot
+RoomService — bell concierge
+Rotate90DegreesCcw — arrow
+RotateLeft — arrow circle refresh reload reset
+RotateRight — arrow circle
+RoundedCorner — shape square transform
+Router — device network
+Rowing — activity boat canoe human person sports water
+RssFeed — network wifi
+RvHookup
+Satellite
+Save — diskette floppy write
+SaveAlt — diskette floppy write
+Scanner — device
+ScatterPlot
+Schedule — calendar clock date mark save time
+School — college university
+Score
+ScreenLockLandscape — mobile phone security
+ScreenLockPortrait — mobile phone security
+ScreenLockRotation — mobile phone
+ScreenRotation — mobile phone
+ScreenShare — laptop monitor
+SdCard
+SdStorage — microsd
+Search — filter find glass look magnifying up
+Security — shield
+SelectAll
+Send — chat message telegram
+SentimentDissatisfied — emoji emoticon sad smiley
+SentimentSatisfied — emoji emoticon happy like smiley
+SentimentSatisfiedAlt
+SentimentVeryDissatisfied — emoji emoticon sad smiley unhappy
+SentimentVerySatisfied — emoji emoticon happy like smiley
+Settings — gear
+SettingsApplications — details gear information personal save service
+SettingsBackupRestore — arrow backwards history refresh reverse rotate time undo
+SettingsBluetooth — connection connectivity network wifi
+SettingsBrightness — dark light mode sun
+SettingsCell — cellphone device mobile
+SettingsEthernet — arrows brackets connection connectivity dots network parenthesis wifi
+SettingsInputAntenna — connection connectivity network wifi
+SettingsInputComponent — cable connection connectivity plugs points
+SettingsInputComposite — cable component connection connectivity plugs points
+SettingsInputHdmi — cable connection connectivity plugin points
+SettingsInputSvideo — connection connectivity plugin plugs points svideo,
+SettingsOverscan — arrows expand image photo picture
+SettingsPhone — cell device mobile
+SettingsPower — information off save shutdown
+SettingsRemote — bluetooth control wifi
+SettingsSystemDaydream — cloud
+SettingsVoice — microphone recorder speaker
+Share
+Shop — arrow briefcase buy cart google play purchase shopping
+ShopTwo — arrow briefcase buy cart google play purchase shopping
+ShoppingBasket — add buy cart purchase
+ShoppingCart — add buy checkout purchase
+ShortText — lines
+ShowChart — analytics graph line stock
+Shuffle — arrows controls music video
+ShutterSpeed
+SignalCellular0Bar
+SignalCellular1Bar
+SignalCellular2Bar
+SignalCellular3Bar
+SignalCellular4Bar — network
+SignalCellularAlt
+SignalCellularConnectedNoInternet0Bar — network
+SignalCellularConnectedNoInternet1Bar — network
+SignalCellularConnectedNoInternet2Bar — network
+SignalCellularConnectedNoInternet3Bar — network
+SignalCellularConnectedNoInternet4Bar — network
+SignalCellularNoSim — network
+SignalCellularNull — network
+SignalCellularOff — network
+SignalWifi0Bar — network
+SignalWifi1Bar — network
+SignalWifi1BarLock — network
+SignalWifi2Bar — network
+SignalWifi2BarLock — network
+SignalWifi3Bar — network
+SignalWifi3BarLock — network
+SignalWifi4Bar — network
+SignalWifi4BarLock — network
+SignalWifiOff — network
+SimCard — network
+SingleBed — hotel queen sleep
+SkipNext — arrow back controls music play previous video
+SkipPrevious — arrow controls forward music next play video
+Slideshow — presentation
+SlowMotionVideo — arrow circle controls music play time
+Smartphone — mobile
+SmokeFree — cigarette
+SmokingRooms — cigarette
+Sms — chat comment message
+SmsFailed — chat comment message
+Snooze — alarm clock set timer
+Sort — lines
+SortByAlpha — alphabetize letters list order organize
+Spa — flower
+SpaceBar
+Speaker — audio
+SpeakerGroup — audio
+SpeakerNotes — bubble cards chat comment format list message speech
+SpeakerNotesOff — bubble cards chat comment format list message speech
+SpeakerPhone — mobile
+Speed — clock dial measure
+Spellcheck — alphabet checkmark edit letter processor word write
+Sports — whistle
+SportsBaseball
+SportsBasketball
+SportsCricket
+SportsEsports — controller gamepad playstation xbox
+SportsFootball — american
+SportsGolf
+SportsHandball
+SportsHockey — ice
+SportsKabaddi — fighting judo martial
+SportsMma
+SportsMotorsports
+SportsRugby
+SportsSoccer — football
+SportsTennis
+SportsVolleyball
+SquareFoot
+Star — rating
+StarBorder — rating
+StarHalf — rating
+StarOutline
+StarRate
+Stars — circle favorite like love rate rating
+StayCurrentLandscape — mobile phone
+StayCurrentPortrait — mobile phone
+StayPrimaryLandscape — mobile phone
+StayPrimaryPortrait — mobile phone
+Stop — arrow controls music play square video
+StopScreenShare — laptop monitor
+Storage — database network server
+Store — building buy e-commerce purchase shop storefront
+StoreMallDirectory — building
+Storefront — merchant shop stall
+Straighten — piano
+Streetview — gps location map
+StrikethroughS
+Style
+SubdirectoryArrowLeft — arrow
+SubdirectoryArrowRight — arrow
+Subject — document email full justify lines list note text writing
+Subscriptions — enroll order playlist queue subscribe youtube
+Subtitles — accessibility accessible captions language translate
+Subway — metro
+SupervisedUserCircle — avatar human people person profile supervisor
+SupervisorAccount — administrator avatar human people person profile supervised user
+SurroundSound — audio circle speaker system volumn
+SwapCalls — arrow
+SwapHoriz — arrows back direction horizontal
+SwapHorizontalCircle — arrows back direction
+SwapVert — arrows back direction vertical
+SwapVerticalCircle — arrows back direction horizontal
+SwitchCamera
+SwitchVideo
+Sync — arrows refresh
+SyncAlt — arrows
+SyncDisabled — arrows refresh
+SyncProblem — arrows refresh
+SystemUpdate — arrow download
+SystemUpdateAlt — arrow download
+Tab
+TabUnselected
+TableChart
+Tablet
+TabletAndroid
+TabletMac — apple
+TagFaces
+TapAndPlay — nfc wifi
+Telegram — brand call chat logo messaging voice
+Terrain
+TextFields
+TextFormat — letter
+TextRotateUp — arrow field move
+TextRotateVertical — arrow field move verticle
+TextRotationAngledown — arrow field move rotate
+TextRotationAngleup — arrow field move rotate
+TextRotationDown — arrow field move rotate
+TextRotationNone — arrow field move rotate
+Textsms — chat comment message
+Texture
+Theaters — media movies photography showtimes video watch
+ThreeDRotation — arrows vr
+ThreeSixty
+ThumbDown — dislike favorite finger hand rate rating reject up vote
+ThumbDownAlt — dislike hand reject vote
+ThumbUp — approve dislike down favorite finger hand rate rating success vote
+ThumbUpAlt — approve hand like success vote
+ThumbsUpDown — dislike favorite finger hand rate rating vote
+TimeToLeave
+Timelapse
+Timeline — analytics chart graph history line movement points trending zigzap
+Timer — clock stopwatch wait
+Timer10
+Timer3
+TimerOff — clock stopwatch
+Title
+Toc — content format lines list reorder stacked table text titles
+Today — agenda calendar date event mark month range remember reminder week
+ToggleOff
+ToggleOn
+Toll — booth car circles payment ticket
+Tonality
+TouchApp — arrow finger gesture hand swipe
+Toys — fan
+TrackChanges — bullseye circle evolve lines movement radar rotate shift target
+Traffic — light
+Train
+Tram
+TransferWithinAStation — man person transit
+Transform
+TransitEnterexit
+Translate — alphabet language letter speaking speech text translator words
+TrendingDown — arrow change chart graph metric movement rate sale tracking
+TrendingFlat — arrow change chart graph metric movement rate tracking
+TrendingUp — arrow change chart graph metric movement rate tracking
+TripOrigin
+Tune — settings sliders
+TurnedIn — bookmark item remember save submit
+TurnedInNot — bookmark item outline remember save submit
+Tv — television
+TvOff
+Twitter — brand logo social
+TwoWheeler
+Unarchive — arrow
+Undo — arrow
+UnfoldLess — arrow
+UnfoldMore — arrow
+Unsubscribe
+Update — arrow backwards clock future history refresh reverse rotate time
+Usb
+VerifiedUser — audit certified checkmark security shield
+VerticalAlignBottom — arrow
+VerticalAlignCenter — arrow
+VerticalAlignTop — arrow
+VerticalSplit — format paragraph text website
+Vibration — mobile phone
+VideoCall — camera chat conference plus screen
+VideoLabel — device item screen
+VideoLibrary — collection
+Videocam — camera chat conference screen
+VideocamOff — camera chat conference screen
+VideogameAsset — controller gamepad nintendo playstation xbox
+ViewAgenda — blocks cards format website,stacked
+ViewArray — blocks format website
+ViewCarousel — banner blocks cards format images
+ViewColumn — blocks format grid vertical website
+ViewComfy — grid
+ViewCompact — grid
+ViewDay — blocks calendar cards carousel format week
+ViewHeadline — blocks format paragraph text website
+ViewList — blocks format lines reorder stacked title
+ViewModule — blocks format reorder squares stacked title
+ViewQuilt — blocks format reorder squares stacked title
+ViewStream — blocks format lines list reorder stacked title
+ViewWeek — bars blocks columns day format
+Vignette — effect photo
+Visibility — eye on password reveal see shown view visability preview
+VisibilityOff — eye hidden invisible on password reveal see show view visability
+VoiceChat — camera
+VoiceOverOff
+Voicemail
+VolumeDown — control sound
+VolumeMute — control sound
+VolumeOff — control sound
+VolumeUp — control sound
+VpnKey — login password security signin signup register
+VpnLock — earth globe password security world
+Wallpaper — image picture
+Warning — alert announcement danger error exclamation feedback problem triangle
+Watch — smartwatch
+WatchLater — clock hour minute time
+Waves
+WbAuto
+WbCloudy
+WbIncandescent — lamp lightbulb
+WbIridescent
+WbSunny — weather
+Wc — gender person toilet unisex gender
+Web — blocks browser internet screen website www
+WebAsset — browser download image internet screen video website www
+Weekend — chair couch seat
+WhatsApp — brand call chat logo messaging voice
+Whatshot — fire trending
+WhereToVote
+Widgets — blocks
+Wifi — network
+WifiLock — network
+WifiOff
+WifiTethering — network
+Work — briefcase job suitcase
+WorkOff — briefcase job suitcase
+WorkOutline — briefcase job suitcase
+WrapText — arrow
+YouTube — brand logo social video
+YoutubeSearchedFor — arrow backwards refresh restore reverse rotate
+ZoomIn — bigger glass grow magnifier magnifying plus scale size
+ZoomOut — glass magnifier magnifying minus negative scale size smaller
+ZoomOutMap — arrows


### PR DESCRIPTION
### What does this PR do?

Adds a reference file to the `ui` Claude Code skill listing all 1,120 `@material-ui/icons` (MUI v4) base icon names, each with the search synonyms MUI's own docs site uses (e.g. `AccountBalanceWallet — money payment transaction`). Lets an icon be looked up by name or concept (grep the file) instead of guessing or opening the live v4 docs site.

Generated by merging the actually-installed `@material-ui/icons@4.11.3` package's exported names with the synonym data from `docs/src/pages/components/material-icons/synonyms.js` on the `mui/material-ui` `v4.x` branch. Regeneration steps are documented in the file header.

### What is the effect of this change to users?

None — this only affects the `.claude/skills/` directory used by Claude Code, not application code.

### How does it look like?

N/A (skill reference file, no UI change).

### Any background context you can provide?

Came up while investigating MUI v4's icon set and search behavior; no existing skill had a reference for available icon names.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.