### PR TITLE
test(muster): widen the sign-in deadline window in useServerSignIn

### DIFF
--- a/plugins/muster/src/components/shared/useServerSignIn.test.tsx
+++ b/plugins/muster/src/components/shared/useServerSignIn.test.tsx
@@ -171,7 +171,10 @@ describe('useServerSignIn', () => {
       () =>
         useServerSignIn('pro', 'gazelle', {
           pollIntervalMs: 20,
-          timeoutMs: 60,
+          // Long enough that `authUrl` is still observable below: the deadline
+          // clears it, so a window measured in tens of milliseconds can elapse
+          // before the first `waitFor` poll on a loaded CI worker.
+          timeoutMs: 750,
         }),
       { wrapper: wrapper(api, queryClient) },
     );
@@ -180,7 +183,9 @@ describe('useServerSignIn', () => {
     await act(async () => result.current.signIn());
     await waitFor(() => expect(result.current.authUrl).toBe(AUTH_URL));
 
-    await waitFor(() => expect(result.current.authUrl).toBeUndefined());
+    await waitFor(() => expect(result.current.authUrl).toBeUndefined(), {
+      timeout: 3_000,
+    });
     expect(result.current.isWaiting).toBe(false);
     // Nothing left in the cache pinning the row open.
     expect(


### PR DESCRIPTION
### What does this PR do?

Removes a load-sensitive race in `useServerSignIn.test.tsx`.

The `clears a pending sign-in at the deadline so the row can act again` test drove the hook with `timeoutMs: 60`, then asserted `authUrl === AUTH_URL` before waiting for the deadline to clear it. That asserted state only existed for 60 ms, so a loaded CI worker could clear the pending entry before `waitFor`'s first poll ran and read `undefined` — after which the value never comes back and `waitFor` times out.

Widening the injected deadline to 750 ms keeps the intermediate state comfortably observable while leaving the test under a second. The subsequent `waitFor` gets an explicit 3 s timeout so it outlasts the new deadline.

### Any background context you can provide?

Caught while investigating why #2079 (`@testing-library/jest-dom` v7) was not mergeable. That PR's `node-build` failed on this test alone, 1 of 2012 — but the bump is not the cause: `toBe` is core Jest, not a jest-dom matcher, and the same commit passed `node-build` twice on that branch (CircleCI pipelines 9694 and 9708) before failing on the third run. The test landed on `main` 68 commits ago and has been green there, so this is a low-frequency flake that #2079 happened to draw.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] A changeset describing the change and affected packages was added. ([more info](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md))

Test-only change, so no changeset — nothing in the published package output changes.