### PR TITLE
chore(renovate): keep path-to-regexp's express 4 pin on the 0.1.x line

### DIFF
--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -157,6 +157,24 @@
       allowedVersions: '<4',
     },
     {
+      // path-to-regexp is resolved on two independent lines here. The 0.1.x
+      // resolution pins the copy express 4 requires (@backstage/backend-defaults
+      // bundles express 4, whose router/layer.js does
+      // `require('path-to-regexp')(path, keys, opts)`). That line is a
+      // maintenance branch carrying security backports onto express 4's API
+      // (CVE-2024-45296, CVE-2024-52798), so anything semver-newer regresses it:
+      // 0.2.5 was published in 2014, predates both fixes, and makes `*` a
+      // literal so wildcard routes stop matching (#2057); 8.x is named-exports
+      // only, so the call above throws and the backend container dies at startup
+      // with "pathRegexp is not a function" (#2061, caught only by
+      // execute-chart-tests). Keep it on the 0.1.x line -- patches still flow --
+      // while the 8.x resolutions update freely. Lift when backend-defaults
+      // ships express 5.
+      matchPackageNames: ['path-to-regexp'],
+      matchCurrentVersion: '<0.2.0',
+      allowedVersions: '<0.2.0',
+    },
+    {
       // Backstage core packages (v1.52) peer-require react "^17 || ^18" -- no
       // React 19. A key blocker is MUI v4, still used by Backstage core, which
       // doesn't support React 19 (upstream tracking:


### PR DESCRIPTION
### What does this PR do?

Adds a Renovate rule keeping the `path-to-regexp` resolution that serves express 4 on its own `0.1.x` line, while leaving the `^8.x` resolutions free to update.

`package.json` resolves `path-to-regexp` on two independent lines. The `0.1.x` one exists to pin the copy **express 4** requires — `@backstage/backend-defaults` bundles express 4, whose `router/layer.js` does `require('path-to-regexp')(path, keys, opts)`. That line is a maintenance branch whose releases are security backports onto express 4's API, so its version numbers are *lower* than, but chronologically *newer* than, everything Renovate offers as an "upgrade":

| version | published |
|---|---|
| 0.2.5 | 2014-08-07 |
| 0.1.10 | 2024-09-01 (CVE-2024-45296) |
| 0.1.12 | 2024-12-05 (CVE-2024-52798) |
| 0.1.13 | 2026-03-26 |

Renovate only sees semver ordering, so it has proposed two regressions:

- **#2057** (`0.1.13` → `0.2.5`) — 0.2.5 predates both CVE fixes, so merging it silently un-patches them. It also dropped `*`-matches-everything, making the asterisk a literal:
  ```
  '*'      0.1.13 → ^(.*)\/?$          0.2.5 → ^\*(?:\/(?=$))?$
  '/api/*' 0.1.13 → ^\/api\/(.*)\/?$   0.2.5 → ^\/api\/\*(?:\/(?=$))?$

  '*'.test('/api/foo')   0.1.13: true   0.2.5: false
  ```
  Express wildcard routes stop matching. 0.2.5 still exports a callable module, so the backend boots and CI stays green — this one would have looked mergeable.

- **#2061** (`0.1.13` → `8.4.2`, bundled in with the legitimate `^8.x` bumps) — 8.x is named-exports only, so the call above throws and the backend container dies at startup:
  ```
  TypeError: pathRegexp is not a function
      at new Layer (.../backend-defaults/node_modules/express/lib/router/layer.js:45:17)
      at new DefaultRootHttpRouter (.../rootHttpRouter/DefaultRootHttpRouter.cjs.js:34:18)
  ```

The rule keys on `matchCurrentVersion` rather than the literal resolution key, so it survives patch bumps, and uses `allowedVersions` rather than `enabled: false` so future `0.1.x` security backports still get proposed.

### What is the effect of this change to users?

None directly — this prevents two dependency updates that would each break the backend (one at startup, one silently at routing time).

### How does it look like?

Verified with a Renovate dry-run against the pushed branch (`RENOVATE_FORCE` pinning the preset ref, per the `renovate` skill — a local `RENOVATE_CONFIG_FILE` run would have silently tested the old rules):

```
path-to-regexp updates planned: 2  (was 3)
  path-to-regexp  8.4.0 → 8.4.2   branch renovate/path-to-regexp-8.x
  path-to-regexp  8.4.0 → 8.4.2   branch renovate/path-to-regexp-8.x

renovate/path-to-regexp-0.x planned? False
0.2.5 offered as a candidate?     False
```

So Renovate should close #2057 on its own and regenerate #2061 without the `0.1.x` entry.

### Any background context you can provide?

- #2061 is currently red on `execute-chart-tests` — the smoke test that boots the real container was the **only** job to catch it. `node-build`, unit tests and `js-dependency-audit` all passed on a backend that cannot start. Same blind spot as the `global-agent` v4 hold already in this file.
- The current pins were established by #1995.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

No changeset — CI/Renovate config only, no published package is affected.
