### PR TITLE
feat(agent-platform): delete a session from the details page

### DIFF
--- a/.changeset/agent-platform-delete-session.md
+++ b/.changeset/agent-platform-delete-session.md
@@ -1,0 +1,67 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+'@giantswarm/backstage-plugin-agent-platform-backend': minor
+---
+
+Add **Delete session…** to the session detail page's kebab menu. It calls kagent's
+`DELETE /api/sessions/:id` through the agent-platform proxy — the first write on the
+kagent REST side, so `agent-platform-backend` gains a `DELETE
+/kagent/sessions/:sessionId` route and its client a method parameter. Everything
+else about the transport is the reads' machinery reused: same installation
+resolution, same forwarded per-installation Dex token, same status mapping.
+
+**There is no permission gate, because there is nothing to ask.** Unlike the agent
+delete's `SelfSubjectAccessReview`, a session is not a Kubernetes object: kagent
+derives the acting user from the forwarded token alone, so the item is simply offered
+on any session that loaded. The route makes that token **required** for the same
+reason — without one, a controller running in `unsecure` mode would delete the shared
+default user's session on behalf of nobody in particular.
+
+**The dialog states both halves of what "deleted" means**, because an earlier draft
+of the copy could only have been wrong in one direction or the other. kagent's delete
+is soft (`UPDATE session SET deleted_at = NOW()`, with every read filtering
+`deleted_at IS NULL`), so the conversation is gone as far as anything in Backstage
+can see and there is no undo anywhere in this UI — but the record is not erased from
+kagent's store. On a deployment the `/me` probe reports as **not user-scoped**, the
+dialog adds a line saying the session may have been started by somebody else. That
+warns rather than withholding the action: kagent authorizes the call either way, and
+the person reading is the one who knows whose session it is.
+
+**A delete that matched nothing still answers 200.** kagent's statement is an
+`:exec`, so zero affected rows is not an error — a session that never existed, was
+already deleted, or belongs to another user all succeed silently. Nothing tries to
+detect that: a resolved promise means "kagent accepted this", and the refreshed list
+is what shows the truth a moment later. It also means there is no 404 path and no
+"already gone" case on the write side.
+
+**One non-obvious piece of cache handling.** The sessions list key is invalidated
+normally — it is shared with `useAgentSessions`, so the fleet list and the agent
+page's recent-sessions card both correct themselves. This session's own two reads are
+invalidated with `refetchType: 'none'`: the detail page is still mounted at that
+moment, so refetching would race the navigation with a request that now 404s and
+flash "Session not found" at someone who just deleted it deliberately. Marked stale
+without refetching, a later visit to the same URL revalidates and reaches the
+not-found state properly.
+
+The frontend client's write path also tolerates a body it does not need — a 2xx with
+an empty or non-JSON body is a success, since a future kagent answering 204 has still
+performed the delete — while still refusing an error reported in-band on a 200, the
+same rule the session readers already apply.
+
+**The kebab menu is given an explicit width, and that line is load-bearing.** bui
+leaves `.bui-MenuContent`'s width to its content above a `min-width: 150px` (its own
+`width` fallback is the string `"undefined"`, which the browser discards), and a
+`MenuItem` puts `gap: var(--bui-space-6)` — 24px — between label and trailing slot.
+"Delete session…" with its icon wants ~155px, just over the minimum, so the popover
+rendered at the natural width and then settled back to 150px. That second layout pass
+made react-aria's popover resize observer trip the browser's "ResizeObserver loop
+completed with undelivered notifications" — twice, on every open of the menu. Sentry
+filters that message by default and production has no error overlay, but the
+dev-server overlay covers the page with it, which makes the page miserable to work on.
+Sizing the menu up front means one layout pass and no warning. The agent kebab escapes
+this only because its items happen to measure just under 150px.
+
+Verified against the kagent source at both `v0.9.9` (what the fleet runs) and
+`v0.10.0-rc1`: the handler, the SQL and the 200-with-envelope response are identical
+in both. Deleting from a list row is deliberately not offered, since a destructive
+action on a row someone is scanning past is easy to hit by accident.

--- a/.changeset/agent-platform-delete-session.md
+++ b/.changeset/agent-platform-delete-session.md
@@ -35,8 +35,11 @@ is what shows the truth a moment later. It also means there is no 404 path and n
 "already gone" case on the write side.
 
 **One non-obvious piece of cache handling.** The sessions list key is invalidated
-normally — it is shared with `useAgentSessions`, so the fleet list and the agent
-page's recent-sessions card both correct themselves. This session's own two reads are
+normally, so the list the user lands back on is correct. That reaches the Sessions tab
+only — each tab's router mounts its own `QueryClientProvider`, so the agent page's
+recent-sessions card reads the same key from a different cache, and needs no help
+because a fresh client starts empty and these keys are never persisted. This
+session's own two reads are
 invalidated with `refetchType: 'none'`: the detail page is still mounted at that
 moment, so refetching would race the navigation with a request that now 404s and
 flash "Session not found" at someone who just deleted it deliberately. Marked stale

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -586,9 +586,13 @@ call either way, and the person reading is the one who knows whose session it is
 An unresolved probe claims nothing.
 
 **Cache handling has one non-obvious half.** The sessions list key
-(`['agent-platform', 'kagent', 'sessions', <installation>]`) is invalidated normally
-— it is shared with `useAgentSessions`, so the fleet list and the agent page's recent
-sessions card both correct themselves. This session's own two reads are invalidated
+(`['agent-platform', 'kagent', 'sessions', <installation>]`) is invalidated normally,
+so the list the user lands back on is correct. Note this reaches the Sessions tab
+only: `useAgentSessions` reads the same key for the agent page's recent-sessions
+card, but each tab's router mounts its own `QueryClientProvider` with a fresh
+`QueryClient`, so that is a different cache. It needs nothing — a fresh client starts
+empty and these keys are never persisted, so the card refetches when the Agents tab
+mounts. This session's own two reads are invalidated
 with **`refetchType: 'none'`**: the detail page is still mounted at that moment, so
 refetching would race the navigation with a request that now 404s and flash "Session
 not found" at someone who just deleted it deliberately. Stale-without-refetch leaves

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -233,7 +233,9 @@ the open TODOs.
 ## The Sessions tab
 
 `/agent-platform/sessions` lists the signed-in user's kagent chat sessions across
-the fleet. Read-only: no create, delete, rename, or detail view.
+the fleet. The list itself carries no actions: a session opens into its detail page,
+where it can be **deleted** (see "Deleting a session"), but nothing here creates or
+renames one.
 
 ### Why it needs a backend proxy
 
@@ -428,8 +430,9 @@ than active filtering today.
 stats strip, and the conversation. The installation is in the path because it is
 part of the session's identity — kagent ids are only unique within one.
 
-**Read-only.** kagent can rename, delete and continue a session, and the prototype
-offers all three. None are wired up, so this screen ships without a write path.
+A session can be **deleted** from the kebab menu (see "Deleting a session"). kagent
+can also rename and continue a session, and the prototype offers both — neither is
+wired up.
 
 ### Two reads, and why the events are ignored
 
@@ -541,6 +544,66 @@ rendered "Started 1 day ago · last activity 1 day ago" for a session that took
 three minutes, and printed "1 day ago" identically on every turn marker — hiding
 the progression the timeline exists to show. The list keeps the relative form,
 where scanning for recency is the point.
