### PR TITLE
chore(renovate): match Giant Swarm github: tag deps in the release-age opt-out

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -105,8 +105,13 @@
     {
       // Opt Giant Swarm-owned npm packages out of the 14-day minimumReleaseAge
       // supply-chain delay from renovate-presets default.json5.
+      //
+      // Both name forms are needed: `matchPackageNames` matches `packageName`,
+      // and a `github:giantswarm/<repo>#<tag>` dependency resolves through the
+      // github-tags datasource, so its packageName is the bare repo slug rather
+      // than the `@giantswarm/...` name it is declared under.
       matchManagers: ['npm'],
-      matchPackageNames: ['@giantswarm{/,}**'],
+      matchPackageNames: ['@giantswarm{/,}**', 'giantswarm{/,}**'],
       minimumReleaseAge: null,
     },
     {


### PR DESCRIPTION
### What does this PR do?

Adds the bare repo-slug form to the `minimumReleaseAge` opt-out for Giant Swarm
packages, so it also covers dependencies declared as
`github:giantswarm/<repo>#<tag>`.

```diff
-      matchPackageNames: ['@giantswarm{/,}**'],
+      matchPackageNames: ['@giantswarm{/,}**', 'giantswarm{/,}**'],
```

`matchPackageNames` matches on `packageName`, not on the `depName` that shows up
in the PR title. For a registry dependency the two are equal, but
`@giantswarm/k8s-types` is declared as
`github:giantswarm/k8s-typescript-types#v0.7.0` — still the npm manager, but
Renovate resolves it through the `github-tags` datasource and sets
`packageName` to `giantswarm/k8s-typescript-types`. The `@giantswarm` glob never
matched it, so the 14-day delay from `renovate-presets:default.json5` stayed in
force.

The visible symptom is worse than a delayed update: once every tag younger than
14 days is filtered out, the newest *allowed* version is older than the tag the
repo pins, and Renovate opens a **rollback** PR. That is #2060 — proposing
`v0.7.0` → `v0.6.1`, with `v0.6.2`/`v0.6.3`/`v0.7.0` listed as pending. It would
recur after every hand-bump of this dependency.

### What is the effect of this change to users?

None — CI/bot configuration only.

### How does it look like?

Verified with `renovate --dry-run=lookup` against this repo (v44.14.5), A/B on
the matcher list with an otherwise identical forced config:

| `matchPackageNames` | result for `@giantswarm/k8s-types` |
|---|---|
| `['@giantswarm{/,}**']` (current) | `newVersion: v0.6.1`, `pendingVersions: [v0.6.2, v0.6.3, v0.7.0]` — the downgrade |
| `['@giantswarm{/,}**', 'giantswarm{/,}**']` (this PR) | `newVersion: v0.7.0`, no pending versions, lockfile-only update |

`renovate-config-validator` passes.

### Any background context you can provide?

Blast radius is limited to this one dependency today. `matchManagers: ['npm']`
keeps the new glob scoped to `package.json`; the repo's other `giantswarm/*`
lookups — `architect` (orb), `github-workflows` (github-actions),
`postgresql-cnpg` (helm), `renovate-presets` and `backstage` (config) — are not
npm-manager deps. Any future `github:giantswarm/…` dependency in a
`package.json` is covered, which is the intent.

Closes the need for #2060, which can be closed once this merges.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

No changeset — this changes Renovate configuration only, no published package.
