### PR TITLE
feat(agent-platform): auto-refresh the session detail page

### DIFF
--- a/.changeset/agent-platform-session-detail-polling.md
+++ b/.changeset/agent-platform-session-detail-polling.md
@@ -1,0 +1,70 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': minor
+---
+
+Make the session detail page refresh itself. It read the session and its
+conversation once at mount and never again, so someone watching an agent work saw a
+frozen page until they navigated away and back. Both reads now poll, on the two-tier
+shape the agent views already use — but with different constants, and each deviation
+is deliberate.
+
+**The two reads poll at different cadences.** The conversation goes to 10 s while the
+newest task is in an active A2A state and recent, and 60 s otherwise. The session
+object stays on a flat 60 s: it is title, agent and timestamps, none of which move
+while an agent works, so it polls only so a session renamed or deleted elsewhere
+stops looking current. The visible cost is that "last activity" and the duration stat
+can trail the timeline by a minute during an active run; both render as absolute
+timestamps, so that reads as older rather than as wrong.
+
+**A terminal session relaxes to the baseline rather than stopping.** The tempting
+alternative — return `false` and stop, as muster's workflow page does for a finished
+execution — is wrong here, because a kagent session is not finished in the same
+sense: it can be continued, renamed or deleted from another client. Stopping would
+freeze the page for exactly the case this change exists to fix. 60 s equals the query
+client's `staleTime`, so nothing is refetched that the client still considers fresh.
+
+**The fast tier is 10 s, not the agents' 5 s, and the age bound is 5 minutes against
+their 3.** The agents' constants move a small Kubernetes object on a controller
+reconcile cadence. This one moves the whole conversation — a real four-turn session
+measured ~500 KB, re-parsed row by row through `a2aTaskWireSchema` and then
+deep-compared, all on the main thread — and it tracks an agent _turn_, which
+routinely runs minutes when there are many tool calls. A 3-minute bound would have
+backed off in the middle of exactly the run someone opened the page to watch.
+
+**`input-required` and `auth-required` are handled by that bound, not by a special
+case.** They are active states, but they wait on a human and this page offers no way
+to reply. They start fast, relax once nobody answers inside the window, and re-engage
+on their own when someone answers elsewhere and the newest task's timestamp advances.
+
+**There is no cheaper probe, which is why the interval carries the whole cost.**
+kagent's API serves no `HEAD` — every route is registered for one method on a
+gorilla/mux router, which matches methods exactly — and sets no `ETag` or
+`Last-Modified`, so there is no conditional GET and a full re-read is the only way to
+ask whether anything changed. The session object's `updated_at` tracks task-status
+writes to the millisecond and could gate the expensive read later, but only once
+somebody confirms kagent bumps it per appended event rather than only on state
+transitions; if it is the latter, a gated design would show nothing for the whole
+duration of a turn.
+
+**One non-obvious thing that made the simple design viable.** An unchanged poll costs
+no re-render at all: react-query's structural sharing returns the previous reference
+when the refetched payload is deep-equal, and `normalizeTaskList` yields plain
+objects out of zod, so the `useMemo`s that rebuild the timeline never re-run. No
+`select`, memoisation or content hashing was needed.
+
+**Polling also made an existing condition wrong, so that is fixed here too.** The
+page treated any error as fatal. react-query keeps `data` and sets `error` on a
+failed _refetch_, and the query client deliberately does not retry
+`ServiceUnavailable`/`Unauthorized`/`Forbidden` — so with polling, one proxy hiccup
+would have replaced a fully rendered conversation with a danger alert until the next
+successful poll. The fatal branch is now gated on having no session at all, and an
+error with one in hand shows a warning notice above the page instead. A local `Alert`
+rather than the shared `ErrorsProvider` notice the agent detail page uses, because
+the sessions router mounts no `ErrorsProvider` and adding one would mean splitting
+this page into wrapper and content for a one-line message.
+
+Manual refresh is deliberately still absent. Staleness is capped at 60 s now, and the
+control would have to live in the page header, which renders outside this plugin's
+`QueryClientProvider` — so it needs new fields on `SessionDetailView` threaded
+through the memo whose whole purpose is to stop the header slot re-registering on
+every poll. That is a bigger change than the polling it would accompany.

--- a/.changeset/agent-platform-session-detail-polling.md
+++ b/.changeset/agent-platform-session-detail-polling.md
@@ -52,6 +52,17 @@ when the refetched payload is deep-equal, and `normalizeTaskList` yields plain
 objects out of zod, so the `useMemo`s that rebuild the timeline never re-run. No
 `select`, memoisation or content hashing was needed.
 
+**The age bound applies on every path, including the one where it is most needed.**
+`status.timestamp` is optional at the parse boundary, and `normalizeTimestamp` also
+rejects Go zero time and anything unparseable — so an active task can carry no usable
+time of its own. Treating that as "just changed" (which is what `isAgentConverging`
+does, safely, because a Kubernetes object always has `lastTransitionTime`) would make
+the fast tier _unbounded_ on exactly the case the bound exists for: an agent that died
+mid-turn. The interval falls back to the newest usable timestamp anywhere in the
+conversation, and drops to the baseline when nothing in it carries one — losing the
+"state and timestamp from the same task" property on purpose, because an age basis
+that exists beats a fast tier nothing can stop.
+
 **Polling also made an existing condition wrong, so that is fixed here too.** The
 page treated any error as fatal. react-query keeps `data` and sets `error` on a
 failed _refetch_, and the query client deliberately does not retry