+
+### Deleting a session
+
+`useDeleteSession` + `SessionDeleteDialog`, offered as a `Delete session…` item in
+the kebab — the first write path on the kagent REST side, so
+`agent-platform-backend` grew a `DELETE /kagent/sessions/:sessionId` route and its
+client a method parameter to go with it. Everything about the transport is otherwise
+the reads' machinery reused: same installation resolution, same forwarded Dex token,
+same status mapping.
+
+**There is no permission check to make, which is why there is no gating.** Unlike
+the agent delete — three conditions and a `SelfSubjectAccessReview` — a session is
+not a Kubernetes object, and kagent derives the acting user from the forwarded token
+alone (`GetUserID` → `GetPrincipal`). There is nothing to ask in advance and nothing
+to withhold the affordance for, so the item is always offered on a session that
+loaded. The forwarded token is correspondingly **required** by the backend route:
+without one, a controller in `unsecure` mode would delete the shared default user's
+session on behalf of nobody.
+
+**kagent's delete is soft, and both halves of that matter.** The statement is
+`UPDATE session SET deleted_at = NOW() WHERE id = $1 AND user_id = $2 AND deleted_at
+IS NULL`, and every read filters `deleted_at IS NULL` — the session's row, events and
+tasks all survive on kagent's side while disappearing from every API response. So
+"deleted" is total as far as this UI is concerned and there is no undo anywhere in
+it, but it is not erasure, and the dialog says exactly that rather than picking one
+of the two and being wrong about the other.
+
+**A delete that changed nothing still answers 200.** The statement is an `:exec`, so
+zero affected rows is not an error: a session that never existed, was already
+deleted, or belongs to another user all succeed silently. Nothing here tries to
+detect that — a resolved promise means "kagent accepted this", and the invalidated
+list is what shows the truth a moment later. It also means there is no 404 path to
+handle on the write side, and no "already gone" case to special-case.
+
+**On a non-user-scoped deployment the dialog adds a line.** `isUserScoped === false`
+(from the `/me` probe — see "User scoping") means kagent ignores the forwarded
+identity and serves one shared user, so the session on screen may have been started
+by someone else. It warns rather than withholding the action: kagent authorizes the
+call either way, and the person reading is the one who knows whose session it is.
+An unresolved probe claims nothing.
+
+**Cache handling has one non-obvious half.** The sessions list key
+(`['agent-platform', 'kagent', 'sessions', <installation>]`) is invalidated normally
+— it is shared with `useAgentSessions`, so the fleet list and the agent page's recent
+sessions card both correct themselves. This session's own two reads are invalidated
+with **`refetchType: 'none'`**: the detail page is still mounted at that moment, so
+refetching would race the navigation with a request that now 404s and flash "Session
+not found" at someone who just deleted it deliberately. Stale-without-refetch leaves
+a later visit to the same URL to revalidate and land on the not-found state properly.
+
+On success the user goes back to the sessions list with a toast that says
+**"deleted"**, in the past tense — unlike the agent's "Deleting", because kagent's
+delete is synchronous and nothing is still settling behind it. On failure the dialog
+stays open and shows the message, with no toast, since the user is still looking at
+the modal. The confirmation itself is `ConfirmDialog` from `ui-react`, the same
+component the agent delete uses.
+
+Verified against the kagent source at both `v0.9.9` (what the fleet runs) and
+`v0.10.0-rc1`: the handler, the SQL and the 200-with-envelope response are identical
+in both.
 
 ## The agent detail page
 
@@ -845,10 +908,11 @@ above). What remains is a separate, deeper concern:
   form driven from an existing agent, plus a decision about whether that produces
   a live apply or a PR (GitOps-managed agents are read-only, see "GitOps
   provenance"). "Launch session" also has no write path today.
-- **Session management + detail.** The Sessions tab is read-only. kagent supports
-  deleting (soft) and renaming sessions, and exposes a session's events and A2A
-  tasks — enough for a detail view. Deliberately deferred: rename in particular
-  deviates from the prototype, where sessions are never user-named.
+- **Renaming and continuing a session.** The detail view and delete exist (see
+  "Deleting a session"); kagent's `PUT /api/sessions/:id` and its chat endpoint have
+  no UI. Rename in particular deviates from the prototype, where sessions are never
+  user-named. Deleting from a list row is also unimplemented — deliberately, since a
+  destructive action on a row someone is scanning past is easy to hit by accident.
 - **Landing page.** The section still opens on the Agents tab. Whether the
   platform wants a proper landing page above the tabs — fleet health, recent
   activity — is an open product question, not a gap in the tabs themselves.

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -366,6 +366,20 @@ describe('KagentClient', () => {
       expect(result).toEqual(body);
     });
 
+    it('treats a 204 as an empty success, not a sign-in page', async () => {
+      // kagent returns 200 with its envelope today. If a version ever answered 204,
+      // the deletion has *happened* — and without this the missing content-type
+      // hits the sign-in-page guard, so the frontend would keep the confirmation
+      // dialog open reporting an auth failure for a session that is already gone.
+      const fetchFn = jest
+        .fn()
+        .mockResolvedValue(new Response(null, { status: 204 }));
+
+      await expect(
+        build(fetchFn).deleteSession('abc', { userToken: 't' }),
+      ).resolves.toBeUndefined();
+    });
+
     it('reports an absent route as a version problem', async () => {
       // Defensive only — the route has existed since v0.9.x — but the plain-text
       // 404 must not read as "that session is gone", which is exactly the outcome a

--- a/plugins/agent-platform-backend/src/KagentClient.test.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.test.ts
@@ -298,6 +298,94 @@ describe('KagentClient', () => {
     });
   });
 
+  describe('session delete', () => {
+    it('sends a DELETE to the session path, with the forwarded token', async () => {
+      const fetchFn = jest.fn().mockResolvedValue(
+        jsonResponse({
+          error: false,
+          data: {},
+          message: 'Session deleted successfully',
+        }),
+      );
+
+      await build(fetchFn).deleteSession('abc123', {
+        userToken: 'user-token',
+      });
+
+      const [url, init] = fetchFn.mock.calls[0];
+      // No `limit` here: unlike the read, nothing comes back that needs trimming.
+      expect(url).toBe('https://kagent.gazelle.example.io/api/sessions/abc123');
+      expect(init.method).toBe('DELETE');
+      expect(init.headers).toEqual({
+        Accept: 'application/json',
+        Authorization: 'Bearer user-token',
+      });
+      expect(init.redirect).toBe('manual');
+    });
+
+    it('leaves the reads on GET', async () => {
+      // The method is now a parameter, so this pins the default: a typo that sent
+      // every read as a DELETE would otherwise be caught by nothing here.
+      const fetchFn = jest
+        .fn()
+        .mockImplementation(async () => jsonResponse({}));
+      const client = build(fetchFn);
+
+      await client.listSessions({ userToken: 't' });
+      await client.getSession('abc', { userToken: 't' });
+      await client.listSessionTasks('abc', { userToken: 't' });
+      await client.getMe({ userToken: 't' });
+
+      for (const [, init] of fetchFn.mock.calls) {
+        expect(init.method).toBe('GET');
+      }
+    });
+
+    it('escapes a session id that is not URL-safe', async () => {
+      const fetchFn = jest.fn().mockResolvedValue(jsonResponse({}));
+
+      await build(fetchFn).deleteSession('a/b?c=d', { userToken: 't' });
+
+      expect(fetchFn.mock.calls[0][0]).toBe(
+        'https://kagent.gazelle.example.io/api/sessions/a%2Fb%3Fc%3Dd',
+      );
+    });
+
+    it('returns kagent’s envelope verbatim', async () => {
+      const body = {
+        error: false,
+        data: {},
+        message: 'Session deleted successfully',
+      };
+      const fetchFn = jest.fn().mockResolvedValue(jsonResponse(body));
+
+      const result = await build(fetchFn).deleteSession('abc123', {
+        userToken: 't',
+      });
+
+      expect(result).toEqual(body);
+    });
+
+    it('reports an absent route as a version problem', async () => {
+      // Defensive only — the route has existed since v0.9.x — but the plain-text
+      // 404 must not read as "that session is gone", which is exactly the outcome a
+      // user would then stop worrying about.
+      const fetchFn = jest.fn().mockResolvedValue(
+        new Response('404 page not found', {
+          status: 404,
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+        }),
+      );
+
+      await expect(
+        build(fetchFn).deleteSession('abc', { userToken: 't' }),
+      ).rejects.toMatchObject({
+        name: 'NotFoundError',
+        message: expect.stringContaining('has no session delete endpoint'),
+      });
+    });
+  });
+
   it('requests /me under the API base URL', async () => {
     const fetchFn = jest.fn().mockResolvedValue(jsonResponse({ sub: 'a@b.c' }));
 

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -244,10 +244,12 @@ export class KagentClient {
       )}?limit=1`,
       options,
       {
-        // The id is left out on purpose: it is opaque and high-cardinality, and
-        // the user already has it in the URL they followed.
-        missingResource: `That session does not exist on installation '${this.installation.name}'. It may have been deleted, or it may belong to another user.`,
-        endpoint: 'session detail',
+        notFound: {
+          // The id is left out on purpose: it is opaque and high-cardinality, and
+          // the user already has it in the URL they followed.
+          missingResource: `That session does not exist on installation '${this.installation.name}'. It may have been deleted, or it may belong to another user.`,
+          endpoint: 'session detail',
+        },
       },
     );
   }
@@ -272,8 +274,50 @@ export class KagentClient {
       )}/tasks`,
       options,
       {
-        missingResource: `That session does not exist on installation '${this.installation.name}'. It may have been deleted, or it may belong to another user.`,
-        endpoint: 'session tasks',
+        notFound: {
+          missingResource: `That session does not exist on installation '${this.installation.name}'. It may have been deleted, or it may belong to another user.`,
+          endpoint: 'session tasks',
+        },
+      },
+    );
+  }
+
+  /**
+   * `DELETE <apiBaseUrl>/sessions/<id>` — kagent's session delete.
+   *
+   * Scoped to the forwarded token's user, and **soft**: kagent sets `deleted_at`
+   * on the row (`UPDATE session SET deleted_at = NOW() WHERE id = $1 AND
+   * user_id = $2`) and every read filters `deleted_at IS NULL`, so the session and
+   * its events stay in the database while disappearing from the API.
+   *
+   * Identical on v0.9.9 and v0.10, including two things worth knowing:
+   *
+   * - **Deleting something that is not there succeeds.** The statement is an
+   *   `:exec`, so zero affected rows is not an error — a session that never
+   *   existed, was already deleted, or belongs to another user all answer 200.
+   *   There is no 404 to handle here, and no "already gone" case to special-case.
+   * - **The response is a 200 with kagent's usual JSON envelope**, not a 204.
+   *
+   * Returned verbatim like every other response: this client is transport only.
+   */
+  async deleteSession(
+    sessionId: string,
+    options: KagentRequestOptions,
+  ): Promise<unknown> {
+    return this.request(
+      `${this.installation.apiBaseUrl}/sessions/${encodeURIComponent(
+        sessionId,
+      )}`,
+      options,
+      {
+        method: 'DELETE',
+        notFound: {
+          // Only reachable for a `text/plain` 404, i.e. no such route — kagent's
+          // own handler never 404s here (see above). The route has existed since
+          // v0.9.x, so this wording is purely defensive.
+          missingResource: `That session does not exist on installation '${this.installation.name}'.`,
+          endpoint: 'session delete',
+        },
       },
     );
   }
