### PR TITLE
fix(agent-platform): render the question a session is waiting on

### DIFF
--- a/.changeset/agent-platform-pending-ask-user.md
+++ b/.changeset/agent-platform-pending-ask-user.md
@@ -1,0 +1,46 @@
+---
+'@giantswarm/backstage-plugin-agent-platform': patch
+---
+
+Render the question a session is waiting on. A session whose last turn ends by asking
+the user something showed nothing at all for that question — the timeline stopped at
+the agent's previous message, so it read as if the agent had trailed off mid
+conversation, with only the "Waiting for input" badge in the header hinting otherwise.
+
+The question fell between two paths that each assumed the other had it. The raw
+`ask_user` call **is** in `task.history`, but it is deliberately skipped as ADK
+plumbing (`INTERNAL_TOOL_NAMES`) on the grounds that the approval path renders it —
+and that path only ever read `history`. For an _unanswered_ question there is nothing
+there to read: kagent puts the pending `adk_request_confirmation` on
+`task.status.message` and nowhere else. Verified against a live gazelle session, where
+the pending message carries a `messageId` that appears in none of its task's history
+entries.
+
+So `status.message` is now appended as a final history entry when the task is waiting
+on it, which gets the existing approval handling — dedupe, part walking, the
+`ask_user` -> `asks: 'input'` discrimination, and the cross-task verdict tracking —
+without a second code path. kagent's own UI solves the same problem with two separate
+passes that are then concatenated; one list keeps the question in its chronological
+place instead of at the end.
+
+Gated on the state (`input-required` / `auth-required`) rather than merely on the
+message being present, which is what makes the card self-clearing. Once the user
+answers elsewhere the task reaches a terminal state, the prompt stops being emitted
+from `status`, and the now-answered confirmation renders from history with its
+verdict — so a question cannot linger on screen after it has been answered. The
+alternative, emitting whenever `status.message` exists, would also risk duplicating a
+terminal task's final text if kagent ever put it there.
+
+**The question itself now renders as prose.** Making the row appear was not quite
+enough: `ask_user` arguments were only reachable by expanding the row, where they
+showed as JSON in a monospace, single-line-ellipsised slot built for tool payloads. A
+question is the last thing the agent _said_, so the approval item now carries the
+extracted `questions` and the entry renders them as markdown, numbered when an
+`ask_user` asks several at once. With the questions on the row there is nothing left
+behind the expander, so it renders as a plain row rather than offering a click that
+reveals a worse copy of what is already on screen. This applies to already-answered
+questions too, which had the same problem less visibly.
+
+Extraction is deliberately narrow — `questions[].question` strings and nothing else.
+A question rendered from a guessed field would put words in the agent's mouth, so an
+unrecognised payload falls back to showing the raw arguments as before.

--- a/.changeset/agent-platform-pending-ask-user.md
+++ b/.changeset/agent-platform-pending-ask-user.md
@@ -24,12 +24,17 @@ passes that are then concatenated; one list keeps the question in its chronologi
 place instead of at the end.
 
 Gated on the state (`input-required` / `auth-required`) rather than merely on the
-message being present, which is what makes the card self-clearing. Once the user
-answers elsewhere the task reaches a terminal state, the prompt stops being emitted
-from `status`, and the now-answered confirmation renders from history with its
-verdict — so a question cannot linger on screen after it has been answered. The
-alternative, emitting whenever `status.message` exists, would also risk duplicating a
-terminal task's final text if kagent ever put it there.
+message being present, which is what makes the card self-clearing. kagent's resume
+path settles this: a HITL decision resumes the **stored** task — `executor.go` takes
+the `StoredTask != nil` branch, emits `working` on that same task and appends the
+decision to its history, and `BuildResumeHITLMessage` will not even build a resume
+unless that task is currently `input-required`. So the asking task always leaves
+`input-required` once answered, the prompt stops being emitted from `status`, and the
+now-answered confirmation renders from history with its verdict. The question cannot
+appear twice, and cannot linger as "Awaiting a reply" after it has been answered;
+there is a test for exactly that overlap. The alternative — emitting whenever
+`status.message` exists — would also risk duplicating a terminal task's final message,
+which is what `status.message` holds once a task completes.
 
 **The question itself now renders as prose.** Making the row appear was not quite
 enough: `ask_user` arguments were only reachable by expanding the row, where they