@@ -62,6 +73,19 @@ error with one in hand shows a warning notice above the page instead. A local `A
 rather than the shared `ErrorsProvider` notice the agent detail page uses, because
 the sessions router mounts no `ErrorsProvider` and adding one would mean splitting
 this page into wrapper and content for a one-line message.
+
+Keeping the page up needed three further distinctions, because the two reads fail
+independently. A tasks read that fails on **first** load leaves the timeline, turns
+and tokens at zero while the session read succeeds, so the hook now reports
+`hasConversation` and the page keeps the fatal branch when the conversation is
+_absent_ rather than empty. A poll answering 200 with no readable session no longer
+claims the session was deleted once one has already been read — and the query function
+coerces that case to `null`, because react-query rejects an `undefined` resolve, which
+was surfacing `[…query key…] data is undefined` to the user and had quietly made the
+`isSuccess && !data` branch unreachable. And a delete in flight now disables both
+reads (`enabled: !isDeleting && !isDeleted`): `refetchType: 'none'` governs
+invalidation-driven refetches only, so it never held off a scheduled interval tick
+landing mid-navigation.
 
 Manual refresh is deliberately still absent. Staleness is capped at 60 s now, and the
 control would have to live in the page header, which renders outside this plugin's

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -535,6 +535,35 @@ rather than the shared `ErrorsProvider`/`useShowErrors` notice the agent detail 
 uses, because the sessions router mounts no `ErrorsProvider` and adding one would
 mean splitting this page into wrapper and content for a one-line message.
 
+**"Keep what you have" is not the same as "render whatever is in hand", and three
+cases pull them apart.** The two reads fail independently, so each needed its own
+answer:
+
+- **The conversation never loaded.** A tasks read that fails on _first_ load leaves
+  the timeline, turn count and tokens at their zero values while the session read
+  succeeds. Rendering that would state "no activity", `Turns 0` and "no messages
+  yet" about a session with a full conversation. The hook exposes `hasConversation`
+  (`tasksQuery.data !== undefined`) and the page keeps the fatal branch when it is
+  false — absent is not empty. A session that genuinely never ran reads as `[]`,
+  which is data, and still renders as "no activity".
+- **A poll returns a 200 with no readable session.** `getSessionDetail` resolves
+  `undefined` for that, and react-query _rejects_ an `undefined` resolve — the query
+  errors with `[…query key…] data is undefined`, which leaked a raw query key into
+  the UI and made the `isSuccess && !data` branch unreachable. The query function
+  now coerces to `null`, which react-query stores. On top of that, an empty read
+  only means "no such session" **before** one has been read: once the page is
+  showing a conversation, the same answer means unreadable, not deleted — an expired
+  oauth2-proxy serving an HTML sign-in page under a 200 is the realistic trigger,
+  and telling someone their session "may have been deleted" for that would be a lie.
+  A genuine 404 still counts at any point, since that is how a delete elsewhere
+  shows up.
+- **A delete is in flight.** `refetchType: 'none'` governs invalidation-driven
+  refetches only; a scheduled interval tick is neither, so it could land in the
+  window between kagent accepting the delete and the caller navigating away, 404 and
+  flash "Session not found" at someone who just deleted the session deliberately.
+  The page passes `enabled: !isDeleting && !isDeleted` into the hook, which stops
+  both reads outright for the duration.
+
 ### What the timeline shows
 
 Built by `lib/kagentTimeline.ts` from task history. Conversation messages render in

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -205,12 +205,12 @@ Two consequences to keep in mind:
 `kube:apply` (tagged `hidden` so it stays out of the `/create` list). It applies
 the manifest verbatim, so what the review page shows is exactly what is applied.
 
-> **Note:** `/catalog` is gitignored — this template is a **local-dev artifact**
-> only, like `app-deployment`. Real deployments load templates from the external
-> `giantswarm/backstage-catalogs` repo, so **the template must also be added
-> there** for the deploy button to work outside local development. Register it
-> for local dev via `catalog.locations` in `app-config.local.yaml` (see
-> `app-config.local.yaml.example`).
+> **Note:** `/catalog` is gitignored — the copy there is a **local-dev artifact**
+> only, like `app-deployment`; register it via `catalog.locations` in
+> `app-config.local.yaml` (see `app-config.local.yaml.example`). Real deployments
+> load the template from the external
+> [`giantswarm/backstage-catalogs`](https://github.com/giantswarm/backstage-catalogs/tree/main/templates/agent-deployment)
+> repo, where it is published. Keep the two in sync when changing it.
 
 ### Namespace
 
@@ -457,6 +457,84 @@ timestamp is the finest granularity that exists, so the timeline shows it once p
 turn rather than repeating it on every entry, which would imply precision we do not
 have.
 
+### Refreshing
+
+Both reads poll, on different cadences (`lib/kagentSessionPolling.ts`):
+
+| Read             | Interval                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| the session      | a flat 60 s                                                                         |
+| the conversation | **10 s** while the newest task is in an active A2A state and recent, 60 s otherwise |
+
+The session object is title, agent and timestamps, none of which move while an agent
+works, so it gets no fast tier — it polls at all only so a session renamed or deleted
+elsewhere stops looking current. The conversation gets the two tiers, decided from
+the data already in hand, exactly as `getAgentRefetchInterval` does for one agent
+(see "The agent detail page").
+
+**There is nothing cheaper to poll.** kagent's API serves no `HEAD` — every route is
+registered for a single method on a gorilla/mux router, which matches methods
+exactly — and sets no `ETag`, `Last-Modified` or `Cache-Control` (`RespondWithJSON`
+in `go/core/internal/httpserver/handlers/helpers.go` marshals and writes; the
+middleware chain only sets `Content-Type`). So there is no conditional GET to make
+"has this changed?" cheap, and a full re-read is the only probe available. The
+closest thing is the session object's `updated_at`, which tracks task-status writes
+to the millisecond — a future optimisation could gate the expensive read on it, but
+only once someone has confirmed kagent bumps it per appended event rather than only
+on state transitions. If it is the latter, a gated design would show nothing for the
+whole duration of a turn.
+
+That is also why the fast tier is **10 s and not the agents' 5 s**: this one moves
+the whole conversation, ~500 KB for a four-turn session, re-parsed row by row
+through `a2aTaskWireSchema` and then deep-compared on the main thread. A turn takes
+tens of seconds, so nothing reads as less live for it.
+
+**The age bound is 5 minutes, against the agents' 3.** Both exist for the same
+reason — an agent that died mid-turn without writing a terminal state would
+otherwise pin the fast tier for as long as the tab stays open — but they are
+calibrated to different things: the agents' bound tracks a controller reconcile
+loop, this one tracks an agent _turn_, which routinely runs minutes when there are
+many tool calls. A 3-minute bound would back off in the middle of exactly the run
+the page was opened to watch.
+
+The bound is also what handles `input-required` and `auth-required`. Those states
+are active — the session may still produce output — but they wait on a human, and
+this page offers no way to reply. They start on the fast tier, relax once nobody has
+answered inside the window, and re-engage on their own when someone answers
+elsewhere and the newest task's timestamp advances.
+
+**A terminal session relaxes to 60 s rather than stopping.** Unlike a finished
+workflow execution, a kagent session is not immutable: it can be continued, renamed
+or deleted from another client. Stopping would freeze the page for exactly the case
+this polling exists to fix. 60 s equals the query client's `staleTime`, so nothing
+is refetched that the client still considers fresh.
+
+Polls only fire while the tab is **visible** — `refetchIntervalInBackground` defaults
+to `false`, and react-query's focus manager keys off `document.visibilityState`, not
+window focus, so a visible-but-unfocused window keeps polling. Verified on gazelle:
+nothing was requested across 80 s hidden, and the interval resumed by itself
+afterwards.
+
+Going **offline** is different again, and quieter than it looks: react-query's
+default `networkMode: 'online'` _pauses_ these queries rather than failing them, so a
+disconnected browser makes no request, raises no error and shows no warning — the
+page just stops updating until the connection returns, at which point the interval
+resumes on its own. Also verified on gazelle.
+
+An unchanged response costs no re-render: react-query's structural sharing returns
+the previous reference when the payload is deep-equal, so the `useMemo`s that rebuild
+the timeline do not re-run.
+
+**A failed refresh does not replace the page.** react-query keeps `data` and sets
+`error` on a failed _refetch_, and the query client deliberately does not retry
+`ServiceUnavailable`/`Unauthorized`/`Forbidden` — so treating any error as fatal
+would let one proxy hiccup blank a conversation someone is reading, for up to a
+minute. The fatal branch is gated on having no session at all; an error with one in
+hand shows a warning notice above the page instead. That notice is a local `Alert`
+rather than the shared `ErrorsProvider`/`useShowErrors` notice the agent detail page
+uses, because the sessions router mounts no `ErrorsProvider` and adding one would
+mean splitting this page into wrapper and content for a one-line message.
+
 ### What the timeline shows
 
 Built by `lib/kagentTimeline.ts` from task history. Conversation messages render in
@@ -623,7 +701,9 @@ a re-release rather than a menu item.
 The agent is fetched with a **single targeted `useResource`**, not read out of the
 list's `AgentsDataProvider`, so a deep link works without the list having loaded.
 It polls on the same two tiers as the list (`isAgentConverging` is now shared):
-5 s while an agent is converging, 60 s once it settles or stays durably broken.
+5 s while an agent is converging, 60 s once it settles or stays durably broken. The
+session detail page follows the same policy with different constants, and
+"Refreshing" above explains why they differ.
 
 ### Layout
 
@@ -887,9 +967,6 @@ above). What remains is a separate, deeper concern:
 - **muster defaults.** The chart wires the muster gateway by default; the create
   flow doesn't set the per-installation `muster.stsWellKnownUri` (or opt out via
   `extraAgentSpec`/config), so this needs revisiting once agents actually run.
-- **Production template registration.** The `agent-deployment` template must be
-  added to `giantswarm/backstage-catalogs` for the deploy button to work outside
-  local development.
 
 ### Features
 
@@ -917,6 +994,25 @@ above). What remains is a separate, deeper concern:
   no UI. Rename in particular deviates from the prototype, where sessions are never
   user-named. Deleting from a list row is also unimplemented — deliberately, since a
   destructive action on a row someone is scanning past is easy to hit by accident.
+- **An unanswered question is not shown.** When a task is `input-required`, the
+  question the agent is waiting on lives in `status.message` — the wire schema
+  already parses it and says so — but `buildTimeline` only ever reads
+  `status.timestamp`, so nothing renders it. The page shows a "Waiting for input"
+  badge above a conversation that just stops, with no indication of what was asked.
+  Observed live on gazelle. The fix is a timeline entry (or a panel above it) for the
+  pending prompt; note it is not part of task `history`, so it needs handling of its
+  own rather than falling out of the existing walk. Answering it is a separate gap —
+  see "Renaming and continuing a session" for the missing write path.
+- **No manual refresh on the session detail page.** The page polls now (see
+  "Refreshing"), so staleness is capped at 60 s and there is nothing frozen to
+  rescue — but there is still no way to say "check again, now", which is the one
+  thing polling cannot answer for a session past the age bound. The reason it was
+  left out is cost, not doubt: the control belongs in the page header, which renders
+  outside this plugin's `QueryClientProvider`, so it needs `refresh` and
+  `isRefreshing` on `SessionDetailView`, threaded through the `actions` memo whose
+  whole job is to keep the header slot from re-registering on every poll.
+  `plugins/muster`'s `FreshnessIndicator` is the shape to copy, ported to bui and
+  promoted to `ui-react`.
 - **Landing page.** The section still opens on the Agents tab. Whether the
   platform wants a proper landing page above the tabs — fleet health, recent
   activity — is an open product question, not a gap in the tabs themselves.

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
@@ -71,6 +71,7 @@ const loadedView: SessionDetailView = {
   timeline,
   state: deriveSessionState(tasks),
   taskCount: tasks.length,
+  hasConversation: true,
   isLoading: false,
   isNotFound: false,
   error: undefined,
@@ -247,6 +248,30 @@ describe('SessionDetailPage', () => {
 
     // A failed poll must not strip the kebab either.
     expect(lastProvidedActions()).not.toBeNull();
+  });
+
+  it('does not fabricate an empty session when the conversation never loaded', async () => {
+    // The two reads fail independently. With the session read fine and the tasks
+    // read failing on *first* load, the timeline/turns/tokens are absent, not empty
+    // — rendering them would claim "no activity", "Turns 0" and "no messages yet"
+    // about a session that has a full conversation.
+    const error = new Error('kagent is unavailable');
+    error.name = 'ServiceUnavailableError';
+    mockUseSessionDetail.mockReturnValue({
+      ...loadedView,
+      timeline: emptyTimeline,
+      taskCount: 0,
+      state: undefined,
+      hasConversation: false,
+      error,
+    });
+
+    await render();
+
+    expect(screen.getByText('Could not load this session')).toBeInTheDocument();
+    expect(screen.getByText(/kagent is unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText('no activity')).not.toBeInTheDocument();
+    expect(screen.queryByText('Turns')).not.toBeInTheDocument();
   });
 
   it('shows progress while loading', async () => {

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.test.tsx
@@ -205,6 +205,8 @@ describe('SessionDetailPage', () => {
   });
 
   it('surfaces a genuine read failure with its message', async () => {
+    // Specifically the *no data* case — an error with a session already in hand is
+    // a stale-refresh notice instead, see the test below. The two are a pair.
     const error = new Error('kagent returned status 500');
     error.name = 'UpstreamError';
     mockUseSessionDetail.mockReturnValue({
@@ -218,6 +220,33 @@ describe('SessionDetailPage', () => {
 
     expect(screen.getByText('Could not load this session')).toBeInTheDocument();
     expect(screen.getByText(/status 500/)).toBeInTheDocument();
+  });
+
+  it('keeps the session on screen when a refresh fails', async () => {
+    // These reads poll, so an error can arrive on a page that is already showing a
+    // perfectly real conversation. Replacing it would mean one proxy hiccup blanks
+    // the session someone is reading, for up to a minute.
+    const error = new Error('kagent is unavailable');
+    error.name = 'ServiceUnavailableError';
+    mockUseSessionDetail.mockReturnValue({ ...loadedView, error });
+
+    await render();
+
+    expect(screen.getByText('Which GitHub issues...')).toBeInTheDocument();
+    expect(screen.getByText(/You have two open issues/)).toBeInTheDocument();
+    expect(
+      screen.queryByText('Could not load this session'),
+    ).not.toBeInTheDocument();
+
+    // Said out loud, so a conversation that has quietly stopped keeping up does
+    // not read as an agent that stopped producing output.
+    expect(
+      screen.getByText('This session may be out of date'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/kagent is unavailable/)).toBeInTheDocument();
+
+    // A failed poll must not strip the kebab either.
+    expect(lastProvidedActions()).not.toBeNull();
   });
 
   it('shows progress while loading', async () => {

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
@@ -167,7 +167,13 @@ export function SessionDetailPage() {
     );
   }
 
-  if (error || !detail || !row) {
+  // Deliberately not `error ||`: these reads poll, and react-query keeps `data`
+  // while setting `error` on a failed *refetch* — which the query client does not
+  // retry for ServiceUnavailable/Unauthorized/Forbidden. Treating any error as
+  // fatal would let one proxy hiccup replace a rendered conversation with an
+  // alert until the next successful poll. With a session in hand the page renders
+  // whatever the last read did, and says so in the notice below.
+  if (!detail || !row) {
     return (
       <Content>
         <Flex direction="column" gap="3">
@@ -194,6 +200,17 @@ export function SessionDetailPage() {
   return (
     <Content>
       <Flex direction="column" gap="4">
+        {/* A refresh that failed after the page had loaded. Shown rather than
+            thrown: the conversation on screen is still real, it has just stopped
+            keeping up, and the user needs to know which of the two it is. */}
+        {error && (
+          <Alert
+            status="warning"
+            title="This session may be out of date"
+            description={`The last refresh failed: ${error.message}`}
+          />
+        )}
+
         <Flex direction="column" gap="2">
           <BackToSessions>← Sessions</BackToSessions>
           <Flex align="center" gap="2" style={{ flexWrap: 'wrap' }}>

--- a/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
+++ b/plugins/agent-platform/src/components/SessionDetailPage/SessionDetailPage.tsx
@@ -98,8 +98,25 @@ export function SessionDetailPage() {
   const { installation = '', sessionId = '' } = useParams();
   const buildAvatarUrl = useAgentAvatarUrl();
 
-  const { detail, timeline, state, taskCount, isLoading, isNotFound, error } =
-    useSessionDetail(installation, sessionId);
+  // Before the reads, because it gates them: a delete is in flight from this very
+  // page, and an interval landing between "kagent accepted the delete" and the
+  // caller's `navigate()` would 404 and flash "Session not found" at someone who
+  // just deleted it deliberately.
+  const deletion = useDeleteSession(installation, sessionId);
+  const { isUserScoped } = useKagentCapabilities(installation);
+
+  const {
+    detail,
+    timeline,
+    state,
+    taskCount,
+    hasConversation,
+    isLoading,
+    isNotFound,
+    error,
+  } = useSessionDetail(installation, sessionId, {
+    enabled: !deletion.isDeleting && !deletion.isDeleted,
+  });
 
   // The same join the list uses, so a session's agent is named identically in both
   // places — and falls back to the same lossy decode when no Agent CR matched.
@@ -118,12 +135,11 @@ export function SessionDetailPage() {
     [detail, agentIndex],
   );
 
-  // Both called here rather than inside the menu: the menu is rendered in the
-  // shared plugin header, which is outside this plugin's `QueryClientProvider`, so
-  // a mutation or a query has no client there. The capabilities probe is a cached
-  // `/me` read with an hour's staleTime, so asking for it on this page is free.
-  const deletion = useDeleteSession(installation, sessionId);
-  const { isUserScoped } = useKagentCapabilities(installation);
+  // Both `useDeleteSession` and `useKagentCapabilities` are called here rather than
+  // inside the menu: the menu is rendered in the shared plugin header, which is
+  // outside this plugin's `QueryClientProvider`, so a mutation or a query has no
+  // client there. The capabilities probe is a cached `/me` read with an hour's
+  // staleTime, so asking for it on this page is free.
 
   /** Shared by the heading, the actions menu and its dialog, so all three agree. */
   const sessionTitle = row?.title || SESSION_TITLE_FALLBACK;
@@ -171,9 +187,15 @@ export function SessionDetailPage() {
   // while setting `error` on a failed *refetch* — which the query client does not
   // retry for ServiceUnavailable/Unauthorized/Forbidden. Treating any error as
   // fatal would let one proxy hiccup replace a rendered conversation with an
-  // alert until the next successful poll. With a session in hand the page renders
-  // whatever the last read did, and says so in the notice below.
-  if (!detail || !row) {
+  // alert until the next successful poll. With both reads in hand the page renders
+  // whatever the last one did, and says so in the notice below.
+  //
+  // `hasConversation` is not redundant with `!detail`. The two reads fail
+  // independently, and a tasks read that fails on *first* load leaves the timeline,
+  // turn count and token stats at their zero values while the session read
+  // succeeds — which would render "no activity", `Turns 0` and "no messages yet"
+  // over a session that has a full conversation. Absent is not empty.
+  if (!detail || !row || !hasConversation) {
     return (
       <Content>
         <Flex direction="column" gap="3">

--- a/plugins/agent-platform/src/hooks/useDeleteSession.ts
+++ b/plugins/agent-platform/src/hooks/useDeleteSession.ts
@@ -44,7 +44,9 @@ export function useDeleteSession(installation: string, sessionId: string) {
       // with a request that now 404s, flashing "Session not found" underneath
       // someone who already knows. `refetchType: 'none'` leaves the entries stale
       // instead, so a later visit to the same URL revalidates and lands on the
-      // not-found state properly.
+      // not-found state properly. Note this is now the only thing holding that
+      // race off: both reads carry a refetch interval, so changing `refetchType`
+      // here would reintroduce the flash the next time a tick lands mid-navigation.
       await Promise.all(
         [
           sessionQueryKey(installation, sessionId),

--- a/plugins/agent-platform/src/hooks/useDeleteSession.ts
+++ b/plugins/agent-platform/src/hooks/useDeleteSession.ts
@@ -44,9 +44,15 @@ export function useDeleteSession(installation: string, sessionId: string) {
       // with a request that now 404s, flashing "Session not found" underneath
       // someone who already knows. `refetchType: 'none'` leaves the entries stale
       // instead, so a later visit to the same URL revalidates and lands on the
-      // not-found state properly. Note this is now the only thing holding that
-      // race off: both reads carry a refetch interval, so changing `refetchType`
-      // here would reintroduce the flash the next time a tick lands mid-navigation.
+      // not-found state properly.
+      //
+      // This alone is **not** enough now that both reads carry a refetch interval:
+      // `refetchType` governs invalidation-driven refetches only, and a scheduled
+      // tick is neither invalidation-driven nor stopped by it. The window is real —
+      // the `invalidateQueries` above does refetch the fleet list, so a full round
+      // trip separates the delete from the caller's `navigate()`. What actually
+      // holds the race off is the page disabling both reads for the duration; see
+      // `isDeleted` below and its use in `SessionDetailPage`.
       await Promise.all(
         [
           sessionQueryKey(installation, sessionId),
@@ -70,10 +76,22 @@ export function useDeleteSession(installation: string, sessionId: string) {
     () => ({
       deleteSession,
       isDeleting: mutation.isPending,
+      /**
+       * Stays true after the mutation settles, unlike `isDeleting`. The page keeps
+       * its reads switched off through the gap between success and the caller's
+       * navigation, which `isDeleting` alone would reopen.
+       */
+      isDeleted: mutation.isSuccess,
       error: mutation.error as Error | null,
       reset,
     }),
-    [deleteSession, mutation.isPending, mutation.error, reset],
+    [
+      deleteSession,
+      mutation.isPending,
+      mutation.isSuccess,
+      mutation.error,
+      reset,
+    ],
   );
 }
 

--- a/plugins/agent-platform/src/hooks/useSessionDetail.test.tsx
+++ b/plugins/agent-platform/src/hooks/useSessionDetail.test.tsx
@@ -1,10 +1,15 @@
 import { PropsWithChildren } from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { TestApiProvider } from '@backstage/test-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { kagentApiRef } from '../apis';
 import { KagentApi } from '../apis/types';
-import { useSessionDetail } from './useSessionDetail';
+import { ACTIVE_REFETCH_INTERVAL_MS } from '../lib/kagentSessionPolling';
+import {
+  sessionQueryKey,
+  sessionTasksQueryKey,
+  useSessionDetail,
+} from './useSessionDetail';
 
 const getSessionDetail = jest.fn();
 const listSessionTasks = jest.fn();
@@ -25,6 +30,32 @@ function neverSettles() {
   return new Promise(() => {});
 }
 
+const SESSION = {
+  session: {
+    id: 'gazelle/abc',
+    sessionId: 'abc',
+    installation: 'gazelle',
+    title: 'Chat',
+  },
+};
+
+/** One A2A task, enough for `buildTimeline` and the polling predicate. */
+function workingTask() {
+  return {
+    id: 'task-1',
+    contextId: 'abc',
+    kind: 'task',
+    status: { state: 'working', timestamp: new Date().toISOString() },
+    history: [
+      {
+        role: 'user',
+        parts: [{ kind: 'text', text: 'hello' }],
+        kind: 'message',
+      },
+    ],
+  };
+}
+
 function renderWith() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -34,7 +65,10 @@ function renderWith() {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </TestApiProvider>
   );
-  return renderHook(() => useSessionDetail('gazelle', 'abc'), { wrapper });
+  return {
+    ...renderHook(() => useSessionDetail('gazelle', 'abc'), { wrapper }),
+    queryClient,
+  };
 }
 
 beforeEach(() => {
@@ -72,14 +106,7 @@ describe('useSessionDetail', () => {
   it('keeps loading while a readable session’s tasks are still in flight', async () => {
     // The other side of that short-circuit: with the session present there is
     // nothing to show until its conversation arrives.
-    getSessionDetail.mockResolvedValue({
-      session: {
-        id: 'gazelle/abc',
-        sessionId: 'abc',
-        installation: 'gazelle',
-        title: 'Chat',
-      },
-    });
+    getSessionDetail.mockResolvedValue(SESSION);
     listSessionTasks.mockImplementation(neverSettles);
 
     const { result } = renderWith();
@@ -87,5 +114,86 @@ describe('useSessionDetail', () => {
     await waitFor(() => expect(getSessionDetail).toHaveBeenCalled());
     expect(result.current.isNotFound).toBe(false);
     expect(result.current.isLoading).toBe(true);
+  });
+
+  it('keeps the conversation on a failed refetch', async () => {
+    // Now that these reads poll, a single failure is no longer "we have nothing":
+    // react-query keeps `data` and sets `error`, and the plugin's client does not
+    // retry ServiceUnavailable/Unauthorized/Forbidden. The page renders from
+    // `detail`, so this is what stops one proxy hiccup blanking a live session.
+    getSessionDetail.mockResolvedValue(SESSION);
+    listSessionTasks
+      .mockResolvedValueOnce([workingTask()])
+      .mockRejectedValue(new Error('proxy hiccup'));
+
+    const { result, queryClient } = renderWith();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const itemCount = result.current.timeline.items.length;
+    expect(itemCount).toBeGreaterThan(0);
+
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: sessionTasksQueryKey('gazelle', 'abc'),
+      });
+    });
+
+    // Through `waitFor`: react-query batches its notifications, so the render
+    // carrying the failure lands a tick after `refetchQueries` resolves.
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe('proxy hiccup'),
+    );
+    expect(result.current.detail).toBeDefined();
+    expect(result.current.timeline.items).toHaveLength(itemCount);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('reports not found when the session is deleted elsewhere', async () => {
+    // A poll is now how the page learns that someone deleted this session in
+    // another client — it must reach the not-found state, not the error one.
+    getSessionDetail
+      .mockResolvedValueOnce(SESSION)
+      .mockRejectedValue(notFoundError());
+    listSessionTasks.mockResolvedValue([workingTask()]);
+
+    const { result, queryClient } = renderWith();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: sessionQueryKey('gazelle', 'abc'),
+      });
+    });
+
+    await waitFor(() => expect(result.current.isNotFound).toBe(true));
+    expect(result.current.error).toBeUndefined();
+  });
+
+  // The only timer-dependent test here: the cadence rules themselves are covered
+  // purely in `lib/kagentSessionPolling.test.ts`, but a pure test cannot prove the
+  // interval is actually passed to `useQuery`. If this ever turns flaky it can go
+  // without losing coverage of the logic.
+  it('refetches the conversation on its own while a task is working', async () => {
+    getSessionDetail.mockResolvedValue(SESSION);
+    listSessionTasks.mockResolvedValue([workingTask()]);
+
+    // Fake timers from before the render: the interval is scheduled at mount, so
+    // switching afterwards would leave a real timer nothing can advance.
+    jest.useFakeTimers();
+    try {
+      const { result } = renderWith();
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(listSessionTasks).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(ACTIVE_REFETCH_INTERVAL_MS);
+      });
+
+      await waitFor(() => expect(listSessionTasks).toHaveBeenCalledTimes(2));
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/plugins/agent-platform/src/hooks/useSessionDetail.test.tsx
+++ b/plugins/agent-platform/src/hooks/useSessionDetail.test.tsx
@@ -56,7 +56,7 @@ function workingTask() {
   };
 }
 
-function renderWith() {
+function renderHookWith(options?: { enabled?: boolean }) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -66,9 +66,15 @@ function renderWith() {
     </TestApiProvider>
   );
   return {
-    ...renderHook(() => useSessionDetail('gazelle', 'abc'), { wrapper }),
+    ...renderHook(() => useSessionDetail('gazelle', 'abc', options), {
+      wrapper,
+    }),
     queryClient,
   };
+}
+
+function renderWith() {
+  return renderHookWith();
 }
 
 beforeEach(() => {
@@ -168,6 +174,85 @@ describe('useSessionDetail', () => {
 
     await waitFor(() => expect(result.current.isNotFound).toBe(true));
     expect(result.current.error).toBeUndefined();
+  });
+
+  it('reports no conversation when the tasks read fails on first load', async () => {
+    // The session read succeeding does not mean the conversation is empty. Callers
+    // need to tell "absent" from "empty" or they render a fabricated blank session.
+    getSessionDetail.mockResolvedValue(SESSION);
+    listSessionTasks.mockRejectedValue(new Error('kagent is unavailable'));
+
+    const { result } = renderWith();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.hasConversation).toBe(false);
+    expect(result.current.detail).toBeDefined();
+    expect(result.current.taskCount).toBe(0);
+    expect(result.current.error?.message).toBe('kagent is unavailable');
+  });
+
+  it('reports a conversation that is genuinely empty', async () => {
+    // The other side of it: a session created but never run reads as `[]`, which is
+    // data, and must render as "no activity" rather than as a failure.
+    getSessionDetail.mockResolvedValue(SESSION);
+    listSessionTasks.mockResolvedValue([]);
+
+    const { result } = renderWith();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.hasConversation).toBe(true);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('keeps a loaded session when a poll returns an unreadable 200', async () => {
+    // `getSessionDetail` resolves undefined for any 200 that does not parse — an
+    // expired oauth2-proxy serving an HTML sign-in page is the realistic trigger.
+    // Nothing was deleted, so the user must not be told the session is gone.
+    getSessionDetail
+      .mockResolvedValueOnce(SESSION)
+      .mockResolvedValue(undefined);
+    listSessionTasks.mockResolvedValue([workingTask()]);
+
+    const { result, queryClient } = renderWith();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: sessionQueryKey('gazelle', 'abc'),
+      });
+    });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.isNotFound).toBe(false);
+    expect(result.current.detail).toBeDefined();
+  });
+
+  it('still reports not found for an empty read before anything loaded', async () => {
+    // The gate above must not swallow the real case: a 200 with no session, on a
+    // page that never had one, is exactly how kagent says "no such session".
+    getSessionDetail.mockResolvedValue(undefined);
+    listSessionTasks.mockResolvedValue([]);
+
+    const { result } = renderWith();
+
+    await waitFor(() => expect(result.current.isNotFound).toBe(true));
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('stops both reads while a delete is in flight', async () => {
+    getSessionDetail.mockResolvedValue(SESSION);
+    listSessionTasks.mockResolvedValue([workingTask()]);
+
+    const { result } = renderHookWith({ enabled: false });
+
+    // Nothing is requested at all, so no scheduled tick can land mid-delete and
+    // 404 under the caller's navigation.
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(getSessionDetail).not.toHaveBeenCalled();
+    expect(listSessionTasks).not.toHaveBeenCalled();
   });
 
   // The only timer-dependent test here: the cadence rules themselves are covered

--- a/plugins/agent-platform/src/hooks/useSessionDetail.ts
+++ b/plugins/agent-platform/src/hooks/useSessionDetail.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import { useQuery } from '@tanstack/react-query';
 import { kagentApiRef } from '../apis';
@@ -28,6 +28,15 @@ export type SessionDetailView = {
   state?: SessionState;
   /** Number of A2A tasks — the session's turn count. */
   taskCount: number;
+  /**
+   * Whether the conversation has ever been read.
+   *
+   * False means the timeline, turn count and token stats are **absent, not empty**,
+   * and must not be rendered: a tasks read that fails on first load leaves them at
+   * their zero values while the session read succeeds, which would otherwise show
+   * "no activity", `Turns 0` and "no messages yet" over a session that has plenty.
+   */
+  hasConversation: boolean;
   isLoading: boolean;
   /**
    * True when the session is not readable: it does not exist, was deleted, or
@@ -44,6 +53,14 @@ const EMPTY_TIMELINE: SessionTimeline = {
   tokens: { total: 0, prompt: 0, completion: 0 },
   skippedMessages: 0,
 };
+
+/**
+ * Stands in for a 200 that carried no readable session, once one has already been
+ * read. A module constant so its identity is stable across renders.
+ */
+const UNREADABLE_SESSION_ERROR = new Error(
+  'kagent returned a session response we could not read.',
+);
 
 /**
  * Read one session: its metadata and its conversation.
@@ -66,12 +83,25 @@ const EMPTY_TIMELINE: SessionTimeline = {
 export function useSessionDetail(
   installation: string,
   sessionId: string,
+  options: { enabled?: boolean } = {},
 ): SessionDetailView {
+  // `enabled: false` stops the intervals dead, which is the only thing that
+  // actually holds off a poll landing mid-delete — see `useDeleteSession`.
+  const { enabled = true } = options;
   const kagentApi = useApi(kagentApiRef);
 
   const sessionQuery = useQuery({
     queryKey: sessionQueryKey(installation, sessionId),
-    queryFn: () => kagentApi.getSessionDetail(installation, sessionId),
+    // `?? null` matters. `getSessionDetail` resolves `undefined` for a 200 that
+    // carried no readable session, and react-query rejects an `undefined` resolve
+    // outright — the query lands in `error` with the message
+    // `["agent-platform","kagent","session",…] data is undefined`, which is both a
+    // raw query key shown to a user and a classification we cannot act on. It also
+    // made the `isSuccess && !data` branch below unreachable. `null` is a value
+    // react-query stores, so an empty read stays an expected outcome.
+    queryFn: async () =>
+      (await kagentApi.getSessionDetail(installation, sessionId)) ?? null,
+    enabled,
     // A flat baseline, not the tasks' two tiers: this object is the title, the
     // agent and the timestamps, none of which move while an agent works. It polls
     // at all so a session renamed or deleted elsewhere stops looking current.
@@ -81,6 +111,7 @@ export function useSessionDetail(
   const tasksQuery = useQuery({
     queryKey: sessionTasksQueryKey(installation, sessionId),
     queryFn: () => kagentApi.listSessionTasks(installation, sessionId),
+    enabled,
     refetchInterval: getSessionTasksRefetchInterval,
   });
 
@@ -98,23 +129,51 @@ export function useSessionDetail(
     [tasks],
   );
 
+  // The last session we read successfully. `getSessionDetail` resolves `undefined`
+  // for any 200 whose body does not parse — an expired oauth2-proxy answering with
+  // an HTML sign-in page is the realistic case — and react-query stores that
+  // `undefined` as the query's data, discarding what we had. Holding the previous
+  // value means one malformed poll degrades to a staleness notice instead of
+  // erasing a live conversation.
+  const lastGoodDetail = useRef<KagentSessionDetail | undefined>(undefined);
+  if (sessionQuery.data) {
+    lastGoodDetail.current = sessionQuery.data;
+  }
+  const detail = sessionQuery.data ?? lastGoodDetail.current;
+
+  const sessionError = (sessionQuery.error as Error | null) ?? undefined;
+
   // The session read is what decides "not found": the tasks endpoint 404s for the
   // same session, but it also 404s on a kagent too old to serve it, and the two
   // must not look the same to the user.
+  //
+  // An empty 200 only means "no such session" *before* we have read one. Once the
+  // page is showing a real conversation, the same response means the answer was
+  // unreadable, not that the session is gone — telling someone it "may have been
+  // deleted" because a proxy served a sign-in page would be a lie. A genuine 404
+  // still counts at any point, since that is how a delete elsewhere shows up.
   const isNotFound =
-    (sessionQuery.isSuccess && !sessionQuery.data) ||
-    (sessionQuery.error as Error | null)?.name === 'NotFoundError';
+    (sessionQuery.isSuccess &&
+      !sessionQuery.data &&
+      lastGoodDetail.current === undefined) ||
+    sessionError?.name === 'NotFoundError';
+
+  const unreadableSession =
+    sessionQuery.isSuccess && !sessionQuery.data && lastGoodDetail.current
+      ? UNREADABLE_SESSION_ERROR
+      : undefined;
 
   // A 404 is an expected outcome, not an error to report.
   const error = isNotFound
     ? undefined
-    : (((sessionQuery.error ?? tasksQuery.error) as Error | null) ?? undefined);
+    : (sessionError ?? (tasksQuery.error as Error | null) ?? unreadableSession);
 
   return {
-    detail: sessionQuery.data ?? undefined,
+    detail,
     timeline,
     state,
     taskCount: tasks?.length ?? 0,
+    hasConversation: tasks !== undefined,
     // `isNotFound` short-circuits loading, because it is decided by the session
     // read alone and the page checks `isLoading` first. Without this, a session
     // that 404s immediately — `NotFoundError` is not retried, so that read settles

--- a/plugins/agent-platform/src/hooks/useSessionDetail.ts
+++ b/plugins/agent-platform/src/hooks/useSessionDetail.ts
@@ -5,6 +5,10 @@ import { kagentApiRef } from '../apis';
 import { KagentSessionDetail } from '../lib/kagentSessionDetail';
 import { buildTimeline, SessionTimeline } from '../lib/kagentTimeline';
 import { deriveSessionState, SessionState } from '../lib/kagentSessionState';
+import {
+  BASELINE_REFETCH_INTERVAL_MS,
+  getSessionTasksRefetchInterval,
+} from '../lib/kagentSessionPolling';
 
 /** Query key for one session's metadata. */
 export function sessionQueryKey(installation: string, sessionId: string) {
@@ -52,6 +56,12 @@ const EMPTY_TIMELINE: SessionTimeline = {
  * They are deliberately **not** chained. Firing both immediately halves the
  * time-to-first-paint, and the cost of a wasted tasks request when the session
  * turns out not to exist is one 404 on a page the user explicitly navigated to.
+ *
+ * Both poll, on different cadences — see `lib/kagentSessionPolling.ts`. Note that
+ * this leaves the two reads out of step during an active session: the conversation
+ * updates on the fast tier while the header's "last activity" and the duration stat
+ * come from the session read a minute behind. Both render as absolute timestamps,
+ * so the lag reads as older rather than as wrong.
  */
 export function useSessionDetail(
   installation: string,
@@ -62,11 +72,16 @@ export function useSessionDetail(
   const sessionQuery = useQuery({
     queryKey: sessionQueryKey(installation, sessionId),
     queryFn: () => kagentApi.getSessionDetail(installation, sessionId),
+    // A flat baseline, not the tasks' two tiers: this object is the title, the
+    // agent and the timestamps, none of which move while an agent works. It polls
+    // at all so a session renamed or deleted elsewhere stops looking current.
+    refetchInterval: BASELINE_REFETCH_INTERVAL_MS,
   });
 
   const tasksQuery = useQuery({
     queryKey: sessionTasksQueryKey(installation, sessionId),
     queryFn: () => kagentApi.listSessionTasks(installation, sessionId),
+    refetchInterval: getSessionTasksRefetchInterval,
   });
 
   const tasks = tasksQuery.data;
@@ -107,6 +122,9 @@ export function useSessionDetail(
     // the full retry ladder (2s/4s/8s) for a non-404 failure, or the fetch timeout
     // on an unreachable installation. The answer was already known; nothing the
     // tasks read can return would change it.
+    //
+    // `isLoading`, deliberately, not `isFetching`: it is false during a refetch,
+    // which is what keeps a poll from flashing the spinner over a rendered page.
     isLoading: !isNotFound && (sessionQuery.isLoading || tasksQuery.isLoading),
     isNotFound,
     error,

--- a/plugins/agent-platform/src/lib/kagentSessionPolling.test.ts
+++ b/plugins/agent-platform/src/lib/kagentSessionPolling.test.ts
@@ -1,0 +1,146 @@
+import type { A2aTaskWire } from './kagentTaskSchema';
+import { deriveSessionState } from './kagentSessionState';
+import {
+  ACTIVE_MAX_AGE_MS,
+  ACTIVE_REFETCH_INTERVAL_MS,
+  BASELINE_REFETCH_INTERVAL_MS,
+  getSessionTasksRefetchInterval,
+} from './kagentSessionPolling';
+
+describe('getSessionTasksRefetchInterval', () => {
+  const BASELINE = BASELINE_REFETCH_INTERVAL_MS;
+  const FAST = ACTIVE_REFETCH_INTERVAL_MS;
+  const NOW = Date.parse('2026-07-31T12:00:00Z');
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** A query whose data is the session's task list, oldest first. */
+  function query(tasks: A2aTaskWire[] | undefined) {
+    return { state: { data: tasks } } as Parameters<
+      typeof getSessionTasksRefetchInterval
+    >[0];
+  }
+
+  function task(
+    state: string | undefined,
+    { ageMs = 0, timestamp }: { ageMs?: number; timestamp?: string } = {},
+  ): A2aTaskWire {
+    return {
+      id: `task-${state ?? 'none'}-${ageMs}`,
+      contextId: 'abc',
+      kind: 'task',
+      status: {
+        state,
+        timestamp: timestamp ?? new Date(NOW - ageMs).toISOString(),
+      },
+    } as unknown as A2aTaskWire;
+  }
+
+  it('uses the baseline before the first fetch resolves', () => {
+    expect(getSessionTasksRefetchInterval(query(undefined))).toBe(BASELINE);
+  });
+
+  it('uses the baseline for a session with no tasks', () => {
+    // Created but never run — there is nothing converging to watch.
+    expect(getSessionTasksRefetchInterval(query([]))).toBe(BASELINE);
+  });
+
+  it.each(['working', 'submitted'])(
+    'polls fast while the newest task is %s',
+    state => {
+      expect(getSessionTasksRefetchInterval(query([task(state)]))).toBe(FAST);
+    },
+  );
+
+  it.each(['completed', 'failed', 'canceled', 'rejected'])(
+    'uses the baseline once the newest task is %s',
+    state => {
+      expect(getSessionTasksRefetchInterval(query([task(state)]))).toBe(
+        BASELINE,
+      );
+    },
+  );
+
+  it('decides from the newest task, not from any earlier one', () => {
+    // An earlier turn having been `working` says nothing about now — the same rule
+    // `deriveSessionState` applies.
+    const tasks = [task('working', { ageMs: 60_000 }), task('completed')];
+
+    expect(getSessionTasksRefetchInterval(query(tasks))).toBe(BASELINE);
+  });
+
+  it('uses the baseline for a state we do not recognise', () => {
+    // Matches `describeSessionState`: claiming a session is live on the strength of
+    // a state we cannot interpret would poll fast forever.
+    expect(getSessionTasksRefetchInterval(query([task('teleporting')]))).toBe(
+      BASELINE,
+    );
+  });
+
+  it('still polls fast just inside the active window', () => {
+    const recent = task('working', { ageMs: ACTIVE_MAX_AGE_MS - 1_000 });
+
+    expect(getSessionTasksRefetchInterval(query([recent]))).toBe(FAST);
+  });
+
+  // The bound that stops an agent which died mid-turn — no terminal state ever
+  // written — from pinning the fast tier for as long as the tab stays open.
+  it('backs off to the baseline for a task stuck working', () => {
+    const stuck = task('working', { ageMs: 10 * 60_000 });
+
+    expect(getSessionTasksRefetchInterval(query([stuck]))).toBe(BASELINE);
+  });
+
+  // `input-required` and `auth-required` are active but wait on a human, and this
+  // page offers no way to answer. The age bound is what keeps them from polling
+  // 500 KB forever; a reply elsewhere moves the timestamp and re-engages the fast
+  // tier on its own.
+  it.each(['input-required', 'auth-required'])(
+    'polls %s fast while fresh and backs off once nobody answers',
+    state => {
+      expect(getSessionTasksRefetchInterval(query([task(state)]))).toBe(FAST);
+      expect(
+        getSessionTasksRefetchInterval(
+          query([task(state, { ageMs: 10 * 60_000 })]),
+        ),
+      ).toBe(BASELINE);
+    },
+  );
+
+  it.each([
+    ['no timestamp at all', undefined],
+    ['Go zero time', '0001-01-01T00:00:00Z'],
+    ['an unparseable timestamp', 'not-a-date'],
+  ])('polls fast when an active task has %s', (_label, timestamp) => {
+    // Treated as just-changed rather than as stuck, mirroring `isAgentConverging`.
+    const noAge = task('working', { timestamp });
+
+    expect(getSessionTasksRefetchInterval(query([noAge]))).toBe(FAST);
+  });
+
+  it('reads the state and its timestamp from the same task', () => {
+    // A trailing task with no state is skipped entirely: its (fresh) timestamp
+    // must not make the earlier, stale `working` task look like it just moved.
+    const stuck = task('working', { ageMs: 10 * 60_000 });
+    const stateless = task(undefined, { ageMs: 0 });
+
+    expect(getSessionTasksRefetchInterval(query([stuck, stateless]))).toBe(
+      BASELINE,
+    );
+  });
+
+  it('agrees with deriveSessionState about which task decides', () => {
+    // The backwards walk is duplicated here rather than shared, so this guards the
+    // two copies against drifting apart.
+    const tasks = [task('completed', { ageMs: 60_000 }), task('working')];
+
+    expect(deriveSessionState(tasks)?.raw).toBe('working');
+    expect(getSessionTasksRefetchInterval(query(tasks))).toBe(FAST);
+  });
+});

--- a/plugins/agent-platform/src/lib/kagentSessionPolling.test.ts
+++ b/plugins/agent-platform/src/lib/kagentSessionPolling.test.ts
@@ -29,16 +29,21 @@ describe('getSessionTasksRefetchInterval', () => {
 
   function task(
     state: string | undefined,
-    { ageMs = 0, timestamp }: { ageMs?: number; timestamp?: string } = {},
+    options: { ageMs?: number; timestamp?: string } = {},
   ): A2aTaskWire {
+    const { ageMs = 0 } = options;
+    // Passing `timestamp` explicitly wins even when it is `undefined` — that is how
+    // these cases express "the task carries no timestamp at all".
+    const timestamp =
+      'timestamp' in options
+        ? options.timestamp
+        : new Date(NOW - ageMs).toISOString();
+
     return {
       id: `task-${state ?? 'none'}-${ageMs}`,
       contextId: 'abc',
       kind: 'task',
-      status: {
-        state,
-        timestamp: timestamp ?? new Date(NOW - ageMs).toISOString(),
-      },
+      status: { state, timestamp },
     } as unknown as A2aTaskWire;
   }
 
@@ -117,11 +122,34 @@ describe('getSessionTasksRefetchInterval', () => {
     ['no timestamp at all', undefined],
     ['Go zero time', '0001-01-01T00:00:00Z'],
     ['an unparseable timestamp', 'not-a-date'],
-  ])('polls fast when an active task has %s', (_label, timestamp) => {
-    // Treated as just-changed rather than as stuck, mirroring `isAgentConverging`.
-    const noAge = task('working', { timestamp });
+  ])(
+    'uses the baseline when the only active task has %s',
+    (_label, timestamp) => {
+      // Nothing in the conversation can bound the fast tier, so it must not engage:
+      // an unconditional fast tier here would re-read ~500 KB every 10 s forever for
+      // an agent that died mid-turn — the exact failure ACTIVE_MAX_AGE_MS prevents.
+      const noAge = task('working', { timestamp });
 
-    expect(getSessionTasksRefetchInterval(query([noAge]))).toBe(FAST);
+      expect(getSessionTasksRefetchInterval(query([noAge]))).toBe(BASELINE);
+    },
+  );
+
+  it('falls back to the newest usable timestamp when the active task has none', () => {
+    // Costs the "same task" property on purpose — an age basis that exists beats a
+    // fast tier nothing can stop.
+    const earlier = task('completed', { ageMs: 30_000 });
+    const active = task('working', { timestamp: undefined });
+
+    expect(getSessionTasksRefetchInterval(query([earlier, active]))).toBe(FAST);
+  });
+
+  it('still ages out via the fallback timestamp', () => {
+    const earlier = task('completed', { ageMs: 10 * 60_000 });
+    const active = task('working', { timestamp: undefined });
+
+    expect(getSessionTasksRefetchInterval(query([earlier, active]))).toBe(
+      BASELINE,
+    );
   });
 
   it('reads the state and its timestamp from the same task', () => {

--- a/plugins/agent-platform/src/lib/kagentSessionPolling.ts
+++ b/plugins/agent-platform/src/lib/kagentSessionPolling.ts
@@ -1,0 +1,116 @@
+import type { Query } from '@tanstack/react-query';
+import type { A2aTaskWire } from './kagentTaskSchema';
+import { normalizeTimestamp } from './kagentSessions';
+import { describeSessionState } from './kagentSessionState';
+
+/**
+ * Baseline poll for a session's conversation, and the flat interval for the
+ * session metadata read beside it.
+ *
+ * Deliberately equal to the query client's `staleTime` (see
+ * `QueryClientProvider`), for the reason spelled out in
+ * `AgentsDataProvider/helpers.ts`: interval refetches are not gated by staleness,
+ * so a shorter baseline would refetch data the client still considers fresh.
+ *
+ * This tier is what notices a session continued, renamed or deleted elsewhere.
+ */
+export const BASELINE_REFETCH_INTERVAL_MS = 60_000;
+
+/**
+ * Poll for a session whose newest task is still active — someone watching an
+ * agent work.
+ *
+ * Half the agents' 5s tier, and the difference is deliberate. Both tiers exist to
+ * watch something converge, but the agents' moves a small Kubernetes object while
+ * this one moves the whole conversation: a real four-turn session's tasks measured
+ * ~500 KB, and every response is re-parsed row by row through
+ * `a2aTaskWireSchema` and then deep-compared by react-query's structural sharing,
+ * all on the main thread. At 10s that stays modest, and a conversation turn is
+ * tens of seconds anyway, so nothing reads as less live for it.
+ *
+ * Note this only ticks while the tab is visible (`refetchIntervalInBackground`
+ * defaults to `false`), and that an offline browser pauses these queries outright
+ * rather than failing them (react-query's default `networkMode: 'online'`).
+ *
+ * kagent offers no cheaper way to ask "has this changed?" — its API serves no HEAD
+ * (every route is registered for GET only on a gorilla/mux router, which matches
+ * methods exactly) and sets no `ETag` or `Last-Modified`, so a full re-read is the
+ * only probe there is.
+ */
+export const ACTIVE_REFETCH_INTERVAL_MS = 10_000;
+
+/**
+ * How long a session's newest task may sit in an active state before we stop
+ * treating it as live and fall back to the baseline.
+ *
+ * Same purpose as `TRANSITIONAL_MAX_AGE_MS` for agents — without a bound, an agent
+ * that died mid-turn without writing a terminal state would pin the fast tier for
+ * as long as anyone leaves the tab open. Calibrated differently, though: the
+ * agents' 3 minutes tracks a controller reconcile loop, while this tracks an agent
+ * *turn*, which routinely runs minutes when there are many tool calls. A 3-minute
+ * bound would back off in the middle of exactly the run the page was opened to
+ * watch.
+ *
+ * This bound is also what handles `input-required` / `auth-required`. Those are
+ * active — the session may still produce output — but they wait on a human, and
+ * this page offers no way to answer. They start on the fast tier, relax once
+ * nobody has replied inside the window, and re-engage on their own when someone
+ * does reply elsewhere and the newest task's timestamp advances.
+ */
+export const ACTIVE_MAX_AGE_MS = 5 * 60_000;
+
+/**
+ * Refetch interval for one session's tasks — the conversation.
+ *
+ * Two tiers decided from the data already in hand, like the agent views: fast
+ * while the newest task is in an active A2A state and recent, baseline once it
+ * reaches a terminal state or stops moving. react-query re-evaluates this after
+ * every fetch resolves, so it needs no external state and is self-correcting.
+ *
+ * Never returns `false`. A terminal session is not immutable the way a finished
+ * workflow execution is — kagent lets it be continued, renamed or deleted from
+ * another client — so stopping altogether would freeze the page for exactly the
+ * case this polling exists to fix.
+ */
+export function getSessionTasksRefetchInterval(
+  query: Query<A2aTaskWire[]>,
+): number {
+  const tasks = query.state.data;
+  if (!tasks?.length) {
+    return BASELINE_REFETCH_INTERVAL_MS;
+  }
+
+  const now = Date.now();
+
+  // The same backwards walk as `deriveSessionState` — kagent returns tasks oldest
+  // first, so the session's state is the newest task's. Repeated here rather than
+  // reusing that function because the decision needs the state *and* the timestamp
+  // from the same task: a trailing task carrying no state must not lend its
+  // timestamp to an earlier task's state.
+  for (let index = tasks.length - 1; index >= 0; index -= 1) {
+    const status = tasks[index]?.status;
+    const state = describeSessionState(status?.state);
+    if (!state) {
+      continue;
+    }
+
+    if (!state.isActive) {
+      return BASELINE_REFETCH_INTERVAL_MS;
+    }
+
+    const changedAt = normalizeTimestamp(status?.timestamp);
+
+    // No usable timestamp — absent, or Go zero time. Treat the task as
+    // just-changed rather than as stuck, mirroring `isAgentConverging`.
+    if (changedAt === undefined) {
+      return ACTIVE_REFETCH_INTERVAL_MS;
+    }
+
+    return now - Date.parse(changedAt) < ACTIVE_MAX_AGE_MS
+      ? ACTIVE_REFETCH_INTERVAL_MS
+      : BASELINE_REFETCH_INTERVAL_MS;
+  }
+
+  // Tasks exist but none reported a state: a session created but never run.
+  return BASELINE_REFETCH_INTERVAL_MS;
+}

--- a/plugins/agent-platform/src/lib/kagentSessionPolling.ts
+++ b/plugins/agent-platform/src/lib/kagentSessionPolling.ts
@@ -60,6 +60,32 @@ export const ACTIVE_REFETCH_INTERVAL_MS = 10_000;
 export const ACTIVE_MAX_AGE_MS = 5 * 60_000;
 
 /**
+ * The most recent usable `status.timestamp` anywhere in the conversation.
+ *
+ * The age basis of last resort. `timestamp` is optional at the parse boundary, and
+ * `normalizeTimestamp` also rejects Go zero time and anything unparseable — so the
+ * newest task can perfectly well carry no usable time of its own, which would
+ * otherwise leave {@link ACTIVE_MAX_AGE_MS} with nothing to measure against.
+ */
+function newestUsableTimestamp(tasks: A2aTaskWire[]): number | undefined {
+  // Compared as parsed instants, not as strings: kagent's timestamps are UTC ISO
+  // today, but string order stops matching time order the moment a value arrives
+  // with an offset or a different fractional precision.
+  let newest: number | undefined;
+  for (const task of tasks) {
+    const at = normalizeTimestamp(task?.status?.timestamp);
+    if (at === undefined) {
+      continue;
+    }
+    const parsed = Date.parse(at);
+    if (newest === undefined || parsed > newest) {
+      newest = parsed;
+    }
+  }
+  return newest;
+}
+
+/**
  * Refetch interval for one session's tasks — the conversation.
  *
  * Two tiers decided from the data already in hand, like the agent views: fast
@@ -98,15 +124,26 @@ export function getSessionTasksRefetchInterval(
       return BASELINE_REFETCH_INTERVAL_MS;
     }
 
-    const changedAt = normalizeTimestamp(status?.timestamp);
+    const own = normalizeTimestamp(status?.timestamp);
+    // Falling back to the conversation's newest usable timestamp costs the "state
+    // and timestamp from the same task" property, deliberately. `isAgentConverging`
+    // can treat a missing timestamp as just-changed because a Kubernetes object
+    // always carries `lastTransitionTime`; here `timestamp` is genuinely optional,
+    // so an unconditional fast tier would be *unbounded* — the exact failure
+    // ACTIVE_MAX_AGE_MS exists to prevent, on the one path where it is most likely
+    // (an agent that died mid-turn, or a kagent that stops emitting the field).
+    const changedAt =
+      own === undefined ? newestUsableTimestamp(tasks) : Date.parse(own);
 
-    // No usable timestamp — absent, or Go zero time. Treat the task as
-    // just-changed rather than as stuck, mirroring `isAgentConverging`.
+    // Nothing in the whole conversation carries a usable time, so there is no way
+    // to bound the fast tier at all. Poll on the baseline: a task genuinely new
+    // this second is seen within a minute, where the alternative is re-reading the
+    // conversation every 10 s for as long as the tab stays open.
     if (changedAt === undefined) {
-      return ACTIVE_REFETCH_INTERVAL_MS;
+      return BASELINE_REFETCH_INTERVAL_MS;
     }
 
-    return now - Date.parse(changedAt) < ACTIVE_MAX_AGE_MS
+    return now - changedAt < ACTIVE_MAX_AGE_MS
       ? ACTIVE_REFETCH_INTERVAL_MS
       : BASELINE_REFETCH_INTERVAL_MS;
   }


### PR DESCRIPTION
### What does this PR do?

Makes the Agent Platform **session detail page refresh itself**. It read the session
and its conversation once at mount and never again, so someone watching an agent work
saw a frozen page until they navigated away and back.

Both reads now poll, on the two-tier shape the agent views already use
(`getAgentRefetchInterval`), via a new pure module `lib/kagentSessionPolling.ts`:

| Read | Interval |
| --- | --- |
| the conversation (`/tasks`) | **10 s** while the newest task is in an active A2A state and under 5 min old, **60 s** otherwise |
| the session object | a flat **60 s** — title, agent and timestamps do not move while an agent works |

Three decisions worth reviewing, each argued in the code comments, the docs and the
changeset:

- **A terminal session relaxes to 60 s rather than stopping.** Unlike a finished
  workflow execution, a kagent session can still be continued, renamed or deleted from
  another client — returning `false` would freeze the page for exactly the case this
  fixes.
- **10 s, not the agents' 5 s, and a 5-minute age bound against their 3.** The agents'
  constants move a small Kubernetes object on a reconcile cadence; this moves the whole
  conversation (~500 KB, re-parsed through zod each time) and tracks an agent *turn*,
  which routinely runs minutes.
- **`input-required`/`auth-required` are handled by the age bound, not a special case.**
  They are active but wait on a human; they start fast, relax after 5 min, and
  re-engage on their own when someone answers elsewhere.

**Polling also made an existing condition wrong, so that is fixed here too.** The page
treated any error as fatal. react-query keeps `data` and sets `error` on a failed
*refetch*, and the query client deliberately does not retry
`ServiceUnavailable`/`Unauthorized`/`Forbidden` — so one proxy hiccup would have
replaced a rendered conversation with a danger alert for up to a minute. The fatal
branch is now gated on having no session at all; an error with one in hand shows a
warning notice above the page instead.

### What is the effect of this change to users?

A session that is still producing output updates on its own, roughly every 10 seconds
— new turns, the state badge, and the turn/token/duration stats all move without
touching anything. Finished sessions still pick up changes made elsewhere within a
minute. A transient backend failure no longer wipes the conversation off the screen;
it shows a "This session may be out of date" notice and keeps what you were reading.

There is still no manual refresh button — deliberately, see the Open TODOs.

### How does it look like?

Verified live against **gazelle** (measured from the page's own resource timings):

```
working    →  10.0s, 10.1s          fast tier
completed  →  60.1s, 61s            relaxed to baseline
new turn   →  fast tier re-engaged on its own, then relaxed again
```

Watched a session go `Working` → `Completed` with no interaction: turns 1 → 3 → 5 → 10,
tokens 32.4k → 57.4k, the full answer rendered, and the timeline's Collapsed toggle
survived every poll.

The 5-minute age bound, on a session parked in `Waiting for input` (last activity 06:49):

```
06:49:39 … 06:54:24   gaps 10,10,10,10,10,11,10,10   fast tier, ~5 min
06:55:33              gap 69                          relaxed
06:56:33              gap 60                          baseline
```

Also confirmed: **0 polls across 80 s with the tab hidden**, resuming by itself
afterwards.

### Any background context you can provide?

**kagent offers no cheaper probe.** Checked the v0.9.9 source: every route is
registered for a single method on a gorilla/mux router (so no `HEAD`), and nothing
sets `ETag`, `Last-Modified` or `Cache-Control` — `RespondWithJSON` marshals and
writes, and the middleware chain only sets `Content-Type`. There is no conditional GET
to make "has this changed?" cheap, so a full re-read is the only option and the
interval carries the whole cost story.

**One non-obvious thing that made the simple design viable.** An unchanged poll costs
no re-render at all: react-query's structural sharing returns the previous reference
when the payload is deep-equal, so the `useMemo`s that rebuild the timeline never
re-run. No `select`, memoisation or content hashing was needed.

**Two open items recorded in the docs rather than fixed here:**

- Whether `status.timestamp` advances *during* a long `working` turn or only on state
  transitions. Every turn in the live session finished well under a minute, so the
  5-minute bound was never approached. If the timestamp is frozen, a >5-minute turn
  drops to 60 s mid-run and `ACTIVE_MAX_AGE_MS` should go up.
- The failed-poll notice is covered by unit tests at both the hook and page level, but
  was **not** exercised end-to-end. Patching `window.fetch` does not intercept
  (Backstage's fetch API holds its own captured reference) and CDP offline emulation
  *pauses* react-query rather than failing it, so neither lever produces an error.

**Two doc changes ride along that are not about polling** — flagging them so they are
not a surprise in review:

- The `agent-deployment` template note, which claimed the template still had to be
  added to `giantswarm/backstage-catalogs`; it is now published there.
- A new TODO: when a task is `input-required`, the question the agent is waiting on
  lives in `status.message` and is parsed by the wire schema, but `buildTimeline` only
  reads `status.timestamp`, so nothing renders it. Found while verifying this PR on
  gazelle. Happy to split either out if you would rather.

### Do the docs need to be updated?

Yes — done in this PR. New "Refreshing" section under "The session detail page", a
cross-reference from the agent detail page so the two read as one policy, and the
"Session detail doesn't refresh" Open TODO rewritten down to the manual-refresh
remainder.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
