### PR TITLE
fix(telemetry): map Plans and Roadmap routes to named pages

### DIFF
--- a/packages/app/src/utils/telemetry.test.ts
+++ b/packages/app/src/utils/telemetry.test.ts
@@ -325,6 +325,50 @@ describe('getTelemetryPageViewPayload', () => {
     });
   });
 
+  it('should return correct payload for plans index page', () => {
+    const result = getTelemetryPageViewPayload('/plans');
+    expect(result).toEqual({
+      page: 'Plans index',
+      path: '/plans',
+    });
+  });
+
+  it('should return correct payload for one plan', () => {
+    // No `view`: the only varying segment is a pull request number, so echoing
+    // it would emit a page name per plan.
+    const result = getTelemetryPageViewPayload('/plans/pr/22');
+    expect(result).toEqual({
+      page: 'Plan detail',
+      path: '/plans/pr/22',
+    });
+  });
+
+  it('should return correct payload for roadmap index page', () => {
+    const result = getTelemetryPageViewPayload('/roadmap');
+    expect(result).toEqual({
+      page: 'Roadmap index',
+      path: '/roadmap',
+    });
+  });
+
+  it('should return correct payload for one roadmap item', () => {
+    const result = getTelemetryPageViewPayload('/roadmap/items/PVTI_abc123');
+    expect(result).toEqual({
+      page: 'Roadmap item',
+      path: '/roadmap/items/PVTI_abc123',
+    });
+  });
+
+  // Seen in Sentry: the item route is navigated to with an empty id while the
+  // board is still resolving. It must not fall through to 'Unknown page'.
+  it('should return correct payload for the item route with no id', () => {
+    const result = getTelemetryPageViewPayload('/roadmap/items/');
+    expect(result).toEqual({
+      page: 'Roadmap item',
+      path: '/roadmap/items/',
+    });
+  });
+
   it('should return correct payload for metrics page', () => {
     const result = getTelemetryPageViewPayload('/metrics');
     expect(result).toEqual({
@@ -389,6 +433,10 @@ describe('getTelemetryPageViewPayload', () => {
       '/agent-platform/agents/gazelle/agentic-platform/pr-reviewer',
       '/agent-platform/sessions',
       '/agent-platform/sessions/gazelle/abc123',
+      '/plans',
+      '/plans/pr/22',
+      '/roadmap',
+      '/roadmap/items/PVTI_abc123',
       '/metrics',
       '/search',
     ];

--- a/packages/app/src/utils/telemetry.ts
+++ b/packages/app/src/utils/telemetry.ts
@@ -179,6 +179,28 @@ export function getTelemetryPageViewPayload(pathname: string): {
       break;
     }
 
+    case pathname === '/plans':
+      payload = { page: 'Plans index' };
+      break;
+
+    // One plan: `/plans/pr/<number>`. Deliberately carries no `view`: the only
+    // varying segment is a pull request number, which would emit a distinct
+    // page name per plan — useless as a metric. The full path is reported
+    // separately as `path` either way.
+    case pathname.startsWith('/plans'):
+      payload = { page: 'Plan detail' };
+      break;
+
+    case pathname === '/roadmap':
+      payload = { page: 'Roadmap index' };
+      break;
+
+    // One roadmap item: `/roadmap/items/<id>`. No `view`, for the same reason
+    // as Plan detail — the varying segment is an opaque item id.
+    case pathname.startsWith('/roadmap'):
+      payload = { page: 'Roadmap item' };
+      break;
+
     case pathname === '/metrics':
       payload = { page: 'Metrics' };
       break;


### PR DESCRIPTION
### What does this PR do?

Adds cases for `/plans` and `/roadmap` to the `switch` in `getTelemetryPageViewPayload` (`packages/app/src/utils/telemetry.ts`).

Both plugins have exactly two routes each — an index and one detail sub-route (`/plans/pr/:number`, `/roadmap/items/:id`) — so each gets an exact-match case for the index and a prefix case for the detail view, following the existing pattern.

The detail cases deliberately carry no `view` attribute: the only varying segment is a pull request number or an opaque roadmap item id, so echoing it would emit a distinct page name per plan/item — useless as a metric. The full path is still reported separately as `path` either way.

### What is the effect of this change to users?

No user-facing change. It stops four recurring Sentry warnings that fired on every visit to the Plans and Roadmap pages.

### Any background context you can provide?

Fixes https://github.com/giantswarm/giantswarm/issues/37350

`/plans` and `/roadmap` are real, registered routes (not bot/scanner probes), so they fell through to `default: 'Unknown page'`, which `TelemetryDeckAnalyticsApi.captureEvent` reports to Sentry as `Untracked page view: <path>` on every single visit:

- [DEVPORTAL-FRONTEND-1T](https://giantswarm.sentry.io/issues/DEVPORTAL-FRONTEND-1T) — `/plans` (39 events)
- [DEVPORTAL-FRONTEND-1V](https://giantswarm.sentry.io/issues/DEVPORTAL-FRONTEND-1V) — `/plans/pr/22` (24 events)
- [DEVPORTAL-FRONTEND-1X](https://giantswarm.sentry.io/issues/DEVPORTAL-FRONTEND-1X) — `/roadmap` (20 events)
- [DEVPORTAL-FRONTEND-1Y](https://giantswarm.sentry.io/issues/DEVPORTAL-FRONTEND-1Y) — `/roadmap/items/` (14 events)

The four representative paths are added to the `knownTopLevelPaths` enumeration in `telemetry.test.ts`, so a future missing mapping fails CI instead of silently recurring in Sentry. `/roadmap/items/` (empty id, as seen in Sentry) gets its own explicit test.

`TelemetryDeckAnalyticsApi.test.tsx` needed no change — it exercises the reporting behaviour with synthetic paths, and that behaviour is unchanged.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added.

`packages/app` is private and not published via Changesets, so no changeset applies.