@@ -309,11 +353,18 @@ export class KagentClient {
   private async request(
     url: string,
     options: KagentRequestOptions,
-    notFound?: NotFoundContext,
+    extra: {
+      /** Defaults to GET; the reads leave it out. */
+      method?: 'GET' | 'DELETE';
+      notFound?: NotFoundContext;
+    } = {},
   ): Promise<unknown> {
+    const { method = 'GET', notFound } = extra;
+
     let response: Response;
     try {
       response = await this.fetchFn(url, {
+        method,
         headers: {
           Accept: 'application/json',
           ...(options.userToken && {

--- a/plugins/agent-platform-backend/src/KagentClient.ts
+++ b/plugins/agent-platform-backend/src/KagentClient.ts
@@ -484,6 +484,19 @@ export class KagentClient {
       );
     }
 
+    // `204 No Content` is a success with nothing to parse, and must be handled
+    // before the guards below: it carries no content-type, so the sign-in-page
+    // check would call it an authentication failure, and `response.json()` would
+    // throw on the empty body. Nothing kagent serves today answers 204 — its
+    // delete returns 200 with the usual envelope on both v0.9.9 and v0.10 — but
+    // getting this wrong is expensive in one specific direction: a future version
+    // that answered 204 to the DELETE would have *performed* the deletion while
+    // this told the user a sign-in page was served, and the frontend would leave
+    // the confirmation dialog open on an error for a session that is already gone.
+    if (response.status === 204) {
+      return undefined;
+    }
+
     // A 2xx with a non-JSON body is oauth2-proxy serving its sign-in page
     // rather than kagent answering.
     const contentType = response.headers.get('content-type') ?? '';

--- a/plugins/agent-platform-backend/src/router.test.ts
+++ b/plugins/agent-platform-backend/src/router.test.ts
@@ -462,6 +462,20 @@ describe('createRouter', () => {
       expect(deleteSession).not.toHaveBeenCalled();
     });
 
+    it('passes an empty upstream success through as a 204', async () => {
+      // Rather than `res.json(undefined)`, which sends an empty body under a JSON
+      // content-type — the frontend would then have to parse nothing as something.
+      deleteSession.mockResolvedValue(undefined);
+
+      const response = await request(app)
+        .delete('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(204);
+      expect(response.text).toBe('');
+    });
+
     it('requires the installation query parameter', async () => {
       const response = await request(app)
         .delete('/kagent/sessions/abc')

--- a/plugins/agent-platform-backend/src/router.test.ts
+++ b/plugins/agent-platform-backend/src/router.test.ts
@@ -21,11 +21,14 @@ describe('createRouter', () => {
   const getSession = jest.fn();
   const listSessionTasks = jest.fn();
 
+  const deleteSession = jest.fn();
+
   const mockClient = {
     listSessions,
     getMe,
     getSession,
     listSessionTasks,
+    deleteSession,
   } as unknown as KagentClient;
 
   // Mirror the production setup: the backend's root HTTP router applies
@@ -56,6 +59,7 @@ describe('createRouter', () => {
     getMe.mockReset();
     getSession.mockReset();
     listSessionTasks.mockReset();
+    deleteSession.mockReset();
     app = await buildApp();
   });
 
@@ -415,6 +419,117 @@ describe('createRouter', () => {
 
       const response = await request(app)
         .get('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBeGreaterThanOrEqual(500);
+    });
+  });
+
+  describe('DELETE /kagent/sessions/:sessionId', () => {
+    const deletedBody = {
+      error: false,
+      data: {},
+      message: 'Session deleted successfully',
+    };
+
+    it('forwards the id and token and echoes the body verbatim', async () => {
+      deleteSession.mockResolvedValue(deletedBody);
+
+      const response = await request(app)
+        .delete('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(deletedBody);
+      expect(deleteSession).toHaveBeenCalledWith('abc', {
+        userToken: 'user-token',
+      });
+    });
+
+    it('does not answer a GET on the same path', async () => {
+      // Express routes by method, so the read route above must keep handling GET —
+      // asserted because both live on the same path.
+      getSession.mockResolvedValue({ error: false, data: {} });
+
+      await request(app)
+        .get('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(getSession).toHaveBeenCalledTimes(1);
+      expect(deleteSession).not.toHaveBeenCalled();
+    });
+
+    it('requires the installation query parameter', async () => {
+      const response = await request(app)
+        .delete('/kagent/sessions/abc')
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(400);
+      expect(deleteSession).not.toHaveBeenCalled();
+    });
+
+    it('requires a forwarded user token', async () => {
+      // The token is the whole authorization story here: kagent derives the user
+      // from it, and without one an `unsecure` controller would delete the shared
+      // default user's session.
+      const response = await request(app)
+        .delete('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' });
+
+      expect(response.status).toBe(401);
+      expect(deleteSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown installation', async () => {
+      const response = await request(app)
+        .delete('/kagent/sessions/abc')
+        .query({ installation: 'nope' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(400);
+      expect(deleteSession).not.toHaveBeenCalled();
+    });
+
+    it('passes an opaque id through undecorated', async () => {
+      deleteSession.mockResolvedValue(deletedBody);
+
+      await request(app)
+        .delete('/kagent/sessions/%20abc%20')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(deleteSession).toHaveBeenCalledWith(' abc ', {
+        userToken: 'user-token',
+      });
+    });
+
+    it('reports an unreachable installation as 404, not a 5xx', async () => {
+      // Same reasoning as the reads: expected outcomes stay below the threshold
+      // at which MiddlewareFactory logs at error and Sentry gets an issue.
+      const notFound = new Error('The kagent API is not available');
+      notFound.name = 'NotFoundError';
+      deleteSession.mockRejectedValue(notFound);
+
+      const response = await request(app)
+        .delete('/kagent/sessions/abc')
+        .query({ installation: 'gazelle' })
+        .set(KAGENT_AUTH_HEADER, 'user-token');
+
+      expect(response.status).toBe(404);
+    });
+
+    it('still reports a failed delete as a 5xx', async () => {
+      // A delete that kagent accepted and could not perform is genuinely
+      // actionable, unlike a read that found nothing.
+      const upstream = new Error('kagent returned status 500');
+      upstream.name = 'UpstreamError';
+      deleteSession.mockRejectedValue(upstream);
+
+      const response = await request(app)
+        .delete('/kagent/sessions/abc')
         .query({ installation: 'gazelle' })
         .set(KAGENT_AUTH_HEADER, 'user-token');
 

--- a/plugins/agent-platform-backend/src/router.ts
+++ b/plugins/agent-platform-backend/src/router.ts
@@ -198,6 +198,29 @@ export async function createRouter(
     res.json(result);
   });
 
+  /**
+   * Delete one session. kagent soft-deletes it, scoped to the forwarded token's
+   * user id — the same scoping the reads rely on.
+   *
+   * The token is **required**, and it is the whole authorization story for this
+   * route: kagent decides who the caller is from it, and a controller running in
+   * `unsecure` mode would otherwise delete the shared default user's session on
+   * behalf of nobody in particular.
+   *
+   * Nothing expected reaches a 5xx here. kagent answers 200 even when the session
+   * does not exist or belongs to somebody else (its statement matches no rows), and
+   * `KagentClient` maps an unreachable installation to a 404 — so this route should
+   * never hit `MiddlewareFactory.error()`'s `>= 500` branch, which forwards to
+   * Sentry.
+   */
+  router.delete('/kagent/sessions/:sessionId', async (req, res) => {
+    const { client } = resolveInstallation(req);
+    const result = await client.deleteSession(readSessionId(req), {
+      userToken: readUserToken(req, { required: true }),
+    });
+    res.json(result);
+  });
+
   /** The session's A2A tasks — the conversation, its state and token usage. */
   router.get('/kagent/sessions/:sessionId/tasks', async (req, res) => {
     const { client } = resolveInstallation(req);

--- a/plugins/agent-platform-backend/src/router.ts
+++ b/plugins/agent-platform-backend/src/router.ts
@@ -218,6 +218,15 @@ export async function createRouter(
     const result = await client.deleteSession(readSessionId(req), {
       userToken: readUserToken(req, { required: true }),
     });
+
+    // Pass an empty upstream success through as one, rather than as `res.json()`'s
+    // empty body with a JSON content-type. Only reachable if a future kagent
+    // answers 204 to the delete; today it returns its envelope with a 200.
+    if (result === undefined) {
+      res.status(204).end();
+      return;
+    }
+
     res.json(result);
   });
 

--- a/plugins/agent-platform/src/apis/KagentApiClient.test.ts
+++ b/plugins/agent-platform/src/apis/KagentApiClient.test.ts
@@ -366,6 +366,109 @@ describe('KagentApiClient', () => {
     });
   });
 
+  describe('deleteSession', () => {
+    /** kagent's actual success response: a 200 carrying its usual envelope. */
+    function deleted() {
+      return jsonResponse({
+        error: false,
+        data: {},
+        message: 'Session deleted successfully',
+      });
+    }
+
+    it('sends a DELETE for the session, with the minted token', async () => {
+      fetchMock.mockResolvedValue(deleted());
+
+      await buildClient().deleteSession('gazelle', 'abc123');
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        'http://backend/api/agent-platform/kagent/sessions/abc123?installation=gazelle',
+      );
+      expect(init.method).toBe('DELETE');
+      expect(init.headers[KAGENT_AUTH_HEADER]).toBe('dex-token');
+    });
+
+    it('escapes a session id that is not URL-safe', async () => {
+      fetchMock.mockResolvedValue(deleted());
+
+      await buildClient().deleteSession('gazelle', 'a/b?c=d');
+
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'http://backend/api/agent-platform/kagent/sessions/a%2Fb%3Fc%3Dd?installation=gazelle',
+      );
+    });
+
+    it('leaves the reads on GET', async () => {
+      // The transport now takes a method. Nothing else would catch a change that
+      // sent every read as a DELETE.
+      fetchMock.mockImplementation(async () => jsonResponse({ error: false }));
+      const client = buildClient();
+
+      await client.listSessions('gazelle');
+      await client.getIdentity('gazelle');
+
+      for (const [, init] of fetchMock.mock.calls) {
+        expect(init.method).toBeUndefined();
+      }
+    });
+
+    it('succeeds on a 2xx with no body', async () => {
+      // kagent answers 200 with an envelope today, but nothing here needs it. A
+      // version answering 204 (or an empty body) has still done the delete, and
+      // demanding JSON would report that as a failure.
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 204,
+        json: async () => {
+          throw new SyntaxError('Unexpected end of JSON input');
+        },
+      } as unknown as Response);
+
+      await expect(
+        buildClient().deleteSession('gazelle', 'abc123'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws on an error reported in-band on a 200', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          error: true,
+          message: 'failed to delete session: database connection lost',
+        }),
+      );
+
+      await expect(
+        buildClient().deleteSession('gazelle', 'abc123'),
+      ).rejects.toMatchObject({
+        name: 'UpstreamError',
+        message: 'failed to delete session: database connection lost',
+      });
+    });
+
+    it('still throws when an in-band error says nothing', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ error: true }));
+
+      await expect(
+        buildClient().deleteSession('gazelle', 'abc123'),
+      ).rejects.toMatchObject({ name: 'UpstreamError' });
+    });
+
+    it.each([
+      [403, 'ForbiddenError'],
+      [404, 'NotFoundError'],
+      [500, 'Error'],
+    ])('maps a %s to %s', async (status, expectedName) => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ error: { message: 'nope' } }, status),
+      );
+
+      await expect(
+        buildClient().deleteSession('gazelle', 'abc123'),
+      ).rejects.toMatchObject({ name: expectedName, message: 'nope' });
+    });
+  });
+
   describe('getIdentity', () => {
     it('reads the subject kagent resolved', async () => {
       fetchMock.mockResolvedValue(

--- a/plugins/agent-platform/src/apis/KagentApiClient.ts
+++ b/plugins/agent-platform/src/apis/KagentApiClient.ts
@@ -229,8 +229,13 @@ export class KagentApiClient implements KagentApi {
     // `{error, data, message}` envelope, and the envelope carries nothing worth
     // returning — but a `200 error: true` would be a failure reported in-band, the
     // same shape the session and list readers already refuse to treat as success.
-    // A version that answered 204, or an empty body, still counts as a success:
-    // requiring JSON here would fail a delete that actually happened.
+    //
+    // An empty body still counts as a success: requiring JSON here would fail a
+    // delete that actually happened. That tolerance only reaches all the way
+    // through because `KagentClient.request` in agent-platform-backend has the
+    // matching half — it returns an upstream 204 as an empty success instead of
+    // reporting a missing content-type as a sign-in page, and the route passes it
+    // on as a 204. Both halves are needed; neither is any use alone.
     const body = await response.json().catch(() => undefined);
     if (isErrorEnvelope(body)) {
       throw upstreamError(

--- a/plugins/agent-platform/src/apis/KagentApiClient.ts
+++ b/plugins/agent-platform/src/apis/KagentApiClient.ts
@@ -55,6 +55,21 @@ function upstreamError(message: string): Error {
   return error;
 }
 
+/**
+ * A kagent envelope reporting a failure in-band on an otherwise successful
+ * response.
+ *
+ * Deliberately narrow — `error === true` and nothing else. The reads go through
+ * the zod layer for this; the write path has no payload to parse, so it checks the
+ * one field that can turn a 200 into a failure.
+ */
+function isErrorEnvelope(body: unknown): body is Record<string, unknown> {
+  if (typeof body !== 'object' || body === null) {
+    return false;
+  }
+  return (body as { error?: unknown }).error === true;
+}
+
 /** Which read produced the drift — part of the dedupe key and of the message. */
 type DriftSource = 'sessions' | 'session' | 'session tasks';
 
@@ -198,6 +213,34 @@ export class KagentApiClient implements KagentApi {
     return tasks;
   }
 
+  async deleteSession(installation: string, sessionId: string): Promise<void> {
+    const { url, headers } = await this.prepare(
+      `/kagent/sessions/${encodeURIComponent(sessionId)}`,
+      installation,
+    );
+    const response = await this.fetchApi.fetch(url, {
+      method: 'DELETE',
+      headers,
+    });
+
+    await this.throwIfNotOk(response);
+
+    // The body is read but not required. kagent answers 200 with its usual
+    // `{error, data, message}` envelope, and the envelope carries nothing worth
+    // returning — but a `200 error: true` would be a failure reported in-band, the
+    // same shape the session and list readers already refuse to treat as success.
+    // A version that answered 204, or an empty body, still counts as a success:
+    // requiring JSON here would fail a delete that actually happened.
+    const body = await response.json().catch(() => undefined);
+    if (isErrorEnvelope(body)) {
+      throw upstreamError(
+        typeof body.message === 'string' && body.message
+          ? body.message
+          : 'kagent reported an error while deleting the session, without saying what.',
+      );
+    }
+  }
+
   async getIdentity(installation: string): Promise<KagentIdentity> {
     // Best-effort token: the backend reads it as optional here, so a broker or
     // Dex-session failure must not stop the probe. This is the one installation
@@ -211,8 +254,24 @@ export class KagentApiClient implements KagentApi {
     return { sub: parsed.success ? parsed.data.sub : undefined };
   }
 
+  /** GET a backend route, forwarding the target installation's Dex token. */
+  private async get<T>(
+    path: string,
+    installation?: string,
+    options: { tokenRequired?: boolean } = {},
+  ): Promise<T> {
+    const { url, headers } = await this.prepare(
+      path,
+      installation,
+      options.tokenRequired ?? true,
+    );
+    const response = await this.fetchApi.fetch(url, { headers });
+    return this.handleResponse<T>(response);
+  }
+
   /**
-   * GET a backend route, forwarding the target installation's Dex token.
+   * Resolve a backend route to a URL and headers, minting the installation's Dex
+   * token on the way.
    *
    * The token is minted lazily, per call: a mint failure then fails only this
    * installation's request, which is what lets the fleet fan-out degrade one
@@ -222,12 +281,11 @@ export class KagentApiClient implements KagentApi {
    * optionally — the request still goes out without it rather than failing
    * before it is sent.
    */
-  private async get<T>(
+  private async prepare(
     path: string,
     installation?: string,
-    options: { tokenRequired?: boolean } = {},
-  ): Promise<T> {
-    const { tokenRequired = true } = options;
+    tokenRequired: boolean = true,
+  ): Promise<{ url: string; headers: Record<string, string> }> {
     const baseUrl = await this.discoveryApi.getBaseUrl('agent-platform');
     const url = new URL(`${baseUrl}${path}`);
 
@@ -240,8 +298,7 @@ export class KagentApiClient implements KagentApi {
       }
     }
 
-    const response = await this.fetchApi.fetch(url.toString(), { headers });
-    return this.handleResponse<T>(response);
+    return { url: url.toString(), headers };
   }
 
   private async mintToken(
@@ -275,6 +332,12 @@ export class KagentApiClient implements KagentApi {
    * couldn't read it" (everything else, surfaced).
    */
   private async handleResponse<T>(response: Response): Promise<T> {
+    await this.throwIfNotOk(response);
+    return response.json() as Promise<T>;
+  }
+
+  /** {@link handleResponse}'s status handling, shared with the write path. */
+  private async throwIfNotOk(response: Response): Promise<void> {
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
       const message =
@@ -306,6 +369,5 @@ export class KagentApiClient implements KagentApi {
       }
       throw error;
     }
-    return response.json() as Promise<T>;
   }
 }

--- a/plugins/agent-platform/src/apis/types.ts
+++ b/plugins/agent-platform/src/apis/types.ts
@@ -25,7 +25,7 @@ export interface KagentApi {
    * The signed-in user's sessions on one installation, already parsed and
    * normalized.
    *
-   * Read-only and user-scoped: kagent lists sessions with
+   * User-scoped: kagent lists sessions with
    * `WHERE user_id = <sub of the forwarded token>`, and exposes no cross-user
    * listing at all.
    *
@@ -60,6 +60,20 @@ export interface KagentApi {
     installation: string,
     sessionId: string,
   ): Promise<A2aTaskWire[]>;
+
+  /**
+   * Delete one session.
+   *
+   * kagent scopes this by the forwarded token's user id and deletes **softly**:
+   * the row keeps its events and tasks, but every read filters it out, so the
+   * session is gone as far as this plugin can tell.
+   *
+   * Resolves for anything kagent accepts, which includes deleting a session that
+   * was already deleted or belongs to somebody else — its statement simply matches
+   * no rows and still answers 200. So a resolved promise means "kagent accepted
+   * this", not "a session was definitely removed".
+   */
+  deleteSession(installation: string, sessionId: string): Promise<void>;
 
   /** Identity kagent resolved, used to detect a non-user-scoped deployment. */
   getIdentity(installation: string): Promise<KagentIdentity>;

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionActionsMenu.test.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionActionsMenu.test.tsx
@@ -1,0 +1,217 @@
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { sessionsRouteRef } from '../../routes';
+import type { UseDeleteSessionResult } from '../../hooks/useDeleteSession';
+import { SessionActionsMenu } from './SessionActionsMenu';
+
+// The delete state arrives as a prop — the menu renders in the shared plugin
+// header, outside the plugin's QueryClientProvider, so it cannot call the hook
+// itself. This test is therefore about what the menu offers and what it does with
+// the outcome; the request and the cache handling are covered by
+// useDeleteSession.test.tsx.
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockToastPost = jest.fn();
+
+// Only the toast API is swapped out — everything else the test app looks up
+// (themes, route resolution) has to keep working.
+jest.mock('@backstage/frontend-plugin-api', () => {
+  const actual = jest.requireActual('@backstage/frontend-plugin-api');
+
+  return {
+    ...actual,
+    useApi: (ref: unknown) =>
+      ref === actual.toastApiRef ? { post: mockToastPost } : actual.useApi(ref),
+  };
+});
+
+const deleteSession = jest.fn();
+const reset = jest.fn();
+
+let deletion: UseDeleteSessionResult;
+
+function setDeleteState(overrides: Partial<UseDeleteSessionResult> = {}) {
+  deletion = {
+    deleteSession,
+    isDeleting: false,
+    error: null,
+    reset,
+    ...overrides,
+  } as UseDeleteSessionResult;
+}
+
+const renderMenu = (isUserScoped?: boolean) =>
+  renderInTestApp(
+    <SessionActionsMenu
+      title="What issues are assigned to me?"
+      deletion={deletion}
+      isUserScoped={isUserScoped}
+    />,
+    { mountedRoutes: { '/agent-platform/sessions': sessionsRouteRef } },
+  );
+
+async function openMenu() {
+  await userEvent.click(
+    screen.getByRole('button', { name: 'Session actions' }),
+  );
+}
+
+async function openDeleteDialog() {
+  await openMenu();
+  await userEvent.click(
+    screen.getByRole('menuitem', { name: /Delete session/ }),
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  mockToastPost.mockReset();
+  deleteSession.mockReset();
+  deleteSession.mockResolvedValue(undefined);
+  reset.mockReset();
+  setDeleteState();
+});
+
+describe('SessionActionsMenu', () => {
+  it('renders without a QueryClient in scope', async () => {
+    // The regression this file exists to prevent. The menu is rendered into the
+    // shared plugin header, which is outside the plugin's QueryClientProvider, so
+    // a react-query hook called here throws "No QueryClient set" and takes the
+    // whole page down with it — the delete state has to arrive as a prop.
+    // `renderInTestApp` deliberately provides no client, so this asserts it.
+    await renderMenu();
+
+    expect(
+      screen.getByRole('button', { name: 'Session actions' }),
+    ).toBeInTheDocument();
+  });
+
+  it('gives the menu a definite width', async () => {
+    // Not cosmetic, and the reason is invisible from here: bui leaves the menu's
+    // width to its content above a 150px minimum, and this menu's one item wants
+    // slightly more than that — so the popover renders wide, settles back to the
+    // minimum, and that second layout pass makes react-aria's resize observer
+    // trip the browser's "ResizeObserver loop completed with undelivered
+    // notifications", which the dev-server overlay throws in your face on every
+    // open. See the comment on MENU_WIDTH. jsdom does no layout, so this can only
+    // assert the width is set — that is still enough to catch its removal.
+    await renderMenu();
+    await openMenu();
+
+    expect(screen.getByRole('menu')).toHaveStyle({ width: '12rem' });
+  });
+
+  it('says what deleting actually means before doing it', async () => {
+    await renderMenu();
+    await openDeleteDialog();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Delete session "What issues are assigned to me?"?'),
+      ).toBeInTheDocument();
+    });
+    // Both halves of the truth: gone as far as anyone here is concerned, and not
+    // restorable from this UI, but not erased from kagent either.
+    expect(screen.getByText(/cannot be opened again/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/no way to restore it from here/),
+    ).toBeInTheDocument();
+    // Opening the dialog does not delete anything.
+    expect(deleteSession).not.toHaveBeenCalled();
+  });
+
+  it('warns when the deployment does not scope sessions per user', async () => {
+    // `unsecure` mode: kagent ignores the forwarded identity and serves one shared
+    // user, so the session on screen may be somebody else's. It warns rather than
+    // withholding — kagent authorizes the call either way, and the reader is the
+    // one who knows whose session this is.
+    await renderMenu(false);
+    await openDeleteDialog();
+
+    expect(
+      await screen.findByText(/may have been started by somebody else/),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ['user-scoped', true],
+    ['unresolved', undefined],
+  ])('claims nothing when the probe says %s', async (_label, isUserScoped) => {
+    await renderMenu(isUserScoped);
+    await openDeleteDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(/cannot be opened again/)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/may have been started by somebody else/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('confirms, reports and returns to the list on success', async () => {
+    await renderMenu();
+    await openDeleteDialog();
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Delete session' }),
+    );
+
+    await waitFor(() => {
+      expect(deleteSession).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockToastPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'success',
+        // Permanent unless a timeout is given, and this is an acknowledgement.
+        timeout: expect.any(Number),
+      }),
+    );
+    // Past tense, unlike the agent's "Deleting…": kagent's delete is synchronous,
+    // so nothing is still settling by the time this shows.
+    expect(mockToastPost.mock.calls[0][0].title).toMatch(
+      /Session "What issues are assigned to me\?" deleted/,
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/agent-platform/sessions');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Delete session "What issues are assigned to me?"?'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the dialog open and says nothing succeeded when the delete fails', async () => {
+    deleteSession.mockRejectedValue(new Error('kagent returned status 500'));
+    setDeleteState({ error: new Error('kagent returned status 500') });
+
+    await renderMenu();
+    await openDeleteDialog();
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Delete session' }),
+    );
+
+    await waitFor(() => {
+      expect(deleteSession).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      screen.getByText('Delete session "What issues are assigned to me?"?'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('kagent returned status 500')).toBeInTheDocument();
+    expect(mockToastPost).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('clears a previous failure when the dialog is reopened', async () => {
+    await renderMenu();
+    await openDeleteDialog();
+
+    expect(reset).toHaveBeenCalled();
+  });
+});

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionActionsMenu.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionActionsMenu.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  toastApiRef,
+  useApi,
+  useRouteRef,
+} from '@backstage/frontend-plugin-api';
+import { ButtonIcon, Menu, MenuItem, MenuTrigger } from '@backstage/ui';
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+
+import type { UseDeleteSessionResult } from '../../hooks/useDeleteSession';
+import { sessionsRouteRef } from '../../routes';
+import { SessionDeleteDialog } from './SessionDeleteDialog';
+
+/** Long enough to read one line, short enough not to follow you to the next page. */
+const TOAST_TIMEOUT_MS = 6000;
+
+/**
+ * An explicit width for the menu, which is not cosmetic.
+ *
+ * bui gives `.bui-MenuContent` `min-width: 150px` and otherwise leaves the width
+ * to the content — its own `width` fallback is the string `"undefined"`, which the
+ * browser discards. A `MenuItem` is a flex row with `gap: var(--bui-space-6)`
+ * (24px) between label and trailing slot, so "Delete session…" plus its icon wants
+ * ~155px: just over the minimum. The popover then renders at the natural width,
+ * settles back to the 150px minimum, and that second layout pass makes the browser
+ * report "ResizeObserver loop completed with undelivered notifications" from
+ * react-aria's popover observer — twice, on every open. Harmless (Sentry filters
+ * that message by default) but it trips the dev-server error overlay, which is very
+ * much not harmless to work with.
+ *
+ * Sizing it up front means one layout pass and no warning. Note bui applies this
+ * prop as CSS `width`, despite the name, so it is the definite width — keep it
+ * comfortably above the longest item rather than trimmed to fit.
+ */
+const MENU_WIDTH = '12rem';
+
+/**
+ * The session details page's header actions.
+ *
+ * Owns the dialog's open state itself, rather than the page doing so: the page
+ * hands this element to `useProvidePageHeaderActions`, which renders it in the
+ * shared plugin header — a different part of the tree — so keeping the state here
+ * is what makes the menu and its dialog one self-contained unit.
+ *
+ * The deletion and `isUserScoped` arrive as props for the same reason, and this is
+ * the constraint to respect when adding an action: rendering in the shared header
+ * means rendering **outside the plugin's `QueryClientProvider`**, so anything backed
+ * by react-query — every read, probe or mutation — has to be called by the page and
+ * passed down. Calling `useDeleteSession` here throws "No QueryClient set".
+ */
+export function SessionActionsMenu({
+  title,
+  deletion,
+  isUserScoped,
+}: {
+  /** The session's display title, for the dialog and the toast. */
+  title: string;
+  deletion: UseDeleteSessionResult;
+  isUserScoped?: boolean;
+}) {
+  const [isDeleteOpen, setDeleteOpen] = useState(false);
+  const toastApi = useApi(toastApiRef);
+  const navigate = useNavigate();
+  const sessionsRoute = useRouteRef(sessionsRouteRef);
+
+  const { deleteSession, isDeleting, error, reset } = deletion;
+
+  const openDeleteDialog = () => {
+    // Clear a previous attempt's error, so the dialog does not open still
+    // showing it.
+    reset();
+    setDeleteOpen(true);
+  };
+
+  const confirmDelete = async () => {
+    try {
+      await deleteSession();
+    } catch {
+      // Left to the dialog, which stays open and renders the hook's `error`. No
+      // toast: the user is still looking at the modal they pressed Delete in.
+      return;
+    }
+
+    setDeleteOpen(false);
+    // Plainly past tense, unlike the agent's "Deleting…": kagent's delete is
+    // synchronous, so by the time this resolves the session is already filtered out
+    // of every read. Nothing is still settling in the background.
+    toastApi.post({
+      title: `Session "${title}" deleted`,
+      status: 'success',
+      // A ToastApi toast without a timeout is permanent, and this is an
+      // acknowledgement, not something to dismiss by hand.
+      timeout: TOAST_TIMEOUT_MS,
+    });
+
+    // An unbound route means the Agent Platform extension is disabled — in which
+    // case this page is not rendering either. Staying put beats hardcoding a
+    // path that would silently rot if the route moved.
+    if (sessionsRoute) {
+      navigate(sessionsRoute());
+    }
+  };
+
+  return (
+    <>
+      <MenuTrigger>
+        <ButtonIcon
+          icon={<MoreVertIcon />}
+          aria-label="Session actions"
+          variant="tertiary"
+        />
+        <Menu maxWidth={MENU_WIDTH}>
+          <MenuItem
+            color="danger"
+            iconStart={<DeleteOutlineIcon />}
+            onAction={openDeleteDialog}
+          >
+            Delete session…
+          </MenuItem>
+        </Menu>
+      </MenuTrigger>
+
+      <SessionDeleteDialog
+        title={title}
+        isOpen={isDeleteOpen}
+        onOpenChange={setDeleteOpen}
+        isDeleting={isDeleting}
+        error={error?.message}
+        onConfirm={confirmDelete}
+        isUserScoped={isUserScoped}
+      />
+    </>
+  );
+}

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDeleteDialog.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDeleteDialog.tsx
@@ -1,0 +1,73 @@
+import { Text } from '@backstage/ui';
+import { ConfirmDialog } from '@giantswarm/backstage-plugin-ui-react';
+
+export type SessionDeleteDialogProps = {
+  /** Shown in the title; falls back to the list's placeholder when unnamed. */
+  title: string;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  isDeleting: boolean;
+  error?: string;
+  onConfirm: () => void;
+  /**
+   * From the `/me` probe. `false` means this kagent runs without per-user session
+   * scoping, and the session may not be the reader's own — worth saying before they
+   * delete it. `undefined` (probe unresolved or unavailable) says nothing either
+   * way, so nothing is claimed.
+   */
+  isUserScoped?: boolean;
+};
+
+/**
+ * Asks before deleting a session.
+ *
+ * Two things, both of them things the reader cannot see for themselves.
+ *
+ * The first is what "deleted" means here, in both directions at once: kagent
+ * soft-deletes, so the record survives on the server, while every read filters it
+ * out — so for anyone using Backstage it is gone, and nothing in this UI can bring
+ * it back. Saying only "permanently deleted" would be wrong about the retention;
+ * saying only "hidden" would imply an undo that does not exist.
+ *
+ * The second is conditional, and is the reason `isUserScoped` is a prop: on a
+ * controller running in `unsecure` mode kagent ignores the forwarded identity and
+ * serves one shared user, so the session on screen may be someone else's. The
+ * sessions list already carries that caveat about reading; deleting is where it
+ * actually costs something. It warns rather than blocks, because kagent authorizes
+ * the call either way and the reader is the one who knows whose session this is.
+ */
+export function SessionDeleteDialog({
+  title,
+  isOpen,
+  onOpenChange,
+  isDeleting,
+  error,
+  onConfirm,
+  isUserScoped,
+}: SessionDeleteDialogProps) {
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      title={`Delete session "${title}"?`}
+      destructive
+      confirmLabel="Delete session"
+      busyLabel="Deleting…"
+      isBusy={isDeleting}
+      error={error}
+      onConfirm={onConfirm}
+    >
+      <Text variant="body-medium">
+        The session and its conversation stop being listed and cannot be opened
+        again. kagent keeps the record on its own server, but there is no way to
+        restore it from here.
+      </Text>
+      {isUserScoped === false && (
+        <Text variant="body-medium">
+          This kagent deployment does not scope sessions to individual users, so
+          this session may have been started by somebody else.
+        </Text>
+      )}
+    </ConfirmDialog>
+  );
+}

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
@@ -38,6 +38,30 @@ jest.mock('../../hooks/useAgentAvatarUrl', () => ({
   useAgentAvatarUrl: () => () => 'https://avatars.example/agent.png',
 }));
 
+// The page calls both of these on the menu's behalf, because the menu renders in
+// the shared header — outside the plugin's QueryClientProvider — and so cannot call
+// them itself. This test mounts no query client, which is why they are stubbed.
+const mockDeleteSession = jest.fn();
+jest.mock('../../hooks/useDeleteSession', () => ({
+  useDeleteSession: () => ({
+    deleteSession: mockDeleteSession,
+    isDeleting: false,
+    error: null,
+    reset: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useKagentCapabilities', () => ({
+  useKagentCapabilities: () => ({ isUserScoped: true }),
+}));
+
+/** What the page handed to the shared header slot on the last render. */
+const providedActions = jest.fn();
+jest.mock('@giantswarm/backstage-plugin-ui-react', () => ({
+  ...jest.requireActual('@giantswarm/backstage-plugin-ui-react'),
+  useProvidePageHeaderActions: (actions: ReactNode) => providedActions(actions),
+}));
+
 const tasks = normalizeTaskList(tasksV099).tasks;
 const timeline = buildTimeline(tasks);
 const detail = normalizeSessionDetail(detailV099, 'gazelle').detail!;
@@ -64,8 +88,15 @@ async function render() {
   });
 }
 
+/** The last element the page provided as header actions. */
+function lastProvidedActions() {
+  const calls = providedActions.mock.calls;
+  return calls[calls.length - 1]?.[0];
+}
+
 describe('SessionDetailPage', () => {
   beforeEach(() => {
+    providedActions.mockClear();
     mockUseSessionDetail.mockReturnValue(loadedView);
     mockUseAgents.mockReturnValue({
       rows: [
@@ -93,6 +124,30 @@ describe('SessionDetailPage', () => {
     // twice on purpose: in the header, and as the author of its messages.
     expect(screen.getAllByText('Issue tracker').length).toBeGreaterThan(0);
     expect(screen.getByText('on gazelle')).toBeInTheDocument();
+  });
+
+  it('offers the actions menu once the session is loaded', async () => {
+    await render();
+
+    expect(lastProvidedActions()).not.toBeNull();
+  });
+
+  it.each([
+    ['a missing session', { detail: undefined, isNotFound: true }],
+    ['a failed read', { detail: undefined, error: new Error('nope') }],
+    ['a load in flight', { detail: undefined, isLoading: true }],
+  ])('offers no actions for %s', async (_label, view) => {
+    // A delete needs a session to delete. Registering the menu regardless would put
+    // a kebab in the header of a page that is showing "Session not found".
+    mockUseSessionDetail.mockReturnValue({
+      ...loadedView,
+      timeline: emptyTimeline,
+      ...view,
+    });
+
+    await render();
+
+    expect(lastProvidedActions()).toBeNull();
   });
 
   it('shows the state from the most recent task', async () => {

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
@@ -9,13 +9,19 @@ import {
 import { useRouteRef } from '@backstage/frontend-plugin-api';
 import { Alert, Avatar, Badge, Box, Flex, Text } from '@backstage/ui';
 import { makeStyles } from '@material-ui/core';
-import { DateComponent } from '@giantswarm/backstage-plugin-ui-react';
+import {
+  DateComponent,
+  useProvidePageHeaderActions,
+} from '@giantswarm/backstage-plugin-ui-react';
 
+import { useDeleteSession } from '../../hooks/useDeleteSession';
+import { useKagentCapabilities } from '../../hooks/useKagentCapabilities';
 import { useSessionDetail } from '../../hooks/useSessionDetail';
 import { useAgentAvatarUrl } from '../../hooks/useAgentAvatarUrl';
 import { AvatarSize } from '../../lib/agentAvatar';
 import { sessionsRouteRef } from '../../routes';
 import { useAgents } from '../AgentsDataProvider';
+import { SessionActionsMenu } from './SessionActionsMenu';
 import {
   buildAgentIndex,
   SESSION_TITLE_FALLBACK,
@@ -78,9 +84,9 @@ function Stat({ label, value }: { label: string; value: string }) {
 /**
  * One kagent session: what it was, how it ended, and what the agent did.
  *
- * Read-only. kagent supports renaming, deleting and continuing a session, and the
- * prototype offers all three — none are wired up here, deliberately, so this
- * screen can ship without a write path.
+ * The session can be **deleted** from the header's actions menu (see "Deleting a
+ * session" in docs/agent-platform.md). kagent also supports renaming and continuing
+ * a session, and the prototype offers both — neither is wired up here.
  *
  * What the prototype shows and this cannot, because kagent stores none of it:
  * cost, tokens-per-second, context-window usage, the owning team, the trigger that
@@ -111,6 +117,32 @@ export function SessionDetailPage() {
     () => (detail ? toSessionRow(detail.session, agentIndex) : undefined),
     [detail, agentIndex],
   );
+
+  // Both called here rather than inside the menu: the menu is rendered in the
+  // shared plugin header, which is outside this plugin's `QueryClientProvider`, so
+  // a mutation or a query has no client there. The capabilities probe is a cached
+  // `/me` read with an hour's staleTime, so asking for it on this page is free.
+  const deletion = useDeleteSession(installation, sessionId);
+  const { isUserScoped } = useKagentCapabilities(installation);
+
+  /** Shared by the heading, the actions menu and its dialog, so all three agree. */
+  const sessionTitle = row?.title || SESSION_TITLE_FALLBACK;
+
+  // `deletion` is memoized on its own contents and `sessionTitle` is a string, so this
+  // element's identity only changes when one of them actually does — which is what
+  // keeps the header slot from re-registering (and re-rendering) on every poll.
+  const actions = useMemo(
+    () =>
+      row ? (
+        <SessionActionsMenu
+          title={sessionTitle}
+          deletion={deletion}
+          isUserScoped={isUserScoped}
+        />
+      ) : null,
+    [row, sessionTitle, deletion, isUserScoped],
+  );
+  useProvidePageHeaderActions(actions);
 
   if (isLoading) {
     return (
@@ -165,9 +197,7 @@ export function SessionDetailPage() {
         <Flex direction="column" gap="2">
           <BackToSessions>← Sessions</BackToSessions>
           <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>
-            <Text variant="title-medium">
-              {row.title || SESSION_TITLE_FALLBACK}
-            </Text>
+            <Text variant="title-medium">{sessionTitle}</Text>
             {/* The raw A2A state is kept as the label for anything we don't
                 recognise, so a future kagent state shows as itself. */}
             {state && <Badge size="small">{state.label}</Badge>}

--- a/plugins/agent-platform/src/hooks/useDeleteSession.test.tsx
+++ b/plugins/agent-platform/src/hooks/useDeleteSession.test.tsx
@@ -1,0 +1,156 @@
+import { PropsWithChildren } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import {
+  InvalidateQueryFilters,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import { kagentApiRef } from '../apis';
+import { KagentApi } from '../apis/types';
+import { useDeleteSession } from './useDeleteSession';
+
+const deleteSession = jest.fn();
+
+const kagentApi = { deleteSession } as unknown as KagentApi;
+
+function renderWith() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+
+  const wrapper = ({ children }: PropsWithChildren<{}>) => (
+    <TestApiProvider apis={[[kagentApiRef, kagentApi]]}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </TestApiProvider>
+  );
+
+  return {
+    ...renderHook(() => useDeleteSession('gazelle', 'abc'), { wrapper }),
+    invalidateQueries,
+  };
+}
+
+/** The filters a given call to `invalidateQueries` was made with. */
+function invalidationFor(
+  invalidateQueries: jest.SpyInstance,
+  queryKey: unknown[],
+): InvalidateQueryFilters | undefined {
+  const call = invalidateQueries.mock.calls.find(
+    ([filters]) =>
+      JSON.stringify(filters?.queryKey) === JSON.stringify(queryKey),
+  );
+  return call?.[0];
+}
+
+beforeEach(() => {
+  deleteSession.mockReset();
+  deleteSession.mockResolvedValue(undefined);
+});
+
+describe('useDeleteSession', () => {
+  it('deletes the session on the installation it was read from', async () => {
+    const { result } = renderWith();
+
+    await act(async () => {
+      await result.current.deleteSession();
+    });
+
+    expect(deleteSession).toHaveBeenCalledWith('gazelle', 'abc');
+  });
+
+  it('refreshes the sessions list', async () => {
+    // The same key `SessionsDataProvider` and `useAgentSessions` read from, so
+    // both the fleet list and the agent page's recent sessions card correct
+    // themselves without either knowing a delete happened.
+    const { result, invalidateQueries } = renderWith();
+
+    await act(async () => {
+      await result.current.deleteSession();
+    });
+
+    expect(
+      invalidationFor(invalidateQueries, [
+        'agent-platform',
+        'kagent',
+        'sessions',
+        'gazelle',
+      ]),
+    ).toBeDefined();
+  });
+
+  it('marks this session’s own reads stale without refetching them', async () => {
+    // The detail page is still mounted when this runs — it is where the delete was
+    // triggered — so a refetch would race the navigation with a request that now
+    // 404s and flash "Session not found" at someone who already knows.
+    const { result, invalidateQueries } = renderWith();
+
+    await act(async () => {
+      await result.current.deleteSession();
+    });
+
+    for (const key of [
+      ['agent-platform', 'kagent', 'session', 'gazelle', 'abc'],
+      ['agent-platform', 'kagent', 'session-tasks', 'gazelle', 'abc'],
+    ]) {
+      expect(invalidationFor(invalidateQueries, key)).toMatchObject({
+        refetchType: 'none',
+      });
+    }
+  });
+
+  it('reports a failure and rejects, leaving the caller to decide', async () => {
+    deleteSession.mockRejectedValue(new Error('kagent said no'));
+
+    const { result } = renderWith();
+
+    await act(async () => {
+      await expect(result.current.deleteSession()).rejects.toThrow(
+        'kagent said no',
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe('kagent said no'),
+    );
+  });
+
+  it('does not refresh anything when the delete failed', async () => {
+    deleteSession.mockRejectedValue(new Error('kagent said no'));
+
+    const { result, invalidateQueries } = renderWith();
+
+    await act(async () => {
+      await expect(result.current.deleteSession()).rejects.toThrow();
+    });
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('clears a previous failure on reset, so a reopened dialog is clean', async () => {
+    deleteSession.mockRejectedValue(new Error('kagent said no'));
+
+    const { result } = renderWith();
+
+    await act(async () => {
+      await expect(result.current.deleteSession()).rejects.toThrow();
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => result.current.reset());
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  it('keeps a stable identity between renders', async () => {
+    // The page memoizes the header actions element on this object, so a new one on
+    // every render would re-register the header slot on every poll.
+    const { result, rerender } = renderWith();
+
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/plugins/agent-platform/src/hooks/useDeleteSession.ts
+++ b/plugins/agent-platform/src/hooks/useDeleteSession.ts
@@ -1,0 +1,73 @@
+import { useCallback, useMemo } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { kagentApiRef } from '../apis';
+import { sessionQueryKey, sessionTasksQueryKey } from './useSessionDetail';
+
+/**
+ * Delete one kagent session.
+ *
+ * Much smaller than {@link useDeleteAgent}, because a session is not a Kubernetes
+ * object: there is no owning resource to resolve, no `SelfSubjectAccessReview` to
+ * consult, and nothing to clean up afterwards. kagent authorizes the call from the
+ * forwarded token alone, so there is no "may I?" to answer before offering the
+ * action — hence no `isDeletable`/`isCheckingDeletable` counterpart here.
+ *
+ * The delete is **soft** on kagent's side and effectively total on ours: the row
+ * keeps its events and tasks, and every kagent read filters it out.
+ */
+export function useDeleteSession(installation: string, sessionId: string) {
+  const kagentApi = useApi(kagentApiRef);
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      await kagentApi.deleteSession(installation, sessionId);
+
+      // The one key that matters, and it is shared: `SessionsDataProvider` and
+      // `useAgentSessions` read the fleet list under it, so this corrects both the
+      // sessions list the user is about to land on and the agent page's recent
+      // sessions card.
+      await queryClient.invalidateQueries({
+        queryKey: ['agent-platform', 'kagent', 'sessions', installation],
+      });
+
+      // This session's own reads are marked stale but deliberately *not*
+      // refetched. The detail page is still mounted at this point — it is where the
+      // delete was triggered from — so a refetch would race the caller's navigation
+      // with a request that now 404s, flashing "Session not found" underneath
+      // someone who already knows. `refetchType: 'none'` leaves the entries stale
+      // instead, so a later visit to the same URL revalidates and lands on the
+      // not-found state properly.
+      await Promise.all(
+        [
+          sessionQueryKey(installation, sessionId),
+          sessionTasksQueryKey(installation, sessionId),
+        ].map(queryKey =>
+          queryClient.invalidateQueries({ queryKey, refetchType: 'none' }),
+        ),
+      );
+    },
+  });
+
+  const { mutateAsync, reset } = mutation;
+
+  // Wrapped so callers get `Promise<void>`: `mutateAsync` resolves with the
+  // mutation's return value, which is nothing anyone should start depending on.
+  const deleteSession = useCallback(async () => {
+    await mutateAsync();
+  }, [mutateAsync]);
+
+  return useMemo(
+    () => ({
+      deleteSession,
+      isDeleting: mutation.isPending,
+      error: mutation.error as Error | null,
+      reset,
+    }),
+    [deleteSession, mutation.isPending, mutation.error, reset],
+  );
+}
+
+/** What {@link useDeleteSession} hands to the confirmation UI. */
+export type UseDeleteSessionResult = ReturnType<typeof useDeleteSession>;

--- a/plugins/agent-platform/src/hooks/useDeleteSession.ts
+++ b/plugins/agent-platform/src/hooks/useDeleteSession.ts
@@ -24,10 +24,16 @@ export function useDeleteSession(installation: string, sessionId: string) {
     mutationFn: async () => {
       await kagentApi.deleteSession(installation, sessionId);
 
-      // The one key that matters, and it is shared: `SessionsDataProvider` and
-      // `useAgentSessions` read the fleet list under it, so this corrects both the
-      // sessions list the user is about to land on and the agent page's recent
-      // sessions card.
+      // The fleet list `SessionsDataProvider` reads — the page the caller is about
+      // to navigate back to.
+      //
+      // Only within this tab. `useAgentSessions` reads the same *key* for the agent
+      // page's recent-sessions card, but the Agents tab mounts its own
+      // `QueryClientProvider` (a fresh `new QueryClient` per mount), so that cache
+      // is not this one and nothing here can invalidate it. It needs no help: a
+      // fresh client starts empty, and these keys are excluded from persistence, so
+      // the card refetches when the tab mounts. Do not read cross-tab correctness
+      // into this call.
       await queryClient.invalidateQueries({
         queryKey: ['agent-platform', 'kagent', 'sessions', installation],
       });


### PR DESCRIPTION
### What does this PR do?

Adds **Delete session…** to the session detail page's kebab menu, mirroring the agent deletion added in #2024. It calls kagent's `DELETE /api/sessions/:id` through the agent-platform proxy — the first write on the kagent REST side, so `agent-platform-backend` gains a `DELETE /kagent/sessions/:sessionId` route and its client a method parameter. Everything else about the transport is the reads' machinery reused: same installation resolution, same forwarded per-installation Dex token, same status mapping.

A few decisions worth reviewing:

**There is no permission gate, because there is nothing to ask.** Unlike the agent delete's `SelfSubjectAccessReview`, a session is not a Kubernetes object — kagent derives the acting user from the forwarded token alone (`GetUserID` → `GetPrincipal`), so the item is simply offered on any session that loaded. The route makes that token **required** for the same reason: without one, a controller running in `unsecure` mode would delete the shared default user's session on behalf of nobody in particular.

**A delete that matched nothing still answers 200.** kagent's statement is an `:exec`, so zero affected rows is not an error — a session that never existed, was already deleted, or belongs to another user all succeed silently. Nothing tries to detect that: a resolved promise means "kagent accepted this", and the refreshed list shows the truth a moment later. There is consequently no 404 path and no "already gone" case on the write side.

**One non-obvious piece of cache handling.** The sessions list key is invalidated normally — it is shared with `useAgentSessions`, so the fleet list and the agent page's recent-sessions card both correct themselves. This session's own two reads are invalidated with `refetchType: 'none'`: the detail page is still mounted at that moment, so refetching would race the navigation with a request that now 404s and flash "Session not found" at someone who just deleted the session deliberately.

**The menu is given an explicit width, and that line is load-bearing.** bui leaves `.bui-MenuContent`'s width to its content above a `min-width: 150px` (its own `width` fallback is the string `"undefined"`, which the browser discards), and `MenuItem` puts a 24px `gap` between label and trailing slot. "Delete session…" with its icon wants ~155px — just over — so the popover rendered at the natural width and then settled back to 150px, and that second layout pass made react-aria's popover resize observer trip the browser's `ResizeObserver loop completed with undelivered notifications`, twice, on every open. Sentry filters that message by default and production has no error overlay, but the dev-server overlay covers the page with it. The agent kebab escapes this only because its items happen to measure just under 150px, so it may be worth an upstream bui issue.

### What is the effect of this change to users?

A session can be deleted from its detail page. The confirmation dialog says:

> The session and its conversation stop being listed and cannot be opened again. kagent keeps the record on its own server, but there is no way to restore it from here.

and, only when the `/me` probe reports the deployment is not user-scoped, adds:

> This kagent deployment does not scope sessions to individual users, so this session may have been started by somebody else.

On success the user lands back on the sessions list with a `Session "…" deleted` toast — past tense, unlike the agent's "Deleting", because kagent's delete is synchronous. On failure the dialog stays open and shows the message, with no toast.

Deleting from a list row is deliberately not offered: a destructive action on a row someone is scanning past is easy to hit by accident.

### How does it look like?

The kebab sits in the shared plugin header next to the section tabs, with a single red `Delete session…` item.

Verified end to end against `gazelle`, deleting a real session:

```
"DELETE /api/agent-platform/kagent/sessions/2f6047bb…?installation=gazelle HTTP/1.1" 200 79
```

That closes the one thing the repo could not answer — whether the installation's ingress passes `DELETE` through (no 405 from nginx or agentgateway). The 79-byte body is exactly kagent's `{"error":false,"data":{},"message":"Session deleted successfully"}` envelope. Afterwards the deep link lands on the existing "Session not found" empty state rather than an error alert, and the session is gone from the list. Nothing was logged at `warn`/`error`, so nothing reached Sentry.

### Any background context you can provide?

Follows #2024, which established the write path for this plugin (kebab → `ConfirmDialog` → toast → navigate back) and left `ui-react`'s `ConfirmDialog` and `useProvidePageHeaderActions` behind to reuse — neither needed a change here.

Behaviour was verified against the kagent source at both `v0.9.9` (what the fleet runs) and `v0.10.0-rc1`: the handler, the SQL (`UPDATE session SET deleted_at = NOW() WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`, with every read filtering `deleted_at IS NULL`) and the 200-with-envelope response are identical in both.

Both react-query hooks are called by the page rather than the menu, because the menu renders in the shared plugin header — outside the plugin's `QueryClientProvider`, where a mutation or query would throw "No QueryClient set". Same constraint `AgentActionsMenu` documents.

### Do the docs need to be updated?

Yes, done in this PR: `docs/agent-platform.md` gains a "Deleting a session" section, and the three stale "read-only" claims plus the "Session management + detail" open-TODO entry are corrected.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