--- a/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/SessionTimeline.test.tsx
@@ -9,6 +9,7 @@ import { SessionTimeline } from './SessionTimeline';
 import tasksV099 from '../../lib/__fixtures__/tasks.v0-9-9.json';
 import tasksApproval from '../../lib/__fixtures__/tasks.approval.json';
 import tasksAskUser from '../../lib/__fixtures__/tasks.ask-user.json';
+import tasksAskUserPending from '../../lib/__fixtures__/tasks.ask-user-pending.json';
 import tasksEmpty from '../../lib/__fixtures__/tasks.empty-no-data.json';
 
 function timelineFor(fixture: unknown) {
@@ -183,16 +184,36 @@ describe('SessionTimeline', () => {
       expect(screen.queryByText('Approved')).not.toBeInTheDocument();
     });
 
-    it('calls the payload questions, and omits the redundant tool name', async () => {
+    it('shows the question as prose, with nothing to expand', async () => {
+      // The question is the last thing the agent said, so it belongs in the
+      // conversation rather than behind an expander as a JSON payload. With the
+      // questions on the row there is nothing left to reveal, so the row offers
+      // no expander at all.
       await render(tasksAskUser, 'SRE Agent');
 
-      await userEvent.click(
-        screen.getByRole('button', { name: /User input requested/ }),
-      );
-
-      expect(screen.getByText('Questions')).toBeInTheDocument();
+      expect(
+        screen.getByText('Which management cluster should I look at?'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /User input requested/ }),
+      ).not.toBeInTheDocument();
       // `ask_user` on every such row carries no information.
       expect(screen.queryByText('ask_user')).not.toBeInTheDocument();
+    });
+
+    it('shows a question the session is still waiting on', async () => {
+      // The unanswered confirmation lives only on `task.status.message`, and the
+      // raw `ask_user` call in history is skipped as ADK plumbing — so a session
+      // ending in a question used to render as if the agent had stopped talking
+      // mid-conversation.
+      await render(tasksAskUserPending, 'SRE Agent');
+
+      expect(
+        screen.getByText(
+          'What would you like to investigate next on the management cluster?',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Awaiting a reply')).toBeInTheDocument();
     });
 
     it('shows what the user actually replied', async () => {

--- a/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
+++ b/plugins/agent-platform/src/components/SessionTimeline/TimelineEntry.tsx
@@ -264,11 +264,26 @@ export function TimelineEntry({
   // No expander when there is nothing behind it. An accordion that opens onto an
   // empty panel invites a click and answers with nothing.
   if (!hasExpandableDetail(item)) {
+    const questions =
+      item.kind === 'approval' ? (item.questions ?? []) : undefined;
     return (
       <div className={classes.entry} data-testid={`timeline-${item.kind}`}>
         <div className={classes.inertSummary}>
           <CollapsedSummary item={item} />
         </div>
+        {/* A question is the last thing the agent said, so it reads as prose in
+            the conversation rather than as a payload to go looking for. Several
+            questions can arrive in one `ask_user`; they are numbered so a reply
+            can refer to them. */}
+        {questions && questions.length > 0 && (
+          <MessageBody
+            text={
+              questions.length === 1
+                ? questions[0]
+                : questions.map((text, i) => `${i + 1}. ${text}`).join('\n\n')
+            }
+          />
+        )}
       </div>
     );
   }

--- a/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
+++ b/plugins/agent-platform/src/components/SessionTimeline/helpers.ts
@@ -48,6 +48,12 @@ export function expandablePayloads(
   ) {
     return undefined;
   }
+  // A question's args *are* the questions, and those now render as prose on the
+  // row itself. Repeating them as a JSON payload behind an expander would offer a
+  // click that reveals a worse copy of what is already on screen.
+  if (item.kind === 'approval' && item.questions?.length) {
+    return undefined;
+  }
   const args = formatPayload(item.args);
   // An approval has no result — it carries the *proposed* call, which never ran as
   // this item.

--- a/plugins/agent-platform/src/lib/__fixtures__/tasks.ask-user-pending.json
+++ b/plugins/agent-platform/src/lib/__fixtures__/tasks.ask-user-pending.json
@@ -1,0 +1,120 @@
+{
+  "comment": "A session whose last turn is still WAITING on an ask_user question. Shapes taken from a live gazelle session (session id and wording replaced): the unanswered confirmation lives only on status.message, with a messageId that appears nowhere in history, while history carries the raw ask_user calls that the timeline skips as ADK plumbing. status.message has no message-level metadata, so it contributes no token usage.",
+  "error": false,
+  "data": [
+    {
+      "id": "task-1",
+      "kind": "task",
+      "status": {
+        "state": "completed",
+        "timestamp": "2026-08-06T06:40:00.000Z"
+      },
+      "history": [
+        {
+          "kind": "message",
+          "messageId": "m-user-1",
+          "role": "user",
+          "parts": [{ "kind": "text", "text": "What is running on gazelle?" }]
+        },
+        {
+          "kind": "message",
+          "messageId": "m-agent-1",
+          "role": "agent",
+          "metadata": { "adk_author": "sre_agent" },
+          "parts": [
+            {
+              "kind": "text",
+              "text": "The management cluster looks healthy — all Helm releases are reconciled."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "comment": "The pending turn. kagent repeats the user's message under one messageId, as it does on every turn.",
+      "id": "task-2",
+      "kind": "task",
+      "status": {
+        "state": "input-required",
+        "timestamp": "2026-08-06T06:49:30.635Z",
+        "message": {
+          "kind": "message",
+          "messageId": "m-pending-ask",
+          "role": "agent",
+          "taskId": "",
+          "contextId": "",
+          "parts": [
+            {
+              "kind": "data",
+              "metadata": {
+                "adk_type": "function_call",
+                "adk_is_long_running": true
+              },
+              "data": {
+                "id": "adk-pending-1",
+                "name": "adk_request_confirmation",
+                "args": {
+                  "originalFunctionCall": {
+                    "id": "call-ask-pending-1",
+                    "name": "ask_user",
+                    "args": {
+                      "questions": [
+                        {
+                          "question": "What would you like to investigate next on the management cluster?"
+                        }
+                      ]
+                    }
+                  },
+                  "toolConfirmation": {
+                    "confirmed": false,
+                    "hint": "What would you like to investigate next on the management cluster?",
+                    "payload": null
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "history": [
+        {
+          "kind": "message",
+          "messageId": "m-user-2",
+          "role": "user",
+          "parts": [{ "kind": "text", "text": "Anything else worth checking?" }]
+        },
+        {
+          "kind": "message",
+          "messageId": "m-user-2",
+          "role": "user",
+          "parts": [{ "kind": "text", "text": "Anything else worth checking?" }]
+        },
+        {
+          "comment": "The raw ask_user call, skipped as ADK plumbing — the approval path is what renders the question.",
+          "kind": "message",
+          "messageId": "m-raw-ask-1",
+          "role": "agent",
+          "metadata": { "adk_author": "sre_agent" },
+          "parts": [
+            {
+              "kind": "data",
+              "metadata": { "adk_type": "function_call" },
+              "data": {
+                "id": "call-ask-pending-1",
+                "name": "ask_user",
+                "args": {
+                  "questions": [
+                    {
+                      "question": "What would you like to investigate next on the management cluster?"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "message": "Successfully retrieved session tasks"
+}

--- a/plugins/agent-platform/src/lib/kagentTimeline.test.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.test.ts
@@ -5,6 +5,7 @@ import { A2aTaskWire } from './kagentTaskSchema';
 import kagentPrefixed from './__fixtures__/tasks.v0-9-9.json';
 import adkPrefixed from './__fixtures__/tasks.adk-prefixed.json';
 import approval from './__fixtures__/tasks.approval.json';
+import askUserPending from './__fixtures__/tasks.ask-user-pending.json';
 import malformed from './__fixtures__/tasks.malformed.json';
 import emptyNoData from './__fixtures__/tasks.empty-no-data.json';
 import bareArray from './__fixtures__/tasks.bare-array.json';
@@ -205,6 +206,90 @@ describe('buildTimeline', () => {
 
       expect(items).toHaveLength(1);
       expect(items[0].at).toBeUndefined();
+    });
+  });
+
+  describe('a question the session is still waiting on', () => {
+    it('renders the pending question from status.message', () => {
+      // The unanswered confirmation is on `status.message` and nowhere in
+      // history, while the raw `ask_user` call in history is skipped as ADK
+      // plumbing. Before this was read, a session that ended by asking the user
+      // something rendered as if the agent had simply stopped talking.
+      const { items } = timelineFor(askUserPending);
+
+      expect(kinds(items)).toEqual([
+        'user-message',
+        'agent-message',
+        'user-message',
+        'approval',
+      ]);
+      expect(items[3]).toMatchObject({
+        kind: 'approval',
+        asks: 'input',
+        toolName: 'ask_user',
+        args: expect.objectContaining({
+          questions: [
+            {
+              question:
+                'What would you like to investigate next on the management cluster?',
+            },
+          ],
+        }),
+      });
+      // Nobody has answered, so it must not claim a verdict either way.
+      expect(items[3]).not.toHaveProperty('verdict', 'approved');
+      expect(items[3]).not.toHaveProperty('verdict', 'rejected');
+    });
+
+    it('takes the pending question at its task timestamp', () => {
+      const { items } = timelineFor(askUserPending);
+
+      expect(items[3].at).toBe('2026-08-06T06:49:30.635Z');
+    });
+
+    it('counts no tokens for it', () => {
+      // `status.message` carries no message-level metadata on a real payload, so
+      // it must not be able to inflate the session total.
+      const { tokens } = timelineFor(askUserPending);
+
+      expect(tokens).toEqual({ total: 0, prompt: 0, completion: 0 });
+    });
+
+    it('does not report it as an unreadable message', () => {
+      const { skippedMessages } = timelineFor(askUserPending);
+
+      expect(skippedMessages).toBe(0);
+    });
+
+    it('drops the prompt once the task is no longer waiting', () => {
+      // Self-clearing: when the user answers elsewhere, the task reaches a
+      // terminal state and the answered confirmation renders from history
+      // instead. Emitting it on state alone would leave a question card standing
+      // after it had been answered.
+      const answered = structuredClone(askUserPending) as typeof askUserPending;
+      answered.data[1].status.state = 'completed';
+
+      const { items } = timelineFor(answered);
+
+      expect(kinds(items)).toEqual([
+        'user-message',
+        'agent-message',
+        'user-message',
+      ]);
+    });
+
+    it('ignores a status message on a task that is not waiting', () => {
+      const terminal = structuredClone(askUserPending) as typeof askUserPending;
+      terminal.data[1].status.state = 'failed';
+
+      expect(kinds(timelineFor(terminal).items)).not.toContain('approval');
+    });
+
+    it('reads a prompt on auth-required too', () => {
+      const auth = structuredClone(askUserPending) as typeof askUserPending;
+      auth.data[1].status.state = 'auth-required';
+
+      expect(kinds(timelineFor(auth).items)).toContain('approval');
     });
   });
 

--- a/plugins/agent-platform/src/lib/kagentTimeline.test.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.test.ts
@@ -278,11 +278,100 @@ describe('buildTimeline', () => {
       ]);
     });
 
+    it('renders one approval, not two, once the question is answered', () => {
+      // The post-answer shape, from kagent's resume path: a HITL decision resumes
+      // the *stored* task (`executor.go` — `StoredTask != nil` emits `working` on
+      // it and appends the decision to its history), so the asking task leaves
+      // `input-required` and its confirmation is now in history with a verdict.
+      // The concern this pins down is the overlap: if the prompt were still
+      // emitted from `status` while the answered copy renders from history, the
+      // same question would appear twice, one of them "Awaiting a reply" forever.
+      // Typed loosely on purpose: the entries appended below are shapes the JSON
+      // fixture's inferred element type does not have, and they are exactly what
+      // kagent writes on resume.
+      const answered = structuredClone(askUserPending) as unknown as {
+        data: { status: { state: string }; history: unknown[] }[];
+      };
+      const task = answered.data[1];
+      task.status.state = 'completed';
+      task.history.push(
+        {
+          kind: 'message',
+          messageId: 'm-confirm-1',
+          role: 'agent',
+          metadata: { adk_author: 'sre_agent' },
+          parts: [
+            {
+              kind: 'data',
+              metadata: {
+                adk_type: 'function_call',
+                adk_is_long_running: true,
+              },
+              data: {
+                id: 'adk-pending-1',
+                name: 'adk_request_confirmation',
+                args: {
+                  originalFunctionCall: {
+                    id: 'call-ask-pending-1',
+                    name: 'ask_user',
+                    args: {
+                      questions: [
+                        {
+                          question:
+                            'What would you like to investigate next on the management cluster?',
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          kind: 'message',
+          messageId: 'm-answer-1',
+          role: 'user',
+          parts: [
+            { kind: 'data', data: { decision_type: 'approve' } },
+            { kind: 'text', text: 'The muster auth config, please.' },
+          ],
+        },
+      );
+
+      const { items } = timelineFor(answered);
+
+      expect(items.filter(item => item.kind === 'approval')).toHaveLength(1);
+      expect(kinds(items)).toEqual([
+        'user-message',
+        'agent-message',
+        'user-message',
+        'approval',
+        'user-message',
+      ]);
+      expect(items[3]).toMatchObject({ kind: 'approval', verdict: 'approved' });
+    });
+
     it('ignores a status message on a task that is not waiting', () => {
       const terminal = structuredClone(askUserPending) as typeof askUserPending;
       terminal.data[1].status.state = 'failed';
 
       expect(kinds(timelineFor(terminal).items)).not.toContain('approval');
+    });
+
+    it('does not report an unreadable status message as data loss', () => {
+      // `status.message` is `z.unknown()` at the parse boundary, so a kagent
+      // version putting a bare string there (an auth-required hint, say) must not
+      // reach the message parser — it would count as `skippedMessages` and the UI
+      // would tell the user "1 message could not be read" about a healthy session.
+      const hint = structuredClone(askUserPending) as typeof askUserPending;
+      (hint.data[1].status as { message?: unknown }).message =
+        'Sign in to continue';
+
+      const { items, skippedMessages } = timelineFor(hint);
+
+      expect(skippedMessages).toBe(0);
+      expect(kinds(items)).not.toContain('approval');
     });
 
     it('reads a prompt on auth-required too', () => {

--- a/plugins/agent-platform/src/lib/kagentTimeline.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.ts
@@ -78,6 +78,16 @@ export type TimelineItem =
       asks: 'approval' | 'input';
       /** The tool the agent proposed to run, when the payload named one. */
       toolName?: string;
+      /**
+       * The questions themselves, when this is an `ask_user`.
+       *
+       * Extracted here rather than left for the UI to dig out of {@link args},
+       * because a question is the last thing the agent *said* — it belongs in the
+       * conversation as prose, not behind an expander as JSON. Empty when the
+       * payload used a shape we don't recognise, in which case the raw args remain
+       * the only record and the UI falls back to showing them.
+       */
+      questions?: string[];
       args?: unknown;
       /** Undefined while the request is still unanswered. */
       verdict?: 'approved' | 'rejected';
@@ -102,6 +112,54 @@ export type SessionTimeline = {
 type OpenCall = { callId: string; itemIndex: number };
 
 const EMPTY_USAGE: TokenUsage = { total: 0, prompt: 0, completion: 0 };
+
+/**
+ * The A2A states in which `status.message` is a prompt the task is *waiting on*,
+ * rather than incidental status text.
+ *
+ * The legacy (v0) spellings, which is what this client reads: `listSessionTasks`
+ * deliberately sends no `A2A-Version` header, and kagent treats a missing header
+ * as the legacy wire.
+ */
+const AWAITING_INPUT_STATES = new Set(['input-required', 'auth-required']);
+
+/**
+ * A task's history, plus the question it is currently waiting on.
+ *
+ * kagent puts an *unanswered* confirmation on `task.status.message` and **not** in
+ * `history`, so a session that ends by asking the user something rendered as if
+ * the agent had simply stopped talking. The raw `ask_user` call does appear in
+ * history, but it is deliberately skipped as ADK plumbing (`INTERNAL_TOOL_NAMES`)
+ * because the approval path is supposed to render it — and that path only ever
+ * looked at history. The question fell between the two.
+ *
+ * Verified against a live gazelle session: the pending `status.message` carries a
+ * distinct `messageId` that appears nowhere in `history`, wrapping the question in
+ * the same `adk_request_confirmation` shape an answered one has. So appending it
+ * as a final entry gets the existing approval handling — including the
+ * `ask_user` -> `asks: 'input'` discrimination — for free.
+ *
+ * Gated on the state rather than merely on the message being present. Two reasons:
+ * it is the documented contract (`status.message` "carries the pending prompt
+ * while a task waits for input"), and it makes the item self-clearing — once the
+ * user answers elsewhere and the task reaches a terminal state, the prompt stops
+ * being emitted here and the answered confirmation renders from history instead,
+ * so the card cannot linger as a question that has already been answered.
+ *
+ * kagent's own UI splits the same problem across two passes
+ * (`extractMessagesFromTasks` skips unresolved confirmations in history;
+ * `extractApprovalMessagesFromTasks` reads `status.message`). One list keeps the
+ * question in its chronological place instead of appending it to the end.
+ */
+function historyWithPendingPrompt(task: A2aTaskWire): unknown[] {
+  const history = Array.isArray(task.history) ? task.history : [];
+  const state = task.status?.state?.toLowerCase();
+  const pending = task.status?.message;
+  if (!pending || !state || !AWAITING_INPUT_STATES.has(state)) {
+    return history;
+  }
+  return [...history, pending];
+}
 
 /**
  * Turn kagent's A2A tasks into a flat, renderable timeline.
@@ -166,14 +224,14 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
     // because this is now the *only* timestamp source — it becomes `at` for every
     // item in the task.
     const taskTimestamp = normalizeTimestamp(task.status?.timestamp);
-    const history = Array.isArray(task.history) ? task.history : [];
+    const entries = historyWithPendingPrompt(task);
 
     // Open calls are per task: a response never answers a call from another turn,
     // and letting them match across tasks would attach a result to the wrong call
     // when a tool is used repeatedly.
     const openCalls: OpenCall[] = [];
 
-    history.forEach((entry, entryIndex) => {
+    entries.forEach((entry, entryIndex) => {
       const parsed = parseHistoryEntry(entry);
       if (parsed.kind === 'unparseable') {
         skippedMessages += 1;
@@ -400,6 +458,7 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
         // sufficient and can't degrade like that.
         if (call.name === CONFIRMATION_TOOL_NAME) {
           const proposed = readProposedCall(call.args);
+          const isQuestion = proposed?.name === ASK_USER_TOOL_NAME;
           openApprovalIndex = items.length;
           items.push({
             kind: 'approval',
@@ -407,8 +466,11 @@ export function buildTimeline(tasks: A2aTaskWire[]): SessionTimeline {
             at,
             author,
             taskIndex,
-            asks: proposed?.name === ASK_USER_TOOL_NAME ? 'input' : 'approval',
+            asks: isQuestion ? 'input' : 'approval',
             toolName: proposed?.name,
+            questions: isQuestion
+              ? readAskUserQuestions(proposed?.args)
+              : undefined,
             args: proposed?.args,
           });
           return;
@@ -498,6 +560,39 @@ function makeCallItem(input: {
  * kagent wraps it as `args.originalFunctionCall` on the `adk_request_confirmation`
  * call (`buildApprovalMessage` in kagent's UI reads the same field).
  */
+/**
+ * The questions an `ask_user` call is putting to the user.
+ *
+ * Shape on the wire, from a live gazelle session:
+ * `args: { questions: [{ question: "…" }] }` — one entry per question, and a real
+ * `ask_user` can ask several at once.
+ *
+ * Anything that doesn't match is skipped rather than coerced: a question rendered
+ * from a guessed field would put words in the agent's mouth, and the raw args are
+ * still shown when nothing here matches.
+ */
+function readAskUserQuestions(args: unknown): string[] {
+  if (!args || typeof args !== 'object') {
+    return [];
+  }
+  const { questions } = args as { questions?: unknown };
+  if (!Array.isArray(questions)) {
+    return [];
+  }
+  return questions
+    .map(entry => {
+      if (typeof entry === 'string') {
+        return entry;
+      }
+      if (entry && typeof entry === 'object') {
+        const { question } = entry as { question?: unknown };
+        return typeof question === 'string' ? question : undefined;
+      }
+      return undefined;
+    })
+    .filter((text): text is string => Boolean(text && text.trim()));
+}
+
 function readProposedCall(
   args: unknown,
 ): { name?: string; args?: unknown } | undefined {

--- a/plugins/agent-platform/src/lib/kagentTimeline.ts
+++ b/plugins/agent-platform/src/lib/kagentTimeline.ts
@@ -150,12 +150,24 @@ const AWAITING_INPUT_STATES = new Set(['input-required', 'auth-required']);
  * (`extractMessagesFromTasks` skips unresolved confirmations in history;
  * `extractApprovalMessagesFromTasks` reads `status.message`). One list keeps the
  * question in its chronological place instead of appending it to the end.
+ *
+ * Only an object-shaped message is appended. `status.message` is `z.unknown()` at
+ * the parse boundary, so a kagent version putting a bare string there — an
+ * `auth-required` hint, say — would otherwise reach `parseHistoryEntry`, fail
+ * `a2aMessageWireSchema` and count as `skippedMessages`, which the UI reports as
+ * "1 message could not be read" on a session that is in fact perfectly healthy.
+ * A shape we cannot render should be invisible, not announced as data loss.
  */
 function historyWithPendingPrompt(task: A2aTaskWire): unknown[] {
   const history = Array.isArray(task.history) ? task.history : [];
   const state = task.status?.state?.toLowerCase();
   const pending = task.status?.message;
-  if (!pending || !state || !AWAITING_INPUT_STATES.has(state)) {
+  if (
+    !pending ||
+    typeof pending !== 'object' ||
+    !state ||
+    !AWAITING_INPUT_STATES.has(state)
+  ) {
     return history;
   }
   return [...history, pending];
@@ -560,6 +572,24 @@ function makeCallItem(input: {
  * kagent wraps it as `args.originalFunctionCall` on the `adk_request_confirmation`
  * call (`buildApprovalMessage` in kagent's UI reads the same field).
  */
+function readProposedCall(
+  args: unknown,
+): { name?: string; args?: unknown } | undefined {
+  if (!args || typeof args !== 'object') {
+    return undefined;
+  }
+  const original = (args as { originalFunctionCall?: unknown })
+    .originalFunctionCall;
+  if (!original || typeof original !== 'object') {
+    return undefined;
+  }
+  const record = original as { name?: unknown; args?: unknown };
+  return {
+    name: typeof record.name === 'string' ? record.name : undefined,
+    args: record.args,
+  };
+}
+
 /**
  * The questions an `ask_user` call is putting to the user.
  *
@@ -591,24 +621,6 @@ function readAskUserQuestions(args: unknown): string[] {
       return undefined;
     })
     .filter((text): text is string => Boolean(text && text.trim()));
-}
-
-function readProposedCall(
-  args: unknown,
-): { name?: string; args?: unknown } | undefined {
-  if (!args || typeof args !== 'object') {
-    return undefined;
-  }
-  const original = (args as { originalFunctionCall?: unknown })
-    .originalFunctionCall;
-  if (!original || typeof original !== 'object') {
-    return undefined;
-  }
-  const record = original as { name?: unknown; args?: unknown };
-  return {
-    name: typeof record.name === 'string' ? record.name : undefined,
-    args: record.args,
-  };
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

A session whose last turn ends by asking the user something showed **nothing at all** for that question. The timeline stopped at the agent's previous message, so it read as if the agent had trailed off mid conversation — only the "Waiting for input" badge in the header hinted otherwise.

The question fell between two paths that each assumed the other had it:

- The raw `ask_user` call **is** in `task.history`, but it is deliberately skipped as ADK plumbing (`INTERNAL_TOOL_NAMES` in `kagentParts.ts`) on the grounds that *"`ask_user` is rendered by the approval path rather than as a tool call."*
- The approval path renders `adk_request_confirmation` — but it only ever read `history`, and for an **unanswered** question there is nothing there to read. kagent puts the pending confirmation on `task.status.message` and nowhere else.

`buildTimeline` now appends `status.message` as a final history entry while the task is waiting on it, so the existing approval handling applies unchanged — dedupe, part walking, the `ask_user` → `asks: 'input'` discrimination, and the cross-task verdict tracking — with no second code path. kagent's own UI solves this with two separate passes that are concatenated; keeping one list means the question stays in its chronological place rather than being appended to the end.

It is gated on the state (`input-required` / `auth-required`) rather than merely on the message being present, which is what makes the card self-clearing: once the user answers elsewhere, the task reaches a terminal state, the prompt stops being emitted from `status`, and the now-answered confirmation renders from history with its verdict. A question therefore cannot linger on screen after it has been answered.

Second part: **the question now renders as prose.** Making the row appear was not quite enough — `ask_user` arguments were only reachable by expanding the row, where they showed as JSON in a monospace, single-line-ellipsised slot built for tool payloads. A question is the last thing the agent *said*, so the approval item now carries the extracted `questions` and the entry renders them as markdown (numbered when one `ask_user` asks several). With the questions on the row there is nothing left behind the expander, so it renders as a plain row instead of offering a click that reveals a worse copy of what is already on screen. This applies to already-answered questions too, which had the same problem less visibly.

Extraction is deliberately narrow — `questions[].question` strings and nothing else. A question rendered from a guessed field would put words in the agent's mouth, so an unrecognised payload falls back to showing the raw arguments as before.

### What is the effect of this change to users?

A session that ends with the agent asking a question now shows that question in the conversation, marked "User input requested / Awaiting a reply", instead of appearing to stop mid conversation. Questions that were already answered are now readable as text rather than as JSON behind an expander.

### How does it look like?

Verified in the browser against a live gazelle session (`019fd5d5-…`), whose last task is `input-required`. The end of the timeline now reads:

```
6 Aug 2026, 06:49 UTC

You
Please ask me a question using the appropriate tool. Just any question will do.

User input requested   [Awaiting a reply]
What would you like to investigate next on the gazelle MC? For example: dig into
the muster auth config, check the agentic-platform-connectivity Helm release, or
look at something else entirely?
```

Before this change, everything from "User input requested" down was absent.

### Any background context you can provide?

The shape was confirmed against the live payload rather than inferred. On that session's final task, `status.message` carries `messageId` `019fd5d5-8f0b-…`, which appears in **none** of the task's four history entries, and wraps the question in the same `adk_request_confirmation` envelope an answered one has:

```json
{ "args": { "originalFunctionCall": { "name": "ask_user",
            "args": { "questions": [ { "question": "…" } ] } },
            "toolConfirmation": { "confirmed": false, "hint": "…" } },
  "name": "adk_request_confirmation" }
```

It carries no message-level metadata, so it contributes no token usage — covered by a test, since a prompt that inflated the session's token total would be a quiet regression.

The new fixture (`tasks.ask-user-pending.json`) is shaped from that payload with the wording and ids replaced; real `/tasks` payloads are not committed, as they contain full conversations including tool arguments and results.

One existing test changed contract: it clicked the expander to assert a "Questions" payload, and now asserts the question is visible as prose with no expander.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))
